### PR TITLE
Fixed a namspace

### DIFF
--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectEnumColumnTypeTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectEnumColumnTypeTest.php
@@ -8,8 +8,8 @@
  * @license    MIT License
  */
 
-require_once dirname(__FILE__) . '/../../../../../generator/lib/util/PropelQuickBuilder.php';
-require_once dirname(__FILE__) . '/../../../../../runtime/lib/Propel.php';
+use Propel\Generator\Util\PropelQuickBuilder;
+use Propel\Runtime\Propel;
 
 /**
  * Tests the generated objects for enum column types accessor & mutator


### PR DESCRIPTION
Fix the namespace of Generator/Builder/Om/GeneratedObjectEnumColumnTypeTest

Now I am getting 

Class 'Foo\Bar\NamespacedAuthor' not found in /media/Linux/Propel2/tests/Propel/Tests/Generator/Builder/NamespaceTest.php on line 63

Looking where the class is .
