### PR TITLE
Fixed errors in `OracleAdapterTest`.

### DIFF
--- a/src/Propel/Runtime/Adapter/Pdo/OracleAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/OracleAdapter.php
@@ -44,7 +44,7 @@ class OracleAdapter extends PdoAdapter implements AdapterInterface
      * @param     PDO    $con
      * @param     array  $settings  A $PDO PDO connection instance
      */
-    public function initConnection($con, array $settings)
+    public function initConnection(ConnectionInterface $con, array $settings)
     {
         $con->exec("ALTER SESSION SET NLS_DATE_FORMAT='YYYY-MM-DD'");
         $con->exec("ALTER SESSION SET NLS_TIMESTAMP_FORMAT='YYYY-MM-DD HH24:MI:SS'");


### PR DESCRIPTION
Because of a change in `PdoAdapter`, the signature of `OrcaleAdapter::initConnection()` wasn't compatible anymore with that of its parent.

Errors in unit tests would occur:

```
1) Propel\Tests\Runtime\Adapter\Pdo\OracleAdapterTest::testApplyLimitSimple
Declaration of Propel\Runtime\Adapter\Pdo\OracleAdapter::initConnection() should be compatible with that of Propel\Runtime\Adapter\Pdo\PdoAdapter::initConnection()

Propel2/src/Propel/Runtime/Adapter/Pdo/OracleAdapter.php:35
Propel2/vendor/Symfony/Component/ClassLoader/UniversalClassLoader.php:229
Propel/Tests/Runtime/Adapter/Pdo/OracleAdapterTest.php:33
```

These are now fixed.
