### PR TITLE
Fix MysqlSchemaParserState

### DIFF
--- a/src/Propel/Generator/Reverse/MysqlSchemaParser.php
+++ b/src/Propel/Generator/Reverse/MysqlSchemaParser.php
@@ -14,6 +14,7 @@ use Propel\Generator\Model\Column;
 use Propel\Generator\Model\Database;
 use Propel\Generator\Model\Table;
 use Propel\Generator\Model\PropelTypes;
+use Propel\Generator\Model\ColumnDefaultValue;
 
 use \PDO;
 

--- a/src/Propel/Runtime/Connection/DebugPDO.php
+++ b/src/Propel/Runtime/Connection/DebugPDO.php
@@ -10,7 +10,7 @@
 
 namespace Propel\Runtime\Connection;
 
-use Propel\Runtime\Connection\PropelPDO;
+use Propel\Runtime\Connection\ConnectionWrapper;
 
 /**
  * PDO connection subclass that provides some basic support for query counting and logging.
@@ -106,7 +106,7 @@ use Propel\Runtime\Connection\PropelPDO;
  * @since      2006-09-22
  * @package    propel.runtime.connection
  */
-class DebugPDO extends PropelPDO
+class DebugPDO extends ConnectionWrapper
 {
     /**
      * @var       boolean


### PR DESCRIPTION
A missing "use" make the test fail. Wonder how come Jenkins never reported this one. Are the reverse tests skipped in Jenkins?
