### PR TITLE
Move `ConnectionPdo` and `StatementPdo` to `Adapter/Pdo`.

### DIFF
--- a/src/Propel/Generator/Builder/Om/PHP5ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/PHP5ObjectBuilder.php
@@ -1863,7 +1863,7 @@ abstract class ".$this->getClassname()." extends ".$parentClass." ";
      * for results of JOIN queries where the resultset row includes columns from two or
      * more tables.
      *
-     * @param      array \$row The row returned by PDOStatement->fetch(PDO::FETCH_NUM)
+     * @param      array \$row The row returned by Statement->fetch(PDO::FETCH_NUM)
      * @param      int \$startcol 0-based offset column which indicates which restultset column to start with.
      * @param      boolean \$rehydrate Whether this object is being re-hydrated from the database.
      * @return     int next starting column

--- a/src/Propel/Generator/Builder/Om/PHP5PeerBuilder.php
+++ b/src/Propel/Generator/Builder/Om/PHP5PeerBuilder.php
@@ -677,7 +677,7 @@ abstract class ".$this->getClassname(). $extendingPeerClass . " {
     $this->applyBehaviorModifier('preSelect', $script);
 
         $script .= "
-        // BasePeer returns a PDOStatement
+        // BasePeer returns a Statement
         \$stmt = ".$this->basePeerClassname."::doCount(\$criteria, \$con);
 
         if (\$row = \$stmt->fetch(PDO::FETCH_NUM)) {
@@ -751,7 +751,7 @@ abstract class ".$this->getClassname(). $extendingPeerClass . " {
 
         $script .= "
     /**
-     * Prepares the Criteria object and uses the parent doSelect() method to execute a PDOStatement.
+     * Prepares the Criteria object and uses the parent doSelect() method to execute a Statement.
      *
      * Use this method directly if you want to work with an executed statement durirectly (for example
      * to perform your own object hydration).
@@ -760,7 +760,7 @@ abstract class ".$this->getClassname(). $extendingPeerClass . " {
      * @param      ConnectionInterface \$con The connection to use
      * @throws     PropelException Any exceptions caught during processing will be
      *         rethrown wrapped into a PropelException.
-     * @return     PDOStatement The executed PDOStatement object.
+     * @return     StatementInterface The executed Statement object.
      * @see        ".$this->basePeerClassname."::doSelect()
      */
     public static function doSelectStmt(Criteria \$criteria, ConnectionInterface \$con = null)
@@ -783,7 +783,7 @@ abstract class ".$this->getClassname(). $extendingPeerClass . " {
         }
         $script .= "
 
-        // BasePeer returns a PDOStatement
+        // BasePeer returns a Statement
         return ".$this->basePeerClassname."::doSelect(\$criteria, \$con);
     }";
     }

--- a/src/Propel/Generator/Util/QuickBuilder.php
+++ b/src/Propel/Generator/Util/QuickBuilder.php
@@ -15,8 +15,8 @@ use Propel\Generator\Config\GeneratorConfigInterface;
 use Propel\Generator\Model\Table;
 
 use Propel\Runtime\Propel;
+use Propel\Runtime\Adapter\Pdo\PdoConnection;
 use Propel\Runtime\Connection\ConnectionInterface;
-use Propel\Runtime\Connection\ConnectionPdo;
 use Propel\Runtime\Connection\ConnectionWrapper;
 use Propel\Runtime\Connection\ConnectionManagerSingle;
 use Propel\Runtime\Connection\StatementInterface;
@@ -96,7 +96,7 @@ class QuickBuilder
         if (null === $adapter) {
             $adapter = new \Propel\Runtime\Adapter\Pdo\SqliteAdapter();
         }
-        $pdo = new ConnectionPdo($dsn, $user, $pass);
+        $pdo = new PdoConnection($dsn, $user, $pass);
         $con = new ConnectionWrapper($pdo);
         $con->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_WARNING);
         $this->buildSQL($con);

--- a/src/Propel/Runtime/Adapter/Pdo/OracleAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/OracleAdapter.php
@@ -18,7 +18,6 @@ use Propel\Runtime\Util\BasePeer;
 use Propel\Runtime\Query\Criteria;
 
 use \PDO;
-use \PDOStatement;
 
 /**
  * Oracle adapter.
@@ -202,7 +201,7 @@ class OracleAdapter extends PdoAdapter implements AdapterInterface
     /**
      * @see       AbstractAdapter::bindValue()
      *
-     * @param     PDOStatement  $stmt
+     * @param     StatementInterface $stmt
      * @param     string        $parameter
      * @param     mixed         $value
      * @param     ColumnMap     $cMap

--- a/src/Propel/Runtime/Adapter/Pdo/PdoAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/PdoAdapter.php
@@ -12,7 +12,6 @@ namespace Propel\Runtime\Adapter\Pdo;
 
 use Propel\Runtime\Adapter\AdapterInterface;
 use Propel\Runtime\Adapter\AdapterException;
-use Propel\Runtime\Connection\ConnectionPdo;
 use Propel\Runtime\Connection\ConnectionInterface;
 use Propel\Runtime\Connection\StatementInterface;
 use Propel\Runtime\Map\ColumnMap;
@@ -35,7 +34,7 @@ abstract class PdoAdapter
      *
      * @param array    $conparams connection parameters
      *
-     * @return Propel\Runtime\Connection\ConnectionPdo
+     * @return Propel\Runtime\Adapter\Pdo\PdoConnection
      */
     public function getConnection($conparams)
     {
@@ -66,7 +65,7 @@ abstract class PdoAdapter
         }
 
         try {
-            $con = new ConnectionPdo($dsn, $user, $password, $driver_options);
+            $con = new PdoConnection($dsn, $user, $password, $driver_options);
             $this->initConnection($con, isset($conparams['settings']) && is_array($conparams['settings']) ? $conparams['settings'] : array());
         } catch (PDOException $e) {
             throw new AdapterException("Unable to open PDO connection", $e);

--- a/src/Propel/Runtime/Adapter/Pdo/PdoConnection.php
+++ b/src/Propel/Runtime/Adapter/Pdo/PdoConnection.php
@@ -8,7 +8,7 @@
  * @license    MIT License
  */
 
-namespace Propel\Runtime\Connection;
+namespace Propel\Runtime\Adapter\Pdo;
 
 use Propel\Runtime\Connection\ConnectionInterface;
 use Propel\Runtime\Exception\PropelException;
@@ -18,7 +18,7 @@ use \PDO;
 /**
  * PDO extension that implements ConnectionInterface and builds statements implementting StatementInterface.
  */
-class ConnectionPdo extends PDO implements ConnectionInterface
+class PdoConnection extends PDO implements ConnectionInterface
 {
     /**
      * Creates a PDO instance representing a connection to a database.
@@ -26,7 +26,7 @@ class ConnectionPdo extends PDO implements ConnectionInterface
     public function __construct($dsn, $user = null, $password = null, array $options = null)
     {
         parent::__construct($dsn, $user, $password, $options);
-        $this->setAttribute(PDO::ATTR_STATEMENT_CLASS, array('\Propel\Runtime\Connection\StatementPdo', array()));
+        $this->setAttribute(PDO::ATTR_STATEMENT_CLASS, array('\Propel\Runtime\Adapter\Pdo\PdoStatement', array()));
         $this->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
     }
 

--- a/src/Propel/Runtime/Adapter/Pdo/PdoStatement.php
+++ b/src/Propel/Runtime/Adapter/Pdo/PdoStatement.php
@@ -8,14 +8,16 @@
  * @license    MIT License
  */
 
-namespace Propel\Runtime\Connection;
+namespace Propel\Runtime\Adapter\Pdo;
 
 use Propel\Runtime\Connection\StatementInterface;
+
+use \PDOStatement as BasePdoStatement;
 
 /**
  * PDO statement that provides the basic enhancements that are required by Propel.
  */
-class StatementPdo extends \PDOStatement implements StatementInterface
+class PdoStatement extends BasePdoStatement implements StatementInterface
 {
     protected function __construct()
     {

--- a/src/Propel/Runtime/Util/BasePeer.php
+++ b/src/Propel/Runtime/Util/BasePeer.php
@@ -454,7 +454,7 @@ class BasePeer
      *
      * @param      Criteria $criteria A Criteria.
      * @param      ConnectionInterface $con A ConnectionInterface connection to use.
-     * @return     PDOStatement The resultset.
+     * @return     Propel\Runtime\Connection\StatementInterface The resultset.
      * @throws     PropelException
      * @see        createSelectSql()
      */
@@ -496,7 +496,7 @@ class BasePeer
      *
      * @param      Criteria $criteria A Criteria.
      * @param      ConnectionInterface $con A ConnectionInterface connection to use.
-     * @return     PDOStatement The resultset statement.
+     * @return     Propel\Runtime\Connection\StatementInterface The resultset statement.
      * @throws     PropelException
      * @see        createSelectSql()
      */

--- a/tests/Propel/Tests/Runtime/Connection/ConnectionFactoryTest.php
+++ b/tests/Propel/Tests/Runtime/Connection/ConnectionFactoryTest.php
@@ -56,7 +56,7 @@ class ConnectionFactoryTest extends BaseTestCase
     {
         $con = ConnectionFactory::create(array('dsn' => 'sqlite::memory:'), new SqliteAdapter());
         $pdo = $con->getWrappedConnection();
-        $this->assertInstanceOf('Propel\Runtime\Connection\ConnectionPdo', $pdo);
+        $this->assertInstanceOf('Propel\Runtime\Adapter\Pdo\PdoConnection', $pdo);
     }
 
     public function testCreateSetsAttributesAfterConnection()

--- a/tests/Propel/Tests/Runtime/Connection/ConnectionManagerMasterSlaveTest.php
+++ b/tests/Propel/Tests/Runtime/Connection/ConnectionManagerMasterSlaveTest.php
@@ -13,7 +13,6 @@ namespace Propel\Tests\Runtime\Connection;
 use Propel\Tests\Helpers\BaseTestCase;
 
 use Propel\Runtime\Connection\ConnectionManagerMasterSlave;
-use Propel\Runtime\Connection\ConnectionPdo;
 use Propel\Runtime\Adapter\Pdo\SqliteAdapter;
 
 use \PDO;
@@ -36,7 +35,7 @@ class ConnectionManagerMasterSlaveTest extends BaseTestCase
         $con = $manager->getWriteConnection(new SqliteAdapter());
         $this->assertInstanceOf('Propel\Runtime\Connection\ConnectionWrapper', $con);
         $pdo = $con->getWrappedConnection();
-        $this->assertInstanceOf('Propel\Runtime\Connection\ConnectionPdo', $pdo);
+        $this->assertInstanceOf('Propel\Runtime\Adapter\Pdo\PdoConnection', $pdo);
     }
 
     public function testGetWriteConnectionBuildsConnectionNotBasedOnReadConfiguration()
@@ -56,7 +55,7 @@ class ConnectionManagerMasterSlaveTest extends BaseTestCase
         $con = $manager->getReadConnection(new SqliteAdapter());
         $this->assertInstanceOf('Propel\Runtime\Connection\ConnectionWrapper', $con);
         $pdo = $con->getWrappedConnection();
-        $this->assertInstanceOf('Propel\Runtime\Connection\ConnectionPdo', $pdo);
+        $this->assertInstanceOf('Propel\Runtime\Adapter\Pdo\PdoConnection', $pdo);
     }
 
     public function testGetReadConnectionBuildsConnectionNotBasedOnWriteConfiguration()

--- a/tests/Propel/Tests/Runtime/Connection/ConnectionManagerSingleTest.php
+++ b/tests/Propel/Tests/Runtime/Connection/ConnectionManagerSingleTest.php
@@ -13,7 +13,7 @@ namespace Propel\Tests\Runtime\Connection;
 use Propel\Tests\Helpers\BaseTestCase;
 
 use Propel\Runtime\Connection\ConnectionManagerSingle;
-use Propel\Runtime\Connection\ConnectionPdo;
+use Propel\Runtime\Adapter\Pdo\PdoConnection;
 use Propel\Runtime\Adapter\Pdo\SqliteAdapter;
 
 class ConnectionManagerSingleTest extends BaseTestCase
@@ -34,7 +34,7 @@ class ConnectionManagerSingleTest extends BaseTestCase
         $con = $manager->getWriteConnection(new SqliteAdapter());
         $this->assertInstanceOf('Propel\Runtime\Connection\ConnectionWrapper', $con);
         $pdo = $con->getWrappedConnection();
-        $this->assertInstanceOf('Propel\Runtime\Connection\ConnectionPdo', $pdo);
+        $this->assertInstanceOf('Propel\Runtime\Adapter\Pdo\PdoConnection', $pdo);
     }
 
     public function testGetReadConnectionReturnsWriteConnection()
@@ -48,7 +48,7 @@ class ConnectionManagerSingleTest extends BaseTestCase
 
     public function testSetConnection()
     {
-        $connection = new ConnectionPdo('sqlite::memory:');
+        $connection = new PdoConnection('sqlite::memory:');
         $manager = new ConnectionManagerSingle();
         $manager->setConnection($connection);
         $conn = $manager->getWriteConnection();

--- a/tests/Propel/Tests/Runtime/Connection/PropelPDOTest.php
+++ b/tests/Propel/Tests/Runtime/Connection/PropelPDOTest.php
@@ -334,10 +334,10 @@ class PropelPDOTest extends BookstoreTestBase
         $con = Propel::getServiceContainer()->getConnection(BookPeer::DATABASE_NAME);
         $con->useDebug(false);
         $stmtClass = $con->getAttribute(PDO::ATTR_STATEMENT_CLASS);
-        $this->assertEquals('Propel\Runtime\Connection\StatementPdo', $stmtClass[0], 'Statement is StatementPdo when debug is false');
+        $this->assertEquals('Propel\Runtime\Adapter\Pdo\PdoStatement', $stmtClass[0], 'Statement is Propel Statement when debug is false');
         $con->useDebug(true);
         $stmtClass = $con->getAttribute(PDO::ATTR_STATEMENT_CLASS);
-        $this->assertEquals('Propel\Runtime\Connection\StatementPdo', $stmtClass[0], 'Statement is StatementPdo when debug is true');
+        $this->assertEquals('Propel\Runtime\Adapter\Pdo\PdoStatement', $stmtClass[0], 'Statement is Propel Statement when debug is true');
     }
 
     public function testDebugLatestQuery()

--- a/tests/Propel/Tests/Runtime/ServiceContainer/StandardServiceContainerTest.php
+++ b/tests/Propel/Tests/Runtime/ServiceContainer/StandardServiceContainerTest.php
@@ -19,7 +19,7 @@ use Propel\Runtime\Adapter\Pdo\SqliteAdapter;
 use Propel\Runtime\Adapter\Pdo\MysqlAdapter;
 use Propel\Runtime\Map\DatabaseMap;
 use Propel\Runtime\Connection\ConnectionManagerSingle;
-use Propel\Runtime\Connection\ConnectionPdo;
+use Propel\Runtime\Adapter\Pdo\PdoConnection;
 
 class StandardServiceContainerTest extends BaseTestCase
 {
@@ -201,7 +201,7 @@ class StandardServiceContainerTest extends BaseTestCase
     public function testSetConnectionManagerClosesExistingConnectionMAnagerForTheSameDatasource()
     {
         $manager = new TestableConnectionManagerSingle();
-        $manager->setConnection(new ConnectionPdo('sqlite::memory:'));
+        $manager->setConnection(new PdoConnection('sqlite::memory:'));
         $this->assertNotNull($manager->connection);
         $this->sc->setConnectionManager('foo', $manager);
         $this->sc->setConnectionManager('foo', new ConnectionManagerSingle());
@@ -224,9 +224,9 @@ class StandardServiceContainerTest extends BaseTestCase
     public function testCloseConnectionsClosesConnectionsOnAllConnectionManagers()
     {
         $manager1 = new TestableConnectionManagerSingle();
-        $manager1->setConnection(new ConnectionPdo('sqlite::memory:'));
+        $manager1->setConnection(new PdoConnection('sqlite::memory:'));
         $manager2 = new TestableConnectionManagerSingle();
-        $manager2->setConnection(new ConnectionPdo('sqlite::memory:'));
+        $manager2->setConnection(new PdoConnection('sqlite::memory:'));
         $this->sc->setConnectionManager('foo1', $manager1);
         $this->sc->setConnectionManager('foo2', $manager2);
         $this->sc->closeConnections();
@@ -278,13 +278,13 @@ class StandardServiceContainerTest extends BaseTestCase
 
     public function testSetConnectionAddsAConnectionManagerSingle()
     {
-        $this->sc->setConnection('foo', new ConnectionPdo('sqlite::memory:'));
+        $this->sc->setConnection('foo', new PdoConnection('sqlite::memory:'));
         $this->assertInstanceOf('Propel\Runtime\Connection\ConnectionManagerSingle', $this->sc->getConnectionManager('foo'));
     }
 
     public function testSetConnectionAddsAConnectionWhichCanBeRetrivedByGetConnection()
     {
-        $con = new ConnectionPdo('sqlite::memory:');
+        $con = new PdoConnection('sqlite::memory:');
         $this->sc->setAdapter('foo', new SqliteAdapter());
         $this->sc->setConnection('foo', $con);
         $this->assertSame($con, $this->sc->getConnection('foo'));


### PR DESCRIPTION
These two classes were in the `Runtime\Connection` namespace, yet they are PDO implementations of an interface defined in the connection namespace. When thinking about other adapters (like oci8), it appears that these would need to have their own connection and statement implementations, and therefore it makes sense to move the PDO ones into the `Propel\Runtime\Adapter\Pdo` namespace.
