### PR TITLE
Fix regression introduced in bec8a587a9ec5bc0d2d96e35c729a2adee44187a.

### DIFF
--- a/src/Propel/Generator/Task/PropelConvertConfTask.php
+++ b/src/Propel/Generator/Task/PropelConvertConfTask.php
@@ -221,11 +221,6 @@ class PropelConvertConfTask extends AbstractPropelDataModelTask
             // add the childs attributes as if they where children
             foreach ( $v->attributes() as $ak => $av ) {
 
-                // if the child is not an array, transform it into one
-                if ( !is_array( $child ) ) {
-                    $child = array( "value" => $child );
-                }
-
                 if ($ak == 'id') {
                     // special exception: if there is a key named 'id'
                     // then we will name the current key after that id


### PR DESCRIPTION
Closes #73.

The problem came from the refactoring of `Propel::initConnection()` into
`ConnectionFactory::create()`. In the process of moving the code, I
inadvertently removed the line saying:

```
// in old Propel.php, line 575
$value = $optiondata['value'];
```

The generated configuration array used to look like

```
      array (
        'classname' => '\\Propel\\Runtime\\Connection\\DebugPDO',
        'dsn' => 'mysql:dbname=test',
        'options' =>
        array (
          'ATTR_PERSISTENT' => array('value' => false),
        ),
```

Which explained why `Propel::initConnection()` did that. So instead of
reading the code from line 575, I changed the generated conf so that it
looks like:

```
      array (
        'classname' => '\\Propel\\Runtime\\Connection\\DebugPDO',
        'dsn' => 'mysql:dbname=test',
        'options' =>
        array (
          'ATTR_PERSISTENT' => false,
        ),
```

Which makes more sense.
