### PR TITLE
Store Date and Time values as DateTime-instances in generated classes

### DIFF
--- a/src/Propel/Generator/Platform/DefaultPlatform.php
+++ b/src/Propel/Generator/Platform/DefaultPlatform.php
@@ -1181,7 +1181,7 @@ ALTER TABLE %s ADD
         $script = '';
         $hasValuePreparation = false;
         if ($column->isTemporalType()) {
-            // nothing special, the internal value was already properly formatted by the setter
+            $columnValueAccessor = $columnValueAccessor . " ? " . $columnValueAccessor . "->format(\""  . $this->getTimeStampFormatter() . "\") : null";
         } elseif ($column->isLobType()) {
             // we always need to make sure that the stream is rewound, otherwise nothing will
             // get written to database.

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectTemporalColumnTypeTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectTemporalColumnTypeTest.php
@@ -11,6 +11,7 @@
 namespace Propel\Tests\Generator\Builder\Om;
 
 use Propel\Generator\Util\QuickBuilder;
+use Propel\Generator\Platform\MysqlPlatform;
 
 use Propel\Runtime\Propel;
 
@@ -32,6 +33,7 @@ class GeneratedObjectTemporalColumnTypeTest extends \PHPUnit_Framework_TestCase
         <column name="bar1" type="DATE" />
         <column name="bar2" type="TIME"  />
         <column name="bar3" type="TIMESTAMP" />
+        <column name="bar4" type="TIMESTAMP" default="2011-12-09" />
     </table>
 </database>
 EOF;
@@ -137,4 +139,57 @@ EOF;
 
         $this->assertInstanceOf('DateTime', $r->getBar3());
     }
+
+	public function testDateTimeGetterReturnsAReference()
+	{
+		$r = new \ComplexColumnTypeEntity5();
+		$r->setBar3(new \DateTime('2011-11-23'));
+		$r->getBar3()->modify('+1 days');
+		$this->assertEquals('2011-11-24', $r->getBar3('Y-m-d'));
+	}
+	
+	public function testHasOnlyDefaultValues()
+	{
+		$r = new \ComplexColumnTypeEntity5();
+		$this->assertEquals('2011-12-09', $r->getBar4('Y-m-d'));
+		$this->assertTrue($r->hasOnlyDefaultValues());
+	}
+	
+	public function testHydrateWithMysqlInvalidDate()
+	{
+	    $schema = <<<EOF
+<database name="generated_object_complex_type_test_6">
+<table name="complex_column_type_entity_6">
+    <column name="id" primaryKey="true" type="INTEGER" autoIncrement="true" />
+    <column name="bar1" type="DATE" />
+    <column name="bar2" type="TIME"  />
+    <column name="bar3" type="TIMESTAMP" />
+</table>
+</database>
+EOF;
+        $builder = new QuickBuilder();
+        $builder->setSchema($schema);
+        $builder->setPlatform(new MysqlPlatform());
+        $builder->buildClasses();
+		$r = new \ComplexColumnTypeEntity6();
+		$r->hydrate(array(
+			123,
+			'0000-00-00',
+			'00:00:00',
+			'0000-00-00 00:00:00'
+		));
+		$this->assertNull($r->getBar1());
+		$this->assertEquals('00:00:00', $r->getBar2()->format('H:i:s'));
+		$this->assertNull($r->getBar3());
+	}
+	
+	public function testDateTimesSerialize()
+	{
+		$r = new \ComplexColumnTypeEntity5();
+		$r->setBar3(new \DateTime('2011-11-23'));
+		$str = serialize($r);
+		
+		$r2 = unserialize($str);
+		$this->assertEquals('2011-11-23', $r2->getBar3('Y-m-d'));
+	}
 }


### PR DESCRIPTION
This PR will fix #59 and obsoletes PR #86 ..

This commit will modify the generated models so that date and time values are internally stored as DateTime instances.

Included in the commit is tests for the behavior.

This commit also takes into account the comparison of default values etc.

This commit also adds tests and handling for hydration of 0000-00-00 and 0000-00-00 00:00:00 values that are supported on MySQL.
