### PR TITLE
[PHPUnit] exclude templates/ directories from the code coverage generati...

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,6 +21,9 @@
     <filter>
         <whitelist>
             <directory>./src/Propel/</directory>
+            <exclude>
+                <directory>./src/Propel/Generator/Behavior/*/templates/</directory>
+            </exclude>
         </whitelist>
     </filter>
 </phpunit>


### PR DESCRIPTION
...on. When running PHPUnit with the --coverage-clover switch, the tests suite fails has PHPUnit tries to generate the coverage for a PHP template file.
