### PR TITLE
Optional condition in AggregateColumn behavior

### DIFF
--- a/src/Propel/Generator/Behavior/AggregateColumn/AggregateColumnBehavior.php
+++ b/src/Propel/Generator/Behavior/AggregateColumn/AggregateColumnBehavior.php
@@ -75,8 +75,7 @@ class AggregateColumnBehavior extends Behavior
     protected function addObjectCompute()
     {
         $conditions = array();
-        if($this->getParameter('condition'))
-        {
+        if ($this->getParameter('condition')) {
             $conditions[] = $this->getParameter('condition');
         }
 


### PR DESCRIPTION
This is a simple change which allows to add condition to AggregateColumn behavior.
It adds your piece of sql code to the query.

This is how the schema looks like:

``` xml
    <behavior name="aggregate_column">
      <parameter name="name" value="nb_units_available" />
      <parameter name="foreign_table" value="unit" />
      <parameter name="expression" value="COUNT(status)" />
      <parameter name="condition" value="status=1" />
    </behavior>
```

And created method:

``` php
<?php
  public function computeNbUnitsAvailable(PropelPDO $con)
  {
    $stmt = $con->prepare('SELECT COUNT(status) FROM unit WHERE status=1 AND unit.INVESTMENT_ID = :p1');
    $stmt->bindValue(':p1', $this->getId());
    $stmt->execute();
    return $stmt->fetchColumn();
  }
```

Of course you can do the same via overriding the compute method but... why if you can do that in schema with less code?
