### PR TITLE
Update documentation based on experience with project unit testing setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,13 @@ Then, install dependencies:
 
     php composer.phar install
 
+Alternatively, if you get errors about composer.lock being out of sync run:
+
+    php composer.phar update
+
 Once done, build fixtures:
 
-    php bin/propel test:prepare
+    php bin/propel.php test:prepare
 
 Now you can run the test suite by running:
 


### PR DESCRIPTION
... the

inclusion of composer.lock in the repository.

Also make clear the fact that the propel executable file under bin/ is
actually named propel.php
