### PR TITLE
Port PR #279 from Propel 1.6

### DIFF
--- a/tests/Propel/Tests/Runtime/Query/ModelCriteriaSelectTest.php
+++ b/tests/Propel/Tests/Runtime/Query/ModelCriteriaSelectTest.php
@@ -123,6 +123,25 @@ class ModelCriteriaSelectTest extends BookstoreTestBase
         $this->assertEquals(count($author), 1, 'findOne() called after select(string) allows for where() statements');
         $expectedSQL = "SELECT author.FIRST_NAME AS \"FirstName\" FROM `author` WHERE author.FIRST_NAME = 'Neal' LIMIT 1";
         $this->assertEquals($expectedSQL, $this->con->getLastExecutedQuery(), 'findOne() called after select(string) allows for where() statements');
+        
+        $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Author');
+        $c->select(AuthorPeer::FIRST_NAME);
+        $author = $c->find($this->con);
+        $expectedSQL = "SELECT author.FIRST_NAME AS \"author.FIRST_NAME\" FROM `author`";
+        $this->assertEquals($expectedSQL, $this->con->getLastExecutedQuery(), 'select(string) accepts model Peer Constants');
+    }
+    
+    /**
+    * @expectedException PropelException
+    */
+    public function testSelectStringFindCalledWithNonExistingColumn()
+    {
+        BookstoreDataPopulator::depopulate($this->con);
+        BookstoreDataPopulator::populate($this->con);
+        	
+        $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Author');
+        $c->select('author.NOT_EXISTING_COLUMN');
+        $author = $c->find($this->con);
     }
 
     public function testSelectStringJoin()


### PR DESCRIPTION
This patch ports [PR #279](https://github.com/propelorm/Propel/pull/279) from version 1.6. Except for the few lines in Propel\Runtime\Query\ModelCriteria, I applied the patch in PR #279 as it is. 

Just one warning, although I spent three nights trying, I wasn't able to get the tests running on my localhost. I added the tests and edited them accordingly, but never saw them running on my local due to that problem. Therefore merge with caution :) 
Btw. it would be great if someone can update the documentation. Currently it is too hard to contribute to this project.
