### PR TITLE
Fix assumption in MysqlAdapter about charset representation

### DIFF
--- a/src/Propel/Runtime/Adapter/Pdo/MysqlAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/MysqlAdapter.php
@@ -196,7 +196,7 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
      */
     protected function prepareParams($params)
     {
-        if (isset($params['settings']['charset']['value'])) {
+        if (isset($params['settings']['charset'])) {
             if (version_compare(PHP_VERSION, '5.3.6', '<')) {
                 throw new PropelException(<<<EXCEPTION
 Connection option "charset" cannot be used for MySQL connections in PHP versions older than 5.3.6.
@@ -206,7 +206,7 @@ EXCEPTION
                 );
             } else {
                 if (false === strpos($params['dsn'], ';charset=')) {
-                    $params['dsn'] .= ';charset=' . $params['settings']['charset']['value'];
+                    $params['dsn'] .= ';charset=' . $params['settings']['charset'];
                     unset($params['settings']['charset']);
                 }
             }

--- a/tests/Propel/Tests/Runtime/Adapter/Pdo/MysqlAdapterTest.php
+++ b/tests/Propel/Tests/Runtime/Adapter/Pdo/MysqlAdapterTest.php
@@ -30,9 +30,7 @@ class MysqlAdapterTest extends BookstoreTestBase
                 array(
                     'dsn' => 'dsn=my_dsn',
                     'settings' => array(
-                        'charset' => array(
-                            'value' => 'foobar'
-                        )
+                        'charset' => 'foobar'
                     )
                 )
             )


### PR DESCRIPTION
MysqlAdapter assumes the charset connection settings is nested into a deeper array with key 'value', which is not the case. Due to this assumption the PDO connection always throw an exception when using the charset option.
