### PR TITLE
Fixed ConfigBuild.php and schema.xml to run test:prepare command on Windows systems

### DIFF
--- a/src/Propel/Generator/Command/ConfigBuild.php
+++ b/src/Propel/Generator/Command/ConfigBuild.php
@@ -38,12 +38,12 @@ class ConfigBuild extends AbstractCommand
     {
         $filesystem = new Filesystem();
         $outputFile = $input->getOption('output-file');
-
-        $parts = explode(DIRECTORY_SEPARATOR, $outputFile);
+        
+        $parts = explode('/', $outputFile);
         array_pop($parts);
-
+      
         if (0 < count($parts)) {
-            $dirs  = implode(DIRECTORY_SEPARATOR, $parts);
+            $dirs  = implode('/', $parts);
         }
 
         $filesystem->mkdir($dirs);

--- a/tests/Fixtures/bookstore/schema.xml
+++ b/tests/Fixtures/bookstore/schema.xml
@@ -148,7 +148,7 @@
     </table>
 
     <table name="book_x_list" phpName="BookListRel" isCrossRef="true"
-        description="Cross-reference table for many-to-many relationship between book rows and book_club_list rows.">
+        description="Cross-reference table between book and book_club_list rows.">
         <column name="book_id" primaryKey="true" type="INTEGER" description="Fkey to book.id" />
         <column name="book_club_list_id" primaryKey="true" type="INTEGER" description="Fkey to book_club_list.id" />
         <foreign-key foreignTable="book" onDelete="cascade">
@@ -179,7 +179,7 @@
     </table>
 
     <!-- Test one-to-one (1:1) relationship, default values -->
-    <table name="bookstore_employee_account" reloadOnInsert="true" reloadOnUpdate="true" description="A table that represents a bookstore employees login credentials.">
+    <table name="bookstore_employee_account" reloadOnInsert="true" reloadOnUpdate="true" description="Bookstore employees login credentials.">
         <column name="employee_id" type="INTEGER" primaryKey="true" description="Primary key for the account ..." />
         <column name="login" type="VARCHAR" size="32" />
         <column name="password" type="VARCHAR" size="100" default="'@''34&quot;" />


### PR DESCRIPTION
- src/Propel/Generator/Command/ConfigBuild.php: on Windows systems, the DIRECTORY_SEPARATOR constant is translated as the character '\'. But, in line 40, $outputFile variable contains a path in unix-style, with '/' separator  (wich is the preferred php path style, in fact it works both on Unix and Windows). So, in line 49, the $dirs variable is null and the script generates an error.
- tests/Fixtures/bookstore/schema.xml: on Windows systems, Mysql 32 bit server accepts comments of no more than 60 characters.
