### PR TITLE
Fix PropelModelPager::getLastPage() return type.

### DIFF
--- a/src/Propel/Runtime/Util/PropelModelPager.php
+++ b/src/Propel/Runtime/Util/PropelModelPager.php
@@ -91,7 +91,7 @@ class PropelModelPager implements IteratorAggregate, Countable
         if (($this->getPage() == 0 || $this->getMaxPerPage() == 0)) {
             $this->setLastPage(0);
         } else {
-            $this->setLastPage(ceil($this->getNbResults() / $this->getMaxPerPage()));
+            $this->setLastPage((int)ceil($this->getNbResults() / $this->getMaxPerPage()));
 
             $offset = ($this->getPage() - 1) * $this->getMaxPerPage();
             $q->offset($offset);

--- a/tests/Propel/Tests/Runtime/Util/PropelModelPagerTest.php
+++ b/tests/Propel/Tests/Runtime/Util/PropelModelPagerTest.php
@@ -168,6 +168,14 @@ class PropelModelPagerTest extends BookstoreEmptyTestBase
         $this->assertTrue($pager->isLastPage(), 'isLastPage() returns true on the last page');
     }
 
+    public function testGetLastPage()
+    {
+        $this->createBooks(5);
+        $pager = $this->getPager(4, 1);
+        $this->assertEquals(2, $pager->getLastPage(), 'getLastPage() returns the last page number');
+        $this->assertInternalType('integer', $pager->getLastPage(), 'getLastPage() returns an integer');
+    }
+
     public function testIsFirstOnFirstPage()
     {
         $this->createBooks(5);


### PR DESCRIPTION
Port of PR #317 in Propel1 (https://github.com/propelorm/Propel/pull/317).

Closes #157.
