### PR TITLE
Port from Propel: Cross ref setter (generated by addCrossFKSet) should use FK relation name (phpName) in query filter and add methods

### DIFF
--- a/tests/Fixtures/bookstore/schema.xml
+++ b/tests/Fixtures/bookstore/schema.xml
@@ -159,6 +159,18 @@
         </foreign-key>
     </table>
 
+    <table name="book_club_list_favorite_books" phpName="BookListFavorite" isCrossRef="true"
+        description="Another cross-reference table for many-to-many relationship between book rows and book_club_list rows for favorite books.">
+        <column name="book_id" primaryKey="true" type="INTEGER" description="Fkey to book.id" />
+        <column name="book_club_list_id" primaryKey="true" type="INTEGER" description="Fkey to book_club_list.id" />
+        <foreign-key foreignTable="book" phpName="FavoriteBook" onDelete="cascade">
+            <reference local="book_id" foreign="id" />
+        </foreign-key>
+        <foreign-key foreignTable="book_club_list" phpName="FavoriteBookClubList" onDelete="cascade">
+            <reference local="book_club_list_id" foreign="id" />
+        </foreign-key>
+    </table>
+
     <!-- test self-referencing foreign keys and inheritance-->
     <table name="bookstore_employee"
         description="Hierarchical table to represent employees of a bookstore.">

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectRelTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectRelTest.php
@@ -24,6 +24,9 @@ use Propel\Tests\Bookstore\BookClubListQuery;
 use Propel\Tests\Bookstore\BookListRel;
 use Propel\Tests\Bookstore\BookListRelPeer;
 use Propel\Tests\Bookstore\BookListRelQuery;
+use Propel\Tests\Bookstore\BookListFavorite;
+use Propel\Tests\Bookstore\BookListFavoritePeer;
+use Propel\Tests\Bookstore\BookListFavoriteQuery;
 use Propel\Tests\Bookstore\BookstoreContest;
 use Propel\Tests\Bookstore\BookstoreContestEntry;
 use Propel\Tests\Bookstore\Contest;
@@ -673,5 +676,39 @@ class GeneratedObjectRelTest extends BookstoreEmptyTestBase
         $this->assertEquals(1, BookClubListQuery::create()->count());
         $this->assertEquals(2, BookListRelQuery::create()->count());
         $this->assertEquals(4, BookQuery::create()->count());
+    }
+
+    public function testSetterCollectionWithCustomNamedFKs() {
+        // Ensure no data
+        BookQuery::create()->deleteAll();
+        BookClubListQuery::create()->deleteAll();
+        BookListRelQuery::create()->deleteAll();
+        BookListFavoriteQuery::create()->deleteAll();
+
+        $books = new ObjectCollection();
+        foreach (array('foo', 'bar', 'test') as $title) {
+            $b = new Book();
+            $b->setTitle($title);
+            $books[] = $b;
+        }
+
+        $bookClubList = new BookClubList();
+        $bookClubList->setFavoriteBooks($books);
+        $bookClubList->save();
+
+        $bookClubList->reload(true);
+
+        $this->assertCount(3, $bookClubList->getFavoriteBooks());
+
+        $bookClubList->reload(true);
+
+        $books->shift();
+
+        $bookClubList->setFavoriteBooks($books);
+        $bookClubList->save();
+
+        $bookClubList->reload(true);
+
+        $this->assertCount(2, $bookClubList->getFavoriteBooks());
     }
 }

--- a/tests/Propel/Tests/Generator/Builder/Om/TableMapBuilderTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/TableMapBuilderTest.php
@@ -46,7 +46,7 @@ class TableMapBuilderTest extends BookstoreTestBase
   public function testRelationCount()
   {
     $bookTable = $this->databaseMap->getTableByPhpName('Propel\Tests\Bookstore\Book');
-    $this->assertEquals(10, count($bookTable->getRelations()), 'The map builder creates relations for both incoming and outgoing keys');
+    $this->assertEquals(12, count($bookTable->getRelations()), 'The map builder creates relations for both incoming and outgoing keys');
   }
 
   public function testSimpleRelationName()


### PR DESCRIPTION
Port from: https://github.com/propelorm/Propel/pull/342
