### PR TITLE
Remove `inConnection()` from the `ConnectionInterface`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Propel2 uses the following Symfony2 Components:
 Propel2 also relies on [**Composer**](https://github.com/composer/composer) to manage dependencies but you
 also can use [ClassLoader](https://github.com/symfony/ClassLoader) (see the `autoload.php.dist` file for instance).
 
-Propel2 is only supported on PHP 5.3.3 and up.
+Propel2 is only supported on PHP 5.3.2 and up.
 
 
 ## Installation ##

--- a/src/Propel/Runtime/Connection/ConnectionInterface.php
+++ b/src/Propel/Runtime/Connection/ConnectionInterface.php
@@ -65,13 +65,6 @@ interface ConnectionInterface
     function rollBack();
 
     /**
-     * Checks if inside a transaction.
-     *
-     * @return bool TRUE if a transaction is currently active, and FALSE if not.
-     */
-    function inTransaction();
-
-    /**
      * Retrieve a database connection attribute.
      *
      * @param string $attribute The name of the attribute to retrieve,


### PR DESCRIPTION
This brings back the compatibility ith Propel 5.3.2

Refs #71
