### PR TITLE
Fix loading autoload from propel.php

### DIFF
--- a/bin/propel.php
+++ b/bin/propel.php
@@ -1,7 +1,7 @@
 <?php
 
 if (!class_exists('\Symfony\Component\Console\Application')) {
-    if (file_exists($file = __DIR__.'/../autoload.php')) {
+    if (file_exists($file = __DIR__.'/../../../autoload.php') || file_exists($file = __DIR__.'/../autoload.php')) {
         require_once $file;
     } elseif (file_exists($file = __DIR__.'/../autoload.php.dist')) {
         require_once $file;


### PR DESCRIPTION
When we install Propel2 via composer, inside an our own project, the `bin/propel` command doesn't load any autoload and fails at line 16, because it can't find `Finder` class.

In fact, composer installs a symlink in `project_dir/vendor/bin` directory, which points to `project_dir/vendor/propel/propel/bin/propel`.
So, in _propel.php_ at line 4, `__DIR__` contains `project_dir/vendor/propel/propel/bin` value and `autoload.php` will never be loaded.
At line 6, `autoload.php.dist` is correctly loaded but inside that file, `__DIR__` contains `project_dir/vendor/propel/propel` so, at lines 3 and 14 no file is loaded again and no autoload is set up.

By this fix, we load `project_dir/vendor/autoload.php`, when we run _propel_ command from an our own project, and we load `autoload.php.dist` when we are working directly inside the Propel2 project (i.e. when we run test suite).
