### PR TITLE
Use lcfirst as it is intended to be used.

### DIFF
--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -3596,13 +3596,8 @@ abstract class ".$this->getUnqualifiedClassName()." extends ".$parentClass." ";
         $relatedName = $this->getRefFKPhpNameAffix($refFK, true);
         $relatedObjectClassName = $this->getRefFKPhpNameAffix($refFK, false);
 
-        // No lcfirst() in PHP < 5.3
-        $inputCollection = $relatedName;
-        $inputCollection[0] = strtolower($inputCollection[0]);
-
-        // No lcfirst() in PHP < 5.3
-        $inputCollectionEntry = $this->getRefFKPhpNameAffix($refFK, false);
-        $inputCollectionEntry[0] = strtolower($inputCollectionEntry[0]);
+        $inputCollection = lcfirst($relatedName);
+        $inputCollectionEntry = lcfirst($this->getRefFKPhpNameAffix($refFK, false));
 
         $collName = $this->getRefFKCollVarName($refFK);
 
@@ -3641,11 +3636,7 @@ abstract class ".$this->getUnqualifiedClassName()." extends ".$parentClass." ";
     protected function addRefFKDoAdd(&$script, $refFK)
     {
         $relatedObjectClassName = $this->getRefFKPhpNameAffix($refFK, false);
-
-        // lcfirst() doesn't exist in PHP < 5.3
-        $lowerRelatedObjectClassName = $relatedObjectClassName;
-        $lowerRelatedObjectClassName[0] = strtolower($lowerRelatedObjectClassName[0]);
-
+        $lowerRelatedObjectClassName = lcfirst($relatedObjectClassName);
         $collName = $this->getRefFKCollVarName($refFK);
 
         $script .= "
@@ -3744,8 +3735,7 @@ abstract class ".$this->getUnqualifiedClassName()." extends ".$parentClass." ";
 
     protected function addScheduledForDeletionAttribute(&$script, $fkName)
     {
-        // No lcfirst() in PHP < 5.3
-        $fkName[0] = strtolower($fkName[0]);
+        $fkName = lcfirst($fkName);
 
         $script .= "
     /**
@@ -3760,12 +3750,8 @@ abstract class ".$this->getUnqualifiedClassName()." extends ".$parentClass." ";
     {
         $queryClassName = $this->getRefFKPhpNameAffix($refFK, false) . 'Query';
         $relatedName = $this->getFKPhpNameAffix($crossFK, true);
-        // No lcfirst() in PHP < 5.3
-        $lowerRelatedName = $relatedName;
-        $lowerRelatedName[0] = strtolower($lowerRelatedName[0]);
-        // No lcfirst() in PHP < 5.3
-        $lowerSingleRelatedName = $this->getFKPhpNameAffix($crossFK, false);
-        $lowerSingleRelatedName[0] = strtolower($lowerSingleRelatedName[0]);
+        $lowerRelatedName = lcfirst($relatedName);
+        $lowerSingleRelatedName = lcfirst($this->getFKPhpNameAffix($crossFK, false));
 
         $script .= "
             if (\$this->{$lowerRelatedName}ScheduledForDeletion !== null) {
@@ -3788,14 +3774,8 @@ abstract class ".$this->getUnqualifiedClassName()." extends ".$parentClass." ";
     protected function addRefFkScheduledForDeletion(&$script, $refFK)
     {
         $relatedName = $this->getRefFKPhpNameAffix($refFK, true);
-
-        // No lcfirst() in PHP < 5.3
-        $lowerRelatedName = $relatedName;
-        $lowerRelatedName[0] = strtolower($lowerRelatedName[0]);
-        // No lcfirst() in PHP < 5.3
-        $lowerSingleRelatedName = $this->getRefFKPhpNameAffix($refFK, false);
-        $lowerSingleRelatedName[0] = strtolower($lowerSingleRelatedName[0]);
-
+        $lowerRelatedName = lcfirst($relatedName);
+        $lowerSingleRelatedName = lcfirst($this->getRefFKPhpNameAffix($refFK, false));
         $queryClassName = $this->getClassNameFromBuilder($this->getNewStubQueryBuilder($refFK->getTable()));
 
         $script .= "
@@ -3944,11 +3924,8 @@ abstract class ".$this->getUnqualifiedClassName()." extends ".$parentClass." ";
         $collName = $this->getCrossFKVarName($crossFK);
         $joinedTableObjectBuilder = $this->getNewObjectBuilder($refFK->getTable());
         $className = $joinedTableObjectBuilder->getStubObjectBuilder()->getUnqualifiedClassName();
-
         $crossRefObjectClassName = '$' . lcfirst($className);
-
         $inputCollection = lcfirst($relatedNamePlural);
-
         $inputCollectionEntry = lcfirst($this->getFKPhpNameAffix($crossFK, false));
 
         $relCol = $this->getRefFKPhpNameAffix($refFK, true);
@@ -4093,11 +4070,7 @@ abstract class ".$this->getUnqualifiedClassName()." extends ".$parentClass." ";
     protected function addCrossFKDoAdd(&$script, ForeignKey $refFK, ForeignKey $crossFK)
     {
         $relatedObjectClassName = $this->getFKPhpNameAffix($crossFK, false);
-
-        // lcfirst() doesn't exist in PHP < 5.3
-        $lowerRelatedObjectClassName = $relatedObjectClassName;
-        $lowerRelatedObjectClassName[0] = strtolower($lowerRelatedObjectClassName[0]);
-
+        $lowerRelatedObjectClassName = lcfirst($relatedObjectClassName);
         $joinedTableObjectBuilder = $this->getNewObjectBuilder($refFK->getTable());
         $className = $joinedTableObjectBuilder->getObjectClassName();
         $unqualifiedClassName = $joinedTableObjectBuilder->getStubObjectBuilder()->getUnqualifiedClassName();

--- a/src/Propel/Runtime/Om/BaseObject.php
+++ b/src/Propel/Runtime/Om/BaseObject.php
@@ -411,8 +411,7 @@ abstract class BaseObject
                 return $this->getVirtualColumn($virtualColumn);
             }
 
-            // no lcfirst in php<5.3...
-            $virtualColumn[0] = strtolower($virtualColumn[0]);
+            $virtualColumn = lcfirst($virtualColumn);
             if ($this->hasVirtualColumn($virtualColumn)) {
                 return $this->getVirtualColumn($virtualColumn);
             }

--- a/src/Propel/Runtime/Query/ModelCriteria.php
+++ b/src/Propel/Runtime/Query/ModelCriteria.php
@@ -2245,9 +2245,7 @@ class ModelCriteria extends Criteria
                     $arguments[0] = null;
                 }
                 array_push($arguments, $joinType);
-                $method = substr($name, $pos);
-                // no lcfirst in php<5.3...
-                $method[0] = strtolower($method[0]);
+                $method = lcfirst(substr($name, $pos));
 
                 return call_user_func_array(array($this, $method), $arguments);
             }


### PR DESCRIPTION
We are using PHP 5.3 now. Thanks for the comment ;)

This is a small performance boost as using `lcfirst` is 40% faster due to the transtyping char/string/char of the actual algorithm.
