### PR TITLE
Ignore phpunit.xml in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 vendor/
 composer.phar
 composer.lock
+autoload.php
+phpunit.xml
 pom.xml
-check_cs
 php-cs-fixer.phar
 
 tests/Fixtures/namespaced/build/


### PR DESCRIPTION
There is a `phpunit.xml.dist` which is named to be overloaded locally.
