### PR TITLE
Change the source of the autoload.php file

### DIFF
--- a/bin/propel.php
+++ b/bin/propel.php
@@ -1,7 +1,7 @@
 <?php
 
 if (!class_exists('\Symfony\Component\Console\Application')) {
-    if (file_exists($file = __DIR__.'/../../../autoload.php') || file_exists($file = __DIR__.'/../autoload.php')) {
+    if (file_exists($file = __DIR__.'/../../autoload.php') || file_exists($file = __DIR__.'/../autoload.php')) {
         require_once $file;
     } elseif (file_exists($file = __DIR__.'/../autoload.php.dist')) {
         require_once $file;


### PR DESCRIPTION
Hello,

I found just a little bug that makes Propel doesn't work for me. When we execute the bin/propel script, if we don't use Composer, we are in the Application Name/vendor/propel/bin directory and the file want to include a file that is located 3 levels higher but autoload.php is 2 levels higher (so two times `../)`. It works for me. I hope this can be useful.

Have a nice day.
