### PR TITLE
Typo: MysqlSchemaParser : query addPrimaryKey 

### DIFF
--- a/src/Propel/Generator/Reverse/MysqlSchemaParser.php
+++ b/src/Propel/Generator/Reverse/MysqlSchemaParser.php
@@ -378,7 +378,7 @@ class MysqlSchemaParser extends AbstractSchemaParser
      */
     protected function addPrimaryKey(Table $table)
     {
-        $stmt = $this->dbh->query(sprintf('SHOW KEYS FROM `%s``', $table->getName()));
+        $stmt = $this->dbh->query(sprintf('SHOW KEYS FROM `%s`', $table->getName()));
 
         // Loop through the returned results, grouping the same key_name together
         // adding each column for that key.


### PR DESCRIPTION
In the following file MysqlSchemaParser.php, function addPrimaryKey, the SQL query contains a typo: see #258
