### PR TITLE
Fix issue #254

### DIFF
--- a/src/Propel/Runtime/Connection/ConnectionManagerSingle.php
+++ b/src/Propel/Runtime/Connection/ConnectionManagerSingle.php
@@ -48,6 +48,11 @@ class ConnectionManagerSingle implements ConnectionManagerInterface
     {
         return $this->name;
     }
+    
+    public function getConfiguration()
+    {
+        return $this->configuration;
+    }
 
     public function setConnection(ConnectionInterface $connection)
     {

--- a/tests/Propel/Tests/Helpers/Bookstore/BookstoreTestBase.php
+++ b/tests/Propel/Tests/Helpers/Bookstore/BookstoreTestBase.php
@@ -41,6 +41,15 @@ abstract class BookstoreTestBase extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
+        if (version_compare(PHP_VERSION, '5.3.6', '<')) {
+            $adapterClass = Propel::getServiceContainer()->getAdapterClass(BookPeer::DATABASE_NAME);
+            $propelConfig = Propel::getServiceContainer()->getConnectionManager(BookPeer::DATABASE_NAME)->getConfiguration();
+            if (('mysql' == $adapterClass) && (isset($propelConfig['settings']['charset']))) {
+                die('Connection option "charset" cannot be used for MySQL connections in PHP versions older than 5.3.6.
+Please refer to http://www.propelorm.org/ticket/1360 for instructions and details 
+about the implications of using a SET NAMES statement in the "queries" setting.');
+            }
+        }
         $this->con = Propel::getServiceContainer()->getConnection(BookPeer::DATABASE_NAME);
         $this->con->beginTransaction();
     }


### PR DESCRIPTION
Imho, issue #254 is a PHPunit issue, indeed.
In PHPunit framework, when an exception is thrown inside `setUp()` method, this method ends silently, the relative test fails and  `tearDown()` method is called however. But inside `setUp()` method it's impossible to catch exceptions and call `markTestSkipped()` method.
In our `tearDown` method, we access  to a variable (`$this->con`) which is not initialized due to an exception, thrown by the instruction at line 44 in `setUp()` method, and it causes the error.
We fix it, checking the conditions that cause the exception, directly in `setUp` method.

I'll submit an issue to PHPunit team as soon as possible.
