### PR TITLE
Updated README to mention Propel2 now relies on the Symfony2 Filesystem ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Propel2 uses the following Symfony2 Components:
 * [Yaml](https://github.com/symfony/Yaml)
 * [Finder](https://github.com/symfony/Finder)
 * [Validator](https://github.com/symfony/Validator)
+* [Filesystem](https://github.com/symfony/Filesystem)
 
 Propel2 also relies on [**Composer**](https://github.com/composer/composer) to manage dependencies but you
 also can use [ClassLoader](https://github.com/symfony/ClassLoader) (see the `autoload.php.dist` file for instance).


### PR DESCRIPTION
...component.
