### PR TITLE
5.4 and up :)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-  - 5.3.3
-  - 5.3
   - 5.4
 
 env:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Propel2 #
 
-Propel2 is an open-source Object-Relational Mapping (ORM) for PHP 5.3.
+Propel2 is an open-source Object-Relational Mapping (ORM) for PHP 5.4.
 
 [![Build Status](https://secure.travis-ci.org/propelorm/Propel2.png?branch=master)](http://travis-ci.org/propelorm/Propel2)
 
@@ -18,7 +18,7 @@ Propel2 uses the following Symfony2 Components:
 Propel2 also relies on [**Composer**](https://github.com/composer/composer) to manage dependencies but you
 also can use [ClassLoader](https://github.com/symfony/ClassLoader) (see the `autoload.php.dist` file for instance).
 
-Propel2 is only supported on PHP 5.3.3 and up.
+Propel2 is only supported on PHP 5.4 and up.
 
 
 ## Installation ##

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "propel/propel",
     "type": "library",
-    "description": "Propel2 is an open-source Object-Relational Mapping (ORM) for PHP 5.3",
+    "description": "Propel2 is an open-source Object-Relational Mapping (ORM) for PHP 5.4",
     "keywords": [
         "ORM",
         "persistence",
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.4",
         "symfony/yaml": "2.1.*",
         "symfony/console": "2.1.*",
         "monolog/monolog": "1.0.*",


### PR DESCRIPTION
I would have loved to mention Propel follows PSR-0, 1, 2 for its following ( I hope its following ).

But if so it will not be pointing to wiki. Do we need to edit the wiki then ( currently it mentions symfony standards ) ?
