### PR TITLE
Add missing use for PropelException in QueryBuilder

### DIFF
--- a/src/Propel/Generator/Builder/Om/QueryBuilder.php
+++ b/src/Propel/Generator/Builder/Om/QueryBuilder.php
@@ -167,7 +167,8 @@ abstract class ".$this->getUnqualifiedClassName()." extends " . $parentClass . "
             '\Propel\Runtime\ActiveQuery\ModelCriteria',
             '\Propel\Runtime\ActiveQuery\Criteria',
             '\Propel\Runtime\ActiveQuery\ModelJoin',
-            '\Exception'
+            '\Exception',
+            '\Propel\Runtime\Exception\PropelException'
         );
         $this->declareClassFromBuilder($this->getStubQueryBuilder(), 'Child');
         $this->declareClassFromBuilder($this->getStubPeerBuilder());


### PR DESCRIPTION
In "findPkSimple" method we use a PropelException which is not in the use statement
