### PR TITLE
Minor fixes

### DIFF
--- a/src/Propel/Runtime/Adapter/Pdo/MysqlAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/MysqlAdapter.php
@@ -197,18 +197,9 @@ class MysqlAdapter extends PdoAdapter implements AdapterInterface
     protected function prepareParams($params)
     {
         if (isset($params['settings']['charset'])) {
-            if (version_compare(PHP_VERSION, '5.3.6', '<')) {
-                throw new PropelException(<<<EXCEPTION
-Connection option "charset" cannot be used for MySQL connections in PHP versions older than 5.3.6.
-Please refer to http://www.propelorm.org/ticket/1360 for instructions and details about the implications of
-using a SET NAMES statement in the "queries" setting.
-EXCEPTION
-                );
-            } else {
-                if (false === strpos($params['dsn'], ';charset=')) {
-                    $params['dsn'] .= ';charset=' . $params['settings']['charset'];
-                    unset($params['settings']['charset']);
-                }
+            if (false === strpos($params['dsn'], ';charset=')) {
+                $params['dsn'] .= ';charset=' . $params['settings']['charset'];
+                unset($params['settings']['charset']);
             }
         }
 

--- a/tests/Propel/Tests/Helpers/Bookstore/BookstoreTestBase.php
+++ b/tests/Propel/Tests/Helpers/Bookstore/BookstoreTestBase.php
@@ -41,15 +41,6 @@ abstract class BookstoreTestBase extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        if (version_compare(PHP_VERSION, '5.3.6', '<')) {
-            $adapterClass = Propel::getServiceContainer()->getAdapterClass(BookPeer::DATABASE_NAME);
-            $propelConfig = Propel::getServiceContainer()->getConnectionManager(BookPeer::DATABASE_NAME)->getConfiguration();
-            if (('mysql' == $adapterClass) && (isset($propelConfig['settings']['charset']))) {
-                die('Connection option "charset" cannot be used for MySQL connections in PHP versions older than 5.3.6.
-Please refer to http://www.propelorm.org/ticket/1360 for instructions and details
-about the implications of using a SET NAMES statement in the "queries" setting.');
-            }
-        }
         $this->con = Propel::getServiceContainer()->getConnection(BookPeer::DATABASE_NAME);
         $this->con->beginTransaction();
     }
@@ -64,10 +55,12 @@ about the implications of using a SET NAMES statement in the "queries" setting.'
         // and we don't want to call ConnectionInterface::commit() in that case
         // since it will trigger an exception on its own
         // ('Cannot commit because a nested transaction was rolled back')
-        if ($this->con->isCommitable()) {
-            $this->con->commit();
+        if (null !== $this->con) {
+            if ($this->con->isCommitable()) {
+                $this->con->commit();
+            }
+            $this->con = null;
         }
-        $this->con = null;
     }
 
     protected function getDriver()

--- a/tests/Propel/Tests/Runtime/Adapter/Pdo/MysqlAdapterTest.php
+++ b/tests/Propel/Tests/Runtime/Adapter/Pdo/MysqlAdapterTest.php
@@ -37,14 +37,6 @@ class MysqlAdapterTest extends BookstoreTestBase
         );
     }
 
-    protected function setUp()
-    {
-        parent::setUp();
-        if (version_compare(PHP_VERSION, '5.3.6', '<')) {
-            $this->setExpectedException('Propel\Runtime\Exception\PropelException');
-        }
-    }
-
     /**
      * @dataProvider getConParams
      */


### PR DESCRIPTION
Some minor fixes:
- `MysqlAdapter` and relative tests: remove references to php versions < 5.4
- `BookstoreTestBase`: when the instruction at line 44, in `setUp` method fails, this method ends silently, the test fails (correctly) but `tearDown` method is executed the same, so it rises a `call to a member function on a non-object` error, because `$con` variable is null.
