### PR TITLE
Small optimization to use strpos instead of preg_match

### DIFF
--- a/src/Propel/Generator/Builder/Om/QueryBuilder.php
+++ b/src/Propel/Generator/Builder/Om/QueryBuilder.php
@@ -871,7 +871,9 @@ abstract class ".$this->getUnqualifiedClassName()." extends " . $parentClass . "
         if (null === \$comparison) {
             if (is_array(\$$variableName)) {
                 \$comparison = Criteria::IN;
-            } elseif (preg_match('/[\%\*]/', \$$variableName)) {
+            } elseif (false !== strpos(\$$variableName, '%')) {
+                \$comparison = Criteria::LIKE;
+            } elseif (false !== strpos(\$$variableName, '*')) {
                 \$$variableName = str_replace('*', '%', \$$variableName);
                 \$comparison = Criteria::LIKE;
             }

--- a/tests/Propel/Tests/Generator/Builder/Om/QueryBuilderTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/QueryBuilderTest.php
@@ -563,8 +563,8 @@ class QueryBuilderTest extends BookstoreTestBase
         $this->assertEquals($q1, $q, 'filterByStringColumn() translates to a Criteria::LIKE when passed a string with a * wildcard, and turns * into %');
 
         $q = BookQuery::create()->filterByTitle('*f%o*o%');
-        $q1 = BookQuery::create()->add(BookPeer::TITLE, '%f%o%o%', Criteria::LIKE);
-        $this->assertEquals($q1, $q, 'filterByStringColumn() translates to a Criteria::LIKE when passed a string with mixed wildcards, and turns *s into %s');
+        $q1 = BookQuery::create()->add(BookPeer::TITLE, '*f%o*o%', Criteria::LIKE);
+        $this->assertEquals($q1, $q, 'filterByStringColumn() translates to a Criteria::LIKE when passed a string with mixed wildcards, and not turns *s into %s');
     }
 
     public function testFilterByBoolean()


### PR DESCRIPTION
Use `strpos` instead of `preg_match` to detect `LIKE` comparison.

In addition, this prevent from WTF effect in case someone want to use something like: 

```
$query->filterByTitle('%foo*%');
```

I can add a test on that.
