### PR TITLE
Fix graphviz:generate command

### DIFF
--- a/src/Propel/Generator/Command/AbstractCommand.php
+++ b/src/Propel/Generator/Command/AbstractCommand.php
@@ -62,6 +62,12 @@ abstract class AbstractCommand extends Command
         return $properties;
     }
 
+    /**
+     * Find every schema files.
+     *
+     * @param  string|array $directory Path to the input directory
+     * @return array        List of schema files
+     */
     protected function getSchemas($directory)
     {
         $finder = new Finder();

--- a/src/Propel/Generator/Command/GraphvizGenerateCommand.php
+++ b/src/Propel/Generator/Command/GraphvizGenerateCommand.php
@@ -52,7 +52,7 @@ class GraphvizGenerateCommand extends AbstractCommand
 
         $manager = new GraphvizManager();
         $manager->setGeneratorConfig($generatorConfig);
-        $manager->setSchemas($this->getSchemas($input));
+        $manager->setSchemas($this->getSchemas($input->getOption('input-dir')));
         $manager->setLoggerClosure(function($message) use ($input, $output) {
             if ($input->getOption('verbose')) {
                 $output->writeln($message);


### PR DESCRIPTION
The method `AbstractCommand::getSchema()` take a string, not the Input object
