### PR TITLE
Fix indentation for stub object classes

### DIFF
--- a/src/Propel/Generator/Builder/Om/ExtensionObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ExtensionObjectBuilder.php
@@ -65,7 +65,7 @@ class ExtensionObjectBuilder extends AbstractObjectBuilder
  */";
         }
         $script .= "
-        ".($table->isAbstract() ? "abstract " : "")."class ".$this->getUnqualifiedClassName()." extends $baseClassName {
+".($table->isAbstract() ? "abstract " : "")."class ".$this->getUnqualifiedClassName()." extends $baseClassName {
 ";
     }
 


### PR DESCRIPTION
This removes the extra indentation before `class` or `abstract class` in generated stub object classes.

Before:

``` php
<?php

namespace Propel\Tests\Bookstore;

use Propel\Tests\Bookstore\Base\Author as BaseAuthor;

        class Author extends BaseAuthor {

}
```

After:

``` php
<?php

namespace Propel\Tests\Bookstore;

use Propel\Tests\Bookstore\Base\Author as BaseAuthor;

class Author extends BaseAuthor {

}
```
