### PR TITLE
LoggerInterface typehint in StandardServiceContainer::setLogger

### DIFF
--- a/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
+++ b/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
@@ -441,7 +441,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      * @param string          $name   the name of the logger to be set
      * @param LoggerInterface $logger A logger instance
      */
-    public function setLogger($name, Logger $logger)
+    public function setLogger($name, LoggerInterface $logger)
     {
         $this->loggers[$name] = $logger;
     }


### PR DESCRIPTION
`StandardServiceContainer::setLogger` accepts a Monolog `Logger` object rather than `LoggerInterface`. This is inconsistent with the docblock and `setLogger` methods in other classes, so I changed it.
