### PR TITLE
Symfony 2.2 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,16 +17,17 @@
     ],
     "require": {
         "php": ">=5.4",
-        "symfony/yaml": "~2.1.0,!=2.1.7",
-        "symfony/console": "~2.1.0",
-        "symfony/finder": "~2.1.0",
-        "symfony/validator": "~2.1.0",
-        "symfony/filesystem": "~2.1.0",
+        "symfony/yaml": "2.2.*",
+        "symfony/console": "2.2.*",
+        "symfony/finder": "2.2.*",
+        "symfony/validator": "2.2.*",
+        "symfony/filesystem": "2.2.*",
         "psr/log": "~1.0"
     },
     "require-dev": {
-        "behat/behat": "2.4@stable",
-        "monolog/monolog": "~1.3"
+        "behat/behat": "2.4.*",
+        "monolog/monolog": "~1.3",
+        "phpunit/phpunit": "3.7.*"
     },
     "suggest": {
         "monolog/monolog": "The recommended logging library to use with Propel."

--- a/documentation/behaviors/validate.markdown
+++ b/documentation/behaviors/validate.markdown
@@ -24,9 +24,9 @@ Then add validation rules via `<parameter>` tag.
 
   <behavior name="validate">
     <parameter name="rule1" value="{column: first_name, validator: NotNull}" />
-    <parameter name="rule2" value="{column: first_name, validator: MaxLength, options: {limit: 128}}" />
+    <parameter name="rule2" value="{column: first_name, validator: Length, options: {max: 128}}" />
     <parameter name="rule3" value="{column: last_name, validator: NotNull}" />
-    <parameter name="rule4" value="{column: last_name, validator: MaxLength, options: {limit: 128}}" />
+    <parameter name="rule4" value="{column: last_name, validator: Length, options: {max: 128}}" />
     <parameter name="rule5" value="{column: email, validator: Email}" />
   </behavior>
 </table>
@@ -126,9 +126,9 @@ Consider the following model:
         <column name="email" type="VARCHAR" size="128" />
         <behavior name="validate">
             <parameter name="rule1" value="{column: first_name, validator: NotNull}" />
-            <parameter name="rule2" value="{column: first_name, validator: MaxLength, options: {limit: 128}}" />
+            <parameter name="rule2" value="{column: first_name, validator: Length, options: {max: 128}}" />
             <parameter name="rule3" value="{column: last_name, validator: NotNull}" />
-            <parameter name="rule4" value="{column: last_name, validator: MaxLength, options: {limit: 128}}" />
+            <parameter name="rule4" value="{column: last_name, validator: Length, options: {max: 128}}" />
             <parameter name="rule5" value="{column: email, validator: Email}" />
         </behavior>
     </table>
@@ -140,9 +140,9 @@ Consider the following model:
         <column name="email" type="VARCHAR" size="128" />
         <behavior name="validate">
             <parameter name="rule1" value="{column: first_name, validator: NotNull}" />
-            <parameter name="rule2" value="{column: first_name, validator: MinLength, options: {limit: 4}}" />
+            <parameter name="rule2" value="{column: first_name, validator: Length, options: {min: 4}}" />
             <parameter name="rule3" value="{column: last_name, validator: NotNull}" />
-            <parameter name="rule4" value="{column: last_name, validator: MaxLength, options: {limit: 128}}" />
+            <parameter name="rule4" value="{column: last_name, validator: Length, options: {max: 128}}" />
             <parameter name="rule5" value="{column: email, validator: Email}" />
         </behavior>
     </table>

--- a/src/Propel/Generator/Behavior/Validate/ValidateBehavior.php
+++ b/src/Propel/Generator/Behavior/Validate/ValidateBehavior.php
@@ -44,6 +44,7 @@ class ValidateBehavior extends Behavior
         $this->builder->declareClasses(
             'Symfony\\Component\\Validator\\Mapping\\ClassMetadata',
             'Symfony\\Component\\Validator\\Validator',
+            'Symfony\\Component\\Validator\\DefaultTranslator',
             'Symfony\\Component\\Validator\\Mapping\\Loader\\StaticMethodLoader',
             'Symfony\\Component\\Validator\\ConstraintValidatorFactory',
             'Symfony\\Component\\Validator\\Mapping\\ClassMetadataFactory',

--- a/src/Propel/Generator/Behavior/Validate/templates/objectValidate.php
+++ b/src/Propel/Generator/Behavior/Validate/templates/objectValidate.php
@@ -9,7 +9,7 @@
 public function validate(Validator $validator = null)
 {
     if (null === $validator) {
-        $validator = new Validator(new ClassMetadataFactory(new StaticMethodLoader()), new ConstraintValidatorFactory());
+        $validator = new Validator(new ClassMetadataFactory(new StaticMethodLoader()), new ConstraintValidatorFactory(), new DefaultTranslator());
     }
 
     $failureMap = new ConstraintViolationList();

--- a/src/Propel/Runtime/Validator/Constraints/UniqueValidator.php
+++ b/src/Propel/Runtime/Validator/Constraints/UniqueValidator.php
@@ -16,24 +16,20 @@ use Symfony\Component\Validator\ConstraintValidator;
 
 class UniqueValidator extends ConstraintValidator
 {
-    public function isValid($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint)
     {
         if (null === $value) {
-            return false;
+            return;
         }
 
         $object     = $this->context->getRoot();
         $className  = get_class($object);
         $tableMap   = $className::TABLE_MAP;
         $queryClass = $className . 'Query';
-        $filter     = sprintf('filterBy%s', $tableMap::translateFieldName($this->context->getCurrentProperty(), TableMap::TYPE_STUDLYPHPNAME, TableMap::TYPE_PHPNAME));
+        $filter     = sprintf('filterBy%s', $tableMap::translateFieldName($this->context->getPropertyName(), TableMap::TYPE_STUDLYPHPNAME, TableMap::TYPE_PHPNAME));
 
         if (0 < $queryClass::create()->$filter($value)->count()) {
-            $this->setMessage($constraint->message);
-
-            return true;
+            $this->context->addViolation($constraint->message);
         }
-
-        return false;
     }
 }

--- a/tests/Fixtures/bookstore/behavior-validate-schema.xml
+++ b/tests/Fixtures/bookstore/behavior-validate-schema.xml
@@ -40,9 +40,9 @@
         <column name="birthday" type="DATE" description="The authors birthday" />
         <behavior name="validate">
             <parameter name="rule1" value="{column: first_name, validator: NotNull}" />
-            <parameter name="rule2" value="{column: first_name, validator: MaxLength, options: {limit: 128}}" />
+            <parameter name="rule2" value="{column: first_name, validator: Length, options: {max: 128}}" />
             <parameter name="rule3" value="{column: last_name, validator: NotNull}" />
-            <parameter name="rule4" value="{column: last_name, validator: MaxLength, options: {limit: 128}}" />
+            <parameter name="rule4" value="{column: last_name, validator: Length, options: {max: 128}}" />
             <parameter name="rule5" value="{column: email, validator: Email}" />
             <parameter name="rule6" value="{column: birthday, validator: Date}" />
         </behavior>
@@ -56,9 +56,9 @@
         <column name="birthday" type="DATE" description="The authors birthday" />
         <behavior name="validate">
             <parameter name="rule1" value="{column: first_name, validator: NotNull}" />
-            <parameter name="rule2" value="{column: first_name, validator: MinLength, options: {limit: 4}}" />
+            <parameter name="rule2" value="{column: first_name, validator: Length, options: {min: 4}}" />
             <parameter name="rule3" value="{column: last_name, validator: NotNull}" />
-            <parameter name="rule4" value="{column: last_name, validator: MaxLength, options: {limit: 128}}" />
+            <parameter name="rule4" value="{column: last_name, validator: Length, options: {max: 128}}" />
             <parameter name="rule5" value="{column: email, validator: Email}" />
             <parameter name="rule6" value="{column: birthday, validator: Date}" />
         </behavior>

--- a/tests/Propel/Tests/Generator/Behavior/Validate/I18nConcreteInheritanceHandleValidateBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Validate/I18nConcreteInheritanceHandleValidateBehaviorTest.php
@@ -34,7 +34,7 @@ class I18nConcreteInheritanceHandleValidateBehaviorTest extends BookstoreTestBas
         $class = 'Propel\Tests\Bookstore\Behavior\ValidateTriggerBook';
         $this->checkClassHasValidateBehavior($class);
 
-        $classMetadata = $this->metadataFactory->getClassMetadata($class);
+        $classMetadata = $this->metadataFactory->getMetadataFor($class);
         $this->assertCount(1, $classMetadata->getConstrainedProperties());
         $this->assertTrue(in_array('isbn', $classMetadata->getConstrainedProperties(), true));
 
@@ -49,7 +49,7 @@ class I18nConcreteInheritanceHandleValidateBehaviorTest extends BookstoreTestBas
         $i18nClass = 'Propel\Tests\Bookstore\Behavior\ValidateTriggerBookI18n';
         $this->checkClassHasValidateBehavior($i18nClass);
 
-        $i18nClassMetadata = $this->metadataFactory->getClassMetadata($i18nClass);
+        $i18nClassMetadata = $this->metadataFactory->getMetadataFor($i18nClass);
         $this->assertCount(1, $i18nClassMetadata->getConstrainedProperties());
         $this->assertTrue(in_array('title', $i18nClassMetadata->getConstrainedProperties(), true));
 
@@ -68,7 +68,7 @@ class I18nConcreteInheritanceHandleValidateBehaviorTest extends BookstoreTestBas
 
         $this->checkClassHasValidateBehavior($fiction);
 
-        $fictionMetadata = $this->metadataFactory->getClassMetadata($fiction);
+        $fictionMetadata = $this->metadataFactory->getMetadataFor($fiction);
         $this->assertCount(1, $fictionMetadata->getConstrainedProperties());
         $this->assertTrue(in_array('isbn', $fictionMetadata->getConstrainedProperties(), true));
 
@@ -87,7 +87,7 @@ class I18nConcreteInheritanceHandleValidateBehaviorTest extends BookstoreTestBas
 
         $this->checkClassHasValidateBehavior($comic);
 
-        $comicMetadata = $this->metadataFactory->getClassMetadata($comic);
+        $comicMetadata = $this->metadataFactory->getMetadataFor($comic);
         $this->assertCount(2, $comicMetadata->getConstrainedProperties());
         $this->assertTrue(in_array('isbn', $comicMetadata->getConstrainedProperties(), true));
         $this->assertTrue(in_array('bar', $comicMetadata->getConstrainedProperties(), true));
@@ -118,7 +118,7 @@ class I18nConcreteInheritanceHandleValidateBehaviorTest extends BookstoreTestBas
         foreach ($classes as $class) {
             $this->checkClassHasValidateBehavior('Propel\Tests\Bookstore\Behavior\\'.$class);
 
-            $classMetadata = $this->metadataFactory->getClassMetadata('Propel\Tests\Bookstore\Behavior\\'.$class);
+            $classMetadata = $this->metadataFactory->getMetadataFor('Propel\Tests\Bookstore\Behavior\\'.$class);
             $this->assertCount(1, $classMetadata->getConstrainedProperties());
             $this->assertTrue(in_array('title', $classMetadata->getConstrainedProperties(), true));
 

--- a/tests/Propel/Tests/Generator/Behavior/Validate/ValidateBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Validate/ValidateBehaviorTest.php
@@ -111,7 +111,7 @@ EOF;
      <column name="first_name" required="true" type="VARCHAR" size="128" description="First Name" />
      <behavior name="validate">
        <parameter name="rule1" value="{validator: NotNull}" />
-       <parameter name="rule2" value="{column: first_name, validator: MaxLength, options: {limit: 128}}" />
+       <parameter name="rule2" value="{column: first_name, validator: Length, options: {max: 128}}" />
       </behavior>
   </table>
   </database>
@@ -132,7 +132,7 @@ EOF;
      <column name="first_name" required="true" type="VARCHAR" size="128" description="First Name" />
      <behavior name="validate">
        <parameter name="rule1" value="{column: first_name}" />
-       <parameter name="rule2" value="{column: first_name, validator: MaxLength, options: {limit: 128}}" />
+       <parameter name="rule2" value="{column: first_name, validator: Length, options: {max: 128}}" />
       </behavior>
   </table>
   </database>
@@ -174,7 +174,7 @@ EOF;
      <column name="first_name" required="true" type="VARCHAR" size="128" description="First Name" />
      <behavior name="validate">
        <parameter name="rule1" value="{column: first_name, validator: NotNull, foo: bar}" />
-       <parameter name="rule2" value="{column: first_name, validator: MaxLength, options: 128}" />
+       <parameter name="rule2" value="{column: first_name, validator: Length, options: 128}" />
       </behavior>
   </table>
   </database>


### PR DESCRIPTION
This makes Propel2 work with Symfony 2.2 libraries. (Almost all the changes are due to the Validator component.)

Previous discussion in #350
