### PR TITLE
Add a short alias for each command from propel 1.6 command names

### DIFF
--- a/src/Propel/Generator/Command/ConfigConvertXmlCommand.php
+++ b/src/Propel/Generator/Command/ConfigConvertXmlCommand.php
@@ -35,6 +35,7 @@ class ConfigConvertXmlCommand extends AbstractCommand
             ->addOption('output-dir',  null, InputOption::VALUE_REQUIRED,  'The output directory',  self::DEFAULT_OUTPUT_DIRECTORY)
             ->addOption('output-file', null, InputOption::VALUE_REQUIRED,  'The output file',       self::DEFAULT_OUTPUT_FILE)
             ->setName('config:convert-xml')
+            ->setAliases(array('convert-conf'))
             ->setDescription('Transform the XML configuration to PHP code leveraging the ServiceContainer')
         ;
     }

--- a/src/Propel/Generator/Command/DatabaseReverseCommand.php
+++ b/src/Propel/Generator/Command/DatabaseReverseCommand.php
@@ -42,6 +42,7 @@ class DatabaseReverseCommand extends AbstractCommand
             ->addOption('schema-name',   null, InputOption::VALUE_REQUIRED, 'The schema name to generate', self::DEFAULT_SCHEMA_NAME)
             ->addArgument('connection',  null, InputArgument::REQUIRED,     'Connection to use')
             ->setName('database:reverse')
+            ->setAliases(array('reverse'))
             ->setDescription('Reverse-engineer a XML schema file based on given database')
             ;
     }

--- a/src/Propel/Generator/Command/GraphvizGenerateCommand.php
+++ b/src/Propel/Generator/Command/GraphvizGenerateCommand.php
@@ -34,6 +34,7 @@ class GraphvizGenerateCommand extends AbstractCommand
         $this
             ->addOption('output-dir',   null, InputOption::VALUE_REQUIRED,  'The output directory', self::DEFAULT_OUTPUT_DIRECTORY)
             ->setName('graphviz:generate')
+            ->setAliases(array('graphviz'))
             ->setDescription('Generate Graphviz files (.dot)')
         ;
     }

--- a/src/Propel/Generator/Command/MigrationDiffCommand.php
+++ b/src/Propel/Generator/Command/MigrationDiffCommand.php
@@ -44,6 +44,7 @@ class MigrationDiffCommand extends AbstractCommand
             ->addOption('connection',       null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Connection to use', array())
             ->addOption('editor',           null, InputOption::VALUE_OPTIONAL,  'The text editor to use to open diff files', null)
             ->setName('migration:diff')
+            ->setAliases(array('diff'))
             ->setDescription('Generate diff classes')
             ;
     }

--- a/src/Propel/Generator/Command/MigrationDownCommand.php
+++ b/src/Propel/Generator/Command/MigrationDownCommand.php
@@ -39,6 +39,7 @@ class MigrationDownCommand extends AbstractCommand
             ->addOption('migration-table',  null, InputOption::VALUE_REQUIRED,  'Migration table name', self::DEFAULT_MIGRATION_TABLE)
             ->addOption('connection',       null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Connection to use', array())
             ->setName('migration:down')
+            ->setAliases(array('down'))
             ->setDescription('Execute migrations down')
         ;
     }

--- a/src/Propel/Generator/Command/MigrationMigrateCommand.php
+++ b/src/Propel/Generator/Command/MigrationMigrateCommand.php
@@ -39,6 +39,7 @@ class MigrationMigrateCommand extends AbstractCommand
             ->addOption('migration-table',  null, InputOption::VALUE_REQUIRED,  'Migration table name', self::DEFAULT_MIGRATION_TABLE)
             ->addOption('connection',       null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Connection to use', array())
             ->setName('migration:migrate')
+            ->setAliases(array('migrate'))
             ->setDescription('Execute all pending migrations')
         ;
     }

--- a/src/Propel/Generator/Command/MigrationStatusCommand.php
+++ b/src/Propel/Generator/Command/MigrationStatusCommand.php
@@ -38,6 +38,7 @@ class MigrationStatusCommand extends AbstractCommand
             ->addOption('migration-table',  null, InputOption::VALUE_REQUIRED,  'Migration table name', self::DEFAULT_MIGRATION_TABLE)
             ->addOption('connection',       null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Connection to use', array())
             ->setName('migration:status')
+            ->setAliases(array('status'))
             ->setDescription('Get migration status')
         ;
     }

--- a/src/Propel/Generator/Command/MigrationUpCommand.php
+++ b/src/Propel/Generator/Command/MigrationUpCommand.php
@@ -39,6 +39,7 @@ class MigrationUpCommand extends AbstractCommand
             ->addOption('migration-table',  null, InputOption::VALUE_REQUIRED,  'Migration table name', self::DEFAULT_MIGRATION_TABLE)
             ->addOption('connection',       null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Connection to use', array())
             ->setName('migration:up')
+            ->setAliases(array('up'))
             ->setDescription('Execute migrations up')
         ;
     }

--- a/src/Propel/Generator/Command/ModelBuildCommand.php
+++ b/src/Propel/Generator/Command/ModelBuildCommand.php
@@ -90,6 +90,7 @@ class ModelBuildCommand extends AbstractCommand
             ->addOption('disable-namespace-auto-package', null, InputOption::VALUE_NONE,
                 'Disable namespace auto-packaging')
             ->setName('model:build')
+            ->setAliases(array('build'))
             ->setDescription('Build the model classes based on Propel XML schemas')
         ;
     }

--- a/src/Propel/Generator/Command/SqlBuildCommand.php
+++ b/src/Propel/Generator/Command/SqlBuildCommand.php
@@ -43,6 +43,7 @@ class SqlBuildCommand extends AbstractCommand
             ->addOption('encoding',     null, InputOption::VALUE_REQUIRED,  'The encoding to use for the database', self::DEFAULT_DATABASE_ENCODING)
             ->addOption('table-prefix', null, InputOption::VALUE_REQUIRED,  'Add a prefix to all the table names in the database', '')
             ->setName('sql:build')
+            ->setAliases(array('sql'))
             ->setDescription('Build SQL files')
         ;
     }

--- a/src/Propel/Generator/Command/SqlInsertCommand.php
+++ b/src/Propel/Generator/Command/SqlInsertCommand.php
@@ -33,6 +33,7 @@ class SqlInsertCommand extends AbstractCommand
             ->addOption('output-dir', null, InputOption::VALUE_REQUIRED,  'The output directory', self::DEFAULT_OUTPUT_DIRECTORY)
             ->addOption('connection', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Connection to use', array())
             ->setName('sql:insert')
+            ->setAliases(array('insert-sql'))
             ->setDescription('Insert SQL statements')
         ;
     }


### PR DESCRIPTION
Refs #200

I took the alias from Propel 1.6 as @fzaninotto suggested (https://github.com/propelorm/Propel/blob/master/generator/build.xml#L82)

The help becomes like this:

```
Propel version 2.0.0-dev

Usage:
  [options] command [arguments]

Options:
  --help           -h Display this help message.
  --quiet          -q Do not output any message.
  --verbose        -v Increase verbosity of messages.
  --version        -V Display this application version.
  --ansi              Force ANSI output.
  --no-ansi           Disable ANSI output.
  --no-interaction -n Do not ask any interactive question.

Available commands:
  build                Build the model classes based on Propel XML schemas
  convert-conf         Transform the XML configuration to PHP code leveraging the ServiceContainer
  diff                 Generate diff classes
  down                 Execute migrations down
  graphviz             Generate Graphviz files (.dot)
  help                 Displays help for a command
  insert-sql           Insert SQL statements
  list                 Lists commands
  migrate              Execute all pending migrations
  reverse              Reverse-engineer a XML schema file based on given database
  sql                  Build SQL files
  status               Get migration status
  up                   Execute migrations up
config
  config:convert-xml   Transform the XML configuration to PHP code leveraging the ServiceContainer
database
  database:reverse     Reverse-engineer a XML schema file based on given database
graphviz
  graphviz:generate    Generate Graphviz files (.dot)
migration
  migration:diff       Generate diff classes
  migration:down       Execute migrations down
  migration:migrate    Execute all pending migrations
  migration:status     Get migration status
  migration:up         Execute migrations up
model
  model:build          Build the model classes based on Propel XML schemas
sql
  sql:build            Build SQL files
  sql:insert           Insert SQL statements
test
  test:prepare         Prepare the Propel test suite by building fixtures
```
