### PR TITLE
Sluggable behavior forward port

### DIFF
--- a/tests/Propel/Tests/Generator/Behavior/Sluggable/SluggableBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Sluggable/SluggableBehaviorTest.php
@@ -258,7 +258,7 @@ class SluggableBehaviorTest extends BookstoreTestBase
 
     public function testQueryFindOneBySlug()
     {
-        $this->assertTrue(method_exists('\Propel\Tests\Bookstore\Behavior\Table13Query', 'findOneBySlug'), 'The generated query provides a findOneBySlug() method');
+        $this->assertFalse(method_exists('\Propel\Tests\Bookstore\Behavior\Table13Query', 'findOneBySlug'), 'The generated query does not provide a findOneBySlug() method if the slug column is "slug".');
         $this->assertTrue(method_exists('\Propel\Tests\Bookstore\Behavior\Table14Query', 'findOneBySlug'), 'The generated query provides a findOneBySlug() method even if the slug column doesn\'t have the default name');
 
         Table14Query::create()->deleteAll();


### PR DESCRIPTION
Reduces the number of queries, and only adds the findOneBySlug method when the slug column doesn't have the default name "slug"
- [x] Length function alternative for MSSQL must be used (postponed)
