### PR TITLE
Use the `build.properties` in almost all commands if `input-dir` is available.

### DIFF
--- a/src/Propel/Generator/Command/AbstractCommand.php
+++ b/src/Propel/Generator/Command/AbstractCommand.php
@@ -10,7 +10,9 @@
 
 namespace Propel\Generator\Command;
 
+use Propel\Generator\Config\GeneratorConfig;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Filesystem\Exception\IOException;
@@ -36,6 +38,28 @@ abstract class AbstractCommand extends Command
             ->addOption('platform',  null, InputOption::VALUE_REQUIRED,  'The platform', self::DEFAULT_PLATFORM)
             ->addOption('input-dir', null, InputOption::VALUE_REQUIRED,  'The input directory', self::DEFAULT_INPUT_DIRECTORY)
         ;
+    }
+
+    /**
+     * Returns a new `GeneratorConfig` object with your `$properties` merged with
+     * the build.properties in the `input-dir` folder.
+     *
+     * @param array $properties
+     * @param       $input
+     *
+     * @return GeneratorConfig
+     */
+    protected function getGeneratorConfig(array $properties, InputInterface $input = null)
+    {
+        $options = $properties;
+        if ($input && $input->hasOption('input-dir')) {
+            $options = array_merge(
+                $properties,
+                $this->getBuildProperties($input->getOption('input-dir') . '/build.properties')
+            );
+        }
+
+        return new GeneratorConfig($options);
     }
 
     protected function getBuildProperties($file)

--- a/src/Propel/Generator/Command/DatabaseReverseCommand.php
+++ b/src/Propel/Generator/Command/DatabaseReverseCommand.php
@@ -15,7 +15,6 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\Output;
-use Propel\Generator\Config\GeneratorConfig;
 use Propel\Generator\Manager\ReverseManager;
 
 /**
@@ -56,10 +55,10 @@ class DatabaseReverseCommand extends AbstractCommand
         $vendor = preg_split('{:}', $vendor);
         $vendor = ucfirst($vendor[0]);
 
-        $generatorConfig = new GeneratorConfig(array(
+        $generatorConfig = $this->getGeneratorConfig(array(
             'propel.platform.class'         => $input->getOption('platform'),
             'propel.reverse.parser.class'   => sprintf('\\Propel\\Generator\\Reverse\\%sSchemaParser', $vendor),
-        ));
+        ), $input);
 
         $this->createDirectory($input->getOption('output-dir'));
 

--- a/src/Propel/Generator/Command/GraphvizGenerateCommand.php
+++ b/src/Propel/Generator/Command/GraphvizGenerateCommand.php
@@ -14,7 +14,6 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\Output;
-use Propel\Generator\Config\GeneratorConfig;
 use Propel\Generator\Manager\GraphvizManager;
 
 /**
@@ -44,10 +43,10 @@ class GraphvizGenerateCommand extends AbstractCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $generatorConfig = new GeneratorConfig(array(
+        $generatorConfig = $this->getGeneratorConfig(array(
             'propel.platform.class'     => $input->getOption('platform'),
             'propel.packageObjectModel' => true,
-        ));
+        ), $input);
 
         $this->createDirectory($input->getOption('output-dir'));
 

--- a/src/Propel/Generator/Command/MigrationDiffCommand.php
+++ b/src/Propel/Generator/Command/MigrationDiffCommand.php
@@ -14,7 +14,6 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\Output;
-use Propel\Generator\Config\GeneratorConfig;
 use Propel\Generator\Exception\RuntimeException;
 use Propel\Generator\Manager\MigrationManager;
 use Propel\Generator\Model\Database;
@@ -54,11 +53,11 @@ class MigrationDiffCommand extends AbstractCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $generatorConfig = new GeneratorConfig(array(
+        $generatorConfig = $this->getGeneratorConfig(array(
             'propel.platform.class'       => $input->getOption('platform'),
             'propel.reverse.parser.class' => $this->getReverseClass($input),
             'propel.migration.table'      => $input->getOption('migration-table')
-        ));
+        ), $input);
 
         $this->createDirectory($input->getOption('output-dir'));
 

--- a/src/Propel/Generator/Command/MigrationDownCommand.php
+++ b/src/Propel/Generator/Command/MigrationDownCommand.php
@@ -14,7 +14,6 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\Output;
-use Propel\Generator\Config\GeneratorConfig;
 use Propel\Generator\Manager\MigrationManager;
 use Propel\Generator\Util\SqlParser;
 
@@ -49,9 +48,9 @@ class MigrationDownCommand extends AbstractCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $generatorConfig = new GeneratorConfig(array(
+        $generatorConfig = $this->getGeneratorConfig(array(
             'propel.platform.class' => $input->getOption('platform'),
-        ));
+        ), $input);
 
         $this->createDirectory($input->getOption('output-dir'));
 

--- a/src/Propel/Generator/Command/MigrationMigrateCommand.php
+++ b/src/Propel/Generator/Command/MigrationMigrateCommand.php
@@ -14,7 +14,6 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\Output;
-use Propel\Generator\Config\GeneratorConfig;
 use Propel\Generator\Manager\MigrationManager;
 use Propel\Generator\Util\SqlParser;
 
@@ -49,9 +48,9 @@ class MigrationMigrateCommand extends AbstractCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $generatorConfig = new GeneratorConfig(array(
+        $generatorConfig = $this->getGeneratorConfig(array(
             'propel.platform.class' => $input->getOption('platform'),
-        ));
+        ), $input);
 
         $this->createDirectory($input->getOption('output-dir'));
 

--- a/src/Propel/Generator/Command/MigrationStatusCommand.php
+++ b/src/Propel/Generator/Command/MigrationStatusCommand.php
@@ -14,7 +14,6 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\Output;
-use Propel\Generator\Config\GeneratorConfig;
 use Propel\Generator\Manager\MigrationManager;
 
 /**
@@ -48,9 +47,9 @@ class MigrationStatusCommand extends AbstractCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $generatorConfig = new GeneratorConfig(array(
+        $generatorConfig = $this->getGeneratorConfig(array(
             'propel.platform.class' => $input->getOption('platform'),
-        ));
+        ), $input);
 
         $this->createDirectory($input->getOption('output-dir'));
 

--- a/src/Propel/Generator/Command/MigrationUpCommand.php
+++ b/src/Propel/Generator/Command/MigrationUpCommand.php
@@ -14,7 +14,6 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\Output;
-use Propel\Generator\Config\GeneratorConfig;
 use Propel\Generator\Manager\MigrationManager;
 use Propel\Generator\Util\SqlParser;
 
@@ -49,9 +48,9 @@ class MigrationUpCommand extends AbstractCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $generatorConfig = new GeneratorConfig(array(
-            'propel.platform.class' => $input->getOption('platform'),
-        ));
+        $generatorConfig = $this->getGeneratorConfig(array(
+            'propel.platform.class' => $input->getOption('platform')
+        ), $input);
 
         $this->createDirectory($input->getOption('output-dir'));
 

--- a/src/Propel/Generator/Command/ModelBuildCommand.php
+++ b/src/Propel/Generator/Command/ModelBuildCommand.php
@@ -14,7 +14,6 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\Output;
-use Propel\Generator\Config\GeneratorConfig;
 use Propel\Generator\Manager\ModelManager;
 
 /**
@@ -92,7 +91,7 @@ class ModelBuildCommand extends AbstractCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $generatorConfig = new GeneratorConfig(array_merge(array(
+        $generatorConfig = $this->getGeneratorConfig(array(
             'propel.platform.class'                     => $input->getOption('platform'),
             'propel.builder.object.class'               => $input->getOption('object-class'),
             'propel.builder.objectstub.class'           => $input->getOption('object-stub-class'),
@@ -121,7 +120,7 @@ class ModelBuildCommand extends AbstractCommand
             // MySQL specific
             'propel.mysql.tableType'                    => $input->getOption('mysql-engine'),
             'propel.mysql.tableEngineKeyword'           => 'ENGINE',
-        ), $this->getBuildProperties($input->getOption('input-dir') . '/build.properties')));
+        ), $input);
 
         $this->createDirectory($input->getOption('output-dir'));
 

--- a/src/Propel/Generator/Command/SqlBuildCommand.php
+++ b/src/Propel/Generator/Command/SqlBuildCommand.php
@@ -14,7 +14,6 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\Output;
-use Propel\Generator\Config\GeneratorConfig;
 use Propel\Generator\Manager\SqlManager;
 
 /**
@@ -54,7 +53,7 @@ class SqlBuildCommand extends AbstractCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $generatorConfig = new GeneratorConfig(array_merge(array(
+        $generatorConfig = $this->getGeneratorConfig(array(
             'propel.platform.class'                 => $input->getOption('platform'),
             'propel.database.schema'                => $input->getOption('schema-name'),
             'propel.database.encoding'              => $input->getOption('encoding'),
@@ -63,7 +62,7 @@ class SqlBuildCommand extends AbstractCommand
             // MySQL specific
             'propel.mysql.tableType'                => $input->getOption('mysql-engine'),
             'propel.mysql.tableEngineKeyword'       => 'ENGINE',
-        ), $this->getBuildProperties($input->getOption('input-dir') . '/build.properties')));
+        ), $input);
 
         $this->createDirectory($input->getOption('output-dir'));
 

--- a/src/Propel/Generator/Command/SqlInsertCommand.php
+++ b/src/Propel/Generator/Command/SqlInsertCommand.php
@@ -10,7 +10,6 @@
 
 namespace Propel\Generator\Command;
 
-use Propel\Generator\Config\GeneratorConfig;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -45,7 +44,6 @@ class SqlInsertCommand extends AbstractCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $manager = new SqlManager();
-        $generatorConfig = new GeneratorConfig();
 
         if (!$input->hasOption('connection')) {
             throw new InvalidArgumentException(sprintf('At least one connection is required'));


### PR DESCRIPTION
As long as the `build.properties` are not officially and completely dead, we should use its values in the commands. (I was not able to 'build' one of my project without my properties)
