### PR TITLE
Allow selection of fields with lowercased names as in propel1.

### DIFF
--- a/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
@@ -1778,8 +1778,8 @@ class ModelCriteria extends BaseModelCriteria
             }
 
             return array($column, $realColumnName);
-        } elseif ($tableMap->hasColumn($phpName, false)) {
-            $column = $tableMap->getColumn($phpName, false);
+        } elseif ($tableMap->hasColumn($phpName)) {
+            $column = $tableMap->getColumn($phpName);
             $realColumnName = $column->getFullyQualifiedName();
 
             return array($column, $realColumnName);


### PR DESCRIPTION
In Propel1 we had the ability to select fields with the lowercased names instead of the `phpName` (which is ucfirst).

``` php
  ->select(array('title', 'bar'))
```

https://github.com/propelorm/Propel/blob/master/runtime/lib/query/ModelCriteria.php#L2088

Since `hasColumnByInsensitiveCase` has been removed I've adjusted the ModelCriteria in the way we can now define in Propel2 fields with lowercased names too.
