### PR TITLE
Fixed table/column renaming bug in migration process.

### DIFF
--- a/src/Propel/Generator/Model/Diff/DatabaseComparator.php
+++ b/src/Propel/Generator/Model/Diff/DatabaseComparator.php
@@ -136,11 +136,13 @@ class DatabaseComparator
             }
         }
 
+        $renamed = [];
         // check for table renamings
         foreach ($this->databaseDiff->getAddedTables() as $addedTableName => $addedTable) {
             foreach ($this->databaseDiff->getRemovedTables() as $removedTableName => $removedTable) {
-                if (!TableComparator::computeDiff($addedTable, $removedTable, $caseInsensitive)) {
+                if (!in_array($addedTableName, $renamed) && !TableComparator::computeDiff($addedTable, $removedTable, $caseInsensitive)) {
                     // no difference except the name, that's probably a renaming
+                    $renamed[] = $addedTableName;
                     $this->databaseDiff->addRenamedTable($removedTableName, $addedTableName);
                     $this->databaseDiff->removeAddedTable($addedTableName);
                     $this->databaseDiff->removeRemovedTable($removedTableName);

--- a/src/Propel/Generator/Model/Diff/TableComparator.php
+++ b/src/Propel/Generator/Model/Diff/TableComparator.php
@@ -136,11 +136,13 @@ class TableComparator
             }
         }
 
+        $renamed = [];
         // check for column renamings
         foreach ($this->tableDiff->getAddedColumns() as $addedColumnName => $addedColumn) {
             foreach ($this->tableDiff->getRemovedColumns() as $removedColumnName => $removedColumn) {
-                if (!ColumnComparator::computeDiff($addedColumn, $removedColumn, $caseInsensitive)) {
+                if (!in_array($addedColumnName, $renamed) && !ColumnComparator::computeDiff($addedColumn, $removedColumn, $caseInsensitive)) {
                     // no difference except the name, that's probably a renaming
+                    $renamed[] = $addedColumnName;
                     $this->tableDiff->addRenamedColumn($removedColumn, $addedColumn);
                     $this->tableDiff->removeAddedColumn($addedColumnName);
                     $this->tableDiff->removeRemovedColumn($removedColumnName);


### PR DESCRIPTION
If the migration process decides to rename a table or a column it needs to make sure that it does not rename multiple tables or columns to the same name. Thus I've implemented a `$renamed` array that tracks each renaming so we don't have a duplicated renaming.
