### PR TITLE
Fixed PostgreSQL reverse bug in defining unique/index.

### DIFF
--- a/src/Propel/Generator/Reverse/PgsqlSchemaParser.php
+++ b/src/Propel/Generator/Reverse/PgsqlSchemaParser.php
@@ -474,7 +474,7 @@ class PgsqlSchemaParser extends AbstractSchemaParser
 
         while ($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
             $name = $row['idxname'];
-            $unique = ('t' === $row['indisunique'] ? true : false);
+            $unique = (in_array($row['indisunique'], ['t', true, 1, '1']) ? true : false);
             if (!isset($indexes[$name])) {
                 if ($unique) {
                     $indexes[$name] = new Unique($name);


### PR DESCRIPTION
On newer versions of PHP/PGSQL the `PgSQLSchemaParser::addIndexes` SQL returns for `indisunique` a real boolean value not 't'.
