### PR TITLE
Added possibility to apply "LIMIT 0" in PostgreSQL adapter

### DIFF
--- a/src/Propel/Runtime/Adapter/Pdo/PgsqlAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/PgsqlAdapter.php
@@ -118,10 +118,10 @@ class PgsqlAdapter extends PdoAdapter implements SqlAdapterInterface
      */
     public function applyLimit(&$sql, $offset, $limit)
     {
-        if ($limit > 0) {
+        if ($limit >= 0) {
             $sql .= sprintf(' LIMIT %u', $limit);
         }
-        if ($offset > 0) {
+        if ($offset >= 0) {
             $sql .= sprintf(' OFFSET %u', $offset);
         }
     }


### PR DESCRIPTION
This is possible in Postgres and may be useful. "OFFSET 0" seems useless but I think it should be added for consistency.
