### PR TITLE
Fixed test:prepare params for Postgresql

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ To match Travis CI MySQL configuration, you must set `@@sql_mode` to `STRICT_ALL
 
 Create mandatory databases, then run:
 
-    bin/propel test:prepare --vendor=postgres --dsn="dbname=test" --user="postgres"
+    bin/propel test:prepare --vendor=pgsql --dsn="pgsql:dbname=test" --user="postgres"
 
 #### SQLite ####
 


### PR DESCRIPTION
I don't know if anyone has run the tests, but I'm unable to pass the preparations. The tables are duplicated in each schema, they have multiple primary keys which are not included in foreign keys... Even after fixing the schemas, I receive fatal:
`Propel\Generator\Exception\EngineException: Table "book" declared twice`
