### PR TITLE
change default locale from en_EN to en_US

### DIFF
--- a/documentation/behaviors/i18n.markdown
+++ b/documentation/behaviors/i18n.markdown
@@ -51,11 +51,11 @@ $item = new Item();
 $item->setPrice('12.99');
 
 // add an English translation
-$item->setLocale('en_EN');
+$item->setLocale('en_US');
 $item->setName('Microwave oven');
 // same as
 $itemI18n = new ItemI18n();
-$itemI18n->setLocale('en_EN');
+$itemI18n->setLocale('en_US');
 $itemI18n->setName('Microwave oven');
 $item->addItemI18n($itemI18n);
 
@@ -68,7 +68,7 @@ $item->save();
 
 // retrieve text and non-text translations directly from the main object
 echo $item->getPrice(); // 12.99
-$item->setLocale('en_EN');
+$item->setLocale('en_US');
 echo $item->getName(); // Microwave oven
 $item->setLocale('fr_FR');
 echo $item->getName(); // Four micro-ondes
@@ -76,7 +76,7 @@ echo $item->getName(); // Four micro-ondes
 
 Getter an setter methods for internationalized columns still exist on the main object ; they are just proxy methods to the current translation object, using the same signature and phpDoc for better IDE integration.
 
->**Tip**<br />Propel uses the [locale](http://en.wikipedia.org/wiki/Locale) concept to identify translations. A locale is a string composed of a language code and a territory code (such as 'en_EN' and 'fr_FR'). This allows different translations for two countries using the same language (such as 'fr_FR' and 'fr_CA');
+>**Tip**<br />Propel uses the [locale](http://en.wikipedia.org/wiki/Locale) concept to identify translations. A locale is a string composed of a language code and a territory code (such as 'en_US' and 'fr_FR'). This allows different translations for two countries using the same language (such as 'fr_FR' and 'fr_CA');
 
 ## Dealing With Locale And Translations ##
 
@@ -88,10 +88,10 @@ $item = new Item();
 $item->setPrice('12.99');
 
 // get the English translation
-$t1 = $item->getTranslation('en_EN');
+$t1 = $item->getTranslation('en_US');
 // same as
 $t1 = new ItemI18n();
-$t1->setLocale('en_EN');
+$t1->setLocale('en_US');
 $item->addItemI18n($t1);
 
 $t1->setName('Microwave oven');
@@ -124,7 +124,7 @@ If you need to display a list, the following code will issue n+1 SQL queries, n 
 ```php
 <?php
 $items = ItemQuery::create()->find(); // one query to retrieve all items
-$locale = 'en_EN';
+$locale = 'en_US';
 foreach ($items as $item) {
   echo $item->getPrice();
   $item->setLocale($locale);
@@ -137,7 +137,7 @@ Fortunately, the behavior adds methods to the Query class, allowing you to hydra
 ```php
 <?php
 $items = ItemQuery::create()
-  ->joinWithI18n('en_EN')
+  ->joinWithI18n('en_US')
   ->find(); // one query to retrieve both all items and their translations
 foreach ($items as $item) {
   echo $item->getPrice();
@@ -154,7 +154,7 @@ If you need to search items using a condition on a translation, use the generate
 ```php
 <?php
 $items = ItemQuery::create()
-  ->useI18nQuery('en_EN') // tests the condition on the English translation
+  ->useI18nQuery('en_US') // tests the condition on the English translation
     ->filterByName('Microwave oven')
   ->endUse()
   ->find();
@@ -186,7 +186,7 @@ Such a schema is almost similar to a schema built for symfony; that means that t
 
 ## Parameters ##
 
-If you don't specify a locale when dealing with a translatable object, Propel uses the default English locale 'en_EN'. This default can be overridden in the schema using the `default_locale` parameter:
+If you don't specify a locale when dealing with a translatable object, Propel uses the default English locale 'en_US'. This default can be overridden in the schema using the `default_locale` parameter:
 
 ```xml
 <table name="item">

--- a/documentation/documentation/whats-new.markdown
+++ b/documentation/documentation/whats-new.markdown
@@ -195,7 +195,7 @@ This works both for setting AND for getting internationalized columns:
 
 ```php
 <?php
-$item->setLocale('en_EN');
+$item->setLocale('en_US');
 echo $item->getName(); //'Microwave oven'
 $item->setLocale('fr_FR');
 echo $item->getName(); // 'Four micro-ondes'
@@ -208,7 +208,7 @@ This new behavior also adds special capabilities to the Query objects. The most 
 ```php
 <?php
 $items = ItemQuery::create()->find(); // one query to retrieve all items
-$locale = 'en_EN';
+$locale = 'en_US';
 foreach ($items as $item) {
   echo $item->getPrice();
   $item->setLocale($locale);
@@ -221,7 +221,7 @@ This code snippet requires 1+n queries, n being the number of items. But just ad
 ```php
 <?php
 $items = ItemQuery::create()
-  ->joinWithI18n('en_EN')
+  ->joinWithI18n('en_US')
   ->find(); // one query to retrieve both all items and their translations
 foreach ($items as $item) {
   echo $item->getPrice();

--- a/src/Propel/Generator/Behavior/I18n/I18nBehavior.php
+++ b/src/Propel/Generator/Behavior/I18n/I18nBehavior.php
@@ -24,7 +24,7 @@ use Propel\Generator\Behavior\Validate\ValidateBehavior;
  */
 class I18nBehavior extends Behavior
 {
-    const DEFAULT_LOCALE = 'en_EN';
+    const DEFAULT_LOCALE = 'en_US';
 
     // default parameters value
     protected $parameters = array(

--- a/tests/Propel/Tests/Generator/Behavior/I18n/I18nBehaviorObjectBuilderModifierTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/I18n/I18nBehaviorObjectBuilderModifierTest.php
@@ -96,7 +96,7 @@ EOF;
         \I18nBehaviorTest1I18nQuery::create()->deleteAll();
         $o = new \I18nBehaviorTest1();
         $o->setFoo(123);
-        $o->setLocale('en_EN');
+        $o->setLocale('en_US');
         $o->setBar('hello');
         $o->setLocale('fr_FR');
         $o->setBar('bonjour');
@@ -143,13 +143,13 @@ EOF;
     {
         $o = new \I18nBehaviorTest1();
         $translation1 = new \I18nBehaviorTest1I18n();
-        $translation1->setLocale('en_EN');
+        $translation1->setLocale('en_US');
         $o->addI18nBehaviorTest1I18n($translation1);
         $translation2 = new \I18nBehaviorTest1I18n();
         $translation2->setLocale('fr_FR');
         $o->addI18nBehaviorTest1I18n($translation2);
         $o->save();
-        $this->assertEquals($translation1, $o->getTranslation('en_EN'));
+        $this->assertEquals($translation1, $o->getTranslation('en_US'));
         $this->assertEquals($translation2, $o->getTranslation('fr_FR'));
     }
 
@@ -158,7 +158,7 @@ EOF;
         $o = new \I18nBehaviorTest1();
         $o->save();
         $translation = $o->getTranslation();
-        $this->assertEquals('en_EN', $translation->getLocale());
+        $this->assertEquals('en_US', $translation->getLocale());
         $o = new \I18nBehaviorTest2();
         $o->save();
         $translation = $o->getTranslation();
@@ -169,12 +169,12 @@ EOF;
     {
         $o = new \I18nBehaviorTest1();
         $translation1 = new \I18nBehaviorTest1I18n();
-        $translation1->setLocale('en_EN');
+        $translation1->setLocale('en_US');
         $o->addI18nBehaviorTest1I18n($translation1);
         $translation2 = new \I18nBehaviorTest1I18n();
         $translation2->setLocale('fr_FR');
         $o->addI18nBehaviorTest1I18n($translation2);
-        $translation = $o->getTranslation('en_EN');
+        $translation = $o->getTranslation('en_US');
         $this->assertEquals($translation1, $translation);
     }
 
@@ -182,7 +182,7 @@ EOF;
     {
         $o = new \I18nBehaviorTest1();
         $translation1 = new \I18nBehaviorTest1I18n();
-        $translation1->setLocale('en_EN');
+        $translation1->setLocale('en_US');
         $o->addI18nBehaviorTest1I18n($translation1);
         $translation2 = new \I18nBehaviorTest1I18n();
         $translation2->setLocale('fr_FR');
@@ -205,7 +205,7 @@ EOF;
     public function testGetLocaleReturnsDefaultLocale()
     {
         $o = new \I18nBehaviorTest1();
-        $this->assertEquals('en_EN', $o->getLocale());
+        $this->assertEquals('en_US', $o->getLocale());
         $o = new \I18nBehaviorTest2();
         $this->assertEquals('fr_FR', $o->getLocale());
     }
@@ -222,7 +222,7 @@ EOF;
         $o = new \I18nBehaviorTest1();
         $o->setLocale('fr_FR');
         $o->setLocale();
-        $this->assertEquals('en_EN', $o->getLocale());
+        $this->assertEquals('en_US', $o->getLocale());
     }
 
     public function testLocaleSetterAndGetterAliasesExist()
@@ -240,15 +240,15 @@ EOF;
     public function testSetLocaleAlias()
     {
         $o = new \I18nBehaviorTest2();
-        $o->setCulture('en_EN');
-        $this->assertEquals('en_EN', $o->getCulture());
+        $o->setCulture('en_US');
+        $this->assertEquals('en_US', $o->getCulture());
     }
 
     public function testGetCurrentTranslationUsesDefaultLocale()
     {
         $o = new \I18nBehaviorTest1();
         $t = $o->getCurrentTranslation();
-        $this->assertEquals('en_EN', $t->getLocale());
+        $this->assertEquals('en_US', $t->getLocale());
         $o = new \I18nBehaviorTest2();
         $t = $o->getCurrentTranslation();
         $this->assertEquals('fr_FR', $t->getLocale());
@@ -272,7 +272,7 @@ EOF;
         $t2 = $o->getCurrentTranslation();
         $t2->setBar('bonjour');
         //$o->save();
-        $o->setLocale('en_EN');
+        $o->setLocale('en_US');
         $this->assertEquals('hello', $o->getBar());
         $o->setLocale('fr_FR');
         $this->assertEquals('bonjour', $o->getBar());
@@ -284,7 +284,7 @@ EOF;
         $o->setBar('hello');
         $o->setLocale('fr_FR');
         $o->setBar('bonjour');
-        $o->setLocale('en_EN');
+        $o->setLocale('en_US');
         $this->assertEquals('hello', $o->getBar());
         $o->setLocale('fr_FR');
         $this->assertEquals('bonjour', $o->getBar());
@@ -316,7 +316,7 @@ EOF;
         $translation1->setLocale('fr_FR');
         $o->addI18nBehaviorTest1I18n($translation1);
         $o->clear();
-        $this->assertEquals('en_EN', $o->getLocale());
+        $this->assertEquals('en_US', $o->getLocale());
         $t1 = $o->getTranslation('fr_FR');
         $this->assertEquals('', $t1->getBar());
     }
@@ -402,13 +402,13 @@ EOF;
     {
         $o = new \I18nBehaviorTestLocalColumn();
         $translation1 = new \I18nBehaviorTestLocalColumnI18n();
-        $translation1->setMyLang('en_EN');
+        $translation1->setMyLang('en_US');
         $o->addI18nBehaviorTestLocalColumnI18n($translation1);
         $translation2 = new \I18nBehaviorTestLocalColumnI18n();
         $translation2->setMyLang('fr_FR');
         $o->addI18nBehaviorTestLocalColumnI18n($translation2);
         $o->save();
-        $this->assertEquals($translation1, $o->getTranslation('en_EN'));
+        $this->assertEquals($translation1, $o->getTranslation('en_US'));
         $this->assertEquals($translation2, $o->getTranslation('fr_FR'));
     }
 }

--- a/tests/Propel/Tests/Generator/Behavior/I18n/I18nBehaviorQueryBuilderModifierTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/I18n/I18nBehaviorQueryBuilderModifierTest.php
@@ -62,7 +62,7 @@ EOF;
         $sql = $q->createSelectSQL($params);
         $expectedSQL = 'SELECT  FROM i18n_behavior_test_11 LEFT JOIN i18n_behavior_test_11_i18n ON (i18n_behavior_test_11.ID=i18n_behavior_test_11_i18n.ID AND i18n_behavior_test_11_i18n.LOCALE = :p1)';
         $this->assertEquals($expectedSQL, $sql);
-        $this->assertEquals('en_EN', $params[0]['value']);
+        $this->assertEquals('en_US', $params[0]['value']);
     }
 
     public function testJoinI18nUsesLocaleInJoinCondition()
@@ -79,23 +79,23 @@ EOF;
     public function testJoinI18nAcceptsARelationAlias()
     {
         $q = \I18nBehaviorTest11Query::create()
-            ->joinI18n('en_EN', 'I18n');
+            ->joinI18n('en_US', 'I18n');
         $params = array();
         $sql = $q->createSelectSQL($params);
         $expectedSQL = 'SELECT  FROM i18n_behavior_test_11 LEFT JOIN i18n_behavior_test_11_i18n I18n ON (i18n_behavior_test_11.ID=I18n.ID AND I18n.LOCALE = :p1)';
         $this->assertEquals($expectedSQL, $sql);
-        $this->assertEquals('en_EN', $params[0]['value']);
+        $this->assertEquals('en_US', $params[0]['value']);
     }
 
     public function testJoinI18nAcceptsAJoinType()
     {
         $q = \I18nBehaviorTest11Query::create()
-            ->joinI18n('en_EN', null, Criteria::INNER_JOIN);
+            ->joinI18n('en_US', null, Criteria::INNER_JOIN);
         $params = array();
         $sql = $q->createSelectSQL($params);
         $expectedSQL = 'SELECT  FROM i18n_behavior_test_11 INNER JOIN i18n_behavior_test_11_i18n ON (i18n_behavior_test_11.ID=i18n_behavior_test_11_i18n.ID AND i18n_behavior_test_11_i18n.LOCALE = :p1)';
         $this->assertEquals($expectedSQL, $sql);
-        $this->assertEquals('en_EN', $params[0]['value']);
+        $this->assertEquals('en_US', $params[0]['value']);
     }
 
     public function testJoinI18nCreatesACorrectQuery()
@@ -160,7 +160,7 @@ EOF;
         $sql = $q->createSelectSQL($params);
         $expectedSQL = 'SELECT i18n_behavior_test_11.ID, i18n_behavior_test_11.FOO, i18n_behavior_test_11_i18n.ID, i18n_behavior_test_11_i18n.LOCALE, i18n_behavior_test_11_i18n.BAR FROM i18n_behavior_test_11 LEFT JOIN i18n_behavior_test_11_i18n ON (i18n_behavior_test_11.ID=i18n_behavior_test_11_i18n.ID AND i18n_behavior_test_11_i18n.LOCALE = :p1)';
         $this->assertEquals($expectedSQL, $sql);
-        $this->assertEquals('en_EN', $params[0]['value']);
+        $this->assertEquals('en_US', $params[0]['value']);
     }
 
     public function testJoinWithI18nDoesNotPruneResultsWithoutTranslation()
@@ -171,7 +171,7 @@ EOF;
         $o->setFoo(123);
         $o->save();
         $res = \I18nBehaviorTest11Query::create()
-            ->joinWithI18n('en_EN')
+            ->joinWithI18n('en_US')
             ->findOne();
         $this->assertEquals($o, $res);
     }
@@ -184,7 +184,7 @@ EOF;
         $o->setFoo(123);
         $o->save();
         $res = \I18nBehaviorTest11Query::create()
-            ->joinWithI18n('en_EN', Criteria::INNER_JOIN)
+            ->joinWithI18n('en_US', Criteria::INNER_JOIN)
             ->findOne();
         $this->assertNull($res);
     }
@@ -197,7 +197,7 @@ EOF;
         \I18nBehaviorTest11I18nQuery::create()->deleteAll();
         $o = new \I18nBehaviorTest11();
         $o->setFoo(123);
-        $o->setLocale('en_EN');
+        $o->setLocale('en_US');
         $o->setBar('hello');
         $o->setLocale('fr_FR');
         $o->setBar('bonjour');
@@ -205,10 +205,10 @@ EOF;
         \Map\I18nBehaviorTest11TableMap::clearInstancePool();
         \Map\I18nBehaviorTest11I18nTableMap::clearInstancePool();
         $o = \I18nBehaviorTest11Query::create()
-            ->joinWithI18n('en_EN')
+            ->joinWithI18n('en_US')
             ->findOne($con);
         $count = $con->getQueryCount();
-        $translation = $o->getTranslation('en_EN', $con);
+        $translation = $o->getTranslation('en_US', $con);
         $this->assertEquals($count, $con->getQueryCount());
         $this->assertEquals('hello', $translation->getBar());
     }
@@ -219,15 +219,15 @@ EOF;
         \I18nBehaviorTest11I18nQuery::create()->deleteAll();
         $o = new \I18nBehaviorTest11();
         $o->setFoo(123);
-        $o->setLocale('en_EN');
+        $o->setLocale('en_US');
         $o->setBar('hello');
         $o->setLocale('fr_FR');
         $o->setBar('bonjour');
         $o->save();
         $o1 = \I18nBehaviorTest11Query::create()
-            ->joinWithI18n('en_EN')
+            ->joinWithI18n('en_US')
             ->findOne();
-        $this->assertEquals('en_EN', $o1->getLocale());
+        $this->assertEquals('en_US', $o1->getLocale());
         $o2 = \I18nBehaviorTest11Query::create()
             ->joinWithI18n('fr_FR')
             ->findOne();
@@ -237,7 +237,7 @@ EOF;
     public function testJoinWithI18nAndLimitDoesNotThrowException()
     {
         $res = \I18nBehaviorTest11Query::create()
-            ->joinWithI18n('en_EN')
+            ->joinWithI18n('en_US')
             ->limit(2)
             ->find();
         $this->assertInstanceOf('\Propel\Runtime\Collection\ObjectCollection', $res);
@@ -249,7 +249,7 @@ EOF;
     // use case:
     // $o = new Object();
     // $t1 = new Translation();
-    // $o->setTranslation($t2, 'en_EN'); // this is what happens during joined hydration
+    // $o->setTranslation($t2, 'en_US'); // this is what happens during joined hydration
     // now the translation collection exists
     // $t2 = $o->getTranslation('fr_FR'); // we MUST issue a query here
     public function testJoinWithI18nDoesNotExecuteAdditionalQueryWhenNoTranslationIsFound()
@@ -263,10 +263,10 @@ EOF;
         $o = new \I18nBehaviorTest11();
         $o->save();
         $o = \I18nBehaviorTest11Query::create()
-            ->joinWithI18n('en_EN')
+            ->joinWithI18n('en_US')
             ->findOne($con);
         $count = $con->getQueryCount();
-        $translation = $o->getTranslation('en_EN', $con);
+        $translation = $o->getTranslation('en_US', $con);
         $this->assertEquals($count, $con->getQueryCount());
     }
 

--- a/tests/Propel/Tests/Generator/Behavior/I18n/I18nBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/I18n/I18nBehaviorTest.php
@@ -111,7 +111,7 @@ EOF;
     </table>
     <table name="i18n_behavior_test_0_i18n">
         <column name="id" primaryKey="true" type="INTEGER" />
-        <column name="locale" primaryKey="true" type="VARCHAR" size="5" default="en_EN" />
+        <column name="locale" primaryKey="true" type="VARCHAR" size="5" default="en_US" />
         <column name="bar" type="VARCHAR" size="100" />
         <foreign-key foreignTable="i18n_behavior_test_0">
             <reference local="id" foreign="id" />
@@ -166,7 +166,7 @@ EOF;
 CREATE TABLE i18n_behavior_test_0_i18n
 (
     id INTEGER NOT NULL,
-    locale VARCHAR(5) DEFAULT 'en_EN' NOT NULL,
+    locale VARCHAR(5) DEFAULT 'en_US' NOT NULL,
 EOF;
         $this->assertContains($expected, $builder->getSQL());
     }
@@ -182,7 +182,7 @@ EOF;
 CREATE TABLE i18n_behavior_test_0_i18n
 (
     id INTEGER NOT NULL,
-    locale VARCHAR(5) DEFAULT 'en_EN' NOT NULL,
+    locale VARCHAR(5) DEFAULT 'en_US' NOT NULL,
     bar VARCHAR(100),
     PRIMARY KEY (id,locale)
 );
@@ -231,7 +231,7 @@ DROP TABLE IF EXISTS foo_table;
 CREATE TABLE foo_table
 (
     id INTEGER NOT NULL,
-    locale VARCHAR(5) DEFAULT 'en_EN' NOT NULL,
+    locale VARCHAR(5) DEFAULT 'en_US' NOT NULL,
     PRIMARY KEY (id,locale)
 );
 EOF;
@@ -262,7 +262,7 @@ DROP TABLE IF EXISTS i18n_behavior_test_0_i18n;
 CREATE TABLE i18n_behavior_test_0_i18n
 (
     id INTEGER NOT NULL,
-    culture VARCHAR(5) DEFAULT 'en_EN' NOT NULL,
+    culture VARCHAR(5) DEFAULT 'en_US' NOT NULL,
     PRIMARY KEY (id,culture)
 );
 EOF;
@@ -324,7 +324,7 @@ DROP TABLE IF EXISTS i18n_behavior_test_0_i18n;
 CREATE TABLE i18n_behavior_test_0_i18n
 (
     id INTEGER NOT NULL,
-    locale VARCHAR(6) DEFAULT 'en_EN' NOT NULL,
+    locale VARCHAR(6) DEFAULT 'en_US' NOT NULL,
     PRIMARY KEY (id,locale)
 );
 EOF;


### PR DESCRIPTION
In propel 1.6.8 the default locale was changed from en_EN to en_US because en_EN seems to not be a standard locale : https://github.com/propelorm/Propel/commit/66d374071d0a37c8ba51f41ada3c8291fe4fb1ba#generator/lib/behavior/i18n/I18nBehavior.php

In propel 2 the default locale is again en_EN, in this PR I change the default locale to en_US.

Thanks
