### PR TITLE
fix autoloading of some classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,12 @@
     },
     "autoload": {
         "psr-0": {
-            "Propel": "src/"
+            "Propel": "src/",
+            "Propel\\Tests": [
+               "tests/",
+               "tests/Fixtures/bookstore/build/classes/",
+               "tests/Fixtures/schemas/build/classes"
+            ]
         }
     },
     "bin": [


### PR DESCRIPTION
Fix for the issue https://github.com/propelorm/Propel2/issues/429
The command `bin/propel test:prepare` was not working when using composer
