### PR TITLE
Look for build.properties and sqldb.map in appropriate directories.

### DIFF
--- a/src/Propel/Generator/Command/SqlInsertCommand.php
+++ b/src/Propel/Generator/Command/SqlInsertCommand.php
@@ -30,7 +30,8 @@ class SqlInsertCommand extends AbstractCommand
     protected function configure()
     {
         $this
-            ->addOption('input-dir', null, InputOption::VALUE_REQUIRED,  'The input directory', self::DEFAULT_OUTPUT_DIRECTORY)
+            ->addOption('input-dir', null, InputOption::VALUE_REQUIRED,  'The input directory', self::DEFAULT_INPUT_DIRECTORY)
+            ->addOption('output-dir', null, InputOption::VALUE_REQUIRED,  'The output directory', self::DEFAULT_OUTPUT_DIRECTORY)
             ->addOption('connection', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Connection to use. Example: bookstore=mysql:host=127.0.0.1;dbname=test;user=root;password=foobar')
             ->setName('sql:insert')
             ->setAliases(array('insert-sql'))
@@ -64,7 +65,7 @@ class SqlInsertCommand extends AbstractCommand
                 $output->writeln($message);
             }
         });
-        $manager->setWorkingDirectory($input->getOption('input-dir'));
+        $manager->setWorkingDirectory($input->getOption('output-dir'));
 
         $manager->insertSql();
     }


### PR DESCRIPTION
Fixes propelorm/Propel2#409 by configuring appropriate working directories to access necessary files for sql:inject command.
