### PR TITLE
must test if setIgnoreCase exists on each criterion

### DIFF
--- a/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
@@ -1979,7 +1979,7 @@ class ModelCriteria extends BaseModelCriteria
                 }
 
                 if (
-                    ($this->isIgnoreCase() || $attachedCriterion->isIgnoreCase())
+                    ($this->isIgnoreCase() || method_exists($attachedCriterion, 'setIgnoreCase'))
                     && $dbMap->getTable($table)->getColumn($attachedCriterion->getColumn())->isText()
                 ) {
                     $attachedCriterion->setIgnoreCase(true);

--- a/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaTest.php
@@ -488,6 +488,30 @@ class ModelCriteriaTest extends BookstoreTestBase
         $this->assertCriteriaTranslation($c, $sql, $params, 'filterBy() accepts a simple column name, even if initialized with an alias');
     }
 
+    public function testGetParams()
+    {
+        $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
+        $c->filterBy('Title', 'foo');
+
+        $expectedParams =  array(
+            array('table' => 'book', 'column' => 'TITLE', 'value' => 'foo'),
+        );
+
+        $params = $c->getParams();
+
+        $this->assertEquals($expectedParams, $params, 'test getting parameters with a simple criterion');
+
+        $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
+        $c->filterBy('Title', 'foo', Criteria::LIKE);
+
+        $expectedParams =  array(
+            array('table' => 'book', 'column' => 'TITLE', 'value' => 'foo'),
+        );
+
+        $this->assertEquals($expectedParams, $params, 'test getting parameters with Specialized Criterion used for LIKE expressions');
+
+    }
+
     public function testHaving()
     {
         $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');


### PR DESCRIPTION
`ModelCriteria::getParams` always call is `setIgnoreCase` method on each attached criteron. However, a criterion may not have this method.

I test if the method `setIgnoreCase` exist on each Criterion.
