### PR TITLE
fix failing tests in ArrayToPhpConverterTest

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,3 +1,12 @@
 <?php
 
 require_once __DIR__.'/../autoload.php.dist';
+
+/**
+ * fix var_export behavior with floating number precision since PHP 5.4.22
+ *
+ * @see https://bugs.php.net/bug.php?id=64760
+ * @see https://github.com/sebastianbergmann/phpunit/issues/1052
+ */
+ini_set('precision', 14);
+ini_set('serialize_precision', 14);


### PR DESCRIPTION
Hi,

This patch fix the phpunit boostrap configuration to repair failing unit tests since PHP 5.4.22 .

For more information, see https://github.com/sebastianbergmann/phpunit/issues/1052 .
