### PR TITLE
Install Behaviors with Composer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 vendor/
 composer.phar
-composer.lock
+/composer.lock
 autoload.php
 phpunit.xml
 pom.xml

--- a/src/Propel/Generator/Command/ModelBuildCommand.php
+++ b/src/Propel/Generator/Command/ModelBuildCommand.php
@@ -15,6 +15,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\Output;
 use Propel\Generator\Manager\ModelManager;
+use Propel\Runtime\Propel;
+use Propel\Generator\Util\ComposerFinder;
 
 /**
  * @author Florian Klein <florian.klein@free.fr>
@@ -80,6 +82,8 @@ class ModelBuildCommand extends AbstractCommand
                 '')
             ->addOption('disable-namespace-auto-package', null, InputOption::VALUE_NONE,
                 'Disable namespace auto-packaging')
+            ->addOption('composer-dir', null, InputOption::VALUE_REQUIRED,
+				'Directory in which your composer.json resides', null)
             ->setName('model:build')
             ->setAliases(array('build'))
             ->setDescription('Build the model classes based on Propel XML schemas')
@@ -102,6 +106,7 @@ class ModelBuildCommand extends AbstractCommand
             'propel.builder.queryinheritancestub.class' => $input->getOption('query-inheritance-stub-class'),
             'propel.builder.tablemap.class'             => $input->getOption('tablemap-class'),
             'propel.builder.pluralizer.class'           => $input->getOption('pluralizer-class'),
+            'propel.builder.composer.dir'               => $input->getOption('composer-dir'),
             'propel.disableIdentifierQuoting'           => !$input->getOption('enable-identifier-quoting'),
             'propel.targetPackage'                      => $input->getOption('target-package'),
             'propel.packageObjectModel'                 => $input->getOption('enable-package-object-model'),

--- a/src/Propel/Generator/Config/GeneratorConfig.php
+++ b/src/Propel/Generator/Config/GeneratorConfig.php
@@ -17,6 +17,7 @@ use Propel\Generator\Reverse\SchemaParserInterface;
 use Propel\Runtime\Adapter\AdapterFactory;
 use Propel\Runtime\Connection\ConnectionFactory;
 use Propel\Runtime\Connection\ConnectionInterface;
+use Propel\Generator\Util\BehaviorLocator;
 
 /**
  * A class that holds build properties and provide a class loading mechanism for
@@ -38,6 +39,11 @@ class GeneratorConfig implements GeneratorConfigInterface
 
     protected $defaultBuildConnection = null;
 
+    /**
+     * @var BehaviorLocator
+     */
+    protected $behaviorLocator = null;
+    
     /**
      * Construct a new GeneratorConfig.
      *
@@ -327,4 +333,13 @@ class GeneratorConfig implements GeneratorConfigInterface
 
         return $con;
     }
+    
+    public function getBehaviorLocator() {
+        if (!$this->behaviorLocator) {
+            $this->behaviorLocator = new BehaviorLocator($this);
+        }
+        
+        return $this->behaviorLocator;
+	}
+
 }

--- a/src/Propel/Generator/Config/GeneratorConfigInterface.php
+++ b/src/Propel/Generator/Config/GeneratorConfigInterface.php
@@ -15,6 +15,7 @@ use Propel\Generator\Builder\DataModelBuilder;
 use Propel\Generator\Model\Table;
 use Propel\Generator\Platform\PlatformInterface;
 use Propel\Runtime\Connection\ConnectionInterface;
+use Propel\Generator\Util\BehaviorLocator;
 
 interface GeneratorConfigInterface
 {
@@ -59,4 +60,11 @@ interface GeneratorConfigInterface
      * @return PlatformInterface
      */
     public function getConfiguredPlatform(ConnectionInterface $con = null, $database = null);
+    
+    /**
+     * Returns the behavior locator.
+     * 
+     * @return BehaviorLocator
+     */
+    public function getBehaviorLocator();
 }

--- a/src/Propel/Generator/Config/QuickGeneratorConfig.php
+++ b/src/Propel/Generator/Config/QuickGeneratorConfig.php
@@ -17,6 +17,7 @@ use Propel\Generator\Config\GeneratorConfigInterface;
 use Propel\Generator\Exception\RuntimeException;
 use Propel\Generator\Model\Table;
 use \Propel\Runtime\Connection\ConnectionInterface;
+use Propel\Generator\Util\BehaviorLocator;
 
 class QuickGeneratorConfig implements GeneratorConfigInterface
 {
@@ -33,6 +34,11 @@ class QuickGeneratorConfig implements GeneratorConfigInterface
     );
 
     protected $buildProperties = array();
+    
+    /**
+     * @var BehaviorLocator
+     */
+    protected $behaviorLocator = null;
 
     public function __construct()
     {
@@ -153,5 +159,14 @@ class QuickGeneratorConfig implements GeneratorConfigInterface
     public function getConfiguredPlatform(ConnectionInterface $con = null, $database = null)
     {
         return null;
+    }
+    
+
+    public function getBehaviorLocator() {
+    	if (!$this->behaviorLocator) {
+    		$this->behaviorLocator = new BehaviorLocator($this);
+    	}
+    
+    	return $this->behaviorLocator;
     }
 }

--- a/src/Propel/Generator/Model/BehaviorableTrait.php
+++ b/src/Propel/Generator/Model/BehaviorableTrait.php
@@ -1,0 +1,116 @@
+<?php
+namespace Propel\Generator\Model;
+
+use Propel\Generator\Util\BehaviorLocator;
+use Propel\Generator\Exception\BuildException;
+use Propel\Generator\Config\GeneratorConfigInterface;
+
+/**
+ * BehaviorableTrait use it on every model that can hold behaviors
+ * 
+ */
+trait BehaviorableTrait
+{
+    /**
+     * @var Behavior[]
+     */
+    protected $behaviors;
+    
+    /**
+     * @var BehaviorLocator
+     */
+    private $behaviorLocator;
+    
+    /**
+     * @return GeneratorConfigInterface
+     */
+    protected abstract function getGeneratorConfig();
+    
+    /**
+     * Returns the behavior locator.
+     *
+     * @return BehaviorLocator
+     */
+    private function getBehaviorLocator()
+    {
+    	if (null === $this->behaviorLocator) {
+    		$config = $this->getGeneratorConfig();
+    		if (null !== $config) {
+    			$this->behaviorLocator = $config->getBehaviorLocator();
+    			if (null === $this->behaviorLocator) {
+    				$this->behaviorLocator = new BehaviorLocator();
+    			}
+    		} else {
+    			$this->behaviorLocator = new BehaviorLocator();
+    		}
+    	}
+    
+    	return $this->behaviorLocator;
+    }
+    
+    /**
+     * Adds a new Behavior
+     *
+     * @param $bdata
+     * @throws BuildException when the added behavior is not an instance of \Propel\Generator\Model\Behavior
+     * @return Behavior $bdata
+     */
+    public function addBehavior($bdata)
+    {
+    	if ($bdata instanceof Behavior) {
+    		$behavior = $bdata;
+    		$this->registerBehavior($behavior);
+    		$this->behaviors[$behavior->getName()] = $behavior;
+    
+    		return $behavior;
+    	}
+    
+    	$locator = $this->getBehaviorLocator();
+    	$class = $locator->getBehavior($bdata['name']);
+    	$behavior = new $class();
+    	if (!($behavior instanceof Behavior)) {
+    		throw new BuildException(sprintf('Behavior [%s: %s] not instance of %s',
+    				$bdata['name'], $class, '\Propel\Generator\Model\Behavior'));
+    	}
+    	$behavior->loadMapping($bdata);
+    
+    	return $this->addBehavior($behavior);
+    }
+    
+    protected abstract function registerBehavior(Behavior $behavior);
+    
+    /**
+     * Returns the list of behaviors.
+     *
+     * @return Behavior[]
+     */
+    public function getBehaviors()
+    {
+    	return $this->behaviors;
+    }
+    
+    /**
+     * check if the given behavior exists
+     *
+     * @param  string  $name the behavior name
+     * @return boolean True if the behavior exists
+     */
+    public function hasBehavior($name)
+    {
+    	return array_key_exists($name, $this->behaviors);
+    }
+    
+    /**
+     * Get behavior by name
+     *
+     * @param  string   $name the behavior name
+     * @return Behavior a behavior object or null if the behavior doesn't exist
+     */
+    public function getBehavior($name)
+    {
+        if ($this->hasBehavior($name)) {
+            return $this->behaviors[$name];
+        }
+    	return null;
+    }
+}

--- a/src/Propel/Generator/Model/Database.php
+++ b/src/Propel/Generator/Model/Database.php
@@ -13,6 +13,9 @@ namespace Propel\Generator\Model;
 use Propel\Generator\Exception\EngineException;
 use Propel\Generator\Exception\InvalidArgumentException;
 use Propel\Generator\Platform\PlatformInterface;
+use Propel\Generator\Util\BehaviorLocator;
+use Propel\Generator\Config\QuickGeneratorConfig;
+use Propel\Generator\Exception\BuildException;
 
 /**
  * A class for holding application data structures.
@@ -27,6 +30,9 @@ use Propel\Generator\Platform\PlatformInterface;
  */
 class Database extends ScopedMappingModel
 {
+    
+    use BehaviorableTrait;
+    
     /**
      * The database's platform.
      *
@@ -89,7 +95,6 @@ class Database extends ScopedMappingModel
      */
     private $sequences;
 
-    protected $behaviors;
     protected $defaultStringFormat;
     protected $tablePrefix;
 
@@ -697,64 +702,7 @@ class Database extends ScopedMappingModel
             return $config->getBuildProperty($name);
         }
     }
-
-    /**
-     * Adds a new behavior to the database*
-     *
-     * @param  Behavior|array $bdata
-     * @return Behavior
-     */
-    public function addBehavior($bdata)
-    {
-        if ($bdata instanceof Behavior) {
-            $behavior = $bdata;
-            $behavior->setDatabase($this);
-            $this->behaviors[$behavior->getName()] = $behavior;
-
-            return $behavior;
-        }
-
-        $class = $this->getConfiguredBehavior($bdata['name']);
-        $behavior = new $class();
-        $behavior->loadMapping($bdata);
-
-        return $this->addBehavior($behavior);
-    }
-
-    /**
-     * Returns the list of all database behaviors.
-     *
-     * @return array
-     */
-    public function getBehaviors()
-    {
-        return $this->behaviors;
-    }
-
-    /**
-     * Returns whether or not the database has a specific behavior.
-     *
-     * @param  string  $name
-     * @return boolean
-     */
-    public function hasBehavior($name)
-    {
-        return isset($this->behaviors[$name]);
-    }
-
-    /**
-     * Returns the corresponding behavior identified by its name.
-     *
-     * @param  string   $name
-     * @return Behavior
-     */
-    public function getBehavior($name)
-    {
-        if (isset($this->behaviors[$name])) {
-            return $this->behaviors[$name];
-        }
-    }
-
+    
     /**
      * Returns the table prefix for this database.
      *
@@ -836,6 +784,11 @@ class Database extends ScopedMappingModel
             // setup referrers again, since final initialization may have added columns
             $table->setupReferrers(true);
         }
+    }
+    
+    protected function registerBehavior(Behavior $behavior)
+    {
+        $behavior->setDatabase($this);
     }
 
     /**

--- a/src/Propel/Generator/Model/MappingModel.php
+++ b/src/Propel/Generator/Model/MappingModel.php
@@ -182,29 +182,4 @@ abstract class MappingModel implements MappingModelInterface
         return $this->vendorInfos;
     }
 
-    /**
-     * Returns the best class name for a given behavior.
-     *
-     * If not found, the method tries to autoload \Propel\Generator\Behavior\[Bname]\[Bname]Behavior
-     *
-     * @param  string                    $behavior The behavior name (ie: timestampable)
-     * @return string                    $class The behavior fully qualified class name
-     * @throws BehaviorNotFoundException
-     */
-    public function getConfiguredBehavior($behavior)
-    {
-        if (false !== strpos($behavior, '\\')) {
-            $class = $behavior;
-        } else {
-            $generator = new PhpNameGenerator();
-            $phpName = $generator->generateName([ $behavior, PhpNameGenerator::CONV_METHOD_PHPNAME ]);
-            $class = sprintf('\\Propel\\Generator\\Behavior\\%s\\%sBehavior', $phpName, $phpName);
-        }
-
-        if (!class_exists($class)) {
-            throw new BehaviorNotFoundException(sprintf('Unknown behavior "%s"', $behavior));
-        }
-
-        return $class;
-    }
 }

--- a/src/Propel/Generator/Model/Table.php
+++ b/src/Propel/Generator/Model/Table.php
@@ -31,6 +31,8 @@ use Propel\Generator\Platform\PlatformInterface;
  */
 class Table extends ScopedMappingModel implements IdMethod
 {
+    use BehaviorableTrait;
+    
     /**
      * @var Column[]
      */
@@ -103,10 +105,6 @@ class Table extends ScopedMappingModel implements IdMethod
      */
     private $defaultMutatorVisibility;
 
-    /**
-     * @var Behavior[]
-     */
-    protected $behaviors;
     protected $isCrossRef;
     protected $defaultStringFormat;
 
@@ -226,6 +224,11 @@ class Table extends ScopedMappingModel implements IdMethod
                 $behavior->setTableModified(true);
             }
         }
+    }
+    
+    protected function registerBehavior(Behavior $behavior)
+    {
+        $behavior->setTable($this);
     }
 
     /**
@@ -962,60 +965,7 @@ class Table extends ScopedMappingModel implements IdMethod
         return $this->database->getGeneratorConfig();
     }
 
-    /**
-     * Adds a new Behavior to the table.
-     *
-     * @param $bdata
-     * @return Behavior $bdata
-     */
-    public function addBehavior($bdata)
-    {
-        if ($bdata instanceof Behavior) {
-            $behavior = $bdata;
-            $behavior->setTable($this);
-            $this->behaviors[$behavior->getName()] = $behavior;
-
-            return $behavior;
-        }
-
-        $class = $this->getConfiguredBehavior($bdata['name']);
-        $behavior = new $class();
-        $behavior->loadMapping($bdata);
-
-        return $this->addBehavior($behavior);
-    }
-
-    /**
-     * Returns the list of table behaviors.
-     *
-     * @return Behavior[]
-     */
-    public function getBehaviors()
-    {
-        return $this->behaviors;
-    }
-
-    /**
-     * check if the table has a behavior by name
-     *
-     * @param  string  $name the behavior name
-     * @return boolean True if the behavior exists
-     */
-    public function hasBehavior($name)
-    {
-        return isset($this->behaviors[$name]);
-    }
-
-    /**
-     * Get one table behavior by name
-     *
-     * @param  string   $name the behavior name
-     * @return Behavior a behavior object
-     */
-    public function getBehavior($name)
-    {
-        return $this->behaviors[$name];
-    }
+    
 
     /**
      * Returns whether or not the table behaviors offer additional builders.

--- a/src/Propel/Generator/Util/BehaviorLocator.php
+++ b/src/Propel/Generator/Util/BehaviorLocator.php
@@ -1,0 +1,189 @@
+<?php
+namespace Propel\Generator\Util;
+
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
+use Propel\Generator\Exception\BuildException;
+use Propel\Generator\Model\PhpNameGenerator;
+use Propel\Generator\Exception\BehaviorNotFoundException;
+use Propel\Generator\Config\GeneratorConfigInterface;
+
+/**
+ * Service class to find composer and installed packages
+ *
+ * @author Thomas Gossmann
+ *        
+ */
+class BehaviorLocator
+{
+
+    const BEHAVIOR_PACKAGE_TYPE = 'propel-behavior';
+
+    private $behaviors = null;
+
+    private $composerDir = null;
+
+    /**
+     *
+     * @var GeneratorConfigInterface
+     */
+    private $generatorConfig = null;
+
+    /**
+     * Creates the composer finder
+     *
+     * @param GeneratorConfigInterface $config build config
+     */
+    public function __construct(GeneratorConfigInterface $config = null)
+    {
+        $this->generatorConfig = $config;
+        if (null !== $config) {
+            $this->composerDir = $config->getBuildProperty('builderComposerDir');
+        }
+    }
+
+    /**
+     * Searches the composer.lock file
+     *  
+     * @return SplFileInfo the found composer.lock or null if composer.lock isn't found
+     */
+    private function findComposerLock()
+    {
+        if (null !== $this->composerDir) {
+            $filePath = $this->composerDir . '/composer.lock';
+            
+            if (file_exists($filePath)) {
+                return new SplFileInfo($filePath, dirname($filePath), dirname($filePath));
+            }
+        }
+        
+        $finder = new Finder();
+        $result = $finder->name('composer.lock')
+            ->in($this->getSearchDirs())
+            ->depth(0);
+        
+        if (count($result)) {
+            return $result->getIterator()->current();
+        }
+        
+        return null;
+    }
+
+    /**
+     * Returns the directories to search the composer lock file in
+     *
+     * @return array[string]
+     */
+    private function getSearchDirs()
+    {
+        return [
+            getcwd(),
+            getcwd() . '/../',                  // cwd is a subfolder
+            __DIR__ . '/../../../../../../',    // vendor/propel/propel
+            __DIR__ . '/../../../../'           // propel development environment
+        ];
+    }
+
+    /**
+     * Returns the loaded behaviors and loads them if not done before
+     *
+     * @return array behaviors
+     */
+    public function getBehaviors()
+    {
+        if (null === $this->behaviors) {
+            $lock = $this->findComposerLock();
+            
+            if (null === $lock) {
+                $this->behaviors = [];
+            } else {
+                $this->behaviors = $this->loadBehaviors($lock);
+            }
+        }
+        
+        return $this->behaviors;
+    }
+
+    /**
+     * Returns the class name for a given behavior name
+     *
+     * @param string $name The behavior name (e.g. timetampable)
+     * @throws BehaviorNotFoundException when the behavior cannot be found
+     * @return string the class name
+     */
+    public function getBehavior($name)
+    {
+        if (false !== strpos($name, '\\')) {
+            $class = $name;
+        } else {
+            $class = $this->getCoreBehavior($name);
+            
+            if (!class_exists($class)) {
+                $behaviors = $this->getBehaviors();
+                if (array_key_exists($name, $behaviors)) {
+                    $class = $behaviors[$name]['class'];
+                }
+            }
+        }
+        
+        if (!class_exists($class)) {
+            throw new BehaviorNotFoundException(sprintf('Unknown behavior "%s". You may try running `composer update` or passing the `--composer-dir` option.', $name));
+        }
+        
+        return $class;
+    }
+
+    /**
+     * Searches for the given behavior name in the Propel\Generator\Behavior namespace as
+     * \Propel\Generator\Behavior\[Bname]\[Bname]Behavior
+     *
+     * @param string $name The behavior name (ie: timestampable)
+     * @return string The behavior fully qualified class name
+     */
+    private function getCoreBehavior($name)
+    {
+        $generator = new PhpNameGenerator();
+        $phpName = $generator->generateName([$name, PhpNameGenerator::CONV_METHOD_PHPNAME]);
+        return sprintf('\\Propel\\Generator\\Behavior\\%s\\%sBehavior', $phpName, $phpName);
+    }
+
+    /**
+     * Finds all behaviors by parsing composer.lock file
+     *
+     * @param SplFileInfo $composerLock            
+     */
+    private function loadBehaviors($composerLock)
+    {
+        $behaviors = [];
+        
+        if (null === $composerLock) {
+            return $behaviors;
+        }
+        
+        $json = json_decode($composerLock->getContents(), true);
+        
+        if (array_key_exists('packages', $json)) {
+            foreach ($json['packages'] as $package) {
+                if (array_key_exists('type', $package) && $package['type'] == self::BEHAVIOR_PACKAGE_TYPE) {
+                    
+                    // find propel behavior information
+                    if (array_key_exists('extra', $package)) {
+                        $extra = $package['extra'];
+                        
+                        if (array_key_exists('name', $extra) && array_key_exists('class', $extra)) {
+                            $behaviors[$extra['name']] = [
+                                'name' => $extra['name'],
+                                'class' => $extra['class'],
+                                'package' => $package['name']
+                            ];
+                        } else {
+                            throw new BuildException(sprintf('Cannot read behavior name and class from package %s', $package['name']));
+                        }
+                    }
+                }
+            }
+        }
+        
+        return $behaviors;
+    }
+}

--- a/tests/Fixtures/behavior-installer/composer.lock
+++ b/tests/Fixtures/behavior-installer/composer.lock
@@ -1,0 +1,540 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
+    ],
+    "hash": "bbb45b125cd91ef4191452cc67d7410a",
+    "packages": [
+        {
+            "name": "gossi/propel-l10n-behavior",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/gossi/propel-l10n-behavior.git",
+                "reference": "bc37ed7c449bbd1fd9120a88d16abc7ab2ba4e5e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/gossi/propel-l10n-behavior/zipball/bc37ed7c449bbd1fd9120a88d16abc7ab2ba4e5e",
+                "reference": "bc37ed7c449bbd1fd9120a88d16abc7ab2ba4e5e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "propel/propel": "dev-master@dev"
+            },
+            "type": "propel-behavior",
+            "extra": {
+                "name": "l10n",
+                "class": "\\gossi\\propel\\behavior\\l10n\\L10nBehavior"
+            },
+            "autoload": {
+                "psr-0": {
+                    "gossi\\propel\\behavior\\l10n": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "keywords": [
+                "Behavior",
+                "l10n",
+                "propel"
+            ],
+            "time": "2014-01-12 21:08:39"
+        },
+        {
+            "name": "propel/propel",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/propelorm/Propel2.git",
+                "reference": "a828b44220809051dd76191d01e2e79dfdc2ea4d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/propelorm/Propel2/zipball/a828b44220809051dd76191d01e2e79dfdc2ea4d",
+                "reference": "a828b44220809051dd76191d01e2e79dfdc2ea4d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "psr/log": "~1.0",
+                "symfony/console": "~2.2",
+                "symfony/filesystem": "~2.2",
+                "symfony/finder": "~2.2",
+                "symfony/validator": "~2.2",
+                "symfony/yaml": "~2.2"
+            },
+            "require-dev": {
+                "behat/behat": "~2.4",
+                "monolog/monolog": "~1.3",
+                "phpunit/phpunit": "3.7.*"
+            },
+            "suggest": {
+                "monolog/monolog": "The recommended logging library to use with Propel."
+            },
+            "bin": [
+                "bin/propel"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Propel": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "William Durand",
+                    "email": "william.durand1@gmail.com",
+                    "homepage": "http://www.willdurand.fr"
+                }
+            ],
+            "description": "Propel2 is an open-source Object-Relational Mapping (ORM) for PHP 5.4",
+            "homepage": "http://www.propelorm.org/",
+            "keywords": [
+                "Active Record",
+                "orm",
+                "persistence"
+            ],
+            "time": "2014-01-14 07:55:52"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/fe0936ee26643249e916849d48e3a51d5f5e278b",
+                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Psr\\Log\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2012-12-21 11:40:51"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v2.4.1",
+            "target-dir": "Symfony/Component/Console",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Console.git",
+                "reference": "4c1ed2ff514bd85ee186eebb010ccbdeeab05af7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Console/zipball/4c1ed2ff514bd85ee186eebb010ccbdeeab05af7",
+                "reference": "4c1ed2ff514bd85ee186eebb010ccbdeeab05af7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "symfony/event-dispatcher": "~2.1"
+            },
+            "suggest": {
+                "symfony/event-dispatcher": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Console\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Console Component",
+            "homepage": "http://symfony.com",
+            "time": "2014-01-01 08:14:50"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v2.4.1",
+            "target-dir": "Symfony/Component/Filesystem",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Filesystem.git",
+                "reference": "b3c3b5a8108b3e5d604dc23241b4ea84a067fc78"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/b3c3b5a8108b3e5d604dc23241b4ea84a067fc78",
+                "reference": "b3c3b5a8108b3e5d604dc23241b4ea84a067fc78",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Filesystem Component",
+            "homepage": "http://symfony.com",
+            "time": "2013-12-31 13:43:26"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v2.4.1",
+            "target-dir": "Symfony/Component/Finder",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Finder.git",
+                "reference": "6904345cf2b3bbab1f6d6e4ce1724cb99df9f00a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Finder/zipball/6904345cf2b3bbab1f6d6e4ce1724cb99df9f00a",
+                "reference": "6904345cf2b3bbab1f6d6e4ce1724cb99df9f00a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Finder\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Finder Component",
+            "homepage": "http://symfony.com",
+            "time": "2014-01-01 08:14:50"
+        },
+        {
+            "name": "symfony/property-access",
+            "version": "v2.4.1",
+            "target-dir": "Symfony/Component/PropertyAccess",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/PropertyAccess.git",
+                "reference": "274951234150e303c83099a2429be6be35629fe9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/PropertyAccess/zipball/274951234150e303c83099a2429be6be35629fe9",
+                "reference": "274951234150e303c83099a2429be6be35629fe9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\PropertyAccess\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony PropertyAccess Component",
+            "homepage": "http://symfony.com",
+            "keywords": [
+                "access",
+                "array",
+                "extraction",
+                "index",
+                "injection",
+                "object",
+                "property",
+                "property path",
+                "reflection"
+            ],
+            "time": "2013-11-13 21:30:16"
+        },
+        {
+            "name": "symfony/translation",
+            "version": "v2.4.1",
+            "target-dir": "Symfony/Component/Translation",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Translation.git",
+                "reference": "7f76dffd7eaf2c9a3a8f47649404c71440d18c8b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Translation/zipball/7f76dffd7eaf2c9a3a8f47649404c71440d18c8b",
+                "reference": "7f76dffd7eaf2c9a3a8f47649404c71440d18c8b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "symfony/config": "~2.0",
+                "symfony/yaml": "~2.2"
+            },
+            "suggest": {
+                "symfony/config": "",
+                "symfony/yaml": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Translation\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Translation Component",
+            "homepage": "http://symfony.com",
+            "time": "2013-12-31 13:43:26"
+        },
+        {
+            "name": "symfony/validator",
+            "version": "v2.4.1",
+            "target-dir": "Symfony/Component/Validator",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Validator.git",
+                "reference": "7ea4e53f8d68bf3ae9cca28765d49d7930618730"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Validator/zipball/7ea4e53f8d68bf3ae9cca28765d49d7930618730",
+                "reference": "7ea4e53f8d68bf3ae9cca28765d49d7930618730",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "symfony/property-access": "~2.2",
+                "symfony/translation": "~2.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "~1.0",
+                "doctrine/cache": "~1.0",
+                "symfony/config": "~2.2",
+                "symfony/http-foundation": "~2.1",
+                "symfony/intl": "~2.3",
+                "symfony/yaml": "~2.0"
+            },
+            "suggest": {
+                "doctrine/annotations": "For using the annotation mapping. You will also need doctrine/cache.",
+                "doctrine/cache": "For using the default cached annotation reader",
+                "symfony/config": "",
+                "symfony/http-foundation": "",
+                "symfony/intl": "",
+                "symfony/yaml": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Validator\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Validator Component",
+            "homepage": "http://symfony.com",
+            "time": "2014-01-01 08:14:50"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v2.4.1",
+            "target-dir": "Symfony/Component/Yaml",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Yaml.git",
+                "reference": "4e1a237fc48145fae114b96458d799746ad89aa0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Yaml/zipball/4e1a237fc48145fae114b96458d799746ad89aa0",
+                "reference": "4e1a237fc48145fae114b96458d799746ad89aa0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Yaml\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "http://symfony.com",
+            "time": "2013-12-28 08:12:03"
+        }
+    ],
+    "packages-dev": [
+
+    ],
+    "aliases": [
+
+    ],
+    "minimum-stability": "stable",
+    "stability-flags": {
+        "propel/propel": 20,
+        "gossi/propel-l10n-behavior": 20
+    },
+    "platform": {
+        "php": ">=5.4"
+    },
+    "platform-dev": [
+
+    ]
+}

--- a/tests/Fixtures/behavior-installer/src/gossi/propel/behavior/l10n/L10nBehavior.php
+++ b/tests/Fixtures/behavior-installer/src/gossi/propel/behavior/l10n/L10nBehavior.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace gossi\propel\behavior\l10n;
+
+use Propel\Generator\Model\Behavior;
+
+class L10nBehavior extends Behavior {
+
+	
+	/* (non-PHPdoc)
+	 * @see \Propel\Generator\Model\Behavior::modifyTable()
+	 */
+	public function modifyTable() {
+		// behavior code
+	}
+
+}

--- a/tests/Propel/Tests/Generator/Behavior/BehaviorInstallerTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/BehaviorInstallerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT License
+ */
+
+namespace Propel\Tests\Generator\Behavior;
+
+use Propel\Tests\TestCase;
+use Propel\Generator\Util\BehaviorLocator;
+use Propel\Generator\Config\QuickGeneratorConfig;
+
+/**
+ * Tests the table structure behavior hooks.
+ *
+ * @author Thomas Gossmann
+ */
+class BehaviorInstallerTest extends TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        require_once(__DIR__ . '/../../../../Fixtures/behavior-installer/src/gossi/propel/behavior/l10n/L10nBehavior.php');
+    }
+
+    public function testBehaviorLocator()
+    {
+        $config = new QuickGeneratorConfig();
+        $config->setBuildProperty('builderComposerDir', __DIR__ . '/../../../../Fixtures/behavior-installer');
+        $locator = new BehaviorLocator($config);
+        
+        // test found behaviors
+        $behaviors = $locator->getBehaviors();
+        $this->assertSame(1, count($behaviors));
+        
+        $this->assertTrue(array_key_exists('l10n', $behaviors));
+        $this->assertSame('gossi/propel-l10n-behavior', $behaviors['l10n']['package']);
+        
+        // test class name
+        $this->assertSame('\\gossi\\propel\\behavior\\l10n\\L10nBehavior', $locator->getBehavior('l10n'));
+    }
+}


### PR DESCRIPTION
This let's you install behaviors with composer. I thought it's not that much to do, to implement this. This is all more a proof-of-concept and RFC than a final implementation. However, let me explain.
### What a Behavior Author needs to do

All the dev needs to do is polish his composer.json a little bit.
1. Set type to "propel-behavior"
2. Add propel extra package
3. Set name and class for his behavior

Example:

``` json
{
    "name" : "gossi/propel-l10n-behavior",
    "type" : "propel-behavior",
    "extra": {
        "name": "l10n",
        "class": "\\gossi\\propel\\behavior\\l10n\\L10nBehavior"
    }
}
```
- The `class` must extend the `Propel\Generator\Model\Behavior` class (oh, btw. there is no check for that).
- The `name` is used in the schema as behavior name (`<behavior name="l10n"/>`)

That's it.
### How that works

When composer installs its dependencies, a composer.lock file is created, containing all packages, including their composer.json file contents. This file is scanned, all packages with the `propel-behavior` type are searched and stored in a lookup map. When a behavior is requested, the name is looked up in the map and the class name gets returned.
### Alternative Solution

An alternative solution would be, to create a propel-behavior-installer. It can potentially install behaviors in other locations than the vendor dir, such as the propel behavior folder in the generator namespace and thus loaded from there. This would require a behavior author to mimic a certain folder structure, that the already present behavior loader can find the behavior, which I think is not gonna happen.
Additionally the installer must somehow keep a storage with the installed behaviors (maybe a simple json file). This file must be consumed by propel to read all the available behaviors. Given that propel is installed as package itself, it has no "config" folder itself hence when upgrading it is unsure wether files stay in the propel vendor dir, despite the fact propel can be deleted and reinstalled and loose all its files. The dilemma can be handled with event handlers; even if possible, this is not funny at all (or somehow get some persistent configuration storage).
Last but not least, behavior devs need to include another (require) statement in their composer.json.

composer.lock is a nice and always present storage (even if deleted, the user can easily hinted to run composer update) and the code to handle this is much smaller, which also makes him less error prone plus offers more flexibility to the behavior dev.
(A side note: we use the composer.lock to automatically manage the build path in the eclipse composer plugin and has been proven as a reliable resource).
### Further Considerations

I just had a quick shot at the propel source code, as such I do not know much of its characteristics and for a quick'n'dirty hack a singleton instance for the ComposerFinder sounds ok to me. If propel has a concept for such things, even better. Also I assumed the `extra.propel` path in the composer.json (can also be `extra`). So rethink this location (API) here. I have not implemented any error messages yet (this also includes what happens when no composer.lock is found, maybe requires another cli option to specify the location).

gossi
