### PR TITLE
Fixes #502 - Added COL_ prefix to constant names

### DIFF
--- a/src/Propel/Generator/Behavior/Sortable/SortableBehaviorObjectBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/Sortable/SortableBehaviorObjectBuilderModifier.php
@@ -10,6 +10,8 @@
 
 namespace Propel\Generator\Behavior\Sortable;
 
+use Propel\Generator\Model\Column;
+
 /**
  * Behavior to add sortable columns and abilities
  *
@@ -134,7 +136,7 @@ class SortableBehaviorObjectBuilderModifier
             $condition = array();
 
             foreach ($this->behavior->getScopes() as $scope) {
-                $condition[] = "\$this->isColumnModified({$this->tableMapClassName}::".strtoupper($scope).")";
+                $condition[] = "\$this->isColumnModified({$this->tableMapClassName}::".Column::CONSTANT_PREFIX.strtoupper($scope).")";
             }
 
             $condition = implode(' OR ', $condition);

--- a/src/Propel/Generator/Behavior/Sortable/SortableBehaviorQueryBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/Sortable/SortableBehaviorQueryBuilderModifier.php
@@ -10,6 +10,8 @@
 
 namespace Propel\Generator\Behavior\Sortable;
 
+use Propel\Generator\Model\Column;
+
 /**
  * Behavior to add sortable query methods
  *
@@ -113,12 +115,12 @@ static public function sortableApplyScopeCriteria(Criteria \$criteria, \$scope, 
         if ($this->behavior->hasMultipleScopes()) {
             foreach ($this->behavior->getScopes() as $idx => $scope) {
                 $script .= "
-    \$criteria->\$method({$this->tableMapClassName}::".strtoupper($scope).", \$scope[$idx], Criteria::EQUAL);
+    \$criteria->\$method({$this->tableMapClassName}::".Column::CONSTANT_PREFIX.strtoupper($scope).", \$scope[$idx], Criteria::EQUAL);
 ";
             }
         } else {
             $script .= "
-    \$criteria->\$method({$this->tableMapClassName}::".strtoupper(current($this->behavior->getScopes())).", \$scope, Criteria::EQUAL);
+    \$criteria->\$method({$this->tableMapClassName}::".Column::CONSTANT_PREFIX.strtoupper(current($this->behavior->getScopes())).", \$scope, Criteria::EQUAL);
 ";
         }
 

--- a/src/Propel/Generator/Behavior/Versionable/VersionableBehaviorObjectBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/Versionable/VersionableBehaviorObjectBuilderModifier.php
@@ -10,6 +10,8 @@
 
 namespace Propel\Generator\Behavior\Versionable;
 
+use Propel\Generator\Model\Column;
+
 /**
  * Behavior to add versionable columns and abilities
  *
@@ -673,6 +675,7 @@ public function compareVersions(\$fromVersionNumber, \$toVersionNumber, \$keys =
         $fks = $versionTable->getForeignKeysReferencingTable($this->table->getName());
         $relCol = $this->builder->getRefFKPhpNameAffix($fks[0], $plural);
         $versionGetter = 'get'.$relCol;
+        $colPrefix = Column::CONSTANT_PREFIX;
 
         $script .= <<<EOF
 /**
@@ -684,7 +687,7 @@ public function compareVersions(\$fromVersionNumber, \$toVersionNumber, \$keys =
 public function getLastVersions(\$number = 10, \$criteria = null, \$con = null)
 {
     \$criteria = {$this->getVersionQueryClassName()}::create(null, \$criteria);
-    \$criteria->addDescendingOrderByColumn({$versionTableMapClassName}::VERSION);
+    \$criteria->addDescendingOrderByColumn({$versionTableMapClassName}::{$colPrefix}VERSION);
     \$criteria->limit(\$number);
 
     return \$this->{$versionGetter}(\$criteria, \$con);

--- a/src/Propel/Generator/Builder/Om/AbstractOMBuilder.php
+++ b/src/Propel/Generator/Builder/Om/AbstractOMBuilder.php
@@ -517,7 +517,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
         }
 
         if (null === $classname) {
-            return $this->getBuildProperty('classPrefix') . $col->getConstantName();
+            return $this->getBuildProperty('classPrefix') . $col->getFQConstantName();
         }
 
         // was it overridden in schema.xml ?
@@ -527,7 +527,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
             $const = strtoupper($col->getName());
         }
 
-        return $classname.'::'.$const;
+        return $classname.'::'.Column::CONSTANT_PREFIX.$const;
     }
 
     /**

--- a/src/Propel/Generator/Builder/Om/QueryInheritanceBuilder.php
+++ b/src/Propel/Generator/Builder/Om/QueryInheritanceBuilder.php
@@ -260,7 +260,7 @@ class "  .$this->getUnqualifiedClassName() . " extends " . $baseClassName . "
         $child = $this->getChild();
         $col = $child->getColumn();
 
-        return "\$this->addUsingAlias(" . $col->getConstantName() . ", " . $this->getTableMapClassName()."::CLASSKEY_".strtoupper($child->getKey()).");";
+        return "\$this->addUsingAlias(" . $col->getFQConstantName() . ", " . $this->getTableMapClassName()."::CLASSKEY_".strtoupper($child->getKey()).");";
     }
 
     protected function addDoDeleteAll(&$script)

--- a/src/Propel/Generator/Builder/Om/TableMapBuilder.php
+++ b/src/Propel/Generator/Builder/Om/TableMapBuilder.php
@@ -206,7 +206,7 @@ class ".$this->getUnqualifiedClassName()." extends TableMap
     /**
      * the column name for the " . strtoupper($col->getName()) ." field
      */
-    const ".$col->getConstantColumnName() ." = '" . $this->getTable()->getName() . ".".strtoupper($col->getName())."';
+    const ".$col->getConstantName() ." = '" . $this->getTable()->getName() . ".".strtoupper($col->getName())."';
 ";
         } // foreach
     }
@@ -223,7 +223,7 @@ class ".$this->getUnqualifiedClassName()." extends TableMap
     /** The enumerated values for the " . strtoupper($col->getName()) . " field */";
                 foreach ($col->getValueSet() as $value) {
                     $script .= "
-    const " . $col->getConstantColumnName() . '_' . $this->getEnumValueConstant($value) . " = '" . $value . "';";
+    const " . $col->getConstantName() . '_' . $this->getEnumValueConstant($value) . " = '" . $value . "';";
                 }
                 $script .= "
 ";
@@ -243,10 +243,10 @@ class ".$this->getUnqualifiedClassName()." extends TableMap
         foreach ($this->getTable()->getColumns() as $col) {
             if ($col->isEnumType()) {
                 $script .= "
-                {$col->getConstantName()} => array(
+                {$col->getFQConstantName()} => array(
                 ";
                 foreach ($col->getValueSet() as $value) {
-                    $script .= "            self::" . $col->getConstantColumnName() . '_' . $this->getEnumValueConstant($value) . ",
+                    $script .= "            self::" . $col->getConstantName() . '_' . $this->getEnumValueConstant($value) . ",
 ";
                 }
                 $script .= "        ),";
@@ -373,14 +373,14 @@ class ".$this->getUnqualifiedClassName()." extends TableMap
             $fieldNamesPhpName       .= "'" . $col->getPhpName() . "', ";
             $fieldNamesStudlyPhpName .= "'" . $col->getStudlyPhpName() . "', ";
             $fieldNamesColname       .= $this->getColumnConstant($col, $this->getTableMapClass()) . ", ";
-            $fieldNamesRawColname    .= "'" . $col->getConstantColumnName() . "', ";
+            $fieldNamesRawColname    .= "'" . $col->getConstantName() . "', ";
             $fieldNamesFieldName     .= "'" . $col->getName() . "', ";
             $fieldNamesNum           .= "$num, ";
 
             $fieldKeysPhpName        .= "'" . $col->getPhpName() . "' => $num, ";
             $fieldKeysStudlyPhpName  .= "'" . $col->getStudlyPhpName() . "' => $num, ";
             $fieldKeysColname        .= $this->getColumnConstant($col, $this->getTableMapClass())." => $num, ";
-            $fieldKeysRawColname     .= "'" . $col->getConstantColumnName() . "' => $num, ";
+            $fieldKeysRawColname     .= "'" . $col->getConstantName() . "' => $num, ";
             $fieldKeysFieldName      .= "'" . $col->getName() . "' => $num, ";
             $fieldKeysNum            .= "$num, ";
         }
@@ -1147,7 +1147,7 @@ class ".$this->getUnqualifiedClassName()." extends TableMap
         foreach ($this->getTable()->getColumns() as $col) {
             if (!$col->isLazyLoad()) {
                 $script .= "
-            \$criteria->addSelectColumn({$col->getConstantName()});";
+            \$criteria->addSelectColumn({$col->getFQConstantName()});";
             } // if !col->isLazyLoad
         } // foreach
         $script .= "
@@ -1155,7 +1155,7 @@ class ".$this->getUnqualifiedClassName()." extends TableMap
         foreach ($this->getTable()->getColumns() as $col) {
             if (!$col->isLazyLoad()) {
                 $script .= "
-            \$criteria->addSelectColumn(\$alias . '." . $col->getConstantColumnName()."');";
+            \$criteria->addSelectColumn(\$alias . '." . $col->getUppercasedName()."');";
             } // if !col->isLazyLoad
         } // foreach
         $script .= "

--- a/src/Propel/Generator/Builder/Om/templates/tableMapConstants.php
+++ b/src/Propel/Generator/Builder/Om/templates/tableMapConstants.php
@@ -42,7 +42,7 @@
     /**
      * the column name for the <?php echo strtoupper($col->getName()) ?> field
      */
-    const <?php echo $col->getConstantColumnName() ?> = '<?php echo $tableName ?>.<?php echo strtoupper($col->getName()) ?>';
+    const <?php echo $col->getConstantName() ?> = '<?php echo $tableName ?>.<?php echo strtoupper($col->getName()) ?>';
 <?php endforeach; ?>
 
     /**

--- a/src/Propel/Generator/Model/Column.php
+++ b/src/Propel/Generator/Model/Column.php
@@ -29,6 +29,7 @@ class Column extends MappingModel
 {
     const DEFAULT_TYPE       = 'VARCHAR';
     const DEFAULT_VISIBILITY = 'public';
+    const CONSTANT_PREFIX    = 'COL_';
 
     public static $validVisibilities = [ 'public', 'protected', 'private' ];
 
@@ -335,6 +336,16 @@ class Column extends MappingModel
     {
         return strtolower($this->name);
     }
+    
+    /**
+     * Returns the uppercased column name.
+     *
+     * @return string
+     */
+    public function getUppercasedName()
+    {
+    	return strtoupper($this->name);
+    }
 
     /**
      * Sets the column name.
@@ -489,14 +500,14 @@ class Column extends MappingModel
     }
 
     /**
-     * Returns the full column constant name (e.g. TableMapName::COLUMN_NAME).
+     * Returns the full column constant name (e.g. TableMapName::COL_COLUMN_NAME).
      *
      * @return string A column constant name for insertion into PHP code
      */
-    public function getConstantName()
+    public function getFQConstantName()
     {
         $classname = $this->parentTable->getPhpName() . 'TableMap';
-        $const = $this->getConstantColumnName();
+        $const = $this->getConstantName();
 
         return $classname.'::'.$const;
     }
@@ -506,14 +517,14 @@ class Column extends MappingModel
      *
      * @return string
      */
-    public function getConstantColumnName()
+    public function getConstantName()
     {
         // was it overridden in schema.xml ?
         if ($this->getTableMapName()) {
-            return strtoupper($this->getTableMapName());
+            return self::CONSTANT_PREFIX.strtoupper($this->getTableMapName());
         }
 
-        return strtoupper($this->getName());
+        return self::CONSTANT_PREFIX.strtoupper($this->getName());
     }
 
     /**

--- a/tests/Propel/Tests/BookstoreTest.php
+++ b/tests/Propel/Tests/BookstoreTest.php
@@ -299,17 +299,17 @@ class BookstoreTest extends BookstoreEmptyTestBase
         // re-fetch books and lists from db to be sure that nothing is cached
 
         $crit = new Criteria();
-        $crit->add(BookTableMap::ID, $phoenix->getId());
+        $crit->add(BookTableMap::COL_ID, $phoenix->getId());
         $phoenix = BookQuery::create(null, $crit)->findOne();
         $this->assertNotNull($phoenix, "book 'phoenix' has been re-fetched from db");
 
         $crit = new Criteria();
-        $crit->add(BookClubListTableMap::ID, $blc1->getId());
+        $crit->add(BookClubListTableMap::COL_ID, $blc1->getId());
         $blc1 = BookClubListQuery::create(null, $crit)->findOne();
         $this->assertNotNull($blc1, 'BookClubList 1 has been re-fetched from db');
 
         $crit = new Criteria();
-        $crit->add(BookClubListTableMap::ID, $blc2->getId());
+        $crit->add(BookClubListTableMap::COL_ID, $blc2->getId());
         $blc2 = BookClubListQuery::create(null, $crit)->findOne();
         $this->assertNotNull($blc2, 'BookClubList 2 has been re-fetched from db');
 
@@ -332,12 +332,12 @@ class BookstoreTest extends BookstoreEmptyTestBase
 
         // Attempting to delete [multi-table] by found pk
         $c = new Criteria();
-        $c->add(BookTableMap::ID, $hp->getId());
+        $c->add(BookTableMap::COL_ID, $hp->getId());
         // The only way for cascading to work currently
         // is to specify the author_id and publisher_id (i.e. the fkeys
         // have to be in the criteria).
-        $c->add(AuthorTableMap::ID, $hp->getAuthor()->getId());
-        $c->add(PublisherTableMap::ID, $hp->getPublisher()->getId());
+        $c->add(AuthorTableMap::COL_ID, $hp->getAuthor()->getId());
+        $c->add(PublisherTableMap::COL_ID, $hp->getPublisher()->getId());
         $c->setSingleRecord(true);
         BookTableMap::doDelete($c);
 
@@ -348,9 +348,9 @@ class BookstoreTest extends BookstoreEmptyTestBase
 
         // Attempting to delete books by complex criteria
         $c = new Criteria();
-        $cn = $c->getNewCriterion(BookTableMap::ISBN, "043935806X");
-        $cn->addOr($c->getNewCriterion(BookTableMap::ISBN, "0380977427"));
-        $cn->addOr($c->getNewCriterion(BookTableMap::ISBN, "0140422161"));
+        $cn = $c->getNewCriterion(BookTableMap::COL_ISBN, "043935806X");
+        $cn->addOr($c->getNewCriterion(BookTableMap::COL_ISBN, "0380977427"));
+        $cn->addOr($c->getNewCriterion(BookTableMap::COL_ISBN, "0140422161"));
         $c->add($cn);
         BookTableMap::doDelete($c);
 
@@ -645,17 +645,17 @@ class BookstoreTest extends BookstoreEmptyTestBase
         // re-fetch books and lists from db to be sure that nothing is cached
 
         $crit = new Criteria();
-        $crit->add(BookTableMap::ID, $phoenix->getId());
+        $crit->add(BookTableMap::COL_ID, $phoenix->getId());
         $phoenix = BookQuery::create(null, $crit)->findOne();
         $this->assertNotNull($phoenix, "book 'phoenix' has been re-fetched from db");
 
         $crit = new Criteria();
-        $crit->add(BookClubListTableMap::ID, $blc1->getId());
+        $crit->add(BookClubListTableMap::COL_ID, $blc1->getId());
         $blc1 = BookClubListQuery::create(null, $crit)->findOne();
         $this->assertNotNull($blc1, 'BookClubList 1 has been re-fetched from db');
 
         $crit = new Criteria();
-        $crit->add(BookClubListTableMap::ID, $blc2->getId());
+        $crit->add(BookClubListTableMap::COL_ID, $blc2->getId());
         $blc2 = BookClubListQuery::create(null, $crit)->findOne();
         $this->assertNotNull($blc2, 'BookClubList 2 has been re-fetched from db');
 
@@ -678,12 +678,12 @@ class BookstoreTest extends BookstoreEmptyTestBase
 
         // Attempting to delete [multi-table] by found pk
         $c = new Criteria();
-        $c->add(BookTableMap::ID, $hp->getId());
+        $c->add(BookTableMap::COL_ID, $hp->getId());
         // The only way for cascading to work currently
         // is to specify the author_id and publisher_id (i.e. the fkeys
         // have to be in the criteria).
-        $c->add(AuthorTableMap::ID, $hp->getAuthor()->getId());
-        $c->add(PublisherTableMap::ID, $hp->getPublisher()->getId());
+        $c->add(AuthorTableMap::COL_ID, $hp->getAuthor()->getId());
+        $c->add(PublisherTableMap::COL_ID, $hp->getPublisher()->getId());
         $c->setSingleRecord(true);
         BookTableMap::doDelete($c);
 

--- a/tests/Propel/Tests/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceBehaviorTest.php
@@ -107,7 +107,7 @@ EOF;
         $content = new ConcreteContent();
         $content->save();
         $c = new Criteria;
-        $c->add(ConcreteArticleTableMap::ID, $content->getId());
+        $c->add(ConcreteArticleTableMap::COL_ID, $content->getId());
         try {
             ConcreteArticleTableMap::doInsert($c);
             $this->assertTrue(true, 'modifyTable() removed autoIncrement from copied Primary keys');
@@ -122,7 +122,7 @@ EOF;
         $content = new ConcreteContent();
         $content->save();
         $c = new Criteria;
-        $c->add(ConcreteQuizzTableMap::ID, $content->getId());
+        $c->add(ConcreteQuizzTableMap::COL_ID, $content->getId());
         ConcreteQuizzTableMap::doInsert($c);
     }
 

--- a/tests/Propel/Tests/Generator/Behavior/NestedSet/NestedSetBehaviorObjectBuilderModifierTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/NestedSet/NestedSetBehaviorObjectBuilderModifierTest.php
@@ -440,7 +440,7 @@ class NestedSetBehaviorObjectBuilderModifierTest extends TestCase
         );
         $this->assertEquals($expected, $this->dumpNodes($children, true), 'getChildren() returns a collection of children');
         $c = new Criteria();
-        $c->add(\Map\NestedSetTable9TableMap::TITLE, 't5');
+        $c->add(\Map\NestedSetTable9TableMap::COL_TITLE, 't5');
         $children = $t3->getChildren($c);
         $expected = array(
             't5' => array(7, 12, 2),
@@ -463,7 +463,7 @@ class NestedSetBehaviorObjectBuilderModifierTest extends TestCase
         $this->assertEquals($expected, $this->dumpNodes($children, true), 'getChildren() returns a collection of children');
         // when using criteria, cache is not used
         $c = new Criteria();
-        $c->add(\Map\NestedSetTable9TableMap::TITLE, 't5');
+        $c->add(\Map\NestedSetTable9TableMap::COL_TITLE, 't5');
         $children = $t3->getChildren($c, $con);
         $this->assertEquals($count + 2, $con->getQueryCount(), 'getChildren() issues a new query when âssed a non-null Criteria');
         $expected = array(
@@ -495,7 +495,7 @@ class NestedSetBehaviorObjectBuilderModifierTest extends TestCase
         $this->assertEquals(0, $t2->countChildren(), 'countChildren() returns 0 for leafs');
         $this->assertEquals(2, $t3->countChildren(), 'countChildren() returns the number of children');
         $c = new Criteria();
-        $c->add(\Map\NestedSetTable9TableMap::TITLE, 't5');
+        $c->add(\Map\NestedSetTable9TableMap::COL_TITLE, 't5');
         $this->assertEquals(1, $t3->countChildren($c), 'countChildren() accepts a criteria as parameter');
     }
 
@@ -615,7 +615,7 @@ class NestedSetBehaviorObjectBuilderModifierTest extends TestCase
         );
         $this->assertEquals($expected, $this->dumpNodes($descendants), 'getDescendants() returns an array of descendants');
         $c = new Criteria();
-        $c->add(\Map\NestedSetTable9TableMap::TITLE, 't5');
+        $c->add(\Map\NestedSetTable9TableMap::COL_TITLE, 't5');
         $descendants = $t3->getDescendants($c);
         $expected = array(
             't5' => array(7, 12, 2),
@@ -638,7 +638,7 @@ class NestedSetBehaviorObjectBuilderModifierTest extends TestCase
         $this->assertEquals(0, $t2->countDescendants(), 'countDescendants() returns 0 for leafs');
         $this->assertEquals(4, $t3->countDescendants(), 'countDescendants() returns the number of descendants');
         $c = new Criteria();
-        $c->add(\Map\NestedSetTable9TableMap::TITLE, 't5');
+        $c->add(\Map\NestedSetTable9TableMap::COL_TITLE, 't5');
         $this->assertEquals(1, $t3->countDescendants($c), 'countDescendants() accepts a criteria as parameter');
     }
 
@@ -665,7 +665,7 @@ class NestedSetBehaviorObjectBuilderModifierTest extends TestCase
         );
         $this->assertEquals($expected, $this->dumpNodes($descendants), 'getBranch() returns an array of descendants, including the current node');
         $c = new Criteria();
-        $c->add(\Map\NestedSetTable9TableMap::TITLE, 't3', Criteria::NOT_EQUAL);
+        $c->add(\Map\NestedSetTable9TableMap::COL_TITLE, 't3', Criteria::NOT_EQUAL);
         $descendants = $t3->getBranch($c);
         unset($expected['t3']);
         $this->assertEquals($expected, $this->dumpNodes($descendants), 'getBranch() accepts a criteria as first parameter');
@@ -691,7 +691,7 @@ class NestedSetBehaviorObjectBuilderModifierTest extends TestCase
         );
         $this->assertEquals($expected, $this->dumpNodes($ancestors), 'getAncestors() returns an array of ancestors');
         $c = new Criteria();
-        $c->add(\Map\NestedSetTable9TableMap::TITLE, 't3');
+        $c->add(\Map\NestedSetTable9TableMap::COL_TITLE, 't3');
         $ancestors = $t5->getAncestors($c);
         $expected = array(
             't3' => array(4, 13, 1),

--- a/tests/Propel/Tests/Generator/Behavior/NestedSet/NestedSetBehaviorQueryBuilderModifierWithScopeTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/NestedSet/NestedSetBehaviorQueryBuilderModifierWithScopeTest.php
@@ -329,7 +329,7 @@ class NestedSetBehaviorQueryBuilderModifierWithScopeTest extends TestCase
          */
         $this->assertEquals(array($t1, $t8), \NestedSetTable10Query::retrieveRoots()->getArrayCopy(), 'retrieveRoots() returns the tree roots');
         $c = new Criteria();
-        $c->add(\Map\NestedSetTable10TableMap::TITLE, 't1');
+        $c->add(\Map\NestedSetTable10TableMap::COL_TITLE, 't1');
         $this->assertEquals(array($t1), \NestedSetTable10Query::retrieveRoots($c)->getArrayCopy(), 'retrieveRoots() accepts a Criteria as first parameter');
     }
 

--- a/tests/Propel/Tests/Generator/Behavior/Sortable/SortableBehaviorQueryBuilderModifierTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Sortable/SortableBehaviorQueryBuilderModifierTest.php
@@ -44,15 +44,15 @@ class SortableBehaviorQueryBuilderModifierTest extends TestCase
         $this->assertTrue(SortableTable11Query::create()->orderByRank() instanceof SortableTable11Query, 'orderByRank() returns the current query object');
         // default order
         $query = SortableTable11Query::create()->orderByRank();
-        $expectedQuery = SortableTable11Query::create()->addAscendingOrderByColumn(SortableTable11TableMap::SORTABLE_RANK);
+        $expectedQuery = SortableTable11Query::create()->addAscendingOrderByColumn(SortableTable11TableMap::COL_SORTABLE_RANK);
         $this->assertEquals($expectedQuery, $query, 'orderByRank() orders the query by rank asc');
         // asc order
         $query = SortableTable11Query::create()->orderByRank(Criteria::ASC);
-        $expectedQuery = SortableTable11Query::create()->addAscendingOrderByColumn(SortableTable11TableMap::SORTABLE_RANK);
+        $expectedQuery = SortableTable11Query::create()->addAscendingOrderByColumn(SortableTable11TableMap::COL_SORTABLE_RANK);
         $this->assertEquals($expectedQuery, $query, 'orderByRank() orders the query by rank, using the argument as sort direction');
         // desc order
         $query = SortableTable11Query::create()->orderByRank(Criteria::DESC);
-        $expectedQuery = SortableTable11Query::create()->addDescendingOrderByColumn(SortableTable11TableMap::SORTABLE_RANK);
+        $expectedQuery = SortableTable11Query::create()->addDescendingOrderByColumn(SortableTable11TableMap::COL_SORTABLE_RANK);
         $this->assertEquals($expectedQuery, $query, 'orderByRank() orders the query by rank, using the argument as sort direction');
     }
 

--- a/tests/Propel/Tests/Generator/Behavior/Sortable/SortableBehaviorQueryBuilderModifierWithScopeTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Sortable/SortableBehaviorQueryBuilderModifierWithScopeTest.php
@@ -41,11 +41,11 @@ class SortableBehaviorQueryBuilderModifierWithScopeTest extends TestCase
          row4
         */
         $query = SortableTable12Query::create()->inList(1);
-        $expectedQuery = SortableTable12Query::create()->add(SortableTable12TableMap::MY_SCOPE_COLUMN, 1, Criteria::EQUAL);
+        $expectedQuery = SortableTable12Query::create()->add(SortableTable12TableMap::COL_MY_SCOPE_COLUMN, 1, Criteria::EQUAL);
         $this->assertEquals($expectedQuery, $query, 'inList() filters the query by scope');
         $this->assertEquals(4, $query->count(), 'inList() filters the query by scope');
         $query = SortableTable12Query::create()->inList(2);
-        $expectedQuery = SortableTable12Query::create()->add(SortableTable12TableMap::MY_SCOPE_COLUMN, 2, Criteria::EQUAL);
+        $expectedQuery = SortableTable12Query::create()->add(SortableTable12TableMap::COL_MY_SCOPE_COLUMN, 2, Criteria::EQUAL);
         $this->assertEquals($expectedQuery, $query, 'inList() filters the query by scope');
         $this->assertEquals(2, $query->count(), 'inList() filters the query by scope');
     }
@@ -70,15 +70,15 @@ class SortableBehaviorQueryBuilderModifierWithScopeTest extends TestCase
         $this->assertTrue(SortableTable12Query::create()->orderByRank() instanceof SortableTable12Query, 'orderByRank() returns the current query object');
         // default order
         $query = SortableTable12Query::create()->orderByRank();
-        $expectedQuery = SortableTable12Query::create()->addAscendingOrderByColumn(SortableTable12TableMap::POSITION);
+        $expectedQuery = SortableTable12Query::create()->addAscendingOrderByColumn(SortableTable12TableMap::COL_POSITION);
         $this->assertEquals($expectedQuery, $query, 'orderByRank() orders the query by rank asc');
         // asc order
         $query = SortableTable12Query::create()->orderByRank(Criteria::ASC);
-        $expectedQuery = SortableTable12Query::create()->addAscendingOrderByColumn(SortableTable12TableMap::POSITION);
+        $expectedQuery = SortableTable12Query::create()->addAscendingOrderByColumn(SortableTable12TableMap::COL_POSITION);
         $this->assertEquals($expectedQuery, $query, 'orderByRank() orders the query by rank, using the argument as sort direction');
         // desc order
         $query = SortableTable12Query::create()->orderByRank(Criteria::DESC);
-        $expectedQuery = SortableTable12Query::create()->addDescendingOrderByColumn(SortableTable12TableMap::POSITION);
+        $expectedQuery = SortableTable12Query::create()->addDescendingOrderByColumn(SortableTable12TableMap::COL_POSITION);
         $this->assertEquals($expectedQuery, $query, 'orderByRank() orders the query by rank, using the argument as sort direction');
     }
 

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectTest.php
@@ -666,12 +666,12 @@ class GeneratedObjectTest extends BookstoreTestBase
 
         // Now set different criteria and expect different results
         $c = new Criteria();
-        $c->add(ReviewTableMap::RECOMMENDED, false);
+        $c->add(ReviewTableMap::COL_RECOMMENDED, false);
         $this->assertEquals(floor($num/2), $book->countReviews($c), "Expected " . floor($num/2) . " results from countReviews(recomm=false)");
 
         // Change Criteria, run again -- expect different.
         $c = new Criteria();
-        $c->add(ReviewTableMap::RECOMMENDED, true);
+        $c->add(ReviewTableMap::COL_RECOMMENDED, true);
         $this->assertEquals(ceil($num/2), count($book->getReviews($c)), "Expected " . ceil($num/2) . " results from getReviews(recomm=true)");
 
         $this->assertEquals($num, $book->countReviews(), "Expected countReviews to return $num with new empty Criteria");
@@ -745,15 +745,15 @@ class GeneratedObjectTest extends BookstoreTestBase
 
         $arr1 = $b->toArray(TableMap::TYPE_COLNAME);
         $expectedKeys = array(
-            BookTableMap::ID,
-            BookTableMap::TITLE,
-            BookTableMap::ISBN,
-            BookTableMap::PRICE,
-            BookTableMap::PUBLISHER_ID,
-            BookTableMap::AUTHOR_ID
+            BookTableMap::COL_ID,
+            BookTableMap::COL_TITLE,
+            BookTableMap::COL_ISBN,
+            BookTableMap::COL_PRICE,
+            BookTableMap::COL_PUBLISHER_ID,
+            BookTableMap::COL_AUTHOR_ID
         );
         $this->assertEquals($expectedKeys, array_keys($arr1), 'toArray() accepts a $keyType parameter to change the result keys');
-        $this->assertEquals('Don Juan', $arr1[BookTableMap::TITLE], 'toArray() returns an associative array representation of the object');
+        $this->assertEquals('Don Juan', $arr1[BookTableMap::COL_TITLE], 'toArray() returns an associative array representation of the object');
     }
 
     public function testToArrayKeyTypePreDefined()

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectWithFixturesTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectWithFixturesTest.php
@@ -298,16 +298,16 @@ class GeneratedObjectWithFixturesTest extends BookstoreEmptyTestBase
         }
 
         $arr1 = $m->toArray(TableMap::TYPE_COLNAME);
-        $this->assertNotNull($arr1[MediaTableMap::COVER_IMAGE]);
-        $this->assertInternalType('resource', $arr1[MediaTableMap::COVER_IMAGE]);
+        $this->assertNotNull($arr1[MediaTableMap::COL_COVER_IMAGE]);
+        $this->assertInternalType('resource', $arr1[MediaTableMap::COL_COVER_IMAGE]);
 
         $arr2 = $m->toArray(TableMap::TYPE_COLNAME, false);
-        $this->assertNull($arr2[MediaTableMap::COVER_IMAGE]);
-        $this->assertNull($arr2[MediaTableMap::EXCERPT]);
+        $this->assertNull($arr2[MediaTableMap::COL_COVER_IMAGE]);
+        $this->assertNull($arr2[MediaTableMap::COL_EXCERPT]);
 
         $diffKeys = array_keys(array_diff($arr1, $arr2));
 
-        $expectedDiff = array(MediaTableMap::COVER_IMAGE, MediaTableMap::EXCERPT);
+        $expectedDiff = array(MediaTableMap::COL_COVER_IMAGE, MediaTableMap::COL_EXCERPT);
 
         $this->assertEquals($expectedDiff, $diffKeys);
     }
@@ -320,7 +320,7 @@ class GeneratedObjectWithFixturesTest extends BookstoreEmptyTestBase
         PublisherTableMap::clearInstancePool();
 
         $c = new Criteria();
-        $c->add(BookTableMap::TITLE, 'Don Juan');
+        $c->add(BookTableMap::COL_TITLE, 'Don Juan');
         $books = BookQuery::create(null, $c)->joinWith('Author')->find();
         $book = $books[0];
 

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedQueryDoDeleteTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedQueryDoDeleteTest.php
@@ -71,12 +71,12 @@ class GeneratedQueryDoDeleteTest extends BookstoreEmptyTestBase
 
         // print "Attempting to delete [multi-table] by found pk: ";
         $c = new Criteria();
-        $c->add(BookTableMap::ID, $hp->getId());
+        $c->add(BookTableMap::COL_ID, $hp->getId());
         // The only way for multi-delete to work currently
         // is to specify the author_id and publisher_id (i.e. the fkeys
         // have to be in the criteria).
-        $c->add(AuthorTableMap::ID, $hp->getAuthorId());
-        $c->add(PublisherTableMap::ID, $hp->getPublisherId());
+        $c->add(AuthorTableMap::COL_ID, $hp->getAuthorId());
+        $c->add(PublisherTableMap::COL_ID, $hp->getPublisherId());
         $c->setSingleRecord(true);
         BookTableMap::doDelete($c);
 
@@ -93,9 +93,9 @@ class GeneratedQueryDoDeleteTest extends BookstoreEmptyTestBase
     {
         //print "Attempting to delete books by complex criteria: ";
         $c = new Criteria();
-        $cn = $c->getNewCriterion(BookTableMap::ISBN, "043935806X");
-        $cn->addOr($c->getNewCriterion(BookTableMap::ISBN, "0380977427"));
-        $cn->addOr($c->getNewCriterion(BookTableMap::ISBN, "0140422161"));
+        $cn = $c->getNewCriterion(BookTableMap::COL_ISBN, "043935806X");
+        $cn->addOr($c->getNewCriterion(BookTableMap::COL_ISBN, "0380977427"));
+        $cn->addOr($c->getNewCriterion(BookTableMap::COL_ISBN, "0140422161"));
         $c->add($cn);
         BookTableMap::doDelete($c);
 
@@ -317,7 +317,7 @@ class GeneratedQueryDoDeleteTest extends BookstoreEmptyTestBase
     public function testDoDeleteAll_SetNull()
     {
         $c = new Criteria();
-        $c->add(BookTableMap::AUTHOR_ID, null, Criteria::NOT_EQUAL);
+        $c->add(BookTableMap::COL_AUTHOR_ID, null, Criteria::NOT_EQUAL);
 
         // 1) make sure there are some books with valid authors
         $this->assertGreaterThan(0, count(BookQuery::create()->filterByAuthorId(null, Criteria::NOT_EQUAL)->find()) > 0, "Expect some book.author_id columns that are not NULL.");
@@ -398,7 +398,7 @@ class GeneratedQueryDoDeleteTest extends BookstoreEmptyTestBase
         $name = "A Sample Publisher - " . time();
 
         $values = new Criteria();
-        $values->add(PublisherTableMap::NAME, $name);
+        $values->add(PublisherTableMap::COL_NAME, $name);
         PublisherTableMap::doInsert($values);
 
         $matches = PublisherQuery::create()->filterByName($name)->find();

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedTableMapEnumColumnTypeTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedTableMapEnumColumnTypeTest.php
@@ -40,13 +40,13 @@ EOF;
     public function valueSetConstantProvider()
     {
         return array(
-            array('\Map\ComplexColumnTypeEntity103TableMap::BAR_FOO', 'foo'),
-            array('\Map\ComplexColumnTypeEntity103TableMap::BAR_BAR', 'bar'),
-            array('\Map\ComplexColumnTypeEntity103TableMap::BAR_BAZ', 'baz'),
-            array('\Map\ComplexColumnTypeEntity103TableMap::BAR_1', '1'),
-            array('\Map\ComplexColumnTypeEntity103TableMap::BAR_4', '4'),
-            array('\Map\ComplexColumnTypeEntity103TableMap::BAR__', '('),
-            array('\Map\ComplexColumnTypeEntity103TableMap::BAR_FOO_BAR', 'foo bar'),
+            array('\Map\ComplexColumnTypeEntity103TableMap::COL_BAR_FOO', 'foo'),
+            array('\Map\ComplexColumnTypeEntity103TableMap::COL_BAR_BAR', 'bar'),
+            array('\Map\ComplexColumnTypeEntity103TableMap::COL_BAR_BAZ', 'baz'),
+            array('\Map\ComplexColumnTypeEntity103TableMap::COL_BAR_1', '1'),
+            array('\Map\ComplexColumnTypeEntity103TableMap::COL_BAR_4', '4'),
+            array('\Map\ComplexColumnTypeEntity103TableMap::COL_BAR__', '('),
+            array('\Map\ComplexColumnTypeEntity103TableMap::COL_BAR_FOO_BAR', 'foo bar'),
         );
     }
 
@@ -61,13 +61,13 @@ EOF;
 
     public function testGetValueSets()
     {
-        $expected = array(\Map\ComplexColumnTypeEntity103TableMap::BAR => array('foo', 'bar', 'baz', '1', '4', '(', 'foo bar'));
+        $expected = array(\Map\ComplexColumnTypeEntity103TableMap::COL_BAR => array('foo', 'bar', 'baz', '1', '4', '(', 'foo bar'));
         $this->assertEquals($expected, \Map\ComplexColumnTypeEntity103TableMap::getValueSets());
     }
 
     public function testGetValueSet()
     {
         $expected = array('foo', 'bar', 'baz', '1', '4', '(', 'foo bar');
-        $this->assertEquals($expected, \Map\ComplexColumnTypeEntity103TableMap::getValueSet(\Map\ComplexColumnTypeEntity103TableMap::BAR));
+        $this->assertEquals($expected, \Map\ComplexColumnTypeEntity103TableMap::getValueSet(\Map\ComplexColumnTypeEntity103TableMap::COL_BAR));
     }
 }

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedTableMapTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedTableMapTest.php
@@ -38,10 +38,10 @@ class GeneratedTableMapTest extends BookstoreTestBase
 {
     public function testAlias()
     {
-        $this->assertEquals('foo.ID', BookTableMap::alias('foo', BookTableMap::ID), 'alias() returns a column name using the table alias');
-        $this->assertEquals('book.ID', BookTableMap::alias('book', BookTableMap::ID), 'alias() returns a column name using the table alias');
-        $this->assertEquals('foo.COVER_IMAGE', MediaTableMap::alias('foo', MediaTableMap::COVER_IMAGE), 'alias() also works for lazy-loaded columns');
-        $this->assertEquals('foo.SUBTITLE', EssayTableMap::alias('foo', EssayTableMap::SUBTITLE), 'alias() also works for columns with custom phpName');
+        $this->assertEquals('foo.ID', BookTableMap::alias('foo', BookTableMap::COL_ID), 'alias() returns a column name using the table alias');
+        $this->assertEquals('book.ID', BookTableMap::alias('book', BookTableMap::COL_ID), 'alias() returns a column name using the table alias');
+        $this->assertEquals('foo.COVER_IMAGE', MediaTableMap::alias('foo', MediaTableMap::COL_COVER_IMAGE), 'alias() also works for lazy-loaded columns');
+        $this->assertEquals('foo.SUBTITLE', EssayTableMap::alias('foo', EssayTableMap::COL_SUBTITLE), 'alias() also works for columns with custom phpName');
     }
 
     public function testAddSelectColumns()
@@ -49,12 +49,12 @@ class GeneratedTableMapTest extends BookstoreTestBase
         $c = new Criteria();
         BookTableMap::addSelectColumns($c);
         $expected = array(
-            BookTableMap::ID,
-            BookTableMap::TITLE,
-            BookTableMap::ISBN,
-            BookTableMap::PRICE,
-            BookTableMap::PUBLISHER_ID,
-            BookTableMap::AUTHOR_ID
+            BookTableMap::COL_ID,
+            BookTableMap::COL_TITLE,
+            BookTableMap::COL_ISBN,
+            BookTableMap::COL_PRICE,
+            BookTableMap::COL_PUBLISHER_ID,
+            BookTableMap::COL_AUTHOR_ID
         );
         $this->assertEquals($expected, $c->getSelectColumns(), 'addSelectColumns() adds the columns of the model to the criteria');
     }
@@ -64,8 +64,8 @@ class GeneratedTableMapTest extends BookstoreTestBase
         $c = new Criteria();
         MediaTableMap::addSelectColumns($c);
         $expected = array(
-            MediaTableMap::ID,
-            MediaTableMap::BOOK_ID
+            MediaTableMap::COL_ID,
+            MediaTableMap::COL_BOOK_ID
         );
         $this->assertEquals($expected, $c->getSelectColumns(), 'addSelectColumns() does not add lazy loaded columns');
     }

--- a/tests/Propel/Tests/Generator/Builder/Om/PoisonedCacheBugTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/PoisonedCacheBugTest.php
@@ -75,7 +75,7 @@ class PoisonedCacheBugTest extends BookstoreTestBase
     public function testPoisonedCacheWhenDoSelectJoinAuthor()
     {
         $c = new Criteria();
-        $c->add(BookTableMap::ID, $this->books[0]->getId());
+        $c->add(BookTableMap::COL_ID, $this->books[0]->getId());
 
         $books = BookQuery::create(null, $c)->joinWithAuthor()->find();
 
@@ -125,7 +125,7 @@ class PoisonedCacheBugTest extends BookstoreTestBase
     public function testModifiedObjectsRemainInTheCollection()
     {
         $c = new Criteria();
-        $c->add(BookTableMap::ID, $this->books[0]->getId());
+        $c->add(BookTableMap::COL_ID, $this->books[0]->getId());
 
         $books = BookQuery::create(null, $c)->joinWithAuthor()->find();
         $books[0]->setTitle('Modified');

--- a/tests/Propel/Tests/Generator/Builder/Om/QueryBuilderTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/QueryBuilderTest.php
@@ -342,7 +342,7 @@ class QueryBuilderTest extends BookstoreTestBase
     public function testFilterByPrimaryKeySimpleKey()
     {
         $q = BookQuery::create()->filterByPrimaryKey(12);
-        $q1 = BookQuery::create()->add(BookTableMap::ID, 12, Criteria::EQUAL);
+        $q1 = BookQuery::create()->add(BookTableMap::COL_ID, 12, Criteria::EQUAL);
         $this->assertEquals($q1, $q, 'filterByPrimaryKey() translates to a Criteria::EQUAL in the PK column');
 
         $q = BookQuery::create()->setModelAlias('b', true)->filterByPrimaryKey(12);
@@ -373,15 +373,15 @@ class QueryBuilderTest extends BookstoreTestBase
         $q->filterByPrimaryKey($pk);
 
         $q1 = BookListRelQuery::create()
-            ->add(BookListRelTableMap::BOOK_ID, $pk[0], Criteria::EQUAL)
-            ->add(BookListRelTableMap::BOOK_CLUB_LIST_ID, $pk[1], Criteria::EQUAL);
+            ->add(BookListRelTableMap::COL_BOOK_ID, $pk[0], Criteria::EQUAL)
+            ->add(BookListRelTableMap::COL_BOOK_CLUB_LIST_ID, $pk[1], Criteria::EQUAL);
         $this->assertEquals($q1, $q, 'filterByPrimaryKey() translates to a Criteria::EQUAL in the PK columns');
     }
 
     public function testFilterByPrimaryKeysSimpleKey()
     {
         $q = BookQuery::create()->filterByPrimaryKeys(array(10, 11, 12));
-        $q1 = BookQuery::create()->add(BookTableMap::ID, array(10, 11, 12), Criteria::IN);
+        $q1 = BookQuery::create()->add(BookTableMap::COL_ID, array(10, 11, 12), Criteria::IN);
         $this->assertEquals($q1, $q, 'filterByPrimaryKeys() translates to a Criteria::IN on the PK column');
 
         $q = BookQuery::create()->setModelAlias('b', true)->filterByPrimaryKeys(array(10, 11, 12));
@@ -416,8 +416,8 @@ class QueryBuilderTest extends BookstoreTestBase
 
         $q1 = BookListRelQuery::create();
         foreach ($search as $key) {
-            $cton0 = $q1->getNewCriterion(BookListRelTableMap::BOOK_ID, $key[0], Criteria::EQUAL);
-            $cton1 = $q1->getNewCriterion(BookListRelTableMap::BOOK_CLUB_LIST_ID, $key[1], Criteria::EQUAL);
+            $cton0 = $q1->getNewCriterion(BookListRelTableMap::COL_BOOK_ID, $key[0], Criteria::EQUAL);
+            $cton1 = $q1->getNewCriterion(BookListRelTableMap::COL_BOOK_CLUB_LIST_ID, $key[1], Criteria::EQUAL);
             $cton0->addAnd($cton1);
             $q1->addOr($cton0);
         }
@@ -435,11 +435,11 @@ class QueryBuilderTest extends BookstoreTestBase
     public function testFilterByIntegerPk()
     {
         $q = BookQuery::create()->filterById(12);
-        $q1 = BookQuery::create()->add(BookTableMap::ID, 12, Criteria::EQUAL);
+        $q1 = BookQuery::create()->add(BookTableMap::COL_ID, 12, Criteria::EQUAL);
         $this->assertEquals($q1, $q, 'filterByPkColumn() translates to a Criteria::EQUAL by default');
 
         $q = BookQuery::create()->filterById(12, Criteria::NOT_EQUAL);
-        $q1 = BookQuery::create()->add(BookTableMap::ID, 12, Criteria::NOT_EQUAL);
+        $q1 = BookQuery::create()->add(BookTableMap::COL_ID, 12, Criteria::NOT_EQUAL);
         $this->assertEquals($q1, $q, 'filterByPkColumn() accepts an optional comparison operator');
 
         $q = BookQuery::create()->setModelAlias('b', true)->filterById(12);
@@ -447,22 +447,22 @@ class QueryBuilderTest extends BookstoreTestBase
         $this->assertEquals($q1, $q, 'filterByPkColumn() uses true table alias if set');
 
         $q = BookQuery::create()->filterById(array(10, 11, 12));
-        $q1 = BookQuery::create()->add(BookTableMap::ID, array(10, 11, 12), Criteria::IN);
+        $q1 = BookQuery::create()->add(BookTableMap::COL_ID, array(10, 11, 12), Criteria::IN);
         $this->assertEquals($q1, $q, 'filterByPkColumn() translates to a Criteria::IN when passed a simple array key');
 
         $q = BookQuery::create()->filterById(array(10, 11, 12), Criteria::NOT_IN);
-        $q1 = BookQuery::create()->add(BookTableMap::ID, array(10, 11, 12), Criteria::NOT_IN);
+        $q1 = BookQuery::create()->add(BookTableMap::COL_ID, array(10, 11, 12), Criteria::NOT_IN);
         $this->assertEquals($q1, $q, 'filterByPkColumn() accepts a comparison when passed a simple array key');
     }
 
     public function testFilterByNumber()
     {
         $q = BookQuery::create()->filterByPrice(12);
-        $q1 = BookQuery::create()->add(BookTableMap::PRICE, 12, Criteria::EQUAL);
+        $q1 = BookQuery::create()->add(BookTableMap::COL_PRICE, 12, Criteria::EQUAL);
         $this->assertEquals($q1, $q, 'filterByNumColumn() translates to a Criteria::EQUAL by default');
 
         $q = BookQuery::create()->filterByPrice(12, Criteria::NOT_EQUAL);
-        $q1 = BookQuery::create()->add(BookTableMap::PRICE, 12, Criteria::NOT_EQUAL);
+        $q1 = BookQuery::create()->add(BookTableMap::COL_PRICE, 12, Criteria::NOT_EQUAL);
         $this->assertEquals($q1, $q, 'filterByNumColumn() accepts an optional comparison operator');
 
         $q = BookQuery::create()->setModelAlias('b', true)->filterByPrice(12);
@@ -470,36 +470,36 @@ class QueryBuilderTest extends BookstoreTestBase
         $this->assertEquals($q1, $q, 'filterByNumColumn() uses true table alias if set');
 
         $q = BookQuery::create()->filterByPrice(array(10, 11, 12));
-        $q1 = BookQuery::create()->add(BookTableMap::PRICE, array(10, 11, 12), Criteria::IN);
+        $q1 = BookQuery::create()->add(BookTableMap::COL_PRICE, array(10, 11, 12), Criteria::IN);
         $this->assertEquals($q1, $q, 'filterByNumColumn() translates to a Criteria::IN when passed a simple array key');
 
         $q = BookQuery::create()->filterByPrice(array(10, 11, 12), Criteria::NOT_IN);
-        $q1 = BookQuery::create()->add(BookTableMap::PRICE, array(10, 11, 12), Criteria::NOT_IN);
+        $q1 = BookQuery::create()->add(BookTableMap::COL_PRICE, array(10, 11, 12), Criteria::NOT_IN);
         $this->assertEquals($q1, $q, 'filterByNumColumn() accepts a comparison when passed a simple array key');
 
         $q = BookQuery::create()->filterByPrice(array('min' => 10));
-        $q1 = BookQuery::create()->add(BookTableMap::PRICE, 10, Criteria::GREATER_EQUAL);
+        $q1 = BookQuery::create()->add(BookTableMap::COL_PRICE, 10, Criteria::GREATER_EQUAL);
         $this->assertEquals($q1, $q, 'filterByNumColumn() translates to a Criteria::GREATER_EQUAL when passed a \'min\' key');
 
         $q = BookQuery::create()->filterByPrice(array('max' => 12));
-        $q1 = BookQuery::create()->add(BookTableMap::PRICE, 12, Criteria::LESS_EQUAL);
+        $q1 = BookQuery::create()->add(BookTableMap::COL_PRICE, 12, Criteria::LESS_EQUAL);
         $this->assertEquals($q1, $q, 'filterByNumColumn() translates to a Criteria::LESS_EQUAL when passed a \'max\' key');
 
         $q = BookQuery::create()->filterByPrice(array('min' => 10, 'max' => 12));
         $q1 = BookQuery::create()
-            ->add(BookTableMap::PRICE, 10, Criteria::GREATER_EQUAL)
-            ->addAnd(BookTableMap::PRICE, 12, Criteria::LESS_EQUAL);
+            ->add(BookTableMap::COL_PRICE, 10, Criteria::GREATER_EQUAL)
+            ->addAnd(BookTableMap::COL_PRICE, 12, Criteria::LESS_EQUAL);
         $this->assertEquals($q1, $q, 'filterByNumColumn() translates to a between when passed both a \'min\' and a \'max\' key');
     }
 
     public function testFilterByTimestamp()
     {
         $q = BookstoreEmployeeAccountQuery::create()->filterByCreated(12);
-        $q1 = BookstoreEmployeeAccountQuery::create()->add(BookstoreEmployeeAccountTableMap::CREATED, 12, Criteria::EQUAL);
+        $q1 = BookstoreEmployeeAccountQuery::create()->add(BookstoreEmployeeAccountTableMap::COL_CREATED, 12, Criteria::EQUAL);
         $this->assertEquals($q1, $q, 'filterByDateColumn() translates to a Criteria::EQUAL by default');
 
         $q = BookstoreEmployeeAccountQuery::create()->filterByCreated(12, Criteria::NOT_EQUAL);
-        $q1 = BookstoreEmployeeAccountQuery::create()->add(BookstoreEmployeeAccountTableMap::CREATED, 12, Criteria::NOT_EQUAL);
+        $q1 = BookstoreEmployeeAccountQuery::create()->add(BookstoreEmployeeAccountTableMap::COL_CREATED, 12, Criteria::NOT_EQUAL);
         $this->assertEquals($q1, $q, 'filterByDateColumn() accepts an optional comparison operator');
 
         $q = BookstoreEmployeeAccountQuery::create()->setModelAlias('b', true)->filterByCreated(12);
@@ -507,28 +507,28 @@ class QueryBuilderTest extends BookstoreTestBase
         $this->assertEquals($q1, $q, 'filterByDateColumn() uses true table alias if set');
 
         $q = BookstoreEmployeeAccountQuery::create()->filterByCreated(array('min' => 10));
-        $q1 = BookstoreEmployeeAccountQuery::create()->add(BookstoreEmployeeAccountTableMap::CREATED, 10, Criteria::GREATER_EQUAL);
+        $q1 = BookstoreEmployeeAccountQuery::create()->add(BookstoreEmployeeAccountTableMap::COL_CREATED, 10, Criteria::GREATER_EQUAL);
         $this->assertEquals($q1, $q, 'filterByDateColumn() translates to a Criteria::GREATER_EQUAL when passed a \'min\' key');
 
         $q = BookstoreEmployeeAccountQuery::create()->filterByCreated(array('max' => 12));
-        $q1 = BookstoreEmployeeAccountQuery::create()->add(BookstoreEmployeeAccountTableMap::CREATED, 12, Criteria::LESS_EQUAL);
+        $q1 = BookstoreEmployeeAccountQuery::create()->add(BookstoreEmployeeAccountTableMap::COL_CREATED, 12, Criteria::LESS_EQUAL);
         $this->assertEquals($q1, $q, 'filterByDateColumn() translates to a Criteria::LESS_EQUAL when passed a \'max\' key');
 
         $q = BookstoreEmployeeAccountQuery::create()->filterByCreated(array('min' => 10, 'max' => 12));
         $q1 = BookstoreEmployeeAccountQuery::create()
-            ->add(BookstoreEmployeeAccountTableMap::CREATED, 10, Criteria::GREATER_EQUAL)
-            ->addAnd(BookstoreEmployeeAccountTableMap::CREATED, 12, Criteria::LESS_EQUAL);
+            ->add(BookstoreEmployeeAccountTableMap::COL_CREATED, 10, Criteria::GREATER_EQUAL)
+            ->addAnd(BookstoreEmployeeAccountTableMap::COL_CREATED, 12, Criteria::LESS_EQUAL);
         $this->assertEquals($q1, $q, 'filterByDateColumn() translates to a between when passed both a \'min\' and a \'max\' key');
     }
 
     public function testFilterByString()
     {
         $q = BookQuery::create()->filterByTitle('foo');
-        $q1 = BookQuery::create()->add(BookTableMap::TITLE, 'foo', Criteria::EQUAL);
+        $q1 = BookQuery::create()->add(BookTableMap::COL_TITLE, 'foo', Criteria::EQUAL);
         $this->assertEquals($q1, $q, 'filterByStringColumn() translates to a Criteria::EQUAL by default');
 
         $q = BookQuery::create()->filterByTitle('foo', Criteria::NOT_EQUAL);
-        $q1 = BookQuery::create()->add(BookTableMap::TITLE, 'foo', Criteria::NOT_EQUAL);
+        $q1 = BookQuery::create()->add(BookTableMap::COL_TITLE, 'foo', Criteria::NOT_EQUAL);
         $this->assertEquals($q1, $q, 'filterByStringColumn() accepts an optional comparison operator');
 
         $q = BookQuery::create()->setModelAlias('b', true)->filterByTitle('foo');
@@ -536,46 +536,46 @@ class QueryBuilderTest extends BookstoreTestBase
         $this->assertEquals($q1, $q, 'filterByStringColumn() uses true table alias if set');
 
         $q = BookQuery::create()->filterByTitle(array('foo', 'bar'));
-        $q1 = BookQuery::create()->add(BookTableMap::TITLE, array('foo', 'bar'), Criteria::IN);
+        $q1 = BookQuery::create()->add(BookTableMap::COL_TITLE, array('foo', 'bar'), Criteria::IN);
         $this->assertEquals($q1, $q, 'filterByStringColumn() translates to a Criteria::IN when passed an array');
 
         $q = BookQuery::create()->filterByTitle(array('foo', 'bar'), Criteria::NOT_IN);
-        $q1 = BookQuery::create()->add(BookTableMap::TITLE, array('foo', 'bar'), Criteria::NOT_IN);
+        $q1 = BookQuery::create()->add(BookTableMap::COL_TITLE, array('foo', 'bar'), Criteria::NOT_IN);
         $this->assertEquals($q1, $q, 'filterByStringColumn() accepts a comparison when passed an array');
 
         $q = BookQuery::create()->filterByTitle('foo%');
-        $q1 = BookQuery::create()->add(BookTableMap::TITLE, 'foo%', Criteria::LIKE);
+        $q1 = BookQuery::create()->add(BookTableMap::COL_TITLE, 'foo%', Criteria::LIKE);
         $this->assertEquals($q1, $q, 'filterByStringColumn() translates to a Criteria::LIKE when passed a string with a % wildcard');
 
         $q = BookQuery::create()->filterByTitle('foo%', Criteria::NOT_LIKE);
-        $q1 = BookQuery::create()->add(BookTableMap::TITLE, 'foo%', Criteria::NOT_LIKE);
+        $q1 = BookQuery::create()->add(BookTableMap::COL_TITLE, 'foo%', Criteria::NOT_LIKE);
         $this->assertEquals($q1, $q, 'filterByStringColumn() accepts a comparison when passed a string with a % wildcard');
 
         $q = BookQuery::create()->filterByTitle('foo%', Criteria::EQUAL);
-        $q1 = BookQuery::create()->add(BookTableMap::TITLE, 'foo%', Criteria::EQUAL);
+        $q1 = BookQuery::create()->add(BookTableMap::COL_TITLE, 'foo%', Criteria::EQUAL);
         $this->assertEquals($q1, $q, 'filterByStringColumn() accepts a comparison when passed a string with a % wildcard');
 
         $q = BookQuery::create()->filterByTitle('*foo');
-        $q1 = BookQuery::create()->add(BookTableMap::TITLE, '%foo', Criteria::LIKE);
+        $q1 = BookQuery::create()->add(BookTableMap::COL_TITLE, '%foo', Criteria::LIKE);
         $this->assertEquals($q1, $q, 'filterByStringColumn() translates to a Criteria::LIKE when passed a string with a * wildcard, and turns * into %');
 
         $q = BookQuery::create()->filterByTitle('*f%o*o%');
-        $q1 = BookQuery::create()->add(BookTableMap::TITLE, '%f%o%o%', Criteria::LIKE);
+        $q1 = BookQuery::create()->add(BookTableMap::COL_TITLE, '%f%o%o%', Criteria::LIKE);
         $this->assertEquals($q1, $q, 'filterByStringColumn() translates to a Criteria::LIKE when passed a string with mixed wildcards, and turns *s into %s');
     }
 
     public function testFilterByBoolean()
     {
         $q = ReviewQuery::create()->filterByRecommended(true);
-        $q1 = ReviewQuery::create()->add(ReviewTableMap::RECOMMENDED, true, Criteria::EQUAL);
+        $q1 = ReviewQuery::create()->add(ReviewTableMap::COL_RECOMMENDED, true, Criteria::EQUAL);
         $this->assertEquals($q1, $q, 'filterByBooleanColumn() translates to a Criteria::EQUAL by default');
 
         $q = ReviewQuery::create()->filterByRecommended(true, Criteria::NOT_EQUAL);
-        $q1 = ReviewQuery::create()->add(ReviewTableMap::RECOMMENDED, true, Criteria::NOT_EQUAL);
+        $q1 = ReviewQuery::create()->add(ReviewTableMap::COL_RECOMMENDED, true, Criteria::NOT_EQUAL);
         $this->assertEquals($q1, $q, 'filterByBooleanColumn() accepts an optional comparison operator');
 
         $q = ReviewQuery::create()->filterByRecommended(false);
-        $q1 = ReviewQuery::create()->add(ReviewTableMap::RECOMMENDED, false, Criteria::EQUAL);
+        $q1 = ReviewQuery::create()->add(ReviewTableMap::COL_RECOMMENDED, false, Criteria::EQUAL);
         $this->assertEquals($q1, $q, 'filterByBooleanColumn() translates to a Criteria::EQUAL by default');
 
         $q = ReviewQuery::create()->setModelAlias('b', true)->filterByRecommended(true);
@@ -583,31 +583,31 @@ class QueryBuilderTest extends BookstoreTestBase
         $this->assertEquals($q1, $q, 'filterByBooleanColumn() uses true table alias if set');
 
         $q = ReviewQuery::create()->filterByRecommended('true');
-        $q1 = ReviewQuery::create()->add(ReviewTableMap::RECOMMENDED, true, Criteria::EQUAL);
+        $q1 = ReviewQuery::create()->add(ReviewTableMap::COL_RECOMMENDED, true, Criteria::EQUAL);
         $this->assertEquals($q1, $q, 'filterByBooleanColumn() translates to a = true when passed a true string');
 
         $q = ReviewQuery::create()->filterByRecommended('yes');
-        $q1 = ReviewQuery::create()->add(ReviewTableMap::RECOMMENDED, true, Criteria::EQUAL);
+        $q1 = ReviewQuery::create()->add(ReviewTableMap::COL_RECOMMENDED, true, Criteria::EQUAL);
         $this->assertEquals($q1, $q, 'filterByBooleanColumn() translates to a = true when passed a true string');
 
         $q = ReviewQuery::create()->filterByRecommended('1');
-        $q1 = ReviewQuery::create()->add(ReviewTableMap::RECOMMENDED, true, Criteria::EQUAL);
+        $q1 = ReviewQuery::create()->add(ReviewTableMap::COL_RECOMMENDED, true, Criteria::EQUAL);
         $this->assertEquals($q1, $q, 'filterByBooleanColumn() translates to a = true when passed a true string');
 
         $q = ReviewQuery::create()->filterByRecommended('false');
-        $q1 = ReviewQuery::create()->add(ReviewTableMap::RECOMMENDED, false, Criteria::EQUAL);
+        $q1 = ReviewQuery::create()->add(ReviewTableMap::COL_RECOMMENDED, false, Criteria::EQUAL);
         $this->assertEquals($q1, $q, 'filterByBooleanColumn() translates to a = false when passed a false string');
 
         $q = ReviewQuery::create()->filterByRecommended('no');
-        $q1 = ReviewQuery::create()->add(ReviewTableMap::RECOMMENDED, false, Criteria::EQUAL);
+        $q1 = ReviewQuery::create()->add(ReviewTableMap::COL_RECOMMENDED, false, Criteria::EQUAL);
         $this->assertEquals($q1, $q, 'filterByBooleanColumn() translates to a = false when passed a false string');
 
         $q = ReviewQuery::create()->filterByRecommended('0');
-        $q1 = ReviewQuery::create()->add(ReviewTableMap::RECOMMENDED, false, Criteria::EQUAL);
+        $q1 = ReviewQuery::create()->add(ReviewTableMap::COL_RECOMMENDED, false, Criteria::EQUAL);
         $this->assertEquals($q1, $q, 'filterByBooleanColumn() translates to a = false when passed a false string');
 
         $q = ReviewQuery::create()->filterByRecommended('');
-        $q1 = ReviewQuery::create()->add(ReviewTableMap::RECOMMENDED, false, Criteria::EQUAL);
+        $q1 = ReviewQuery::create()->add(ReviewTableMap::COL_RECOMMENDED, false, Criteria::EQUAL);
         $this->assertEquals($q1, $q, 'filterByBooleanColumn() translates to a = false when passed an empty string');
 
     }
@@ -638,11 +638,11 @@ class QueryBuilderTest extends BookstoreTestBase
         $this->assertEquals($testBook, $book, 'Generated query handles filterByFk() methods correctly for simple fkeys');
 
         $q = BookQuery::create()->filterByAuthor($testAuthor);
-        $q1 = BookQuery::create()->add(BookTableMap::AUTHOR_ID, $testAuthor->getId(), Criteria::EQUAL);
+        $q1 = BookQuery::create()->add(BookTableMap::COL_AUTHOR_ID, $testAuthor->getId(), Criteria::EQUAL);
         $this->assertEquals($q1, $q, 'filterByFk() translates to a Criteria::EQUAL by default');
 
         $q = BookQuery::create()->filterByAuthor($testAuthor, Criteria::NOT_EQUAL);
-        $q1 = BookQuery::create()->add(BookTableMap::AUTHOR_ID, $testAuthor->getId(), Criteria::NOT_EQUAL);
+        $q1 = BookQuery::create()->add(BookTableMap::COL_AUTHOR_ID, $testAuthor->getId(), Criteria::NOT_EQUAL);
         $this->assertEquals($q1, $q, 'filterByFk() accepts an optional comparison operator');
     }
 
@@ -680,7 +680,7 @@ class QueryBuilderTest extends BookstoreTestBase
         $q1 = $this->con->getLastExecutedQuery();
 
         $books = BookQuery::create()
-            ->add(BookTableMap::AUTHOR_ID, $authors->getPrimaryKeys(), Criteria::IN)
+            ->add(BookTableMap::COL_AUTHOR_ID, $authors->getPrimaryKeys(), Criteria::IN)
             ->find($this->con);
         $q2 = $this->con->getLastExecutedQuery();
 
@@ -713,11 +713,11 @@ class QueryBuilderTest extends BookstoreTestBase
         $this->assertEquals($testAuthor, $author, 'Generated query handles filterByRefFk() methods correctly for simple fkeys');
 
         $q = AuthorQuery::create()->filterByBook($testBook);
-        $q1 = AuthorQuery::create()->add(AuthorTableMap::ID, $testBook->getAuthorId(), Criteria::EQUAL);
+        $q1 = AuthorQuery::create()->add(AuthorTableMap::COL_ID, $testBook->getAuthorId(), Criteria::EQUAL);
         $this->assertEquals($q1, $q, 'filterByRefFk() translates to a Criteria::EQUAL by default');
 
         $q = AuthorQuery::create()->filterByBook($testBook, Criteria::NOT_EQUAL);
-        $q1 = AuthorQuery::create()->add(AuthorTableMap::ID, $testBook->getAuthorId(), Criteria::NOT_EQUAL);
+        $q1 = AuthorQuery::create()->add(AuthorTableMap::COL_ID, $testBook->getAuthorId(), Criteria::NOT_EQUAL);
         $this->assertEquals($q1, $q, 'filterByRefFk() accepts an optional comparison operator');
     }
 
@@ -731,14 +731,14 @@ class QueryBuilderTest extends BookstoreTestBase
             ->find($this->con);
 
         $testRelease = ReleasePoolQuery::create()
-            ->addJoin(ReleasePoolTableMap::RECORD_LABEL_ID, RecordLabelTableMap::ID)
+            ->addJoin(ReleasePoolTableMap::COL_RECORD_LABEL_ID, RecordLabelTableMap::COL_ID)
             ->filterByRecordLabel($testLabel)
             ->find($this->con);
         $q1 = $this->con->getLastExecutedQuery();
 
         $releasePool = ReleasePoolQuery::create()
-            ->addJoin(ReleasePoolTableMap::RECORD_LABEL_ID, RecordLabelTableMap::ID)
-            ->add(ReleasePoolTableMap::RECORD_LABEL_ID, $testLabel->toKeyValue('Id', 'Id'), Criteria::IN)
+            ->addJoin(ReleasePoolTableMap::COL_RECORD_LABEL_ID, RecordLabelTableMap::COL_ID)
+            ->add(ReleasePoolTableMap::COL_RECORD_LABEL_ID, $testLabel->toKeyValue('Id', 'Id'), Criteria::IN)
             ->find($this->con);
         $q2 = $this->con->getLastExecutedQuery();
 
@@ -780,8 +780,8 @@ class QueryBuilderTest extends BookstoreTestBase
         $q1 = $this->con->getLastExecutedQuery();
 
         $authors = AuthorQuery::create()
-            ->addJoin(AuthorTableMap::ID, BookTableMap::AUTHOR_ID, Criteria::LEFT_JOIN)
-            ->add(BookTableMap::ID, $books->getPrimaryKeys(), Criteria::IN)
+            ->addJoin(AuthorTableMap::COL_ID, BookTableMap::COL_AUTHOR_ID, Criteria::LEFT_JOIN)
+            ->add(BookTableMap::COL_ID, $books->getPrimaryKeys(), Criteria::IN)
             ->find($this->con);
         $q2 = $this->con->getLastExecutedQuery();
 
@@ -892,7 +892,7 @@ class QueryBuilderTest extends BookstoreTestBase
             ->endUse();
         $q1 = BookQuery::create()
             ->join('Book.Author', Criteria::LEFT_JOIN)
-            ->add(AuthorTableMap::FIRST_NAME, 'Leo', Criteria::EQUAL);
+            ->add(AuthorTableMap::COL_FIRST_NAME, 'Leo', Criteria::EQUAL);
         $this->assertTrue($q->equals($q1), 'useFkQuery() translates to a condition on a left join on non-required columns');
 
         $q = BookSummaryQuery::create()
@@ -901,7 +901,7 @@ class QueryBuilderTest extends BookstoreTestBase
             ->endUse();
         $q1 = BookSummaryQuery::create()
             ->join('BookSummary.SummarizedBook', Criteria::INNER_JOIN)
-            ->add(BookTableMap::TITLE, 'War And Peace', Criteria::EQUAL);
+            ->add(BookTableMap::COL_TITLE, 'War And Peace', Criteria::EQUAL);
         $this->assertTrue($q->equals($q1), 'useFkQuery() translates to a condition on an inner join on required columns');
     }
 
@@ -913,7 +913,7 @@ class QueryBuilderTest extends BookstoreTestBase
             ->endUse();
         $q1 = BookQuery::create()
             ->join('Book.Author', Criteria::LEFT_JOIN)
-            ->add(AuthorTableMap::FIRST_NAME, 'Leo', Criteria::EQUAL);
+            ->add(AuthorTableMap::COL_FIRST_NAME, 'Leo', Criteria::EQUAL);
         $this->assertTrue($q->equals($q1), 'useFkQuery() accepts a join type as second parameter');
     }
 
@@ -944,8 +944,8 @@ class QueryBuilderTest extends BookstoreTestBase
             ->filterByTitle('War And Peace');
         $q1 = BookQuery::create()
             ->join('Book.Author', Criteria::LEFT_JOIN)
-            ->add(AuthorTableMap::FIRST_NAME, 'Leo', Criteria::EQUAL)
-            ->add(BookTableMap::TITLE, 'War And Peace', Criteria::EQUAL);
+            ->add(AuthorTableMap::COL_FIRST_NAME, 'Leo', Criteria::EQUAL)
+            ->add(BookTableMap::COL_TITLE, 'War And Peace', Criteria::EQUAL);
         $this->assertTrue($q->equals($q1), 'useFkQuery() allows combining conditions on main and related query');
     }
 
@@ -960,8 +960,8 @@ class QueryBuilderTest extends BookstoreTestBase
             ->endUse();
         $q1 = BookQuery::create()
             ->join('Book.Author', Criteria::LEFT_JOIN)
-            ->add(AuthorTableMap::FIRST_NAME, 'Leo', Criteria::EQUAL)
-            ->add(AuthorTableMap::LAST_NAME, 'Tolstoi', Criteria::EQUAL);
+            ->add(AuthorTableMap::COL_FIRST_NAME, 'Leo', Criteria::EQUAL)
+            ->add(AuthorTableMap::COL_LAST_NAME, 'Tolstoi', Criteria::EQUAL);
         $this->assertTrue($q->equals($q1), 'useFkQuery() called twice on the same relation does not create two joins');
     }
 
@@ -1005,7 +1005,7 @@ class QueryBuilderTest extends BookstoreTestBase
         $q1 = ReviewQuery::create()
             ->join('Review.Book', Criteria::LEFT_JOIN)
             ->join('Book.Author', Criteria::LEFT_JOIN)
-            ->add(AuthorTableMap::FIRST_NAME, 'Leo', Criteria::EQUAL);
+            ->add(AuthorTableMap::COL_FIRST_NAME, 'Leo', Criteria::EQUAL);
         // embedded queries create joins that keep a relation to the parent
         // as this is not testable, we need to use another testing technique
         $params = array();
@@ -1027,9 +1027,9 @@ class QueryBuilderTest extends BookstoreTestBase
             ->endUse();
         $q1 = BookQuery::create()
             ->join('\Propel\Tests\Bookstore\Book.Author', Criteria::LEFT_JOIN)
-            ->add(AuthorTableMap::FIRST_NAME, 'Leo', Criteria::EQUAL)
+            ->add(AuthorTableMap::COL_FIRST_NAME, 'Leo', Criteria::EQUAL)
             ->join('\Propel\Tests\Bookstore\Book.Publisher', Criteria::LEFT_JOIN)
-            ->add(PublisherTableMap::NAME, 'Penguin', Criteria::EQUAL);
+            ->add(PublisherTableMap::COL_NAME, 'Penguin', Criteria::EQUAL);
         $this->assertTrue($q->equals($q1), 'useFkQuery() called twice on two relations creates two joins');
     }
 
@@ -1045,7 +1045,7 @@ class QueryBuilderTest extends BookstoreTestBase
         $q1 = $con->getLastExecutedQuery();
         $books = BookQuery::create()
             ->leftJoinWithAuthor()
-            ->add(AuthorTableMap::FIRST_NAME, 'Leo', Criteria::EQUAL)
+            ->add(AuthorTableMap::COL_FIRST_NAME, 'Leo', Criteria::EQUAL)
             ->find($con);
         $q2 = $con->getLastExecutedQuery();
         $this->assertEquals($q1, $q2, 'with() can be used after a call to useFkQuery() with no alias');

--- a/tests/Propel/Tests/Generator/Model/ColumnTest.php
+++ b/tests/Propel/Tests/Generator/Model/ColumnTest.php
@@ -25,7 +25,7 @@ class ColumnTest extends ModelTestCase
 
         $this->assertSame('title', $column->getName());
         $this->assertEmpty($column->getAutoIncrementString());
-        $this->assertSame('TITLE', $column->getConstantColumnName());
+        $this->assertSame('COL_TITLE', $column->getConstantName());
         $this->assertSame('public', $column->getMutatorVisibility());
         $this->assertSame('public', $column->getAccessorVisibility());
         $this->assertFalse($column->getSize());
@@ -728,8 +728,8 @@ class ColumnTest extends ModelTestCase
         $column->setTableMapName('created_at');
 
         $this->assertSame('created_at', $column->getTableMapName());
-        $this->assertSame('CREATED_AT', $column->getConstantColumnName());
-        $this->assertSame('ArticleTableMap::CREATED_AT', $column->getConstantName());
+        $this->assertSame('COL_CREATED_AT', $column->getConstantName());
+        $this->assertSame('ArticleTableMap::COL_CREATED_AT', $column->getFQConstantName());
     }
 
     public function testSetDefaultPhpName()

--- a/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaMergeTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaMergeTest.php
@@ -101,51 +101,51 @@ class CriteriaMergeTest extends BookstoreTestBase
     public function testMergeWithSelectColumns()
     {
         $c1 = new Criteria();
-        $c1->addSelectColumn(BookTableMap::TITLE);
-        $c1->addSelectColumn(BookTableMap::ID);
+        $c1->addSelectColumn(BookTableMap::COL_TITLE);
+        $c1->addSelectColumn(BookTableMap::COL_ID);
         $c2 = new Criteria();
         $c1->mergeWith($c2);
-        $this->assertEquals(array(BookTableMap::TITLE, BookTableMap::ID), $c1->getSelectColumns(), 'mergeWith() does not remove an existing select columns');
+        $this->assertEquals(array(BookTableMap::COL_TITLE, BookTableMap::COL_ID), $c1->getSelectColumns(), 'mergeWith() does not remove an existing select columns');
         $c1 = new Criteria();
         $c2 = new Criteria();
-        $c2->addSelectColumn(BookTableMap::TITLE);
-        $c2->addSelectColumn(BookTableMap::ID);
+        $c2->addSelectColumn(BookTableMap::COL_TITLE);
+        $c2->addSelectColumn(BookTableMap::COL_ID);
         $c1->mergeWith($c2);
-        $this->assertEquals(array(BookTableMap::TITLE, BookTableMap::ID), $c1->getSelectColumns(), 'mergeWith() merges the select columns to an empty select');
+        $this->assertEquals(array(BookTableMap::COL_TITLE, BookTableMap::COL_ID), $c1->getSelectColumns(), 'mergeWith() merges the select columns to an empty select');
         $c1 = new Criteria();
-        $c1->addSelectColumn(BookTableMap::TITLE);
+        $c1->addSelectColumn(BookTableMap::COL_TITLE);
         $c2 = new Criteria();
-        $c2->addSelectColumn(BookTableMap::ID);
+        $c2->addSelectColumn(BookTableMap::COL_ID);
         $c1->mergeWith($c2);
-        $this->assertEquals(array(BookTableMap::TITLE, BookTableMap::ID), $c1->getSelectColumns(), 'mergeWith() merges the select columns after the existing select columns');
+        $this->assertEquals(array(BookTableMap::COL_TITLE, BookTableMap::COL_ID), $c1->getSelectColumns(), 'mergeWith() merges the select columns after the existing select columns');
         $c1 = new Criteria();
-        $c1->addSelectColumn(BookTableMap::TITLE);
+        $c1->addSelectColumn(BookTableMap::COL_TITLE);
         $c2 = new Criteria();
-        $c2->addSelectColumn(BookTableMap::TITLE);
+        $c2->addSelectColumn(BookTableMap::COL_TITLE);
         $c1->mergeWith($c2);
-        $this->assertEquals(array(BookTableMap::TITLE, BookTableMap::TITLE), $c1->getSelectColumns(), 'mergeWith() merges the select columns to an existing select, even if duplicated');
+        $this->assertEquals(array(BookTableMap::COL_TITLE, BookTableMap::COL_TITLE), $c1->getSelectColumns(), 'mergeWith() merges the select columns to an existing select, even if duplicated');
     }
 
     public function testMergeWithAsColumns()
     {
         $c1 = new Criteria();
-        $c1->addAsColumn('foo', BookTableMap::TITLE);
-        $c1->addAsColumn('bar', BookTableMap::ID);
+        $c1->addAsColumn('foo', BookTableMap::COL_TITLE);
+        $c1->addAsColumn('bar', BookTableMap::COL_ID);
         $c2 = new Criteria();
         $c1->mergeWith($c2);
-        $this->assertEquals(array('foo' => BookTableMap::TITLE, 'bar' => BookTableMap::ID), $c1->getAsColumns(), 'mergeWith() does not remove an existing as columns');
+        $this->assertEquals(array('foo' => BookTableMap::COL_TITLE, 'bar' => BookTableMap::COL_ID), $c1->getAsColumns(), 'mergeWith() does not remove an existing as columns');
         $c1 = new Criteria();
         $c2 = new Criteria();
-        $c2->addAsColumn('foo', BookTableMap::TITLE);
-        $c2->addAsColumn('bar', BookTableMap::ID);
+        $c2->addAsColumn('foo', BookTableMap::COL_TITLE);
+        $c2->addAsColumn('bar', BookTableMap::COL_ID);
         $c1->mergeWith($c2);
-        $this->assertEquals(array('foo' => BookTableMap::TITLE, 'bar' => BookTableMap::ID), $c1->getAsColumns(), 'mergeWith() merges the select columns to an empty as');
+        $this->assertEquals(array('foo' => BookTableMap::COL_TITLE, 'bar' => BookTableMap::COL_ID), $c1->getAsColumns(), 'mergeWith() merges the select columns to an empty as');
         $c1 = new Criteria();
-        $c1->addAsColumn('foo', BookTableMap::TITLE);
+        $c1->addAsColumn('foo', BookTableMap::COL_TITLE);
         $c2 = new Criteria();
-        $c2->addAsColumn('bar', BookTableMap::ID);
+        $c2->addAsColumn('bar', BookTableMap::COL_ID);
         $c1->mergeWith($c2);
-        $this->assertEquals(array('foo' => BookTableMap::TITLE, 'bar' => BookTableMap::ID), $c1->getAsColumns(), 'mergeWith() merges the select columns after the existing as columns');
+        $this->assertEquals(array('foo' => BookTableMap::COL_TITLE, 'bar' => BookTableMap::COL_ID), $c1->getAsColumns(), 'mergeWith() merges the select columns after the existing as columns');
     }
 
     /**
@@ -154,107 +154,107 @@ class CriteriaMergeTest extends BookstoreTestBase
     public function testMergeWithAsColumnsThrowsException()
     {
         $c1 = new Criteria();
-        $c1->addAsColumn('foo', BookTableMap::TITLE);
+        $c1->addAsColumn('foo', BookTableMap::COL_TITLE);
         $c2 = new Criteria();
-        $c2->addAsColumn('foo', BookTableMap::ID);
+        $c2->addAsColumn('foo', BookTableMap::COL_ID);
         $c1->mergeWith($c2);
     }
 
     public function testMergeWithOrderByColumns()
     {
         $c1 = new Criteria();
-        $c1->addAscendingOrderByColumn(BookTableMap::TITLE);
-        $c1->addAscendingOrderByColumn(BookTableMap::ID);
+        $c1->addAscendingOrderByColumn(BookTableMap::COL_TITLE);
+        $c1->addAscendingOrderByColumn(BookTableMap::COL_ID);
         $c2 = new Criteria();
         $c1->mergeWith($c2);
-        $this->assertEquals(array(BookTableMap::TITLE . ' ASC', BookTableMap::ID . ' ASC'), $c1->getOrderByColumns(), 'mergeWith() does not remove an existing orderby columns');
+        $this->assertEquals(array(BookTableMap::COL_TITLE . ' ASC', BookTableMap::COL_ID . ' ASC'), $c1->getOrderByColumns(), 'mergeWith() does not remove an existing orderby columns');
         $c1 = new Criteria();
         $c2 = new Criteria();
-        $c2->addAscendingOrderByColumn(BookTableMap::TITLE);
-        $c2->addAscendingOrderByColumn(BookTableMap::ID);
+        $c2->addAscendingOrderByColumn(BookTableMap::COL_TITLE);
+        $c2->addAscendingOrderByColumn(BookTableMap::COL_ID);
         $c1->mergeWith($c2);
-        $this->assertEquals(array(BookTableMap::TITLE . ' ASC', BookTableMap::ID . ' ASC'), $c1->getOrderByColumns(), 'mergeWith() merges the select columns to an empty order by');
+        $this->assertEquals(array(BookTableMap::COL_TITLE . ' ASC', BookTableMap::COL_ID . ' ASC'), $c1->getOrderByColumns(), 'mergeWith() merges the select columns to an empty order by');
         $c1 = new Criteria();
-        $c1->addAscendingOrderByColumn(BookTableMap::TITLE);
+        $c1->addAscendingOrderByColumn(BookTableMap::COL_TITLE);
         $c2 = new Criteria();
-        $c2->addAscendingOrderByColumn(BookTableMap::ID);
+        $c2->addAscendingOrderByColumn(BookTableMap::COL_ID);
         $c1->mergeWith($c2);
-        $this->assertEquals(array(BookTableMap::TITLE . ' ASC', BookTableMap::ID . ' ASC'), $c1->getOrderByColumns(), 'mergeWith() merges the select columns after the existing orderby columns');
+        $this->assertEquals(array(BookTableMap::COL_TITLE . ' ASC', BookTableMap::COL_ID . ' ASC'), $c1->getOrderByColumns(), 'mergeWith() merges the select columns after the existing orderby columns');
         $c1 = new Criteria();
-        $c1->addAscendingOrderByColumn(BookTableMap::TITLE);
+        $c1->addAscendingOrderByColumn(BookTableMap::COL_TITLE);
         $c2 = new Criteria();
-        $c2->addAscendingOrderByColumn(BookTableMap::TITLE);
+        $c2->addAscendingOrderByColumn(BookTableMap::COL_TITLE);
         $c1->mergeWith($c2);
-        $this->assertEquals(array(BookTableMap::TITLE . ' ASC'), $c1->getOrderByColumns(), 'mergeWith() does not merge duplicated orderby columns');
+        $this->assertEquals(array(BookTableMap::COL_TITLE . ' ASC'), $c1->getOrderByColumns(), 'mergeWith() does not merge duplicated orderby columns');
         $c1 = new Criteria();
-        $c1->addAscendingOrderByColumn(BookTableMap::TITLE);
+        $c1->addAscendingOrderByColumn(BookTableMap::COL_TITLE);
         $c2 = new Criteria();
-        $c2->addDescendingOrderByColumn(BookTableMap::TITLE);
+        $c2->addDescendingOrderByColumn(BookTableMap::COL_TITLE);
         $c1->mergeWith($c2);
-        $this->assertEquals(array(BookTableMap::TITLE . ' ASC', BookTableMap::TITLE . ' DESC'), $c1->getOrderByColumns(), 'mergeWith() merges duplicated orderby columns with inverse direction');
+        $this->assertEquals(array(BookTableMap::COL_TITLE . ' ASC', BookTableMap::COL_TITLE . ' DESC'), $c1->getOrderByColumns(), 'mergeWith() merges duplicated orderby columns with inverse direction');
     }
 
     public function testMergeWithGroupByColumns()
     {
         $c1 = new Criteria();
-        $c1->addGroupByColumn(BookTableMap::TITLE);
-        $c1->addGroupByColumn(BookTableMap::ID);
+        $c1->addGroupByColumn(BookTableMap::COL_TITLE);
+        $c1->addGroupByColumn(BookTableMap::COL_ID);
         $c2 = new Criteria();
         $c1->mergeWith($c2);
-        $this->assertEquals(array(BookTableMap::TITLE, BookTableMap::ID), $c1->getGroupByColumns(), 'mergeWith() does not remove an existing groupby columns');
+        $this->assertEquals(array(BookTableMap::COL_TITLE, BookTableMap::COL_ID), $c1->getGroupByColumns(), 'mergeWith() does not remove an existing groupby columns');
         $c1 = new Criteria();
         $c2 = new Criteria();
-        $c2->addGroupByColumn(BookTableMap::TITLE);
-        $c2->addGroupByColumn(BookTableMap::ID);
+        $c2->addGroupByColumn(BookTableMap::COL_TITLE);
+        $c2->addGroupByColumn(BookTableMap::COL_ID);
         $c1->mergeWith($c2);
-        $this->assertEquals(array(BookTableMap::TITLE, BookTableMap::ID), $c1->getGroupByColumns(), 'mergeWith() merges the select columns to an empty groupby');
+        $this->assertEquals(array(BookTableMap::COL_TITLE, BookTableMap::COL_ID), $c1->getGroupByColumns(), 'mergeWith() merges the select columns to an empty groupby');
         $c1 = new Criteria();
-        $c1->addGroupByColumn(BookTableMap::TITLE);
+        $c1->addGroupByColumn(BookTableMap::COL_TITLE);
         $c2 = new Criteria();
-        $c2->addGroupByColumn(BookTableMap::ID);
+        $c2->addGroupByColumn(BookTableMap::COL_ID);
         $c1->mergeWith($c2);
-        $this->assertEquals(array(BookTableMap::TITLE, BookTableMap::ID), $c1->getGroupByColumns(), 'mergeWith() merges the select columns after the existing groupby columns');
+        $this->assertEquals(array(BookTableMap::COL_TITLE, BookTableMap::COL_ID), $c1->getGroupByColumns(), 'mergeWith() merges the select columns after the existing groupby columns');
         $c1 = new Criteria();
-        $c1->addGroupByColumn(BookTableMap::TITLE);
+        $c1->addGroupByColumn(BookTableMap::COL_TITLE);
         $c2 = new Criteria();
-        $c2->addGroupByColumn(BookTableMap::TITLE);
+        $c2->addGroupByColumn(BookTableMap::COL_TITLE);
         $c1->mergeWith($c2);
-        $this->assertEquals(array(BookTableMap::TITLE), $c1->getGroupByColumns(), 'mergeWith() does not merge duplicated groupby columns');
+        $this->assertEquals(array(BookTableMap::COL_TITLE), $c1->getGroupByColumns(), 'mergeWith() does not merge duplicated groupby columns');
     }
 
     public function testMergeWithWhereConditions()
     {
         $c1 = new Criteria();
-        $c1->add(BookTableMap::TITLE, 'foo');
+        $c1->add(BookTableMap::COL_TITLE, 'foo');
         $c2 = new Criteria();
         $c1->mergeWith($c2);
         $sql = $this->getSql('SELECT  FROM `book` WHERE book.TITLE=:p1');
         $this->assertCriteriaTranslation($c1, $sql, 'mergeWith() does not remove an existing where condition');
         $c1 = new Criteria();
         $c2 = new Criteria();
-        $c2->add(BookTableMap::TITLE, 'foo');
+        $c2->add(BookTableMap::COL_TITLE, 'foo');
         $c1->mergeWith($c2);
         $sql = $this->getSql('SELECT  FROM `book` WHERE book.TITLE=:p1');
         $this->assertCriteriaTranslation($c1, $sql, 'mergeWith() merges where condition to an empty condition');
         $c1 = new Criteria();
-        $c1->add(BookTableMap::ID, 123);
+        $c1->add(BookTableMap::COL_ID, 123);
         $c2 = new Criteria();
-        $c2->add(BookTableMap::TITLE, 'foo');
+        $c2->add(BookTableMap::COL_TITLE, 'foo');
         $c1->mergeWith($c2);
         $sql = $this->getSql('SELECT  FROM `book` WHERE book.ID=:p1 AND book.TITLE=:p2');
         $this->assertCriteriaTranslation($c1, $sql, 'mergeWith() merges where condition to existing conditions');
         $c1 = new Criteria();
-        $c1->add(BookTableMap::TITLE, 'foo');
+        $c1->add(BookTableMap::COL_TITLE, 'foo');
         $c2 = new Criteria();
-        $c2->add(BookTableMap::TITLE, 'bar');
+        $c2->add(BookTableMap::COL_TITLE, 'bar');
         $c1->mergeWith($c2);
         $sql = $this->getSql('SELECT  FROM `book` WHERE (book.TITLE=:p1 AND book.TITLE=:p2)');
         $this->assertCriteriaTranslation($c1, $sql, 'mergeWith() merges where condition to existing conditions on the same column');
         $c1 = new Criteria();
-        $c1->add(BookTableMap::TITLE, 'foo');
-        $c1->addJoin(BookTableMap::AUTHOR_ID, AuthorTableMap::ID, Criteria::LEFT_JOIN);
+        $c1->add(BookTableMap::COL_TITLE, 'foo');
+        $c1->addJoin(BookTableMap::COL_AUTHOR_ID, AuthorTableMap::COL_ID, Criteria::LEFT_JOIN);
         $c2 = new Criteria();
-        $c2->add(AuthorTableMap::FIRST_NAME, 'bar');
+        $c2->add(AuthorTableMap::COL_FIRST_NAME, 'bar');
         $c1->mergeWith($c2);
         $sql = $this->getSql('SELECT  FROM `book` LEFT JOIN `author` ON (book.AUTHOR_ID=author.ID) WHERE book.TITLE=:p1 AND author.FIRST_NAME=:p2');
         $this->assertCriteriaTranslation($c1, $sql, 'mergeWith() merges where condition to existing conditions on the different tables');
@@ -263,36 +263,36 @@ class CriteriaMergeTest extends BookstoreTestBase
     public function testMergeOrWithWhereConditions()
     {
         $c1 = new Criteria();
-        $c1->add(BookTableMap::TITLE, 'foo');
+        $c1->add(BookTableMap::COL_TITLE, 'foo');
         $c2 = new Criteria();
         $c1->mergeWith($c2, Criteria::LOGICAL_OR);
         $sql = $this->getSql('SELECT  FROM `book` WHERE book.TITLE=:p1');
         $this->assertCriteriaTranslation($c1, $sql, 'mergeWith() does not remove an existing where condition');
         $c1 = new Criteria();
         $c2 = new Criteria();
-        $c2->add(BookTableMap::TITLE, 'foo');
+        $c2->add(BookTableMap::COL_TITLE, 'foo');
         $c1->mergeWith($c2, Criteria::LOGICAL_OR);
         $sql = $this->getSql('SELECT  FROM `book` WHERE book.TITLE=:p1');
         $this->assertCriteriaTranslation($c1, $sql, 'mergeWith() merges where condition to an empty condition');
         $c1 = new Criteria();
-        $c1->add(BookTableMap::ID, 123);
+        $c1->add(BookTableMap::COL_ID, 123);
         $c2 = new Criteria();
-        $c2->add(BookTableMap::TITLE, 'foo');
+        $c2->add(BookTableMap::COL_TITLE, 'foo');
         $c1->mergeWith($c2, Criteria::LOGICAL_OR);
         $sql = $this->getSql('SELECT  FROM `book` WHERE (book.ID=:p1 OR book.TITLE=:p2)');
         $this->assertCriteriaTranslation($c1, $sql, 'mergeWith() merges where condition to existing conditions');
         $c1 = new Criteria();
-        $c1->add(BookTableMap::TITLE, 'foo');
+        $c1->add(BookTableMap::COL_TITLE, 'foo');
         $c2 = new Criteria();
-        $c2->add(BookTableMap::TITLE, 'bar');
+        $c2->add(BookTableMap::COL_TITLE, 'bar');
         $c1->mergeWith($c2, Criteria::LOGICAL_OR);
         $sql = $this->getSql('SELECT  FROM `book` WHERE (book.TITLE=:p1 OR book.TITLE=:p2)');
         $this->assertCriteriaTranslation($c1, $sql, 'mergeWith() merges where condition to existing conditions on the same column');
         $c1 = new Criteria();
-        $c1->add(BookTableMap::TITLE, 'foo');
-        $c1->addJoin(BookTableMap::AUTHOR_ID, AuthorTableMap::ID, Criteria::LEFT_JOIN);
+        $c1->add(BookTableMap::COL_TITLE, 'foo');
+        $c1->addJoin(BookTableMap::COL_AUTHOR_ID, AuthorTableMap::COL_ID, Criteria::LEFT_JOIN);
         $c2 = new Criteria();
-        $c2->add(AuthorTableMap::FIRST_NAME, 'bar');
+        $c2->add(AuthorTableMap::COL_FIRST_NAME, 'bar');
         $c1->mergeWith($c2, Criteria::LOGICAL_OR);
         $sql = $this->getSql('SELECT  FROM `book` LEFT JOIN `author` ON (book.AUTHOR_ID=author.ID) WHERE (book.TITLE=:p1 OR author.FIRST_NAME=:p2)');
         $this->assertCriteriaTranslation($c1, $sql, 'mergeWith() merges where condition to existing conditions on the different tables');
@@ -301,7 +301,7 @@ class CriteriaMergeTest extends BookstoreTestBase
     public function testMerge_OrWithWhereConditions()
     {
         $c1 = new Criteria();
-        $c1->add(BookTableMap::TITLE, 'foo');
+        $c1->add(BookTableMap::COL_TITLE, 'foo');
         $c2 = new Criteria();
         $c1->_or();
         $c1->mergeWith($c2);
@@ -309,33 +309,33 @@ class CriteriaMergeTest extends BookstoreTestBase
         $this->assertCriteriaTranslation($c1, $sql, 'mergeWith() does not remove an existing where condition');
         $c1 = new Criteria();
         $c2 = new Criteria();
-        $c2->add(BookTableMap::TITLE, 'foo');
+        $c2->add(BookTableMap::COL_TITLE, 'foo');
         $c1->_or();
         $c1->mergeWith($c2);
         $sql = $this->getSql('SELECT  FROM `book` WHERE book.TITLE=:p1');
         $this->assertCriteriaTranslation($c1, $sql, 'mergeWith() merges where condition to an empty condition');
         $c1 = new Criteria();
-        $c1->add(BookTableMap::ID, 123);
+        $c1->add(BookTableMap::COL_ID, 123);
         $c1->_or();
         $c2 = new Criteria();
-        $c2->add(BookTableMap::TITLE, 'foo');
+        $c2->add(BookTableMap::COL_TITLE, 'foo');
         $c1->mergeWith($c2);
         $sql = $this->getSql('SELECT  FROM `book` WHERE (book.ID=:p1 OR book.TITLE=:p2)');
         $this->assertCriteriaTranslation($c1, $sql, 'mergeWith() merges where condition to existing conditions');
         $c1 = new Criteria();
-        $c1->add(BookTableMap::TITLE, 'foo');
+        $c1->add(BookTableMap::COL_TITLE, 'foo');
         $c1->_or();
         $c2 = new Criteria();
-        $c2->add(BookTableMap::TITLE, 'bar');
+        $c2->add(BookTableMap::COL_TITLE, 'bar');
         $c1->mergeWith($c2);
         $sql = $this->getSql('SELECT  FROM `book` WHERE (book.TITLE=:p1 OR book.TITLE=:p2)');
         $this->assertCriteriaTranslation($c1, $sql, 'mergeWith() merges where condition to existing conditions on the same column');
         $c1 = new Criteria();
-        $c1->add(BookTableMap::TITLE, 'foo');
-        $c1->addJoin(BookTableMap::AUTHOR_ID, AuthorTableMap::ID, Criteria::LEFT_JOIN);
+        $c1->add(BookTableMap::COL_TITLE, 'foo');
+        $c1->addJoin(BookTableMap::COL_AUTHOR_ID, AuthorTableMap::COL_ID, Criteria::LEFT_JOIN);
         $c1->_or();
         $c2 = new Criteria();
-        $c2->add(AuthorTableMap::FIRST_NAME, 'bar');
+        $c2->add(AuthorTableMap::COL_FIRST_NAME, 'bar');
         $c1->mergeWith($c2);
         $sql = $this->getSql('SELECT  FROM `book` LEFT JOIN `author` ON (book.AUTHOR_ID=author.ID) WHERE (book.TITLE=:p1 OR author.FIRST_NAME=:p2)');
         $this->assertCriteriaTranslation($c1, $sql, 'mergeWith() merges where condition to existing conditions on the different tables');
@@ -344,7 +344,7 @@ class CriteriaMergeTest extends BookstoreTestBase
     public function testMergeWithHavingConditions()
     {
         $c1 = new Criteria();
-        $cton = $c1->getNewCriterion(BookTableMap::TITLE, 'foo', Criteria::EQUAL);
+        $cton = $c1->getNewCriterion(BookTableMap::COL_TITLE, 'foo', Criteria::EQUAL);
         $c1->addHaving($cton);
         $c2 = new Criteria();
         $c1->mergeWith($c2);
@@ -352,16 +352,16 @@ class CriteriaMergeTest extends BookstoreTestBase
         $this->assertCriteriaTranslation($c1, $sql, 'mergeWith() does not remove an existing having condition');
         $c1 = new Criteria();
         $c2 = new Criteria();
-        $cton = $c2->getNewCriterion(BookTableMap::TITLE, 'foo', Criteria::EQUAL);
+        $cton = $c2->getNewCriterion(BookTableMap::COL_TITLE, 'foo', Criteria::EQUAL);
         $c2->addHaving($cton);
         $c1->mergeWith($c2);
         $sql = 'SELECT  FROM  HAVING book.TITLE=:p1';
         $this->assertCriteriaTranslation($c1, $sql, 'mergeWith() merges having condition to an empty having');
         $c1 = new Criteria();
-        $cton = $c1->getNewCriterion(BookTableMap::TITLE, 'foo', Criteria::EQUAL);
+        $cton = $c1->getNewCriterion(BookTableMap::COL_TITLE, 'foo', Criteria::EQUAL);
         $c1->addHaving($cton);
         $c2 = new Criteria();
-        $cton = $c2->getNewCriterion(BookTableMap::TITLE, 'bar', Criteria::EQUAL);
+        $cton = $c2->getNewCriterion(BookTableMap::COL_TITLE, 'bar', Criteria::EQUAL);
         $c2->addHaving($cton);
         $c1->mergeWith($c2);
         $sql = 'SELECT  FROM  HAVING (book.TITLE=:p1 AND book.TITLE=:p2)';
@@ -403,7 +403,7 @@ class CriteriaMergeTest extends BookstoreTestBase
     public function testMergeWithJoins()
     {
         $c1 = new Criteria();
-        $c1->addJoin(BookTableMap::AUTHOR_ID, AuthorTableMap::ID, Criteria::LEFT_JOIN);
+        $c1->addJoin(BookTableMap::COL_AUTHOR_ID, AuthorTableMap::COL_ID, Criteria::LEFT_JOIN);
         $c2 = new Criteria();
         $c1->mergeWith($c2);
         $joins = $c1->getJoins();
@@ -411,15 +411,15 @@ class CriteriaMergeTest extends BookstoreTestBase
         $this->assertEquals('LEFT JOIN author ON (book.AUTHOR_ID=author.ID)', $joins[0]->toString(), 'mergeWith() does not remove an existing join');
         $c1 = new Criteria();
         $c2 = new Criteria();
-        $c2->addJoin(BookTableMap::AUTHOR_ID, AuthorTableMap::ID, Criteria::LEFT_JOIN);
+        $c2->addJoin(BookTableMap::COL_AUTHOR_ID, AuthorTableMap::COL_ID, Criteria::LEFT_JOIN);
         $c1->mergeWith($c2);
         $joins = $c1->getJoins();
         $this->assertEquals(1, count($joins), 'mergeWith() merge joins to an empty join');
         $this->assertEquals('LEFT JOIN author ON (book.AUTHOR_ID=author.ID)', $joins[0]->toString(), 'mergeWith() merge joins to an empty join');
         $c1 = new Criteria();
-        $c1->addJoin(BookTableMap::AUTHOR_ID, AuthorTableMap::ID, Criteria::LEFT_JOIN);
+        $c1->addJoin(BookTableMap::COL_AUTHOR_ID, AuthorTableMap::COL_ID, Criteria::LEFT_JOIN);
         $c2 = new Criteria();
-        $c2->addJoin(BookTableMap::PUBLISHER_ID, PublisherTableMap::ID, Criteria::INNER_JOIN);
+        $c2->addJoin(BookTableMap::COL_PUBLISHER_ID, PublisherTableMap::COL_ID, Criteria::INNER_JOIN);
         $c1->mergeWith($c2);
         $joins = $c1->getJoins();
         $this->assertEquals(2, count($joins), 'mergeWith() merge joins to an existing join');

--- a/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaTest.php
@@ -317,7 +317,7 @@ class CriteriaTest extends BookstoreTestBase
 
         $criteria = new Criteria();
         $criteria->setIgnoreCase(true);
-        $criteria->addAscendingOrderByColumn(BookTableMap::TITLE);
+        $criteria->addAscendingOrderByColumn(BookTableMap::COL_TITLE);
         BookTableMap::addSelectColumns($criteria);
         $params=array();
         $sql = $criteria->createSelectSql($params);
@@ -894,8 +894,8 @@ class CriteriaTest extends BookstoreTestBase
     public function testHavingAlias()
     {
         $c = new Criteria();
-        $c->addSelectColumn(BookTableMap::TITLE);
-        $c->addAsColumn('isb_n', BookTableMap::ISBN);
+        $c->addSelectColumn(BookTableMap::COL_TITLE);
+        $c->addAsColumn('isb_n', BookTableMap::COL_ISBN);
         $crit = $c->getNewCriterion('isb_n', '1234567890123');
         $c->addHaving($crit);
         $expected = $this->getSql('SELECT book.TITLE, book.ISBN AS isb_n FROM `book` HAVING isb_n=:p1');
@@ -910,12 +910,12 @@ class CriteriaTest extends BookstoreTestBase
     public function testHaving()
     {
         $c = new Criteria();
-        $c->addSelectColumn(BookTableMap::TITLE);
-        $c->addSelectColumn(BookTableMap::ISBN);
+        $c->addSelectColumn(BookTableMap::COL_TITLE);
+        $c->addSelectColumn(BookTableMap::COL_ISBN);
         $crit = $c->getNewCriterion('ISBN', '1234567890123');
         $c->addHaving($crit);
-        $c->addGroupByColumn(BookTableMap::TITLE);
-        $c->addGroupByColumn(BookTableMap::ISBN);
+        $c->addGroupByColumn(BookTableMap::COL_TITLE);
+        $c->addGroupByColumn(BookTableMap::COL_ISBN);
         $expected = $this->getSql('SELECT book.TITLE, book.ISBN FROM `book` GROUP BY book.TITLE,book.ISBN HAVING ISBN=:p1');
         $params = array();
         $result = $c->createSelectSql($params);
@@ -931,8 +931,8 @@ class CriteriaTest extends BookstoreTestBase
     public function testHavingAliasRaw()
     {
         $c = new Criteria();
-        $c->addSelectColumn(BookTableMap::TITLE);
-        $c->addAsColumn("isb_n", BookTableMap::ISBN);
+        $c->addSelectColumn(BookTableMap::COL_TITLE);
+        $c->addAsColumn("isb_n", BookTableMap::COL_ISBN);
         $c->addHaving('isb_n = ?', '1234567890123', \PDO::PARAM_STR);
         $expected = $this->getSql('SELECT book.TITLE, book.ISBN AS isb_n FROM `book` HAVING isb_n = :p1');
         $params = array();

--- a/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaSelectTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaSelectTest.php
@@ -127,7 +127,7 @@ class ModelCriteriaSelectTest extends BookstoreTestBase
         $this->assertEquals($expectedSQL, $this->con->getLastExecutedQuery(), 'findOne() called after select(string) allows for where() statements');
 
         $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Author');
-        $c->select(AuthorTableMap::FIRST_NAME);
+        $c->select(AuthorTableMap::COL_FIRST_NAME);
         $author = $c->find($this->con);
         $expectedSQL = $this->getSql("SELECT author.FIRST_NAME AS \"author.FIRST_NAME\" FROM `author`");
         $this->assertEquals($expectedSQL, $this->con->getLastExecutedQuery(), 'select(string) accepts model TableMap Constants');

--- a/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaTest.php
@@ -443,7 +443,7 @@ class ModelCriteriaTest extends BookstoreTestBase
     {
         $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
         $c->where('Propel\Tests\Bookstore\Book.Title = ?', 'foo');
-        $c->add(BookTableMap::ID, array(1, 2), Criteria::IN);
+        $c->add(BookTableMap::COL_ID, array(1, 2), Criteria::IN);
 
         $sql = $this->getSql('SELECT  FROM `book` WHERE book.TITLE = :p1 AND book.ID IN (:p2,:p3)');
 
@@ -613,7 +613,7 @@ class ModelCriteriaTest extends BookstoreTestBase
     public function testOrderByAlias()
     {
         $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
-        $c->addAsColumn('t', BookTableMap::TITLE);
+        $c->addAsColumn('t', BookTableMap::COL_TITLE);
         $c->orderBy('t');
 
         $sql = 'SELECT book.TITLE AS t FROM  ORDER BY t ASC';
@@ -652,7 +652,7 @@ class ModelCriteriaTest extends BookstoreTestBase
     public function testGroupByAlias()
     {
         $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
-        $c->addAsColumn('t', BookTableMap::TITLE);
+        $c->addAsColumn('t', BookTableMap::COL_TITLE);
         $c->groupBy('t');
 
         $sql = 'SELECT book.TITLE AS t FROM  GROUP BY t';
@@ -757,8 +757,8 @@ class ModelCriteriaTest extends BookstoreTestBase
     public function testAddJoin()
     {
         $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
-        $c->addJoin(BookTableMap::AUTHOR_ID, AuthorTableMap::ID);
-        $c->addJoin(BookTableMap::PUBLISHER_ID, PublisherTableMap::ID);
+        $c->addJoin(BookTableMap::COL_AUTHOR_ID, AuthorTableMap::COL_ID);
+        $c->addJoin(BookTableMap::COL_PUBLISHER_ID, PublisherTableMap::COL_ID);
         $sql = $this->getSql('SELECT  FROM `book` INNER JOIN `author` ON (book.AUTHOR_ID=author.ID) INNER JOIN `publisher` ON (book.PUBLISHER_ID=publisher.ID)');
         $params = array();
         $this->assertCriteriaTranslation($c, $sql, $params, 'addJoin() works the same as in Criteria');
@@ -1074,7 +1074,7 @@ class ModelCriteriaTest extends BookstoreTestBase
         $con = Propel::getServiceContainer()->getConnection(BookTableMap::DATABASE_NAME);
         $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
         $c->join('Propel\Tests\Bookstore\Book.Author', Criteria::INNER_JOIN);
-        $criterion = $c->getNewCriterion(BookTableMap::TITLE, BookTableMap::TITLE . ' = ' . AuthorTableMap::FIRST_NAME, Criteria::CUSTOM);
+        $criterion = $c->getNewCriterion(BookTableMap::COL_TITLE, BookTableMap::COL_TITLE . ' = ' . AuthorTableMap::COL_FIRST_NAME, Criteria::CUSTOM);
         $c->setJoinCondition('Author', $criterion);
         $books = BookQuery::create(null, $c)->find($con);
         $expectedSQL = $this->getSql("SELECT book.ID, book.TITLE, book.ISBN, book.PRICE, book.PUBLISHER_ID, book.AUTHOR_ID FROM `book` INNER JOIN `author` ON book.TITLE = author.FIRST_NAME");
@@ -1147,17 +1147,17 @@ class ModelCriteriaTest extends BookstoreTestBase
         $c->join('Propel\Tests\Bookstore\Book.Author');
         $c->with('Author');
         $expectedColumns = array(
-            BookTableMap::ID,
-            BookTableMap::TITLE,
-            BookTableMap::ISBN,
-            BookTableMap::PRICE,
-            BookTableMap::PUBLISHER_ID,
-            BookTableMap::AUTHOR_ID,
-            AuthorTableMap::ID,
-            AuthorTableMap::FIRST_NAME,
-            AuthorTableMap::LAST_NAME,
-            AuthorTableMap::EMAIL,
-            AuthorTableMap::AGE
+            BookTableMap::COL_ID,
+            BookTableMap::COL_TITLE,
+            BookTableMap::COL_ISBN,
+            BookTableMap::COL_PRICE,
+            BookTableMap::COL_PUBLISHER_ID,
+            BookTableMap::COL_AUTHOR_ID,
+            AuthorTableMap::COL_ID,
+            AuthorTableMap::COL_FIRST_NAME,
+            AuthorTableMap::COL_LAST_NAME,
+            AuthorTableMap::COL_EMAIL,
+            AuthorTableMap::COL_AGE
         );
         $this->assertEquals($expectedColumns, $c->getSelectColumns(), 'with() adds the columns of the related table');
     }
@@ -1169,12 +1169,12 @@ class ModelCriteriaTest extends BookstoreTestBase
         $c->join('Propel\Tests\Bookstore\Book.Author a');
         $c->with('a');
         $expectedColumns = array(
-            BookTableMap::ID,
-            BookTableMap::TITLE,
-            BookTableMap::ISBN,
-            BookTableMap::PRICE,
-            BookTableMap::PUBLISHER_ID,
-            BookTableMap::AUTHOR_ID,
+            BookTableMap::COL_ID,
+            BookTableMap::COL_TITLE,
+            BookTableMap::COL_ISBN,
+            BookTableMap::COL_PRICE,
+            BookTableMap::COL_PUBLISHER_ID,
+            BookTableMap::COL_AUTHOR_ID,
             'a.ID',
             'a.FIRST_NAME',
             'a.LAST_NAME',
@@ -1190,17 +1190,17 @@ class ModelCriteriaTest extends BookstoreTestBase
         $c->join('Propel\Tests\Bookstore\Book.Author');
         $c->with('Author');
         $expectedColumns = array(
-            BookTableMap::ID,
-            BookTableMap::TITLE,
-            BookTableMap::ISBN,
-            BookTableMap::PRICE,
-            BookTableMap::PUBLISHER_ID,
-            BookTableMap::AUTHOR_ID,
-            AuthorTableMap::ID,
-            AuthorTableMap::FIRST_NAME,
-            AuthorTableMap::LAST_NAME,
-            AuthorTableMap::EMAIL,
-            AuthorTableMap::AGE
+            BookTableMap::COL_ID,
+            BookTableMap::COL_TITLE,
+            BookTableMap::COL_ISBN,
+            BookTableMap::COL_PRICE,
+            BookTableMap::COL_PUBLISHER_ID,
+            BookTableMap::COL_AUTHOR_ID,
+            AuthorTableMap::COL_ID,
+            AuthorTableMap::COL_FIRST_NAME,
+            AuthorTableMap::COL_LAST_NAME,
+            AuthorTableMap::COL_EMAIL,
+            AuthorTableMap::COL_AGE
         );
         $this->assertEquals($expectedColumns, $c->getSelectColumns(), 'with() adds the columns of the main table if required');
     }
@@ -1234,17 +1234,17 @@ class ModelCriteriaTest extends BookstoreTestBase
         $c->leftJoin('Propel\Tests\Bookstore\Author.Book');
         $c->with('Book');
         $expectedColumns = array(
-            AuthorTableMap::ID,
-            AuthorTableMap::FIRST_NAME,
-            AuthorTableMap::LAST_NAME,
-            AuthorTableMap::EMAIL,
-            AuthorTableMap::AGE,
-            BookTableMap::ID,
-            BookTableMap::TITLE,
-            BookTableMap::ISBN,
-            BookTableMap::PRICE,
-            BookTableMap::PUBLISHER_ID,
-            BookTableMap::AUTHOR_ID,
+            AuthorTableMap::COL_ID,
+            AuthorTableMap::COL_FIRST_NAME,
+            AuthorTableMap::COL_LAST_NAME,
+            AuthorTableMap::COL_EMAIL,
+            AuthorTableMap::COL_AGE,
+            BookTableMap::COL_ID,
+            BookTableMap::COL_TITLE,
+            BookTableMap::COL_ISBN,
+            BookTableMap::COL_PRICE,
+            BookTableMap::COL_PUBLISHER_ID,
+            BookTableMap::COL_AUTHOR_ID,
         );
         $this->assertEquals($expectedColumns, $c->getSelectColumns(), 'with() adds the columns of the related table even in a one-to-many relationship');
     }
@@ -1254,17 +1254,17 @@ class ModelCriteriaTest extends BookstoreTestBase
         $c = new TestableModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
         $c->joinWith('Propel\Tests\Bookstore\Book.Author');
         $expectedColumns = array(
-            BookTableMap::ID,
-            BookTableMap::TITLE,
-            BookTableMap::ISBN,
-            BookTableMap::PRICE,
-            BookTableMap::PUBLISHER_ID,
-            BookTableMap::AUTHOR_ID,
-            AuthorTableMap::ID,
-            AuthorTableMap::FIRST_NAME,
-            AuthorTableMap::LAST_NAME,
-            AuthorTableMap::EMAIL,
-            AuthorTableMap::AGE
+            BookTableMap::COL_ID,
+            BookTableMap::COL_TITLE,
+            BookTableMap::COL_ISBN,
+            BookTableMap::COL_PRICE,
+            BookTableMap::COL_PUBLISHER_ID,
+            BookTableMap::COL_AUTHOR_ID,
+            AuthorTableMap::COL_ID,
+            AuthorTableMap::COL_FIRST_NAME,
+            AuthorTableMap::COL_LAST_NAME,
+            AuthorTableMap::COL_EMAIL,
+            AuthorTableMap::COL_AGE
         );
         $this->assertEquals($expectedColumns, $c->getSelectColumns(), 'joinWith() adds the join');
         $joins = $c->getJoins();
@@ -1286,12 +1286,12 @@ class ModelCriteriaTest extends BookstoreTestBase
         $c = new TestableModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
         $c->joinWith('Propel\Tests\Bookstore\Book.Author a');
         $expectedColumns = array(
-            BookTableMap::ID,
-            BookTableMap::TITLE,
-            BookTableMap::ISBN,
-            BookTableMap::PRICE,
-            BookTableMap::PUBLISHER_ID,
-            BookTableMap::AUTHOR_ID,
+            BookTableMap::COL_ID,
+            BookTableMap::COL_TITLE,
+            BookTableMap::COL_ISBN,
+            BookTableMap::COL_PRICE,
+            BookTableMap::COL_PUBLISHER_ID,
+            BookTableMap::COL_AUTHOR_ID,
             'a.ID',
             'a.FIRST_NAME',
             'a.LAST_NAME',
@@ -1308,25 +1308,25 @@ class ModelCriteriaTest extends BookstoreTestBase
         $c->joinWith('Propel\Tests\Bookstore\Book.Author');
         $c->joinWith('Book.Publisher');
         $expectedColumns = array(
-            ReviewTableMap::ID,
-            ReviewTableMap::REVIEWED_BY,
-            ReviewTableMap::REVIEW_DATE,
-            ReviewTableMap::RECOMMENDED,
-            ReviewTableMap::STATUS,
-            ReviewTableMap::BOOK_ID,
-            BookTableMap::ID,
-            BookTableMap::TITLE,
-            BookTableMap::ISBN,
-            BookTableMap::PRICE,
-            BookTableMap::PUBLISHER_ID,
-            BookTableMap::AUTHOR_ID,
-            AuthorTableMap::ID,
-            AuthorTableMap::FIRST_NAME,
-            AuthorTableMap::LAST_NAME,
-            AuthorTableMap::EMAIL,
-            AuthorTableMap::AGE,
-            PublisherTableMap::ID,
-            PublisherTableMap::NAME
+            ReviewTableMap::COL_ID,
+            ReviewTableMap::COL_REVIEWED_BY,
+            ReviewTableMap::COL_REVIEW_DATE,
+            ReviewTableMap::COL_RECOMMENDED,
+            ReviewTableMap::COL_STATUS,
+            ReviewTableMap::COL_BOOK_ID,
+            BookTableMap::COL_ID,
+            BookTableMap::COL_TITLE,
+            BookTableMap::COL_ISBN,
+            BookTableMap::COL_PRICE,
+            BookTableMap::COL_PUBLISHER_ID,
+            BookTableMap::COL_AUTHOR_ID,
+            AuthorTableMap::COL_ID,
+            AuthorTableMap::COL_FIRST_NAME,
+            AuthorTableMap::COL_LAST_NAME,
+            AuthorTableMap::COL_EMAIL,
+            AuthorTableMap::COL_AGE,
+            PublisherTableMap::COL_ID,
+            PublisherTableMap::COL_NAME
         );
         $this->assertEquals($expectedColumns, $c->getSelectColumns(), 'joinWith() adds the with');
         $joins = $c->getJoins();
@@ -1341,23 +1341,23 @@ class ModelCriteriaTest extends BookstoreTestBase
         $c->joinWith('Propel\Tests\Bookstore\Book.Author');
         $c->joinWith('Propel\Tests\Bookstore\Book.Review');
         $expectedColumns = array(
-            BookTableMap::ID,
-            BookTableMap::TITLE,
-            BookTableMap::ISBN,
-            BookTableMap::PRICE,
-            BookTableMap::PUBLISHER_ID,
-            BookTableMap::AUTHOR_ID,
-            AuthorTableMap::ID,
-            AuthorTableMap::FIRST_NAME,
-            AuthorTableMap::LAST_NAME,
-            AuthorTableMap::EMAIL,
-            AuthorTableMap::AGE,
-            ReviewTableMap::ID,
-            ReviewTableMap::REVIEWED_BY,
-            ReviewTableMap::REVIEW_DATE,
-            ReviewTableMap::RECOMMENDED,
-            ReviewTableMap::STATUS,
-            ReviewTableMap::BOOK_ID,
+            BookTableMap::COL_ID,
+            BookTableMap::COL_TITLE,
+            BookTableMap::COL_ISBN,
+            BookTableMap::COL_PRICE,
+            BookTableMap::COL_PUBLISHER_ID,
+            BookTableMap::COL_AUTHOR_ID,
+            AuthorTableMap::COL_ID,
+            AuthorTableMap::COL_FIRST_NAME,
+            AuthorTableMap::COL_LAST_NAME,
+            AuthorTableMap::COL_EMAIL,
+            AuthorTableMap::COL_AGE,
+            ReviewTableMap::COL_ID,
+            ReviewTableMap::COL_REVIEWED_BY,
+            ReviewTableMap::COL_REVIEW_DATE,
+            ReviewTableMap::COL_RECOMMENDED,
+            ReviewTableMap::COL_STATUS,
+            ReviewTableMap::COL_BOOK_ID,
         );
         $this->assertEquals($expectedColumns, $c->getSelectColumns(), 'joinWith() adds the with');
         $joins = $c->getJoins();
@@ -2223,12 +2223,12 @@ class ModelCriteriaTest extends BookstoreTestBase
         $c = new TestableModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
         $c->leftJoinWith('Propel\Tests\Bookstore\Book.Author a');
         $expectedColumns = array(
-            BookTableMap::ID,
-            BookTableMap::TITLE,
-            BookTableMap::ISBN,
-            BookTableMap::PRICE,
-            BookTableMap::PUBLISHER_ID,
-            BookTableMap::AUTHOR_ID,
+            BookTableMap::COL_ID,
+            BookTableMap::COL_TITLE,
+            BookTableMap::COL_ISBN,
+            BookTableMap::COL_PRICE,
+            BookTableMap::COL_PUBLISHER_ID,
+            BookTableMap::COL_AUTHOR_ID,
             'a.ID',
             'a.FIRST_NAME',
             'a.LAST_NAME',
@@ -2246,17 +2246,17 @@ class ModelCriteriaTest extends BookstoreTestBase
         $c = new TestableModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
         $c->joinWithAuthor();
         $expectedColumns = array(
-            BookTableMap::ID,
-            BookTableMap::TITLE,
-            BookTableMap::ISBN,
-            BookTableMap::PRICE,
-            BookTableMap::PUBLISHER_ID,
-            BookTableMap::AUTHOR_ID,
-            AuthorTableMap::ID,
-            AuthorTableMap::FIRST_NAME,
-            AuthorTableMap::LAST_NAME,
-            AuthorTableMap::EMAIL,
-            AuthorTableMap::AGE
+            BookTableMap::COL_ID,
+            BookTableMap::COL_TITLE,
+            BookTableMap::COL_ISBN,
+            BookTableMap::COL_PRICE,
+            BookTableMap::COL_PUBLISHER_ID,
+            BookTableMap::COL_AUTHOR_ID,
+            AuthorTableMap::COL_ID,
+            AuthorTableMap::COL_FIRST_NAME,
+            AuthorTableMap::COL_LAST_NAME,
+            AuthorTableMap::COL_EMAIL,
+            AuthorTableMap::COL_AGE
         );
         $this->assertEquals($expectedColumns, $c->getSelectColumns(), 'joinWithXXX() adds the join with the XXX relation');
         $joins = $c->getJoins();
@@ -2269,17 +2269,17 @@ class ModelCriteriaTest extends BookstoreTestBase
         $c = new TestableModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
         $c->leftJoinWithAuthor();
         $expectedColumns = array(
-            BookTableMap::ID,
-            BookTableMap::TITLE,
-            BookTableMap::ISBN,
-            BookTableMap::PRICE,
-            BookTableMap::PUBLISHER_ID,
-            BookTableMap::AUTHOR_ID,
-            AuthorTableMap::ID,
-            AuthorTableMap::FIRST_NAME,
-            AuthorTableMap::LAST_NAME,
-            AuthorTableMap::EMAIL,
-            AuthorTableMap::AGE
+            BookTableMap::COL_ID,
+            BookTableMap::COL_TITLE,
+            BookTableMap::COL_ISBN,
+            BookTableMap::COL_PRICE,
+            BookTableMap::COL_PUBLISHER_ID,
+            BookTableMap::COL_AUTHOR_ID,
+            AuthorTableMap::COL_ID,
+            AuthorTableMap::COL_FIRST_NAME,
+            AuthorTableMap::COL_LAST_NAME,
+            AuthorTableMap::COL_EMAIL,
+            AuthorTableMap::COL_AGE
         );
         $this->assertEquals($expectedColumns, $c->getSelectColumns(), 'leftJoinWithXXX() adds the join with the XXX relation');
         $joins = $c->getJoins();
@@ -2570,32 +2570,32 @@ class ModelCriteriaTest extends BookstoreTestBase
     public function testGetAliasedColName()
     {
         $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
-        $this->assertEquals(BookTableMap::TITLE, $c->getAliasedColName(BookTableMap::TITLE), 'getAliasedColName() returns the input when the table has no alias');
+        $this->assertEquals(BookTableMap::COL_TITLE, $c->getAliasedColName(BookTableMap::COL_TITLE), 'getAliasedColName() returns the input when the table has no alias');
 
         $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
         $c->setModelAlias('foo');
-        $this->assertEquals(BookTableMap::TITLE, $c->getAliasedColName(BookTableMap::TITLE), 'getAliasedColName() returns the input when the table has a query alias');
+        $this->assertEquals(BookTableMap::COL_TITLE, $c->getAliasedColName(BookTableMap::COL_TITLE), 'getAliasedColName() returns the input when the table has a query alias');
 
         $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
         $c->setModelAlias('foo', true);
-        $this->assertEquals('foo.TITLE', $c->getAliasedColName(BookTableMap::TITLE), 'getAliasedColName() returns the column name with table alias when the table has a true alias');
+        $this->assertEquals('foo.TITLE', $c->getAliasedColName(BookTableMap::COL_TITLE), 'getAliasedColName() returns the column name with table alias when the table has a true alias');
     }
 
     public function testAddUsingAliasNoAlias()
     {
         $c1 = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
-        $c1->addUsingAlias(BookTableMap::TITLE, 'foo');
+        $c1->addUsingAlias(BookTableMap::COL_TITLE, 'foo');
         $c2 = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
-        $c2->add(BookTableMap::TITLE, 'foo');
+        $c2->add(BookTableMap::COL_TITLE, 'foo');
         $this->assertEquals($c2, $c1, 'addUsingalias() translates to add() when the table has no alias');
     }
 
     public function testAddUsingAliasQueryAlias()
     {
         $c1 = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book', 'b');
-        $c1->addUsingAlias(BookTableMap::TITLE, 'foo');
+        $c1->addUsingAlias(BookTableMap::COL_TITLE, 'foo');
         $c2 = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book', 'b');
-        $c2->add(BookTableMap::TITLE, 'foo');
+        $c2->add(BookTableMap::COL_TITLE, 'foo');
         $this->assertEquals($c2, $c1, 'addUsingalias() translates the colname using the table alias before calling add() when the table has a true alias');
     }
 
@@ -2603,7 +2603,7 @@ class ModelCriteriaTest extends BookstoreTestBase
     {
         $c1 = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
         $c1->setModelAlias('b', true);
-        $c1->addUsingAlias(BookTableMap::TITLE, 'foo');
+        $c1->addUsingAlias(BookTableMap::COL_TITLE, 'foo');
         $c2 = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
         $c2->setModelAlias('b', true);
         $c2->add('b.TITLE', 'foo');
@@ -2613,11 +2613,11 @@ class ModelCriteriaTest extends BookstoreTestBase
     public function testAddUsingAliasTwice()
     {
         $c1 = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
-        $c1->addUsingAlias(BookTableMap::TITLE, 'foo');
-        $c1->addUsingAlias(BookTableMap::TITLE, 'bar');
+        $c1->addUsingAlias(BookTableMap::COL_TITLE, 'foo');
+        $c1->addUsingAlias(BookTableMap::COL_TITLE, 'bar');
         $c2 = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
-        $c2->add(BookTableMap::TITLE, 'foo');
-        $c2->addAnd(BookTableMap::TITLE, 'bar');
+        $c2->add(BookTableMap::COL_TITLE, 'foo');
+        $c2->addAnd(BookTableMap::COL_TITLE, 'bar');
         $this->assertEquals($c2, $c1, 'addUsingalias() translates to addAnd() when the table already has a condition on the column');
     }
 
@@ -2625,8 +2625,8 @@ class ModelCriteriaTest extends BookstoreTestBase
     {
         $c1 = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
         $c1->setModelAlias('b', true);
-        $c1->addUsingAlias(BookTableMap::TITLE, 'foo');
-        $c1->addUsingAlias(BookTableMap::TITLE, 'bar');
+        $c1->addUsingAlias(BookTableMap::COL_TITLE, 'foo');
+        $c1->addUsingAlias(BookTableMap::COL_TITLE, 'bar');
         $c2 = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
         $c2->setModelAlias('b', true);
         $c2->add('b.TITLE', 'foo');

--- a/tests/Propel/Tests/Runtime/ActiveQuery/ModelJoinTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/ModelJoinTest.php
@@ -56,8 +56,8 @@ class ModelJoinTest extends BookstoreTestBase
         $join = new ModelJoin();
         $join->setTableMap($bookTable);
         $join->setRelationMap($bookTable->getRelation('Author'));
-        $this->assertEquals(array(BookTableMap::AUTHOR_ID), $join->getLeftColumns(), 'setRelationMap() automatically sets the left columns');
-        $this->assertEquals(array(AuthorTableMap::ID), $join->getRightColumns(), 'setRelationMap() automatically sets the right columns');
+        $this->assertEquals(array(BookTableMap::COL_AUTHOR_ID), $join->getLeftColumns(), 'setRelationMap() automatically sets the left columns');
+        $this->assertEquals(array(AuthorTableMap::COL_ID), $join->getRightColumns(), 'setRelationMap() automatically sets the right columns');
     }
 
     public function testSetRelationMapLeftAlias()
@@ -67,7 +67,7 @@ class ModelJoinTest extends BookstoreTestBase
         $join->setTableMap($bookTable);
         $join->setRelationMap($bookTable->getRelation('Author'), 'b');
         $this->assertEquals(array('b.AUTHOR_ID'), $join->getLeftColumns(), 'setRelationMap() automatically sets the left columns using the left table alias');
-        $this->assertEquals(array(AuthorTableMap::ID), $join->getRightColumns(), 'setRelationMap() automatically sets the right columns');
+        $this->assertEquals(array(AuthorTableMap::COL_ID), $join->getRightColumns(), 'setRelationMap() automatically sets the right columns');
     }
 
     public function testSetRelationMapRightAlias()
@@ -76,7 +76,7 @@ class ModelJoinTest extends BookstoreTestBase
         $join = new ModelJoin();
         $join->setTableMap($bookTable);
         $join->setRelationMap($bookTable->getRelation('Author'), null, 'a');
-        $this->assertEquals(array(BookTableMap::AUTHOR_ID), $join->getLeftColumns(), 'setRelationMap() automatically sets the left columns');
+        $this->assertEquals(array(BookTableMap::COL_AUTHOR_ID), $join->getLeftColumns(), 'setRelationMap() automatically sets the left columns');
         $this->assertEquals(array('a.ID'), $join->getRightColumns(), 'setRelationMap() automatically sets the right columns  using the right table alias');
     }
 
@@ -86,8 +86,8 @@ class ModelJoinTest extends BookstoreTestBase
         $join = new ModelJoin();
         $join->setTableMap($table);
         $join->setRelationMap($table->getRelation('BookOpinion'));
-        $this->assertEquals(array(ReaderFavoriteTableMap::BOOK_ID, ReaderFavoriteTableMap::READER_ID), $join->getLeftColumns(), 'setRelationMap() automatically sets the left columns for composite relationships');
-        $this->assertEquals(array(BookOpinionTableMap::BOOK_ID, BookOpinionTableMap::READER_ID), $join->getRightColumns(), 'setRelationMap() automatically sets the right columns for composite relationships');
+        $this->assertEquals(array(ReaderFavoriteTableMap::COL_BOOK_ID, ReaderFavoriteTableMap::COL_READER_ID), $join->getLeftColumns(), 'setRelationMap() automatically sets the left columns for composite relationships');
+        $this->assertEquals(array(BookOpinionTableMap::COL_BOOK_ID, BookOpinionTableMap::COL_READER_ID), $join->getRightColumns(), 'setRelationMap() automatically sets the right columns for composite relationships');
     }
 
 }

--- a/tests/Propel/Tests/Runtime/Adapter/DBAdapterTest.php
+++ b/tests/Propel/Tests/Runtime/Adapter/DBAdapterTest.php
@@ -27,11 +27,11 @@ class AbstractAdapterTest extends BookstoreTestBase
     {
         $db = Propel::getServiceContainer()->getAdapter(BookTableMap::DATABASE_NAME);
         $c1 = new Criteria();
-        $c1->addSelectColumn(BookTableMap::ID);
+        $c1->addSelectColumn(BookTableMap::COL_ID);
         $db->turnSelectColumnsToAliases($c1);
 
         $c2 = new Criteria();
-        $c2->addAsColumn('book_ID', BookTableMap::ID);
+        $c2->addAsColumn('book_ID', BookTableMap::COL_ID);
         $this->assertTrue($c1->equals($c2));
     }
 
@@ -39,13 +39,13 @@ class AbstractAdapterTest extends BookstoreTestBase
     {
         $db = Propel::getServiceContainer()->getAdapter(BookTableMap::DATABASE_NAME);
         $c1 = new Criteria();
-        $c1->addSelectColumn(BookTableMap::ID);
-        $c1->addAsColumn('foo', BookTableMap::TITLE);
+        $c1->addSelectColumn(BookTableMap::COL_ID);
+        $c1->addAsColumn('foo', BookTableMap::COL_TITLE);
         $db->turnSelectColumnsToAliases($c1);
 
         $c2 = new Criteria();
-        $c2->addAsColumn('book_ID', BookTableMap::ID);
-        $c2->addAsColumn('foo', BookTableMap::TITLE);
+        $c2->addAsColumn('book_ID', BookTableMap::COL_ID);
+        $c2->addAsColumn('foo', BookTableMap::COL_TITLE);
         $this->assertTrue($c1->equals($c2));
     }
 
@@ -53,13 +53,13 @@ class AbstractAdapterTest extends BookstoreTestBase
     {
         $db = Propel::getServiceContainer()->getAdapter(BookTableMap::DATABASE_NAME);
         $c1 = new Criteria();
-        $c1->addSelectColumn(BookTableMap::ID);
-        $c1->addAsColumn('book_ID', BookTableMap::ID);
+        $c1->addSelectColumn(BookTableMap::COL_ID);
+        $c1->addAsColumn('book_ID', BookTableMap::COL_ID);
         $db->turnSelectColumnsToAliases($c1);
 
         $c2 = new Criteria();
-        $c2->addAsColumn('book_ID_1', BookTableMap::ID);
-        $c2->addAsColumn('book_ID', BookTableMap::ID);
+        $c2->addAsColumn('book_ID_1', BookTableMap::COL_ID);
+        $c2->addAsColumn('book_ID', BookTableMap::COL_ID);
         $this->assertTrue($c1->equals($c2));
     }
 
@@ -67,13 +67,13 @@ class AbstractAdapterTest extends BookstoreTestBase
     {
         $db = Propel::getServiceContainer()->getAdapter(BookTableMap::DATABASE_NAME);
         $c1 = new Criteria();
-        $c1->addSelectColumn(BookTableMap::ID);
-        $c1->addSelectColumn(BookTableMap::ID);
+        $c1->addSelectColumn(BookTableMap::COL_ID);
+        $c1->addSelectColumn(BookTableMap::COL_ID);
         $db->turnSelectColumnsToAliases($c1);
 
         $c2 = new Criteria();
-        $c2->addAsColumn('book_ID', BookTableMap::ID);
-        $c2->addAsColumn('book_ID_1', BookTableMap::ID);
+        $c2->addAsColumn('book_ID', BookTableMap::COL_ID);
+        $c2->addAsColumn('book_ID_1', BookTableMap::COL_ID);
         $this->assertTrue($c1->equals($c2));
     }
 
@@ -81,8 +81,8 @@ class AbstractAdapterTest extends BookstoreTestBase
     {
         $db = Propel::getServiceContainer()->getAdapter(BookTableMap::DATABASE_NAME);
         $c = new Criteria();
-        $c->addSelectColumn(BookTableMap::ID);
-        $c->addAsColumn('book_ID', BookTableMap::ID);
+        $c->addSelectColumn(BookTableMap::COL_ID);
+        $c->addAsColumn('book_ID', BookTableMap::COL_ID);
         $fromClause = array();
         $selectSql = $db->createSelectSqlPart($c, $fromClause);
         $this->assertEquals('SELECT book.ID, book.ID AS book_ID', $selectSql, 'createSelectSqlPart() returns a SQL SELECT clause with both select and as columns');
@@ -93,8 +93,8 @@ class AbstractAdapterTest extends BookstoreTestBase
     {
         $db = Propel::getServiceContainer()->getAdapter(BookTableMap::DATABASE_NAME);
         $c = new Criteria();
-        $c->addSelectColumn(BookTableMap::ID);
-        $c->addAsColumn('book_ID', 'IF(1, '.BookTableMap::ID.', '.BookTableMap::TITLE.')');
+        $c->addSelectColumn(BookTableMap::COL_ID);
+        $c->addAsColumn('book_ID', 'IF(1, '.BookTableMap::COL_ID.', '.BookTableMap::COL_TITLE.')');
         $fromClause = array();
         $selectSql = $db->createSelectSqlPart($c, $fromClause);
         $this->assertEquals('SELECT book.ID, IF(1, book.ID, book.TITLE) AS book_ID', $selectSql, 'createSelectSqlPart() returns a SQL SELECT clause with both select and as columns');
@@ -105,8 +105,8 @@ class AbstractAdapterTest extends BookstoreTestBase
     {
         $db = Propel::getServiceContainer()->getAdapter(BookTableMap::DATABASE_NAME);
         $c = new Criteria();
-        $c->addSelectColumn(BookTableMap::ID);
-        $c->addAsColumn('book_ID', BookTableMap::ID);
+        $c->addSelectColumn(BookTableMap::COL_ID);
+        $c->addAsColumn('book_ID', BookTableMap::COL_ID);
         $c->setDistinct();
         $fromClause = array();
         $selectSql = $db->createSelectSqlPart($c, $fromClause);
@@ -118,8 +118,8 @@ class AbstractAdapterTest extends BookstoreTestBase
     {
         $db = Propel::getServiceContainer()->getAdapter(BookTableMap::DATABASE_NAME);
         $c = new Criteria();
-        $c->addSelectColumn(BookTableMap::ID);
-        $c->addAsColumn('book_ID', BookTableMap::ID);
+        $c->addSelectColumn(BookTableMap::COL_ID);
+        $c->addAsColumn('book_ID', BookTableMap::COL_ID);
         $fromClause = array();
         $selectSql = $db->createSelectSqlPart($c, $fromClause, true);
         $this->assertEquals('SELECT book.ID AS book_ID_1, book.ID AS book_ID', $selectSql, 'createSelectSqlPart() aliases all columns if passed true as last parameter');

--- a/tests/Propel/Tests/Runtime/Adapter/Pdo/OracleAdapterTest.php
+++ b/tests/Propel/Tests/Runtime/Adapter/Pdo/OracleAdapterTest.php
@@ -58,7 +58,7 @@ class OracleAdapterTest extends BookstoreTestBase
         $c->setDbName('oracle');
         BookTableMap::addSelectColumns($c);
         AuthorTableMap::addSelectColumns($c);
-        $c->addAsColumn('BOOK_PRICE', BookTableMap::PRICE);
+        $c->addAsColumn('BOOK_PRICE', BookTableMap::COL_PRICE);
         $c->setLimit(1);
         $params = array();
         $asColumns = $c->getAsColumns();
@@ -72,8 +72,8 @@ class OracleAdapterTest extends BookstoreTestBase
         Propel::getServiceContainer()->setAdapter('oracle', new OracleAdapter());
         $db = Propel::getServiceContainer()->getAdapter();
         $c = new Criteria();
-        $c->addSelectColumn(BookTableMap::ID);
-        $c->addAsColumn('book_ID', BookTableMap::ID);
+        $c->addSelectColumn(BookTableMap::COL_ID);
+        $c->addAsColumn('book_ID', BookTableMap::COL_ID);
         $fromClause = array();
         $selectSql = $db->createSelectSqlPart($c, $fromClause);
         $this->assertEquals('SELECT book.ID, book.ID AS book_ID', $selectSql, 'createSelectSqlPart() returns a SQL SELECT clause with both select and as columns');

--- a/tests/Propel/Tests/Runtime/Connection/PropelPDOTest.php
+++ b/tests/Propel/Tests/Runtime/Connection/PropelPDOTest.php
@@ -323,7 +323,7 @@ class PropelPDOTest extends BookstoreTestBase
     {
         $con = Propel::getServiceContainer()->getConnection(BookTableMap::DATABASE_NAME);
         $c = new Criteria();
-        $c->add(BookTableMap::ID, array(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1), Criteria::IN);
+        $c->add(BookTableMap::COL_ID, array(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1), Criteria::IN);
         $books = BookQuery::create(null, $c)->find($con);
         $expected = $this->getSql("SELECT book.ID, book.TITLE, book.ISBN, book.PRICE, book.PUBLISHER_ID, book.AUTHOR_ID FROM `book` WHERE book.ID IN (1,1,1,1,1,1,1,1,1,1,1,1)");
         $this->assertEquals($expected, $con->getLastExecutedQuery(), 'PropelPDO correctly replaces arguments in queries');
@@ -352,7 +352,7 @@ class PropelPDOTest extends BookstoreTestBase
     {
         $con = Propel::getServiceContainer()->getConnection(BookTableMap::DATABASE_NAME);
         $c = new Criteria();
-        $c->add(BookTableMap::TITLE, 'Harry%s', Criteria::LIKE);
+        $c->add(BookTableMap::COL_TITLE, 'Harry%s', Criteria::LIKE);
 
         $con->useDebug(false);
         $this->assertEquals('', $con->getLastExecutedQuery(), 'PropelPDO reinitializes the latest query when debug is set to false');
@@ -392,7 +392,7 @@ class PropelPDOTest extends BookstoreTestBase
     {
         $con = Propel::getServiceContainer()->getConnection(BookTableMap::DATABASE_NAME);
         $c = new Criteria();
-        $c->add(BookTableMap::TITLE, 'Harry%s', Criteria::LIKE);
+        $c->add(BookTableMap::COL_TITLE, 'Harry%s', Criteria::LIKE);
 
         $con->useDebug(false);
         $this->assertEquals(0, $con->getQueryCount(), 'PropelPDO does not update the query count when useLogging is false');
@@ -474,7 +474,7 @@ class PropelPDOTest extends BookstoreTestBase
         $con->beginTransaction();
 
         $c = new Criteria();
-        $c->add(BookTableMap::TITLE, 'Harry%s', Criteria::LIKE);
+        $c->add(BookTableMap::COL_TITLE, 'Harry%s', Criteria::LIKE);
 
         $books = BookQuery::create(null, $c)->find($con);
         $latestExecutedQuery = $this->getSql("SELECT book.ID, book.TITLE, book.ISBN, book.PRICE, book.PUBLISHER_ID, book.AUTHOR_ID FROM `book` WHERE book.TITLE LIKE 'Harry%s'");

--- a/tests/Propel/Tests/Runtime/Formatter/ArrayFormatterWithTest.php
+++ b/tests/Propel/Tests/Runtime/Formatter/ArrayFormatterWithTest.php
@@ -258,7 +258,7 @@ class ArrayFormatterWithTest extends BookstoreEmptyTestBase
     {
         $c = new ModelCriteria('bookstore', '\Propel\Tests\Bookstore\Book');
         $c->setFormatter(ModelCriteria::FORMAT_ARRAY);
-        $c->add(BookTableMap::ISBN, '043935806X');
+        $c->add(BookTableMap::COL_ISBN, '043935806X');
         $c->leftJoin('Propel\Tests\Bookstore\Book.Review');
         $c->with('Review');
         $c->limit(5);
@@ -274,7 +274,7 @@ class ArrayFormatterWithTest extends BookstoreEmptyTestBase
         ReviewTableMap::clearInstancePool();
         $c = new ModelCriteria('bookstore', '\Propel\Tests\Bookstore\Book');
         $c->setFormatter(ModelCriteria::FORMAT_ARRAY);
-        $c->add(BookTableMap::ISBN, '043935806X');
+        $c->add(BookTableMap::COL_ISBN, '043935806X');
         $c->leftJoin('Propel\Tests\Bookstore\Book.Review');
         $c->with('Review');
         $con = Propel::getServiceContainer()->getConnection(BookTableMap::DATABASE_NAME);
@@ -328,7 +328,7 @@ class ArrayFormatterWithTest extends BookstoreEmptyTestBase
         AuthorTableMap::clearInstancePool();
         ReviewTableMap::clearInstancePool();
         $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Author');
-        $c->add(AuthorTableMap::LAST_NAME, 'Rowling');
+        $c->add(AuthorTableMap::COL_LAST_NAME, 'Rowling');
         $c->leftJoinWith('Propel\Tests\Bookstore\Author.Book');
         $c->leftJoinWith('Book.Review');
         $c->setFormatter(ModelCriteria::FORMAT_ARRAY);
@@ -352,7 +352,7 @@ class ArrayFormatterWithTest extends BookstoreEmptyTestBase
         AuthorTableMap::clearInstancePool();
         ReviewTableMap::clearInstancePool();
         $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Author');
-        $c->add(AuthorTableMap::LAST_NAME, 'Rowling');
+        $c->add(AuthorTableMap::COL_LAST_NAME, 'Rowling');
         $c->leftJoinWith('Propel\Tests\Bookstore\Author.Book b');
         $c->leftJoinWith('b.Review r');
         $c->setFormatter(ModelCriteria::FORMAT_ARRAY);
@@ -380,7 +380,7 @@ class ArrayFormatterWithTest extends BookstoreEmptyTestBase
         $freud->save($this->con);
         $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Author');
         $c->setFormatter(ModelCriteria::FORMAT_ARRAY);
-        $c->add(AuthorTableMap::LAST_NAME, 'Freud');
+        $c->add(AuthorTableMap::COL_LAST_NAME, 'Freud');
         $c->leftJoinWith('Propel\Tests\Bookstore\Author.Book');
         $c->leftJoinWith('Book.Review');
         // should not raise a notice

--- a/tests/Propel/Tests/Runtime/Formatter/ObjectFormatterWithTest.php
+++ b/tests/Propel/Tests/Runtime/Formatter/ObjectFormatterWithTest.php
@@ -308,7 +308,7 @@ class ObjectFormatterWithTest extends BookstoreEmptyTestBase
     public function testFindOneWithOneToManyAndLimit()
     {
         $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
-        $c->add(BookTableMap::ISBN, '043935806X');
+        $c->add(BookTableMap::COL_ISBN, '043935806X');
         $c->leftJoin('Book.Review');
         $c->with('Review');
         $c->limit(5);
@@ -322,7 +322,7 @@ class ObjectFormatterWithTest extends BookstoreEmptyTestBase
         AuthorTableMap::clearInstancePool();
         ReviewTableMap::clearInstancePool();
         $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
-        $c->add(BookTableMap::ISBN, '043935806X');
+        $c->add(BookTableMap::COL_ISBN, '043935806X');
         $c->leftJoin('Propel\Tests\Bookstore\Book.Review');
         $c->with('Review');
         $con = Propel::getServiceContainer()->getConnection(BookTableMap::DATABASE_NAME);
@@ -379,7 +379,7 @@ class ObjectFormatterWithTest extends BookstoreEmptyTestBase
         AuthorTableMap::clearInstancePool();
         ReviewTableMap::clearInstancePool();
         $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Author');
-        $c->add(AuthorTableMap::LAST_NAME, 'Rowling');
+        $c->add(AuthorTableMap::COL_LAST_NAME, 'Rowling');
         $c->leftJoinWith('Propel\Tests\Bookstore\Author.Book');
         $c->leftJoinWith('Book.Review');
         $con = Propel::getServiceContainer()->getConnection(BookTableMap::DATABASE_NAME);
@@ -408,7 +408,7 @@ class ObjectFormatterWithTest extends BookstoreEmptyTestBase
         $freud->setLastName("Freud");
         $freud->save($this->con);
         $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Author');
-        $c->add(AuthorTableMap::LAST_NAME, 'Freud');
+        $c->add(AuthorTableMap::COL_LAST_NAME, 'Freud');
         $c->leftJoinWith('Propel\Tests\Bookstore\Author.Book');
         $c->leftJoinWith('Book.Review');
         // should not raise a notice
@@ -475,7 +475,7 @@ class ObjectFormatterWithTest extends BookstoreEmptyTestBase
         AuthorTableMap::clearInstancePool();
         ReviewTableMap::clearInstancePool();
         $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Author');
-        $c->add(AuthorTableMap::LAST_NAME, 'Rowling');
+        $c->add(AuthorTableMap::COL_LAST_NAME, 'Rowling');
         $c->leftJoinWith('Propel\Tests\Bookstore\Author.Book b');
         $c->leftJoinWith('b.Review r');
         $con = Propel::getServiceContainer()->getConnection(BookTableMap::DATABASE_NAME);

--- a/tests/Propel/Tests/Runtime/Formatter/OnDemandFormatterWithTest.php
+++ b/tests/Propel/Tests/Runtime/Formatter/OnDemandFormatterWithTest.php
@@ -256,7 +256,7 @@ class OnDemandFormatterWithTest extends BookstoreEmptyTestBase
         ReviewTableMap::clearInstancePool();
         $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
         $c->setFormatter(ModelCriteria::FORMAT_ON_DEMAND);
-        $c->add(BookTableMap::ISBN, '043935806X');
+        $c->add(BookTableMap::COL_ISBN, '043935806X');
         $c->leftJoin('Propel\Tests\Bookstore\Book.Review');
         $c->with('Review');
         $books = $c->find();

--- a/tests/Propel/Tests/Runtime/Util/TableMapExceptionsTest.php
+++ b/tests/Propel/Tests/Runtime/Util/TableMapExceptionsTest.php
@@ -29,7 +29,7 @@ class TableMapExceptionsTest extends BookstoreTestBase
     {
         try {
             $c = new Criteria();
-            $c->add(BookTableMap::ID, 12, ' BAD SQL');
+            $c->add(BookTableMap::COL_ID, 12, ' BAD SQL');
             BookTableMap::addSelectColumns($c);
             $c->doSelect();
             $this->fail('Missing expected exception on BAD SQL');
@@ -42,7 +42,7 @@ class TableMapExceptionsTest extends BookstoreTestBase
     {
         try {
             $c = new Criteria();
-            $c->add(BookTableMap::ID, 12, ' BAD SQL');
+            $c->add(BookTableMap::COL_ID, 12, ' BAD SQL');
             BookTableMap::addSelectColumns($c);
             $c->doCount();
             $this->fail('Missing expected exception on BAD SQL');
@@ -56,7 +56,7 @@ class TableMapExceptionsTest extends BookstoreTestBase
         try {
             $c = new Criteria();
             $c->setPrimaryTableName(BookTableMap::TABLE_NAME);
-            $c->add(BookTableMap::ID, 12, ' BAD SQL');
+            $c->add(BookTableMap::COL_ID, 12, ' BAD SQL');
             $c->doDelete(Propel::getServiceContainer()->getWriteConnection(BookTableMap::DATABASE_NAME));
             $this->fail('Missing expected exception on BAD SQL');
         } catch (PropelException $e) {
@@ -69,9 +69,9 @@ class TableMapExceptionsTest extends BookstoreTestBase
         try {
             $c1 = new Criteria();
             $c1->setPrimaryTableName(BookTableMap::TABLE_NAME);
-            $c1->add(BookTableMap::ID, 12, ' BAD SQL');
+            $c1->add(BookTableMap::COL_ID, 12, ' BAD SQL');
             $c2 = new Criteria();
-            $c2->add(BookTableMap::TITLE, 'Foo');
+            $c2->add(BookTableMap::COL_TITLE, 'Foo');
 
             $c1->doUpdate($c2, Propel::getServiceContainer()->getWriteConnection(BookTableMap::DATABASE_NAME));
             $this->fail('Missing expected exception on BAD SQL');
@@ -87,7 +87,7 @@ class TableMapExceptionsTest extends BookstoreTestBase
         try {
             $c = new Criteria();
             $c->setPrimaryTableName(BookTableMap::TABLE_NAME);
-            $c->add(BookTableMap::AUTHOR_ID, 'lkhlkhj');
+            $c->add(BookTableMap::COL_AUTHOR_ID, 'lkhlkhj');
 
             $db = Propel::getServiceContainer()->getAdapter($c->getDbName());
 

--- a/tests/Propel/Tests/Runtime/Util/TableMapTest.php
+++ b/tests/Propel/Tests/Runtime/Util/TableMapTest.php
@@ -57,8 +57,8 @@ class TableMapTest extends BookstoreTestBase
         $this->assertFalse($c->needsSelectAliases(), 'Empty Criterias don\'t need aliases');
 
         $c = new Criteria();
-        $c->addSelectColumn(BookTableMap::ID);
-        $c->addSelectColumn(BookTableMap::TITLE);
+        $c->addSelectColumn(BookTableMap::COL_ID);
+        $c->addSelectColumn(BookTableMap::COL_TITLE);
         $this->assertFalse($c->needsSelectAliases(), 'Criterias with distinct column names don\'t need aliases');
 
         $c = new Criteria();
@@ -66,8 +66,8 @@ class TableMapTest extends BookstoreTestBase
         $this->assertFalse($c->needsSelectAliases(), 'Criterias with only the columns of a model don\'t need aliases');
 
         $c = new Criteria();
-        $c->addSelectColumn(BookTableMap::ID);
-        $c->addSelectColumn(AuthorTableMap::ID);
+        $c->addSelectColumn(BookTableMap::COL_ID);
+        $c->addSelectColumn(AuthorTableMap::COL_ID);
         $this->assertTrue($c->needsSelectAliases(), 'Criterias with common column names do need aliases');
     }
 
@@ -75,9 +75,9 @@ class TableMapTest extends BookstoreTestBase
     {
         $con = Propel::getServiceContainer()->getReadConnection(BookTableMap::DATABASE_NAME);
         $c = new Criteria();
-        $c->addSelectColumn(BookTableMap::ID);
-        $c->addJoin(BookTableMap::AUTHOR_ID, AuthorTableMap::ID);
-        $c->addSelectColumn(AuthorTableMap::ID);
+        $c->addSelectColumn(BookTableMap::COL_ID);
+        $c->addJoin(BookTableMap::COL_AUTHOR_ID, AuthorTableMap::COL_ID);
+        $c->addSelectColumn(AuthorTableMap::COL_ID);
         $c->setLimit(3);
         try {
             $count = $c->doCount($con);
@@ -105,8 +105,8 @@ class TableMapTest extends BookstoreTestBase
 
         $c = new Criteria();
         $c->setIgnoreCase(true);
-        $c->add(BookstoreTableMap::STORE_NAME, 'SortTest%', Criteria::LIKE);
-        $c->addAscendingOrderByColumn(BookstoreTableMap::POPULATION_SERVED);
+        $c->add(BookstoreTableMap::COL_STORE_NAME, 'SortTest%', Criteria::LIKE);
+        $c->addAscendingOrderByColumn(BookstoreTableMap::COL_POPULATION_SERVED);
 
         $rows = BookstoreQuery::create(null, $c)->find();
         $this->assertEquals('SortTest2', $rows[0]->getStoreName());
@@ -122,11 +122,11 @@ class TableMapTest extends BookstoreTestBase
     {
         $this->markTestSkipped('Famous cross join problem, to be solved one day');
         $c = new Criteria(BookTableMap::DATABASE_NAME);
-        $c->addSelectColumn(BookTableMap::ID);
-        $c->addSelectColumn(BookTableMap::TITLE);
+        $c->addSelectColumn(BookTableMap::COL_ID);
+        $c->addSelectColumn(BookTableMap::COL_TITLE);
 
-        $c->addJoin(BookTableMap::PUBLISHER_ID, PublisherTableMap::ID, Criteria::LEFT_JOIN);
-        $c->addJoin(BookTableMap::AUTHOR_ID, AuthorTableMap::ID);
+        $c->addJoin(BookTableMap::COL_PUBLISHER_ID, PublisherTableMap::COL_ID, Criteria::LEFT_JOIN);
+        $c->addJoin(BookTableMap::COL_AUTHOR_ID, AuthorTableMap::COL_ID);
 
         $params = array();
         $sql = $c->createSelectSql($params);
@@ -143,12 +143,12 @@ class TableMapTest extends BookstoreTestBase
         }
 
         $c = new Criteria(BookTableMap::DATABASE_NAME);
-        $c->addSelectColumn(BookTableMap::ID);
-        $c->addSelectColumn(BookTableMap::TITLE);
-        $c->addSelectColumn(PublisherTableMap::NAME);
+        $c->addSelectColumn(BookTableMap::COL_ID);
+        $c->addSelectColumn(BookTableMap::COL_TITLE);
+        $c->addSelectColumn(PublisherTableMap::COL_NAME);
         $c->addAsColumn('PublisherName','(SELECT MAX(publisher.NAME) FROM publisher WHERE publisher.ID = book.PUBLISHER_ID)');
 
-        $c->addJoin(BookTableMap::PUBLISHER_ID, PublisherTableMap::ID, Criteria::LEFT_JOIN);
+        $c->addJoin(BookTableMap::COL_PUBLISHER_ID, PublisherTableMap::COL_ID, Criteria::LEFT_JOIN);
 
         $c->setOffset(0);
         $c->setLimit(20);
@@ -168,11 +168,11 @@ class TableMapTest extends BookstoreTestBase
         }
 
         $c = new Criteria(BookTableMap::DATABASE_NAME);
-        $c->addSelectColumn(BookTableMap::ID);
-        $c->addSelectColumn(BookTableMap::TITLE);
-        $c->addSelectColumn(PublisherTableMap::NAME);
+        $c->addSelectColumn(BookTableMap::COL_ID);
+        $c->addSelectColumn(BookTableMap::COL_TITLE);
+        $c->addSelectColumn(PublisherTableMap::COL_NAME);
         $c->addAsColumn('PublisherName','(SELECT MAX(publisher.NAME) FROM publisher WHERE publisher.ID = book.PUBLISHER_ID)');
-        $c->addJoin(BookTableMap::PUBLISHER_ID, PublisherTableMap::ID, Criteria::LEFT_JOIN);
+        $c->addJoin(BookTableMap::COL_PUBLISHER_ID, PublisherTableMap::COL_ID, Criteria::LEFT_JOIN);
         $c->setOffset(20);
         $c->setLimit(20);
 
@@ -191,11 +191,11 @@ class TableMapTest extends BookstoreTestBase
         }
 
         $c = new Criteria(BookTableMap::DATABASE_NAME);
-        $c->addSelectColumn(BookTableMap::ID);
-        $c->addSelectColumn(BookTableMap::TITLE);
-        $c->addSelectColumn(PublisherTableMap::NAME);
+        $c->addSelectColumn(BookTableMap::COL_ID);
+        $c->addSelectColumn(BookTableMap::COL_TITLE);
+        $c->addSelectColumn(PublisherTableMap::COL_NAME);
         $c->addAsColumn('PublisherName','(SELECT MAX(publisher.NAME) FROM publisher WHERE publisher.ID = book.PUBLISHER_ID)');
-        $c->addJoin(BookTableMap::PUBLISHER_ID, PublisherTableMap::ID, Criteria::LEFT_JOIN);
+        $c->addJoin(BookTableMap::COL_PUBLISHER_ID, PublisherTableMap::COL_ID, Criteria::LEFT_JOIN);
         $c->addDescendingOrderByColumn('PublisherName');
         $c->setOffset(20);
         $c->setLimit(20);
@@ -215,13 +215,13 @@ class TableMapTest extends BookstoreTestBase
         }
 
         $c = new Criteria(BookTableMap::DATABASE_NAME);
-        $c->addSelectColumn(BookTableMap::ID);
-        $c->addSelectColumn(BookTableMap::TITLE);
-        $c->addSelectColumn(PublisherTableMap::NAME);
+        $c->addSelectColumn(BookTableMap::COL_ID);
+        $c->addSelectColumn(BookTableMap::COL_TITLE);
+        $c->addSelectColumn(PublisherTableMap::COL_NAME);
         $c->addAsColumn('PublisherName','(SELECT MAX(publisher.NAME) FROM publisher WHERE publisher.ID = book.PUBLISHER_ID)');
-        $c->addJoin(BookTableMap::PUBLISHER_ID, PublisherTableMap::ID, Criteria::LEFT_JOIN);
+        $c->addJoin(BookTableMap::COL_PUBLISHER_ID, PublisherTableMap::COL_ID, Criteria::LEFT_JOIN);
         $c->addDescendingOrderByColumn('PublisherName');
-        $c->addAscendingOrderByColumn(BookTableMap::TITLE);
+        $c->addAscendingOrderByColumn(BookTableMap::COL_TITLE);
         $c->setOffset(20);
         $c->setLimit(20);
 
@@ -249,8 +249,8 @@ class TableMapTest extends BookstoreTestBase
     {
         $con = Propel::getServiceContainer()->getWriteConnection(BookTableMap::DATABASE_NAME);
         $c = new Criteria(BookTableMap::DATABASE_NAME);
-        $c->add(BookTableMap::TITLE, 'War And Peace');
-        $c->addJoin(BookTableMap::AUTHOR_ID, AuthorTableMap::ID);
+        $c->add(BookTableMap::COL_TITLE, 'War And Peace');
+        $c->addJoin(BookTableMap::COL_AUTHOR_ID, AuthorTableMap::COL_ID);
         $c->doDelete($con);
     }
 
@@ -258,7 +258,7 @@ class TableMapTest extends BookstoreTestBase
     {
         $con = Propel::getServiceContainer()->getWriteConnection(BookTableMap::DATABASE_NAME);
         $c = new Criteria(BookTableMap::DATABASE_NAME);
-        $c->add(BookTableMap::TITLE, 'War And Peace');
+        $c->add(BookTableMap::COL_TITLE, 'War And Peace');
         $c->doDelete($con);
         $expectedSQL = $this->getSql("DELETE FROM `book` WHERE book.TITLE='War And Peace'");
         $this->assertEquals($expectedSQL, $con->getLastExecutedQuery(), 'doDelete() translates a condition into a WHERE');
@@ -268,8 +268,8 @@ class TableMapTest extends BookstoreTestBase
     {
         $con = Propel::getServiceContainer()->getWriteConnection(BookTableMap::DATABASE_NAME);
         $c = new Criteria(BookTableMap::DATABASE_NAME);
-        $c->add(BookTableMap::TITLE, 'War And Peace');
-        $c->add(BookTableMap::ID, 12);
+        $c->add(BookTableMap::COL_TITLE, 'War And Peace');
+        $c->add(BookTableMap::COL_ID, 12);
         $c->doDelete($con);
         $expectedSQL = $this->getSql("DELETE FROM `book` WHERE book.TITLE='War And Peace' AND book.ID=12");
         $this->assertEquals($expectedSQL, $con->getLastExecutedQuery(), 'doDelete() combines conditions in WHERE with an AND');
@@ -304,16 +304,16 @@ class TableMapTest extends BookstoreTestBase
         $con = Propel::getServiceContainer()->getWriteConnection(BookTableMap::DATABASE_NAME);
         $count = $con->getQueryCount();
         $c = new Criteria(BookTableMap::DATABASE_NAME);
-        $c->add(BookTableMap::TITLE, 'War And Peace');
-        $c->add(AuthorTableMap::FIRST_NAME, 'Leo');
+        $c->add(BookTableMap::COL_TITLE, 'War And Peace');
+        $c->add(AuthorTableMap::COL_FIRST_NAME, 'Leo');
         $c->doDelete($con);
         $expectedSQL = $this->getSql("DELETE FROM `author` WHERE author.FIRST_NAME='Leo'");
         $this->assertEquals($expectedSQL, $con->getLastExecutedQuery(), 'doDelete() issues two DELETE queries when passed conditions on two tables');
         $this->assertEquals($count + 2, $con->getQueryCount(), 'doDelete() issues two DELETE queries when passed conditions on two tables');
 
         $c = new Criteria(BookTableMap::DATABASE_NAME);
-        $c->add(AuthorTableMap::FIRST_NAME, 'Leo');
-        $c->add(BookTableMap::TITLE, 'War And Peace');
+        $c->add(AuthorTableMap::COL_FIRST_NAME, 'Leo');
+        $c->add(BookTableMap::COL_TITLE, 'War And Peace');
         $c->doDelete($con);
         $expectedSQL = $this->getSql("DELETE FROM `book` WHERE book.TITLE='War And Peace'");
         $this->assertEquals($expectedSQL, $con->getLastExecutedQuery(), 'doDelete() issues two DELETE queries when passed conditions on two tables');
@@ -324,7 +324,7 @@ class TableMapTest extends BookstoreTestBase
     {
         $c = new Criteria();
         $c->setComment('Foo');
-        $c->addSelectColumn(BookTableMap::ID);
+        $c->addSelectColumn(BookTableMap::COL_ID);
         $expected = $this->getSql('SELECT /* Foo */ book.ID FROM `book`');
         $params = array();
         $this->assertEquals($expected, $c->createSelectSQL($params), 'Criteria::setComment() adds a comment to select queries');
@@ -336,7 +336,7 @@ class TableMapTest extends BookstoreTestBase
         $c1->setPrimaryTableName(BookTableMap::TABLE_NAME);
         $c1->setComment('Foo');
         $c2 = new Criteria();
-        $c2->add(BookTableMap::TITLE, 'Updated Title');
+        $c2->add(BookTableMap::COL_TITLE, 'Updated Title');
         $con = Propel::getServiceContainer()->getConnection(BookTableMap::DATABASE_NAME);
         $c1->doUpdate($c2, $con);
         $expected = $this->getSql('UPDATE /* Foo */ `book` SET `TITLE`=\'Updated Title\'');
@@ -347,7 +347,7 @@ class TableMapTest extends BookstoreTestBase
     {
         $c = new Criteria();
         $c->setComment('Foo');
-        $c->add(BookTableMap::TITLE, 'War And Peace');
+        $c->add(BookTableMap::COL_TITLE, 'War And Peace');
         $con = Propel::getServiceContainer()->getConnection(BookTableMap::DATABASE_NAME);
         $c->doDelete($con);
         $expected = $this->getSql('DELETE /* Foo */ FROM `book` WHERE book.TITLE=\'War And Peace\'');

--- a/tests/Propel/Tests/Ticket520Test.php
+++ b/tests/Propel/Tests/Ticket520Test.php
@@ -59,7 +59,7 @@ class Ticket520Test extends BookstoreTestBase
         $a->addBook($b2);
 
         $c = new Criteria();
-        $c->add(BookTableMap::TITLE, "%Hitchhiker%", Criteria::LIKE);
+        $c->add(BookTableMap::COL_TITLE, "%Hitchhiker%", Criteria::LIKE);
 
         $guides = $a->getBooks($c);
         $this->assertEquals(0, count($guides), 'Passing a Criteria means "force a database query"');
@@ -80,7 +80,7 @@ class Ticket520Test extends BookstoreTestBase
         $a->addBook($b2);
 
         $c = new Criteria();
-        $c->add(BookTableMap::TITLE, "%Hitchhiker%", Criteria::LIKE);
+        $c->add(BookTableMap::COL_TITLE, "%Hitchhiker%", Criteria::LIKE);
 
         $guides = $a->getBooks($c);
 
@@ -105,7 +105,7 @@ class Ticket520Test extends BookstoreTestBase
         $a->addBook($b2);
 
         $c = new Criteria();
-        $c->add(BookTableMap::TITLE, "%Hitchhiker%", Criteria::LIKE);
+        $c->add(BookTableMap::COL_TITLE, "%Hitchhiker%", Criteria::LIKE);
 
         $guides = $a->getBooks($c);
 
@@ -173,7 +173,7 @@ class Ticket520Test extends BookstoreTestBase
         $a->save();
 
         $c = new Criteria();
-        $c->add(BookTableMap::TITLE, "%Restaurant%", Criteria::LIKE);
+        $c->add(BookTableMap::COL_TITLE, "%Restaurant%", Criteria::LIKE);
 
         $this->assertEquals(0, count($a->getBooks($c)));
 


### PR DESCRIPTION
I edited the template in `src/Propel/Generator/Builder/Om/templates/tableMapConstants.php`. However, my first try was to edit method `addColumnNameConstants()` in `\Propel\Generator\Builder\Om\TableMapBuilder` is that method orphaned?
