### PR TITLE
Improvement to develop behaviors

### DIFF
--- a/tests/Fixtures/behavior-development/composer.json
+++ b/tests/Fixtures/behavior-development/composer.json
@@ -1,0 +1,17 @@
+{
+	"name" : "propel/collection-behavior",
+	"description" : "Creates model-related collections for nice IDE support",
+	"type" : "propel-behavior",
+	"require" : {
+		"propel/propel" : "dev-master"
+	},
+	"autoload" : {
+		"psr-4" : {
+			"Propel\\Behavior\\Collection\\" : "src"
+		}
+	},
+	"extra": {
+		"name": "collection",
+		"class": "\\Propel\\Behavior\\Collection\\CollectionBehavior"
+	}
+}

--- a/tests/Fixtures/behavior-development/src/CollectionBehavior.php
+++ b/tests/Fixtures/behavior-development/src/CollectionBehavior.php
@@ -1,0 +1,15 @@
+<?php
+namespace Propel\Behavior\Collection;
+
+use Propel\Generator\Model\Behavior;
+
+class CollectionBehavior extends Behavior {
+
+    /* (non-PHPdoc)
+     * @see \Propel\Generator\Model\Behavior::modifyTable()
+    */
+    public function modifyTable() {
+        // behavior code
+    }
+
+}

--- a/tests/Propel/Tests/Generator/Behavior/BehaviorLocatorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/BehaviorLocatorTest.php
@@ -19,15 +19,16 @@ use Propel\Generator\Config\QuickGeneratorConfig;
  *
  * @author Thomas Gossmann
  */
-class BehaviorInstallerTest extends TestCase
+class BehaviorLocatorTest extends TestCase
 {
     protected function setUp()
     {
         parent::setUp();
         require_once(__DIR__ . '/../../../../Fixtures/behavior-installer/src/gossi/propel/behavior/l10n/L10nBehavior.php');
+        require_once(__DIR__ . '/../../../../Fixtures/behavior-development/src/CollectionBehavior.php');
     }
 
-    public function testBehaviorLocator()
+    public function testBehaviorLocatorWithComposerLock()
     {
         $config = new QuickGeneratorConfig();
         $config->setBuildProperty('builderComposerDir', __DIR__ . '/../../../../Fixtures/behavior-installer');
@@ -42,5 +43,22 @@ class BehaviorInstallerTest extends TestCase
         
         // test class name
         $this->assertSame('\\gossi\\propel\\behavior\\l10n\\L10nBehavior', $locator->getBehavior('l10n'));
+    }
+    
+    public function testBehaviorLocatorWithComposerJson()
+    {
+        $config = new QuickGeneratorConfig();
+        $config->setBuildProperty('builderComposerDir', __DIR__ . '/../../../../Fixtures/behavior-development');
+        $locator = new BehaviorLocator($config);
+    
+        // test found behaviors
+        $behaviors = $locator->getBehaviors();
+        $this->assertSame(1, count($behaviors));
+    
+        $this->assertTrue(array_key_exists('collection', $behaviors));
+        $this->assertSame('propel/collection-behavior', $behaviors['collection']['package']);
+    
+        // test class name
+        $this->assertSame('\\Propel\\Behavior\\Collection\\CollectionBehavior', $locator->getBehavior('collection'));
     }
 }


### PR DESCRIPTION
This is an improvement for behavior devs. When developing a behavior, there is no composer.lock file containing the information about the behavior, instead these information are stored in the composer.json file. This PR also searches in the composer.json. This is extremly handy when writing tests, which involves running a propel build. These builds so far can't find the behavior which is currently worked on. This is fixed with this PR. Tests included.
