### PR TITLE
Only pluralize table's phpName, not the ForeignKey phpName/refPhpName.

### DIFF
--- a/src/Propel/Generator/Builder/Om/AbstractOMBuilder.php
+++ b/src/Propel/Generator/Builder/Om/AbstractOMBuilder.php
@@ -568,6 +568,8 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      * The difference between this method and the getRefFKPhpNameAffix() method is that in this method the
      * classname in the affix is the foreign table classname.
      *
+     * If plural=true and phpName is set then the phpName value is returned directly.
+     *
      * @param  ForeignKey $fk     The local FK that we need a name for.
      * @param  boolean    $plural Whether the php name should be plural (e.g. initRelatedObjs() vs. addRelatedObj()
      * @return string
@@ -575,10 +577,6 @@ abstract class AbstractOMBuilder extends DataModelBuilder
     public function getFKPhpNameAffix(ForeignKey $fk, $plural = false)
     {
         if ($fk->getPhpName()) {
-            if ($plural) {
-                return $this->getPluralizer()->getPluralForm($fk->getPhpName());
-            }
-
             return $fk->getPhpName();
         }
 
@@ -630,20 +628,21 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      * The difference between this method and the getFKPhpNameAffix() method is that in this method the
      * classname in the affix is the classname of the local fkey table.
      *
+     * If plural=true and refPhpName is set then the refPhpName value is returned directly.
+     *
      * @param  ForeignKey $fk     The referrer FK that we need a name for.
      * @param  boolean    $plural Whether the php name should be plural (e.g. initRelatedObjs() vs. addRelatedObj()
      * @return string
      */
     public function getRefFKPhpNameAffix(ForeignKey $fk, $plural = false)
     {
-        $pluralizer = $this->getPluralizer();
         if ($fk->getRefPhpName()) {
-            return $plural ? $pluralizer->getPluralForm($fk->getRefPhpName()) : $fk->getRefPhpName();
+            return $fk->getRefPhpName();
         }
 
         $className = $fk->getTable()->getPhpName();
         if ($plural) {
-            $className = $pluralizer->getPluralForm($className);
+            $className = $this->getPluralizer()->getPluralForm($className);
         }
 
         return $className . $this->getRefRelatedBySuffix($fk);

--- a/tests/Fixtures/bookstore/schema.xml
+++ b/tests/Fixtures/bookstore/schema.xml
@@ -139,7 +139,7 @@
         description="Another cross-reference table for many-to-many relationship between book rows and book_club_list rows for favorite books.">
         <column name="book_id" primaryKey="true" type="INTEGER" description="Fkey to book.id" />
         <column name="book_club_list_id" primaryKey="true" type="INTEGER" description="Fkey to book_club_list.id" />
-        <foreign-key foreignTable="book" phpName="FavoriteBook" onDelete="cascade">
+        <foreign-key foreignTable="book" phpName="FavoriteBooks" onDelete="cascade">
             <reference local="book_id" foreign="id" />
         </foreign-key>
         <foreign-key foreignTable="book_club_list" phpName="FavoriteBookClubList" onDelete="cascade">


### PR DESCRIPTION
The pluralizer should only be used when we have not specified any foreign-key name or refName.
