### PR TITLE
Fixes "Undefined variable" in migration:status

### DIFF
--- a/src/Propel/Generator/Command/MigrationStatusCommand.php
+++ b/src/Propel/Generator/Command/MigrationStatusCommand.php
@@ -92,8 +92,9 @@ class MigrationStatusCommand extends AbstractCommand
             }
         }
 
+        $oldestMigrationTimestamp = $manager->getOldestDatabaseVersion();
         if ($input->getOption('verbose')) {
-            if ($oldestMigrationTimestamp = $manager->getOldestDatabaseVersion()) {
+            if ($oldestMigrationTimestamp) {
                 $output->writeln(sprintf(
                     'Latest migration was executed on %s (timestamp %d)',
                     date('Y-m-d H:i:s', $oldestMigrationTimestamp),


### PR DESCRIPTION
Fixes "Undefined variable: oldestMigrationTimestamp" when running "migration:status" without "-v"

The variable $oldestMigrationTimestamp is set on line 96 only when the verbose option is passed. Because of this, when the code reaches line 129 and tries to access $oldestMigrationTimestamp, the variable is not set, causing an error.
