### PR TITLE
Add "isser" methods for boolean columns

### DIFF
--- a/src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
@@ -50,6 +50,9 @@ abstract class AbstractObjectBuilder extends AbstractOMBuilder
                 }
             } elseif ($col->isEnumType()) {
                 $this->addEnumAccessor($script, $col);
+            } elseif ($col->isBooleanType()) {
+                $this->addDefaultAccessor($script, $col);
+                $this->addBooleanAccessor($script, $col);
             } else {
                 $this->addDefaultAccessor($script, $col);
             }

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -988,6 +988,63 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
     }
 
     /**
+     * Adds a boolean isser method.
+     *
+     * @param string &$script
+     * @param Column $column
+     */
+    protected function addBooleanAccessor(&$script, Column $column)
+    {
+        $this->addDefaultAccessorComment($script, $column);
+        $this->addBooleanAccessorOpen($script, $column);
+        $this->addBooleanAccessorBody($script, $column);
+        $this->addDefaultAccessorClose($script);
+    }
+
+    /**
+     * Adds the function declaration for a boolean accessor.
+     *
+     * @param string &$script
+     * @param Column $column
+     */
+    public function addBooleanAccessorOpen(&$script, Column $column)
+    {
+        $cfc = $column->getPhpName();
+        $cfc = preg_replace('/^Is(?=[A-Z])/', '', $cfc);
+        $visibility = $column->getAccessorVisibility();
+
+        $script .= "
+    ".$visibility." function is$cfc(";
+        if ($column->isLazyLoad()) {
+            $script .= "ConnectionInterface \$con = null";
+        }
+
+        $script .= ")
+    {";
+    }
+
+    /**
+     * Adds the function body for a boolean accessor method.
+     *
+     * @param string &$script
+     * @param Column $column
+     */
+    protected function addBooleanAccessorBody(&$script, Column $column)
+    {
+        $cfc = $column->getPhpName();
+        $clo = $column->getLowercasedName();
+
+        $script .= "
+        return \$this->get$cfc(";
+
+        if ($column->isLazyLoad()) {
+            $script .= '$con';
+        }
+
+        $script .= ");";
+    }
+
+    /**
      * Adds an enum getter method.
      *
      * @param string &$script

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectBooleanColumnTypeTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectBooleanColumnTypeTest.php
@@ -30,11 +30,18 @@ class GeneratedObjectBooleanColumnTypeTest extends TestCase
         <column name="bar" type="BOOLEAN" />
         <column name="true_bar" type="BOOLEAN" defaultValue="true" />
         <column name="false_bar" type="BOOLEAN" defaultValue="false" />
+        <column name="is_baz" type="BOOLEAN" />
     </table>
 </database>
 EOF;
             QuickBuilder::buildSchema($schema);
         }
+    }
+
+    public function testIsserName()
+    {
+        $this->assertTrue(method_exists('ComplexColumnTypeEntity4', 'isBar'));
+        $this->assertTrue(method_exists('ComplexColumnTypeEntity4', 'isBaz'));
     }
 
     public function providerForSetter()
@@ -71,8 +78,10 @@ EOF;
         $e->setBar($value);
         if ($expected) {
             $this->assertTrue($e->getBar());
+            $this->assertTrue($e->isBar());
         } else {
             $this->assertFalse($e->getBar());
+            $this->assertFalse($e->isBar());
         }
     }
 


### PR DESCRIPTION
For boolean columns an "isser" method is added to object class. The isser is calling the getter.

`active` and `is_active` both become `isActive()`.

Resolves #493.
