### PR TITLE
Missing parent Query class

### DIFF
--- a/src/Propel/Generator/Builder/Om/QueryInheritanceBuilder.php
+++ b/src/Propel/Generator/Builder/Om/QueryInheritanceBuilder.php
@@ -97,6 +97,10 @@ class QueryInheritanceBuilder extends AbstractOMBuilder
      */
     protected function getParentClassName()
     {
+        if (is_null($this->getChild()->getAncestor())) {
+            return $this->getNewStubQueryBuilder($this->getTable())->getUnqualifiedClassName();
+        }
+
         $ancestorClassName = ClassTools::classname($this->getChild()->getAncestor());
         if ($this->getDatabase()->hasTableByPhpName($ancestorClassName)) {
             return $this->getNewStubQueryBuilder($this->getDatabase()->getTableByPhpName($ancestorClassName))->getUnqualifiedClassName();

--- a/src/Propel/Generator/Manager/ModelManager.php
+++ b/src/Propel/Generator/Manager/ModelManager.php
@@ -93,7 +93,7 @@ class ModelManager extends AbstractManager
                                 foreach ($col->getChildren() as $child) {
                                     $overwrite = true;
                                     foreach (array('queryinheritance') as $target) {
-                                        if (!$child->getAncestor()) {
+                                        if (!$child->getAncestor() && $child->getClassName() == $table->getPhpName()) {
                                             continue;
                                         }
                                         $builder = $generatorConfig->getConfiguredBuilder($table, $target);

--- a/tests/Propel/Tests/Generator/Builder/Om/QueryBuilderInheritanceTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/QueryBuilderInheritanceTest.php
@@ -35,11 +35,27 @@ use Propel\Runtime\Propel;
  */
 class QueryBuilderInheritanceTest extends BookstoreTestBase
 {
-
-    public function testConstruct()
+    public function constructProvider()
     {
-        $query = BookstoreCashierQuery::create();
-        $this->assertTrue($query instanceof BookstoreCashierQuery, 'the create() factory returns an instance of the correct class');
+        return [
+            ['BookstoreCashierQuery'],
+            ['BookstoreEmployeeQuery'],
+            ['BookstoreManagerQuery'],
+            ['BookstoreHeadQuery'],
+            ['DistributionStoreQuery'],
+            ['DistributionOnlineQuery'],
+            ['DistributionVirtualStoreQuery'],
+        ];
+    }
+
+    /**
+     * @dataProvider constructProvider
+     */
+    public function testConstruct($class)
+    {
+        $class = 'Propel\\Tests\\Bookstore\\' . $class;
+        $query = $class::create();
+        $this->assertTrue($query instanceof $class, 'the create() factory returns an instance of the correct class');
     }
 
     public function testFindFilter()


### PR DESCRIPTION
After building the model classes for the bookstore example I get the two classed `DistributionOnlineQuery` and `DistributionVirtualStoreQuery`. Both extends `DistributionStoreQuery`, but this class is missing.
