### PR TITLE
Default table order behavior

### DIFF
--- a/src/Propel/Generator/Behavior/DefaultOrder/DefaultOrderBehavior.php
+++ b/src/Propel/Generator/Behavior/DefaultOrder/DefaultOrderBehavior.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT License
+ */
+
+namespace Propel\Generator\Behavior\DefaultOrder;
+
+use Propel\Generator\Builder\Om\QueryBuilder;
+use Propel\Generator\Exception\InvalidArgumentException;
+use Propel\Generator\Model\Behavior;
+use Propel\Runtime\ActiveQuery\Criteria;
+
+/**
+ * Sets the default order for tables
+ *
+ * @author Gregor Harlan
+ */
+class DefaultOrderBehavior extends Behavior
+{
+    public function preSelectQuery(QueryBuilder $builder)
+    {
+        $columns = [];
+
+        foreach ($this->getParameters() as $key => $value) {
+            if (0 !== strpos($key, 'column')) {
+                continue;
+            }
+            $column = $this->getColumnForParameter($key);
+            $columnConstant = $builder->getColumnConstant($column);
+
+            $directionKey = 'direction' . substr($key, 6);
+            $direction = isset($this->parameters[$directionKey]) ? $this->getParameter($directionKey) : Criteria::ASC;
+            $direction = strtoupper($direction);
+            switch ($direction) {
+                case Criteria::ASC:
+                    $columns[$columnConstant] = 'Ascending';
+                    break;
+                case Criteria::DESC:
+                    $columns[$columnConstant] = 'Descending';
+                    break;
+                default:
+                    throw new InvalidArgumentException('DefaultOrderBehavior only accepts "asc" or "desc" as direction parameter');
+            }
+        }
+
+        if (empty($columns)) {
+            throw new InvalidArgumentException('DefaultOrderBehavior needs at least one column parameter');
+        }
+
+        $script = 'if (!$this->getOrderByColumns()) {
+    $this';
+
+        $prefix = '';
+        if (count($columns) > 1) {
+            $prefix = "\n        ";
+        }
+        foreach ($columns as $column => $direction) {
+            $script .= $prefix . "->add{$direction}OrderByColumn($column)";
+        }
+
+
+        $script .= ';
+}';
+
+        return $script;
+    }
+}

--- a/tests/Fixtures/bookstore/behavior-default-order-schema.xml
+++ b/tests/Fixtures/bookstore/behavior-default-order-schema.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="ISO-8859-1" standalone="no"?>
+<database name="bookstore-behavior" defaultIdMethod="native" package="behavior.default_order" namespace="Propel\Tests\Bookstore\Behavior">
+
+    <table name="default_order_1">
+        <column name="id" required="true" primaryKey="true" autoIncrement="true" type="INTEGER" />
+        <column name="title" type="VARCHAR" size="100" primaryString="true" />
+
+        <behavior name="default_order">
+            <parameter name="column" value="title"/>
+        </behavior>
+    </table>
+
+    <table name="default_order_2">
+        <column name="id" required="true" primaryKey="true" autoIncrement="true" type="INTEGER" />
+        <column name="title" type="VARCHAR" size="100" primaryString="true" />
+
+        <behavior name="default_order">
+            <parameter name="column1" value="title"/>
+            <parameter name="column2" value="id"/>
+            <parameter name="direction2" value="desc"/>
+        </behavior>
+    </table>
+
+</database>

--- a/tests/Propel/Tests/Generator/Behavior/DefaultOrder/DefaultOrderBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/DefaultOrder/DefaultOrderBehaviorTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT License
+ */
+
+namespace Propel\Tests\Generator\Behavior\DefaultOrder;
+
+use Propel\Runtime\Collection\ObjectCollection;
+use Propel\Tests\Bookstore\Behavior\DefaultOrder1;
+use Propel\Tests\Bookstore\Behavior\DefaultOrder1Query;
+use Propel\Tests\Bookstore\Behavior\DefaultOrder2;
+use Propel\Tests\Bookstore\Behavior\DefaultOrder2Query;
+use Propel\Tests\Bookstore\Behavior\Map\DefaultOrder1TableMap;
+use Propel\Tests\Bookstore\Behavior\Map\DefaultOrder2TableMap;
+use Propel\Tests\Helpers\Bookstore\BookstoreTestBase;
+
+/**
+ * Tests for DefaultOrderBehavior class
+ *
+ * @author Gregor Harlan
+ */
+class DefaultOrderBehaviorTest extends BookstoreTestBase
+{
+    public function testSingleColumn()
+    {
+        DefaultOrder1TableMap::doDeleteAll();
+
+        $obj1 = new DefaultOrder1();
+        $obj1->setTitle('b')->save();
+        $obj2 = new DefaultOrder1();
+        $obj2->setTitle('ab')->save();
+        $obj3 = new DefaultOrder1();
+        $obj3->setTitle('ac')->save();
+
+        $expected = new ObjectCollection();
+        $expected->append($obj2);
+        $expected->append($obj3);
+        $expected->append($obj1);
+
+        $objects = DefaultOrder1Query::create()->find();
+
+        $this->assertEquals($expected->toArray(), $objects->toArray());
+    }
+
+    public function testMultipleColumn()
+    {
+        DefaultOrder2TableMap::doDeleteAll();
+
+        $obj1 = new DefaultOrder2();
+        $obj1->setTitle('b')->save();
+        $obj2 = new DefaultOrder2();
+        $obj2->setTitle('ac')->save();
+        $obj3 = new DefaultOrder2();
+        $obj3->setTitle('ab')->save();
+        $obj4 = new DefaultOrder2();
+        $obj4->setTitle('ac')->save();
+
+        $expected = new ObjectCollection();
+        $expected->append($obj3);
+        $expected->append($obj4);
+        $expected->append($obj2);
+        $expected->append($obj1);
+
+        $objects = DefaultOrder2Query::create()->find();
+
+        $this->assertEquals($expected->toArray(), $objects->toArray());
+    }
+}


### PR DESCRIPTION
This behavior lets you define the default order for tables.

Example usages:

``` xml
    <table name="default_order_1">
        <column name="id" required="true" primaryKey="true" autoIncrement="true" type="INTEGER" />
        <column name="title" type="VARCHAR" />

        <behavior name="default_order">
            <parameter name="column" value="title"/>
        </behavior>
    </table>

    <table name="default_order_2">
        <column name="id" required="true" primaryKey="true" autoIncrement="true" type="INTEGER" />
        <column name="title" type="VARCHAR" />

        <behavior name="default_order">
            <parameter name="column1" value="title"/>
            <parameter name="column2" value="id desc"/>
        </behavior>
    </table>
```

What do you think about the behavior? Any suggestions for improvement? Do you want to merge this?
