### PR TITLE
Update UniqueValidator.php

### DIFF
--- a/src/Propel/Runtime/Validator/Constraints/UniqueValidator.php
+++ b/src/Propel/Runtime/Validator/Constraints/UniqueValidator.php
@@ -22,8 +22,7 @@ class UniqueValidator extends ConstraintValidator
             return;
         }
 
-        $object     = $this->context->getRoot();
-        $className  = get_class($object);
+        $className  = $this->context->getClassName();
         $tableMap   = $className::TABLE_MAP;
         $queryClass = $className . 'Query';
         $filter     = sprintf('filterBy%s', $tableMap::translateFieldName($this->context->getPropertyName(), TableMap::TYPE_STUDLYPHPNAME, TableMap::TYPE_PHPNAME));


### PR DESCRIPTION
``` php
        $object     = $this->context->getRoot();
        $className  = get_class($object);
```

are not needed because `Symfony\Component\Validator\ExecutionContext` provides a `getClassName()` method. Also, `$this->context->getRoot()` was returning a `Form` object, which does not have the `TABLE_MAP` constant defined.
