### PR TITLE
Travis: use fast_finish option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ script:
   - ./tests/bin/phpunit.$DB.sh;
 
 matrix:
+  fast_finish: true
   allow_failures:
     - php: hhvm
     - php: 5.6


### PR DESCRIPTION
Look here for more infos: http://docs.travis-ci.com/user/build-configuration/#Fast-finishing

So we do not have to wait for php 5.6 and hhvm builds to see the build status for a PR etc.
