### PR TITLE
PhpDoc return type for fluent style methods

### DIFF
--- a/src/Propel/Generator/Behavior/Archivable/templates/objectDeleteWithoutArchive.php
+++ b/src/Propel/Generator/Behavior/Archivable/templates/objectDeleteWithoutArchive.php
@@ -4,7 +4,7 @@
  *
  * @param ConnectionInterface $con Optional connection object
  *
- * @return     <?php echo $objectClassName ?> The current object (for fluent API support)
+ * @return $this|<?php echo $objectClassName ?> The current object (for fluent API support)
  */
 public function deleteWithoutArchive(ConnectionInterface $con = null)
 {

--- a/src/Propel/Generator/Behavior/Archivable/templates/objectRestoreFromArchive.php
+++ b/src/Propel/Generator/Behavior/Archivable/templates/objectRestoreFromArchive.php
@@ -7,7 +7,7 @@
  *
  * @throws PropelException If the object has no corresponding archive.
  *
- * @return <?php echo $objectClassName ?> The current object (for fluent API support)
+ * @return $this|<?php echo $objectClassName ?> The current object (for fluent API support)
  */
 public function restoreFromArchive(ConnectionInterface $con = null)
 {

--- a/src/Propel/Generator/Behavior/Archivable/templates/objectSaveWithoutArchive.php
+++ b/src/Propel/Generator/Behavior/Archivable/templates/objectSaveWithoutArchive.php
@@ -4,7 +4,7 @@
  *
  * @param ConnectionInterface $con Optional connection object
  *
- * @return     <?php echo $objectClassName ?> The current object (for fluent API support)
+ * @return $this|<?php echo $objectClassName ?> The current object (for fluent API support)
  */
 public function saveWithoutArchive(ConnectionInterface $con = null)
 {

--- a/src/Propel/Generator/Behavior/I18n/I18nBehaviorObjectBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/I18n/I18nBehaviorObjectBuilderModifier.php
@@ -196,7 +196,7 @@ class I18nBehaviorObjectBuilderModifier
             $objectBuilder->addMutatorOpenOpen($functionStatement, $column);
         }
         $comment = preg_replace('/^\t/m', '', $comment);
-        $comment = str_replace('@return     ' . $i18nTablePhpName, '@return     ' . $tablePhpName, $comment);
+        $comment = str_replace('@return     $this|' . $i18nTablePhpName, '@return     $this|' . $tablePhpName, $comment);
         $functionStatement = preg_replace('/^\t/m', '', $functionStatement);
         preg_match_all('/\$[a-z]+/i', $functionStatement, $params);
 

--- a/src/Propel/Generator/Behavior/I18n/templates/objectRemoveTranslation.php
+++ b/src/Propel/Generator/Behavior/I18n/templates/objectRemoveTranslation.php
@@ -5,7 +5,7 @@
  * @param     string $locale Locale to use for the translation, e.g. 'fr_FR'
  * @param     ConnectionInterface $con an optional connection object
  *
- * @return    <?php echo $objectClassName ?> The current object (for fluent API support)
+ * @return    $this|<?php echo $objectClassName ?> The current object (for fluent API support)
  */
 public function removeTranslation($locale = '<?php echo $defaultLocale ?>', ConnectionInterface $con = null)
 {

--- a/src/Propel/Generator/Behavior/I18n/templates/objectSetLocale.php
+++ b/src/Propel/Generator/Behavior/I18n/templates/objectSetLocale.php
@@ -4,7 +4,7 @@
  *
  * @param     string $locale Locale to use for the translation, e.g. 'fr_FR'
  *
- * @return    <?php echo $objectClassName ?> The current object (for fluent API support)
+ * @return    $this|<?php echo $objectClassName ?> The current object (for fluent API support)
  */
 public function set<?php echo $localeColumnName ?>($locale = '<?php echo $defaultLocale ?>')
 {

--- a/src/Propel/Generator/Behavior/I18n/templates/objectSetLocaleAlias.php
+++ b/src/Propel/Generator/Behavior/I18n/templates/objectSetLocaleAlias.php
@@ -5,7 +5,7 @@
  *
  * @param     string $locale Locale to use for the translation, e.g. 'fr_FR'
  *
- * @return    <?php echo $objectClassName ?> The current object (for fluent API support)
+ * @return    $this|<?php echo $objectClassName ?> The current object (for fluent API support)
  */
 public function set<?php echo $alias ?>($locale = '<?php echo $defaultLocale ?>')
 {

--- a/src/Propel/Generator/Behavior/I18n/templates/objectSetTranslation.php
+++ b/src/Propel/Generator/Behavior/I18n/templates/objectSetTranslation.php
@@ -5,7 +5,7 @@
  * @param     <?php echo $i18nTablePhpName ?> $translation The translation object
  * @param     string $locale Locale to use for the translation, e.g. 'fr_FR'
  *
- * @return    <?php echo $objectClassName ?> The current object (for fluent API support)
+ * @return    $this|<?php echo $objectClassName ?> The current object (for fluent API support)
  */
 public function setTranslation($translation, $locale = '<?php echo $defaultLocale ?>')
 {

--- a/src/Propel/Generator/Behavior/I18n/templates/queryJoinWithI18n.php
+++ b/src/Propel/Generator/Behavior/I18n/templates/queryJoinWithI18n.php
@@ -6,7 +6,7 @@
  * @param     string $locale Locale to use for the join condition, e.g. 'fr_FR'
  * @param     string $joinType Accepted values are null, 'left join', 'right join', 'inner join'. Defaults to left join.
  *
- * @return    <?php echo $queryClass ?> The current query, for fluid interface
+ * @return    $this|<?php echo $queryClass ?> The current query, for fluid interface
  */
 public function joinWithI18n($locale = '<?php echo $defaultLocale ?>', $joinType = Criteria::LEFT_JOIN)
 {

--- a/src/Propel/Generator/Behavior/NestedSet/NestedSetBehaviorObjectBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/NestedSet/NestedSetBehaviorObjectBuilderModifier.php
@@ -309,7 +309,7 @@ public function getScopeValue()
  * It provides a generic way to set the value, whatever the actual column name is.
  *
  * @param      int \$v The nested set right value
- * @return     {$objectClassName} The current object (for fluent API support)
+ * @return     \$this|{$objectClassName} The current object (for fluent API support)
  */
 public function setRightValue(\$v)
 {
@@ -328,7 +328,7 @@ public function setRightValue(\$v)
  * It provides a generic way to set the value, whatever the actual column name is.
  *
  * @param      int \$v The nested set level value
- * @return     {$objectClassName} The current object (for fluent API support)
+ * @return     \$this|{$objectClassName} The current object (for fluent API support)
  */
 public function setLevel(\$v)
 {
@@ -347,7 +347,7 @@ public function setLevel(\$v)
  * It provides a generic way to set the value, whatever the actual column name is.
  *
  * @param      int \$v The nested set scope value
- * @return     {$objectClassName} The current object (for fluent API support)
+ * @return     \$this|{$objectClassName} The current object (for fluent API support)
  */
 public function setScopeValue(\$v)
 {
@@ -364,7 +364,7 @@ public function setScopeValue(\$v)
 /**
  * Creates the supplied node as the root node.
  *
- * @return     {$objectClassName} The current object (for fluent API support)
+ * @return     \$this|{$objectClassName} The current object (for fluent API support)
  * @throws     PropelException
  */
 public function makeRoot()
@@ -497,7 +497,7 @@ public function hasParent()
  * Use moveTofirstChildOf() or moveToLastChildOf() for that purpose
  *
  * @param      $objectClassName \$parent
- * @return     $objectClassName The current object, for fluid interface
+ * @return     \$this|{$objectClassName} The current object, for fluid interface
  */
 public function setParent(\$parent = null)
 {
@@ -518,7 +518,7 @@ public function setParent(\$parent = null)
  * The result is cached so further calls to the same method don't issue any queries
  *
  * @param  ConnectionInterface \$con Connection to use.
- * @return mixed Propel object if exists else false
+ * @return self|boolean Propel object if exists else false
  */
 public function getParent(ConnectionInterface \$con = null)
 {
@@ -987,7 +987,7 @@ public function getAncestors(\$query = null, ConnectionInterface \$con = null)
  *
  * @param      $objectClassName \$child    Propel object for child node
  *
- * @return     $objectClassName The current Propel object
+ * @return     \$this|{$objectClassName} The current Propel object
  */
 public function addChild($objectClassName \$child)
 {
@@ -1015,7 +1015,7 @@ public function addChild($objectClassName \$child)
  *
  * @param      $objectClassName \$parent    Propel object for parent node
  *
- * @return     $objectClassName The current Propel object
+ * @return     \$this|{$objectClassName} The current Propel object
  */
 public function insertAsFirstChildOf(\$parent)
 {
@@ -1072,7 +1072,7 @@ public function insertAsFirstChildOf(\$parent)
  *
  * @param      $objectClassName \$sibling    Propel object for parent node
  *
- * @return     $objectClassName The current Propel object
+ * @return     \$this|{$objectClassName} The current Propel object
  */
 public function insertAsPrevSiblingOf(\$sibling)
 {
@@ -1115,7 +1115,7 @@ public function insertAsPrevSiblingOf(\$sibling)
  *
  * @param      $objectClassName \$sibling    Propel object for parent node
  *
- * @return     $objectClassName The current Propel object
+ * @return     \$this|{$objectClassName} The current Propel object
  */
 public function insertAsNextSiblingOf(\$sibling)
 {
@@ -1155,7 +1155,7 @@ public function insertAsNextSiblingOf(\$sibling)
  * @param      $objectClassName \$parent    Propel object for parent node
  * @param      ConnectionInterface \$con    Connection to use.
  *
- * @return     $objectClassName The current Propel object
+ * @return     \$this|{$objectClassName} The current Propel object
  */
 public function moveToFirstChildOf(\$parent, ConnectionInterface \$con = null)
 {
@@ -1187,7 +1187,7 @@ public function moveToFirstChildOf(\$parent, ConnectionInterface \$con = null)
  * @param      $objectClassName \$parent    Propel object for parent node
  * @param      ConnectionInterface \$con    Connection to use.
  *
- * @return     $objectClassName The current Propel object
+ * @return     \$this|{$objectClassName} The current Propel object
  */
 public function moveToLastChildOf(\$parent, ConnectionInterface \$con = null)
 {
@@ -1219,7 +1219,7 @@ public function moveToLastChildOf(\$parent, ConnectionInterface \$con = null)
  * @param      $objectClassName \$sibling    Propel object for sibling node
  * @param      ConnectionInterface \$con    Connection to use.
  *
- * @return     $objectClassName The current Propel object
+ * @return     \$this|{$objectClassName} The current Propel object
  */
 public function moveToPrevSiblingOf(\$sibling, ConnectionInterface \$con = null)
 {
@@ -1254,7 +1254,7 @@ public function moveToPrevSiblingOf(\$sibling, ConnectionInterface \$con = null)
  * @param      $objectClassName \$sibling    Propel object for sibling node
  * @param      ConnectionInterface \$con    Connection to use.
  *
- * @return     $objectClassName The current Propel object
+ * @return     \$this|{$objectClassName} The current Propel object
  */
 public function moveToNextSiblingOf(\$sibling, ConnectionInterface \$con = null)
 {

--- a/src/Propel/Generator/Behavior/NestedSet/NestedSetBehaviorQueryBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/NestedSet/NestedSetBehaviorQueryBuilderModifier.php
@@ -104,7 +104,7 @@ class NestedSetBehaviorQueryBuilderModifier
 /**
  * Filter the query to restrict the result to root objects
  *
- * @return    {$this->queryClassName} The current query, for fluid interface
+ * @return    \$this|{$this->queryClassName} The current query, for fluid interface
  */
 public function treeRoots()
 {
@@ -121,7 +121,7 @@ public function treeRoots()
  *
  * @param     int \$scope        Scope to determine which objects node to return
  *
- * @return    {$this->queryClassName} The current query, for fluid interface
+ * @return    \$this|{$this->queryClassName} The current query, for fluid interface
  */
 public function inTree(\$scope = null)
 {
@@ -190,7 +190,7 @@ public function branchOf($objectName)
  *
  * @param     {$this->objectClassName} $objectName The object to use for child search
  *
- * @return    {$this->queryClassName} The current query, for fluid interface
+ * @return    \$this|{$this->queryClassName} The current query, for fluid interface
  */
 public function childrenOf($objectName)
 {
@@ -212,7 +212,7 @@ public function childrenOf($objectName)
  * @param     {$this->objectClassName} $objectName The object to use for sibling search
  * @param      ConnectionInterface \$con Connection to use.
  *
- * @return    {$this->queryClassName} The current query, for fluid interface
+ * @return    \$this|{$this->queryClassName} The current query, for fluid interface
  */
 public function siblingsOf($objectName, ConnectionInterface \$con = null)
 {

--- a/src/Propel/Generator/Behavior/NestedSet/templates/objectInsertAsLastChildOf.php
+++ b/src/Propel/Generator/Behavior/NestedSet/templates/objectInsertAsLastChildOf.php
@@ -5,7 +5,7 @@
  * are not persisted until the current object is saved.
  *
  * @param  <?= $objectClassName ?> $parent Propel object for parent node
- * @return <?= $objectClassName ?> The current Propel object
+ * @return $this|<?= $objectClassName ?> The current Propel object
  */
 public function insertAsLastChildOf($parent)
 {

--- a/src/Propel/Generator/Behavior/NestedSet/templates/objectSetLeft.php
+++ b/src/Propel/Generator/Behavior/NestedSet/templates/objectSetLeft.php
@@ -4,7 +4,7 @@
  * It provides a generic way to set the value, whatever the actual column name is.
  *
  * @param  int $v The nested set left value
- * @return <?= $objectClassName ?> The current object (for fluent API support)
+ * @return $this|<?= $objectClassName ?> The current object (for fluent API support)
  */
 public function setLeftValue($v)
 {

--- a/src/Propel/Generator/Behavior/Sluggable/SluggableBehavior.php
+++ b/src/Propel/Generator/Behavior/Sluggable/SluggableBehavior.php
@@ -128,7 +128,7 @@ if (\$this->isColumnModified($const) && \$this->{$this->getColumnGetter()}()) {
  * Wrap the setter for slug value
  *
  * @param   string
- * @return  " . $this->getTable()->getPhpName() . "
+ * @return  \$this|" . $this->getTable()->getPhpName() . "
  */
 public function setSlug(\$v)
 {
@@ -321,7 +321,7 @@ protected function makeSlugUnique(\$slug, \$separator = '" . $this->getParameter
  *
  * @param     string \$slug The value to use as filter.
  *
- * @return    " . $this->builder->getQueryClassName() . " The current query, for fluid interface
+ * @return    \$this|" . $this->builder->getQueryClassName() . " The current query, for fluid interface
  */
 public function filterBySlug(\$slug)
 {

--- a/src/Propel/Generator/Behavior/Sortable/SortableBehaviorObjectBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/Sortable/SortableBehaviorObjectBuilderModifier.php
@@ -269,7 +269,7 @@ public function getRank()
  * Wrap the setter for rank value
  *
  * @param     int
- * @return    {$this->objectClassName}
+ * @return    \$this|{$this->objectClassName}
  */
 public function setRank(\$v)
 {
@@ -328,7 +328,7 @@ public function getScopeValue(\$returnNulls = true)
  * Wrap the setter for scope value
  *
  * @param     mixed A array or a native type
- * @return    {$this->objectClassName}
+ * @return    \$this|{$this->objectClassName}
  */
 public function setScopeValue(\$v)
 {
@@ -488,7 +488,7 @@ public function getPrevious(ConnectionInterface \$con = null)
  * @param     integer    \$rank rank value
  * @param     ConnectionInterface  \$con      optional connection
  *
- * @return    {$this->objectClassName} the current object
+ * @return    \$this|{$this->objectClassName} the current object
  *
  * @throws    PropelException
  */
@@ -524,7 +524,7 @@ public function insertAtRank(\$rank, ConnectionInterface \$con = null)
  *
  * @param ConnectionInterface \$con optional connection
  *
- * @return    {$this->objectClassName} the current object
+ * @return    \$this|{$this->objectClassName} the current object
  *
  * @throws    PropelException
  */
@@ -545,7 +545,7 @@ public function insertAtBottom(ConnectionInterface \$con = null)
  * Insert in the first rank
  * The modifications are not persisted until the object is saved.
  *
- * @return    {$this->objectClassName} the current object
+ * @return    \$this|{$this->objectClassName} the current object
  */
 public function insertAtTop()
 {
@@ -565,7 +565,7 @@ public function insertAtTop()
  * @param     integer   \$newRank rank value
  * @param     ConnectionInterface \$con optional connection
  *
- * @return    {$this->objectClassName} the current object
+ * @return    \$this|{$this->objectClassName} the current object
  *
  * @throws    PropelException
  */
@@ -616,7 +616,7 @@ public function moveToRank(\$newRank, ConnectionInterface \$con = null)
  * @param     {$this->objectClassName} \$object
  * @param     ConnectionInterface \$con optional connection
  *
- * @return    {$this->objectClassName} the current object
+ * @return    \$this|{$this->objectClassName} the current object
  *
  * @throws Exception if the database cannot execute the two updates
  */
@@ -665,7 +665,7 @@ public function swapWith(\$object, ConnectionInterface \$con = null)
  *
  * @param     ConnectionInterface \$con optional connection
  *
- * @return    {$this->objectClassName} the current object
+ * @return    \$this|{$this->objectClassName} the current object
  */
 public function moveUp(ConnectionInterface \$con = null)
 {
@@ -698,7 +698,7 @@ public function moveUp(ConnectionInterface \$con = null)
  *
  * @param     ConnectionInterface \$con optional connection
  *
- * @return    {$this->objectClassName} the current object
+ * @return    \$this|{$this->objectClassName} the current object
  */
 public function moveDown(ConnectionInterface \$con = null)
 {
@@ -731,7 +731,7 @@ public function moveDown(ConnectionInterface \$con = null)
  *
  * @param     ConnectionInterface \$con optional connection
  *
- * @return    {$this->objectClassName} the current object
+ * @return    \$this|{$this->objectClassName} the current object
  */
 public function moveToTop(ConnectionInterface \$con = null)
 {
@@ -786,7 +786,7 @@ public function moveToBottom(ConnectionInterface \$con = null)
  * Removes the current object from the list".($useScope ? ' (moves it to the null scope)' : '').".
  * The modifications are not persisted until the object is saved.
  *
- * @return    {$this->objectClassName} the current object
+ * @return    \$this|{$this->objectClassName} the current object
  */
 public function removeFromList()
 {";

--- a/src/Propel/Generator/Behavior/Sortable/SortableBehaviorQueryBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/Sortable/SortableBehaviorQueryBuilderModifier.php
@@ -139,7 +139,7 @@ static public function sortableApplyScopeCriteria(Criteria \$criteria, \$scope, 
  *
 $paramsDoc
  *
- * @return    {$this->queryClassName} The current query, for fluid interface
+ * @return    \$this|{$this->queryClassName} The current query, for fluid interface
  */
 public function inList($methodSignature)
 {
@@ -201,7 +201,7 @@ public function filterByRank(\$rank" . ($useScope ? ", $methodSignature" : "") .
  *
  * @param     string \$order either Criteria::ASC (default) or Criteria::DESC
  *
- * @return    " . $this->queryClassName . " The current query, for fluid interface
+ * @return    \$this|" . $this->queryClassName . " The current query, for fluid interface
  */
 public function orderByRank(\$order = Criteria::ASC)
 {

--- a/src/Propel/Generator/Behavior/Timestampable/TimestampableBehavior.php
+++ b/src/Propel/Generator/Behavior/Timestampable/TimestampableBehavior.php
@@ -95,7 +95,7 @@ if (!\$this->isColumnModified(" . $this->getColumnConstant('update_column', $bui
 /**
  * Mark the current object so that the update date doesn't get updated during next save
  *
- * @return     " . $builder->getObjectClassName() . " The current object (for fluent API support)
+ * @return     \$this|" . $builder->getObjectClassName() . " The current object (for fluent API support)
  */
 public function keepUpdateDateUnchanged()
 {
@@ -118,7 +118,7 @@ public function keepUpdateDateUnchanged()
  *
  * @param      int \$nbDays Maximum age of the latest update in days
  *
- * @return     $queryClassName The current query, for fluid interface
+ * @return     \$this|$queryClassName The current query, for fluid interface
  */
 public function recentlyUpdated(\$nbDays = 7)
 {
@@ -130,7 +130,7 @@ public function recentlyUpdated(\$nbDays = 7)
  *
  * @param      int \$nbDays Maximum age of in days
  *
- * @return     $queryClassName The current query, for fluid interface
+ * @return     \$this|$queryClassName The current query, for fluid interface
  */
 public function recentlyCreated(\$nbDays = 7)
 {
@@ -140,7 +140,7 @@ public function recentlyCreated(\$nbDays = 7)
 /**
  * Order by update date desc
  *
- * @return     $queryClassName The current query, for fluid interface
+ * @return     \$this|$queryClassName The current query, for fluid interface
  */
 public function lastUpdatedFirst()
 {
@@ -150,7 +150,7 @@ public function lastUpdatedFirst()
 /**
  * Order by update date asc
  *
- * @return     $queryClassName The current query, for fluid interface
+ * @return     \$this|$queryClassName The current query, for fluid interface
  */
 public function firstUpdatedFirst()
 {
@@ -160,7 +160,7 @@ public function firstUpdatedFirst()
 /**
  * Order by create date desc
  *
- * @return     $queryClassName The current query, for fluid interface
+ * @return     \$this|$queryClassName The current query, for fluid interface
  */
 public function lastCreatedFirst()
 {
@@ -170,7 +170,7 @@ public function lastCreatedFirst()
 /**
  * Order by create date asc
  *
- * @return     $queryClassName The current query, for fluid interface
+ * @return     \$this|$queryClassName The current query, for fluid interface
  */
 public function firstCreatedFirst()
 {

--- a/src/Propel/Generator/Behavior/Versionable/VersionableBehaviorObjectBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/Versionable/VersionableBehaviorObjectBuilderModifier.php
@@ -172,7 +172,7 @@ protected \$enforceVersion = false;
  * Wrap the setter for version value
  *
  * @param   string
- * @return  " . $this->table->getPhpName() . "
+ * @return  \$this|" . $this->table->getPhpName() . "
  */
 public function setVersion(\$v)
 {
@@ -203,7 +203,7 @@ public function getVersion()
 /**
  * Enforce a new Version of this object upon next save.
  *
- * @return {$objectClass}
+ * @return \$this|{$objectClass}
  */
 public function enforceVersioning()
 {
@@ -332,7 +332,7 @@ public function addVersion(\$con = null)
  * @param   integer \$versionNumber The version number to read
  * @param   ConnectionInterface \$con The connection to use
  *
- * @return  {$ARclassName} The current object (for fluent API support)
+ * @return  \$this|{$ARclassName} The current object (for fluent API support)
  */
 public function toVersion(\$versionNumber, \$con = null)
 {
@@ -363,7 +363,7 @@ public function toVersion(\$versionNumber, \$con = null)
  * @param ConnectionInterface   \$con the connection to use
  * @param array                 \$loadedObjects objects that been loaded in a chain of populateFromVersion calls on referrer or fk objects.
  *
- * @return {$ARclassName} The current object (for fluent API support)
+ * @return \$this|{$ARclassName} The current object (for fluent API support)
  */
 public function populateFromVersion(\$version, \$con = null, &\$loadedObjects = array())
 {";
@@ -527,7 +527,7 @@ public function getOneVersion(\$versionNumber, \$con = null)
  *
  * @param   ConnectionInterface \$con the connection to use
  *
- * @return  ObjectCollection A list of {$versionARClassName} objects
+ * @return  ObjectCollection|{$versionARClassName}[] A list of {$versionARClassName} objects
  */
 public function getAllVersions(\$con = null)
 {
@@ -682,7 +682,7 @@ public function compareVersions(\$fromVersionNumber, \$toVersionNumber, \$keys =
  * retrieve the last \$number versions.
  *
  * @param Integer \$number the number of record to return.
- * @return PropelCollection|array {$versionARClassName}[] List of {$versionARClassName} objects
+ * @return PropelCollection|{$versionARClassName}[] List of {$versionARClassName} objects
  */
 public function getLastVersions(\$number = 10, \$criteria = null, \$con = null)
 {

--- a/src/Propel/Generator/Behavior/Versionable/VersionableBehaviorQueryBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/Versionable/VersionableBehaviorQueryBuilderModifier.php
@@ -112,7 +112,7 @@ static \$isVersioningEnabled = true;
  *
  * @param     integer \$version
  * @param     string  \$comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
- * @return    " . $this->builder->getQueryClassName() . " The current query, for fluid interface
+ * @return    \$this|" . $this->builder->getQueryClassName() . " The current query, for fluid interface
  */
 public function filterByVersion(\$version = null, \$comparison = null)
 {
@@ -128,7 +128,7 @@ public function filterByVersion(\$version = null, \$comparison = null)
  * Wrap the order on the version column
  *
  * @param   string \$order The sorting order. Criteria::ASC by default, also accepts Criteria::DESC
- * @return  " . $this->builder->getQueryClassName() . " The current query, for fluid interface
+ * @return  \$this|" . $this->builder->getQueryClassName() . " The current query, for fluid interface
  */
 public function orderByVersion(\$order = Criteria::ASC)
 {

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -1401,7 +1401,7 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
      * Set the value of [$clo] column.
      * ".$column->getDescription()."
      * @param      ".$column->getPhpType()." \$v new value
-     * @return   ".$this->getObjectClassName(true)." The current object (for fluent API support)
+     * @return     \$this|".$this->getObjectClassName(true)." The current object (for fluent API support)
      */";
     }
 
@@ -1614,7 +1614,7 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
      * ".$col->getDescription()."
      * @param      mixed \$v string, integer (timestamp), or \DateTime value.
      *               Empty strings are treated as NULL.
-     * @return   ".$this->getObjectClassName(true)." The current object (for fluent API support)
+     * @return     \$this|".$this->getObjectClassName(true)." The current object (for fluent API support)
      */";
     }
 
@@ -1683,7 +1683,7 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
      * @param      ConnectionInterface \$con An optional ConnectionInterface connection to use for fetching this lazy-loaded column.";
         }
         $script .= "
-     * @return   ".$this->getObjectClassName(true)." The current object (for fluent API support)
+     * @return     \$this|".$this->getObjectClassName(true)." The current object (for fluent API support)
      */
     $visibility function add$singularPhpName(\$value";
         if ($col->isLazyLoad()) {
@@ -1727,7 +1727,7 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
      * @param      ConnectionInterface \$con An optional ConnectionInterface connection to use for fetching this lazy-loaded column.";
         }
         $script .= "
-     * @return   ".$this->getObjectClassName(true)." The current object (for fluent API support)
+     * @return     \$this|".$this->getObjectClassName(true)." The current object (for fluent API support)
      */
     $visibility function remove$singularPhpName(\$value";
         if ($col->isLazyLoad()) {
@@ -1797,7 +1797,7 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
      * Set the value of [$clo] column.
      * ".$column->getDescription()."
      * @param      string \$v new value
-     * @return   ".$this->getObjectClassName(true)." The current object (for fluent API support)
+     * @return     \$this|".$this->getObjectClassName(true)." The current object (for fluent API support)
      */";
     }
 
@@ -1845,7 +1845,7 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
      * Check on string values is case insensitive (so 'FaLsE' is seen as 'false').
      * ".$col->getDescription()."
      * @param      boolean|integer|string \$v The new value
-     * @return   ".$this->getObjectClassName(true)." The current object (for fluent API support)
+     * @return     \$this|".$this->getObjectClassName(true)." The current object (for fluent API support)
      */";
     }
 
@@ -2542,7 +2542,7 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
      *                     one of the class type constants TableMap::TYPE_PHPNAME, TableMap::TYPE_STUDLYPHPNAME
      *                     TableMap::TYPE_COLNAME, TableMap::TYPE_FIELDNAME, TableMap::TYPE_NUM.
      *                     Defaults to TableMap::$defaultKeyType.
-     * @return void
+     * @return     \$this|".$this->getObjectClassName(true)."
      */
     public function setByName(\$name, \$value, \$type = TableMap::$defaultKeyType)
     {
@@ -2563,7 +2563,7 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
      *
      * @param      int \$pos position in xml schema
      * @param      mixed \$value field value
-     * @return void
+     * @return     \$this|".$this->getObjectClassName(true)."
      */
     public function setByPosition(\$pos, \$value)
     {
@@ -2596,6 +2596,8 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
         } /* foreach */
         $script .= "
         } // switch()
+
+        return \$this;
     }
 ";
     }
@@ -3157,7 +3159,7 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
      * Declares an association between this object and a $className object.
      *
      * @param                  $className \$v
-     * @return                 ".$this->getObjectClassName(true)." The current object (for fluent API support)
+     * @return                 \$this|".$this->getObjectClassName(true)." The current object (for fluent API support)
      * @throws PropelException
      */
     public function set".$this->getFKPhpNameAffix($fk, false)."($className \$v = null)
@@ -3333,7 +3335,7 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
      * overridden in <code>".$table->getPhpName()."</code>.";
         }
         $script .= "
-     * @return                 ".$this->getObjectClassName(true)." The current object (for fluent API support)
+     * @return                 \$this|".$this->getObjectClassName(true)." The current object (for fluent API support)
      * @throws PropelException
      */
     public function set".$methodAffix."Key(\$key)
@@ -3613,7 +3615,7 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
      * through the $className foreign key attribute.
      *
      * @param    $className \$l $className
-     * @return   ".$this->getObjectClassName(true)." The current object (for fluent API support)
+     * @return   \$this|".$this->getObjectClassName(true)." The current object (for fluent API support)
      */
     public function add".$this->getRefFKPhpNameAffix($refFK, false)."($className \$l)
     {
@@ -3782,7 +3784,7 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
      *
      * @param      Collection \${$inputCollection} A Propel collection.
      * @param      ConnectionInterface \$con Optional connection object
-     * @return   ".$this->getObjectClassname()." The current object (for fluent API support)
+     * @return     \$this|".$this->getObjectClassname()." The current object (for fluent API support)
      */
     public function set{$relatedName}(Collection \${$inputCollection}, ConnectionInterface \$con = null)
     {
@@ -3880,7 +3882,7 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
         $script .= "
     /**
      * @param  {$className} \${$lowerRelatedObjectClassName} The $className object to remove.
-     * @return ". $this->getObjectClassname() ." The current object (for fluent API support)
+     * @return \$this|". $this->getObjectClassname() ." The current object (for fluent API support)
      */
     public function remove{$relatedObjectClassName}($className \${$lowerRelatedObjectClassName})
     {
@@ -3962,7 +3964,7 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
      * Sets a single $className object as related to this object by a one-to-one relationship.
      *
      * @param                  $className \$v $className
-     * @return                 ".$this->getObjectClassName(true)." The current object (for fluent API support)
+     * @return                 \$this|".$this->getObjectClassName(true)." The current object (for fluent API support)
      * @throws PropelException
      */
     public function set".$this->getRefFKPhpNameAffix($refFK, false)."($className \$v = null)
@@ -4270,7 +4272,7 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
      *
      * @param  Collection \${$inputCollection} A Propel collection.
      * @param  ConnectionInterface \$con Optional connection object
-     * @return " . $this->getObjectClassname() . " The current object (for fluent API support)
+     * @return \$this|" . $this->getObjectClassname() . " The current object (for fluent API support)
      */
     public function set{$relatedNamePlural}(Collection \${$inputCollection}, ConnectionInterface \$con = null)
     {
@@ -4361,7 +4363,7 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
      * through the " . $tblFK->getName() . " cross reference table.
      *
      * @param  " . $crossObjectClassName . " " . $crossObjectName . " The $className object to relate
-     * @return "   . $this->getObjectClassname() . " The current object (for fluent API support)
+     * @return \$this|"   . $this->getObjectClassname() . " The current object (for fluent API support)
      */
     public function add{$relatedObjectClassName}($crossObjectClassName $crossObjectName)
     {
@@ -4440,7 +4442,7 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
      * through the {$tblFK->getName()} cross reference table.
      *
      * @param {$crossObjectClassName} {$crossObjectName} The $className object to relate
-     * @return " . $this->getObjectClassname() . " The current object (for fluent API support)
+     * @return \$this|" . $this->getObjectClassname() . " The current object (for fluent API support)
      */
     public function remove{$relatedObjectClassName}($crossObjectClassName $crossObjectName)
     {

--- a/src/Propel/Generator/Builder/Om/QueryBuilder.php
+++ b/src/Propel/Generator/Builder/Om/QueryBuilder.php
@@ -146,13 +146,15 @@ class QueryBuilder extends AbstractOMBuilder
  * @method     $modelClass findOneBy" . $column->getPhpName() . "(" . $column->getPhpType() . " \$" . $column->getName() . ") Return the first $modelClass filtered by the " . $column->getName() . " column";
         }
         $script .= "
- *";
+ *
+ * @method     {$modelClass}[]|ObjectCollection find(ConnectionInterface \$con = null) Return $modelClass objects based on current ModelCriteria";
         foreach ($this->getTable()->getColumns() as $column) {
             $script .= "
- * @method     array findBy" . $column->getPhpName() . "(" . $column->getPhpType() . " \$" . $column->getName() . ") Return $modelClass objects filtered by the " . $column->getName() . " column";
+ * @method     {$modelClass}[]|ObjectCollection findBy" . $column->getPhpName() . "(" . $column->getPhpType() . " \$" . $column->getName() . ") Return $modelClass objects filtered by the " . $column->getName() . " column";
         }
 
         $script .= "
+ * @method     {$modelClass}[]|\\Propel\\Runtime\\Util\\PropelModelPager paginate(\$page = 1, \$maxPerPage = 10, ConnectionInterface \$con = null) Issue a SELECT query based on the current ModelCriteria and uses a page and a maximum number of results per page to compute an offset and a limit
  *
  */
 abstract class ".$this->getUnqualifiedClassName()." extends " . $parentClass . "
@@ -717,7 +719,7 @@ abstract class ".$this->getUnqualifiedClassName()." extends " . $parentClass . "
      *
      * @param     mixed \$key Primary key to use for the query
      *
-     * @return " . $this->getQueryClassName() . " The current query, for fluid interface
+     * @return \$this|" . $this->getQueryClassName() . " The current query, for fluid interface
      */
     public function filterByPrimaryKey(\$key)
     {";
@@ -769,7 +771,7 @@ abstract class ".$this->getUnqualifiedClassName()." extends " . $parentClass . "
      *
      * @param     array \$keys The list of primary key to use for the query
      *
-     * @return " . $this->getQueryClassName() . " The current query, for fluid interface
+     * @return \$this|" . $this->getQueryClassName() . " The current query, for fluid interface
      */
     public function filterByPrimaryKeys(\$keys)
     {";
@@ -906,7 +908,7 @@ abstract class ".$this->getUnqualifiedClassName()." extends " . $parentClass . "
         $script .= "
      * @param     string \$comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
      *
-     * @return " . $this->getQueryClassName() . " The current query, for fluid interface
+     * @return \$this|" . $this->getQueryClassName() . " The current query, for fluid interface
      */
     public function filterBy$colPhpName(\$$variableName = null, \$comparison = null)
     {";
@@ -1034,7 +1036,7 @@ abstract class ".$this->getUnqualifiedClassName()." extends " . $parentClass . "
      * @param     mixed \$$variableName The value to use as filter
      * @param     string \$comparison Operator to use for the column comparison, defaults to Criteria::CONTAINS_ALL
      *
-     * @return " . $this->getQueryClassName() . " The current query, for fluid interface
+     * @return \$this|" . $this->getQueryClassName() . " The current query, for fluid interface
      */
     public function filterBy$singularPhpName(\$$variableName = null, \$comparison = null)
     {
@@ -1240,7 +1242,7 @@ abstract class ".$this->getUnqualifiedClassName()." extends " . $parentClass . "
      * @param     string \$relationAlias optional alias for the relation
      * @param     string \$joinType Accepted values are null, 'left join', 'right join', 'inner join'
      *
-     * @return ". $queryClass . " The current query, for fluid interface
+     * @return \$this|". $queryClass . " The current query, for fluid interface
      */
     public function join" . $relationName . "(\$relationAlias = null, \$joinType = " . $joinType . ")
     {
@@ -1373,7 +1375,7 @@ abstract class ".$this->getUnqualifiedClassName()." extends " . $parentClass . "
      *
      * @param   $class $objectName Object to remove from the list of results
      *
-     * @return " . $this->getQueryClassName() . " The current query, for fluid interface
+     * @return \$this|" . $this->getQueryClassName() . " The current query, for fluid interface
      */
     public function prune($objectName = null)
     {

--- a/src/Propel/Generator/Builder/Om/templates/baseObjectMethods.php
+++ b/src/Propel/Generator/Builder/Om/templates/baseObjectMethods.php
@@ -171,7 +171,7 @@
      * @param string $name  The virtual column name
      * @param mixed  $value The value to give to the virtual column
      *
-     * @return <?php echo $className ?> The current object, for fluid interface
+     * @return $this|<?php echo $className ?> The current object, for fluid interface
      */
     public function setVirtualColumn($name, $value)
     {
@@ -203,7 +203,7 @@
      *                       or a format name ('XML', 'YAML', 'JSON', 'CSV')
      * @param string $data The source data to import from
      *
-     * @return <?php echo $className ?> The current object, for fluid interface
+     * @return $this|<?php echo $className ?> The current object, for fluid interface
      */
     public function importFrom($parser, $data)
     {

--- a/src/Propel/Generator/Model/Behavior.php
+++ b/src/Propel/Generator/Model/Behavior.php
@@ -343,7 +343,7 @@ class Behavior extends MappingModel
      *
      * The current object is returned by default.
      *
-     * @return Behavior
+     * @return $this|Behavior
      */
     public function getTableModifier()
     {
@@ -355,7 +355,7 @@ class Behavior extends MappingModel
      *
      * The current object is returned by default.
      *
-     * @return Behavior
+     * @return $this|Behavior
      */
     public function getObjectBuilderModifier()
     {
@@ -367,7 +367,7 @@ class Behavior extends MappingModel
      *
      * The current object is returned by default.
      *
-     * @return Behavior
+     * @return $this|Behavior
      */
     public function getQueryBuilderModifier()
     {
@@ -379,7 +379,7 @@ class Behavior extends MappingModel
      *
      * The current object is returned by default.
      *
-     * @return Behavior
+     * @return $this|Behavior
      */
     public function getTableMapBuilderModifier()
     {

--- a/src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
@@ -59,7 +59,7 @@ class BaseModelCriteria extends Criteria implements \IteratorAggregate
      *
      * @param    array
      *
-     * @return ModelCriteria The current object, for fluid interface
+     * @return $this|ModelCriteria The current object, for fluid interface
      */
     public function setWith($with)
     {
@@ -77,7 +77,7 @@ class BaseModelCriteria extends Criteria implements \IteratorAggregate
      * </code>
      *
      * @param  string|AbstractFormatter $formatter a formatter class name, or a formatter instance
-     * @return ModelCriteria            The current object, for fluid interface
+     * @return $this|ModelCriteria                    The current object, for fluid interface
      *
      * @throws InvalidArgumentException
      */
@@ -128,7 +128,7 @@ class BaseModelCriteria extends Criteria implements \IteratorAggregate
      *
      * @param string $modelName
      *
-     * @return ModelCriteria The current object, for fluid interface
+     * @return $this|ModelCriteria The current object, for fluid interface
      */
     public function setModelName($modelName)
     {
@@ -158,7 +158,7 @@ class BaseModelCriteria extends Criteria implements \IteratorAggregate
      * @param string  $modelAlias    The model alias
      * @param boolean $useAliasInSQL Whether to use the alias in the SQL code (false by default)
      *
-     * @return ModelCriteria The current object, for fluid interface
+     * @return $this|ModelCriteria The current object, for fluid interface
      */
     public function setModelAlias($modelAlias, $useAliasInSQL = false)
     {

--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -317,7 +317,7 @@ class Criteria
      * @param string $name   Wanted Name of the column (alias).
      * @param string $clause SQL clause to select from the table
      *
-     * @return Criteria A modified Criteria object.
+     * @return $this|Criteria A modified Criteria object.
      */
     public function addAsColumn($name, $clause)
     {
@@ -357,7 +357,7 @@ class Criteria
      * @param string $alias
      * @param string $table
      *
-     * @return Criteria A modified Criteria object.
+     * @return $this|Criteria A modified Criteria object.
      */
     public function addAlias($alias, $table)
     {
@@ -371,7 +371,7 @@ class Criteria
      *
      * @param string $alias
      *
-     * @return Criteria A modified Criteria object.
+     * @return $this|Criteria A modified Criteria object.
      */
     public function removeAlias($alias)
     {
@@ -724,7 +724,7 @@ class Criteria
      *
      * @param  string   $key
      * @param  mixed    $value
-     * @return Criteria Instance of self.
+     * @return $this|Criteria    Instance of self.
      */
     public function put($key, $value)
     {
@@ -775,7 +775,7 @@ class Criteria
      * @param mixed  $value
      * @param string $comparison   A String.
      *
-     * @return Criteria A modified Criteria object.
+     * @return $this|Criteria A modified Criteria object.
      */
     public function add($p1, $value = null, $comparison = null)
     {
@@ -817,7 +817,7 @@ class Criteria
      * @param mixed  $value
      * @param string $comparison A String.
      *
-     * @return Criteria A modified Criteria object.
+     * @return $this|Criteria A modified Criteria object.
      */
     public function addCond($name, $p1, $value = null, $comparison = null)
     {
@@ -832,6 +832,7 @@ class Criteria
      * @param array  $criterions array of the name of the criterions to combine
      * @param string $operator   logical operator, either Criteria::LOGICAL_AND, or Criteria::LOGICAL_OR
      * @param string $name       optional name to combine the criterion later
+     * @return $this|Criteria
      */
     public function combine($criterions = array(), $operator = self::LOGICAL_AND, $name = null)
     {
@@ -872,7 +873,7 @@ class Criteria
      *                             among Criteria::INNER_JOIN, Criteria::LEFT_JOIN,
      *                             and Criteria::RIGHT_JOIN
      *
-     * @return Criteria A modified Criteria object.
+     * @return $this|Criteria A modified Criteria object.
      */
     public function addJoin($left, $right, $joinType = null)
     {
@@ -929,7 +930,7 @@ class Criteria
      * @param array  $conditions An array of conditions, each condition being an array (left, right, operator)
      * @param string $joinType   A String with the join operator. Defaults to an implicit join.
      *
-     * @return Criteria A modified Criteria object.
+     * @return $this|Criteria A modified Criteria object.
      */
     public function addMultipleJoin($conditions, $joinType = null)
     {
@@ -988,7 +989,7 @@ class Criteria
      *
      * @param Join $join A join object
      *
-     * @return Criteria A modified Criteria object
+     * @return $this|Criteria A modified Criteria object
      */
     public function addJoinObject(Join $join)
     {
@@ -1014,7 +1015,7 @@ class Criteria
      * @param Criteria $subQueryCriteria Criteria to build the subquery from
      * @param string   $alias            alias for the subQuery
      *
-     * @return Criteria this modified Criteria object (Fluid API)
+     * @return $this|Criteria this modified Criteria object (Fluid API)
      */
     public function addSelectQuery(Criteria $subQueryCriteria, $alias = null)
     {
@@ -1080,7 +1081,7 @@ class Criteria
 
     /**
      * Adds 'ALL' modifier to the SQL statement.
-     * @return Criteria Modified Criteria object (for fluent API)
+     * @return $this|Criteria Modified Criteria object (for fluent API)
      */
     public function setAll()
     {
@@ -1092,7 +1093,7 @@ class Criteria
 
     /**
      * Adds 'DISTINCT' modifier to the SQL statement.
-     * @return Criteria Modified Criteria object (for fluent API)
+     * @return $this|Criteria Modified Criteria object (for fluent API)
      */
     public function setDistinct()
     {
@@ -1108,7 +1109,7 @@ class Criteria
      *
      * @param string $modifier The modifier to add
      *
-     * @return Criteria Modified Criteria object (for fluent API)
+     * @return $this|Criteria Modified Criteria object (for fluent API)
      */
     public function addSelectModifier($modifier)
     {
@@ -1126,7 +1127,7 @@ class Criteria
      *
      * @param string $modifier The modifier to add
      *
-     * @return Criteria Modified Criteria object (for fluent API)
+     * @return $this|Criteria Modified Criteria object (for fluent API)
      */
     public function removeSelectModifier($modifier)
     {
@@ -1151,7 +1152,7 @@ class Criteria
      * Sets ignore case.
      *
      * @param  boolean  $b True if case should be ignored.
-     * @return Criteria Modified Criteria object (for fluent API)
+     * @return $this|Criteria Modified Criteria object (for fluent API)
      */
     public function setIgnoreCase($b)
     {
@@ -1180,7 +1181,7 @@ class Criteria
      * should be using setLimit(1).
      *
      * @param  boolean  $b Set to TRUE if you expect the query to select just one record.
-     * @return Criteria Modified Criteria object (for fluent API)
+     * @return $this|Criteria Modified Criteria object (for fluent API)
      */
     public function setSingleRecord($b)
     {
@@ -1203,7 +1204,7 @@ class Criteria
      * Set limit.
      *
      * @param  int      $limit An int with the value for limit.
-     * @return Criteria Modified Criteria object (for fluent API)
+     * @return $this|Criteria Modified Criteria object (for fluent API)
      */
     public function setLimit($limit)
     {
@@ -1228,7 +1229,7 @@ class Criteria
      *
      * @param int $offset An int with the value for offset.  (Note this values is
      *                             cast to a 32bit integer and may result in truncation)
-     * @return Criteria Modified Criteria object (for fluent API)
+     * @return $this|Criteria Modified Criteria object (for fluent API)
      */
     public function setOffset($offset)
     {
@@ -1251,7 +1252,7 @@ class Criteria
      * Add select column.
      *
      * @param  string   $name Name of the select column.
-     * @return Criteria Modified Criteria object (for fluent API)
+     * @return $this|Criteria Modified Criteria object (for fluent API)
      */
     public function addSelectColumn($name)
     {
@@ -1264,7 +1265,7 @@ class Criteria
      * Set the query comment, that appears after the first verb in the SQL query
      *
      * @param  string   $comment The comment to add to the query, without comment sign
-     * @return Criteria Modified Criteria object (for fluent API)
+     * @return $this|Criteria Modified Criteria object (for fluent API)
      */
     public function setComment($comment = null)
     {
@@ -1310,7 +1311,7 @@ class Criteria
     /**
      * Clears current select columns.
      *
-     * @return Criteria Modified Criteria object (for fluent API)
+     * @return $this|Criteria Modified Criteria object (for fluent API)
      */
     public function clearSelectColumns()
     {
@@ -1333,7 +1334,7 @@ class Criteria
      * Add group by column name.
      *
      * @param  string $groupBy The name of the column to group by.
-     * @return Criteria A modified Criteria object.
+     * @return $this|Criteria A modified Criteria object.
      */
     public function addGroupByColumn($groupBy)
     {
@@ -1346,7 +1347,7 @@ class Criteria
      * Add order by column name, explicitly specifying ascending.
      *
      * @param  string $name The name of the column to order by.
-     * @return Criteria A modified Criteria object.
+     * @return $this|Criteria A modified Criteria object.
      */
     public function addAscendingOrderByColumn($name)
     {
@@ -1359,7 +1360,7 @@ class Criteria
      * Add order by column name, explicitly specifying descending.
      *
      * @param  string   $name The name of the column to order by.
-     * @return Criteria Modified Criteria object (for fluent API)
+     * @return $this|Criteria Modified Criteria object (for fluent API)
      */
     public function addDescendingOrderByColumn($name)
     {
@@ -1381,7 +1382,7 @@ class Criteria
     /**
      * Clear the order-by columns.
      *
-     * @return Criteria Modified Criteria object (for fluent API)
+     * @return $this|Criteria Modified Criteria object (for fluent API)
      */
     public function clearOrderByColumns()
     {
@@ -1393,7 +1394,7 @@ class Criteria
     /**
      * Clear the group-by columns.
      *
-     * @return Criteria
+     * @return $this|Criteria
      */
     public function clearGroupByColumns()
     {
@@ -1553,7 +1554,7 @@ class Criteria
      *            Defaults to Criteria::LOGICAL_AND, also accepts Criteria::LOGICAL_OR
      *            This parameter is deprecated, use _or() instead
      *
-     * @return Criteria The current criteria object
+     * @return $this|Criteria The current criteria object
      */
     public function mergeWith(Criteria $criteria, $operator = null)
     {
@@ -1648,7 +1649,7 @@ class Criteria
      * @param mixed $value      The value to bind in the condition
      * @param mixed $comparison A PDO::PARAM_ class constant
      *
-     * @return Criteria A modified Criteria object.
+     * @return $this|Criteria A modified Criteria object.
      */
     public function addHaving($p1, $value = null, $comparison = null)
     {
@@ -1702,7 +1703,7 @@ class Criteria
      *  - addAnd(column, value)
      *  - addAnd(Criterion)
      *
-     * @return Criteria A modified Criteria object.
+     * @return $this|Criteria A modified Criteria object.
      */
     public function addAnd($p1, $p2 = null, $p3 = null, $preferColumnCondition = true)
     {
@@ -1732,7 +1733,7 @@ class Criteria
      *  - addOr(column, value)
      *  - addOr(Criterion)
      *
-     * @return Criteria A modified Criteria object.
+     * @return $this|Criteria A modified Criteria object.
      */
     public function addOr($p1, $p2 = null, $p3 = null, $preferColumnCondition = true)
     {
@@ -1762,7 +1763,7 @@ class Criteria
     *                      (necessary for Propel 1.4 compatibility).
      *                     If false, the condition is combined with the last existing condition.
      *
-     * @return Criteria A modified Criteria object.
+     * @return $this|Criteria A modified Criteria object.
      */
     public function addUsingOperator($p1, $value = null, $operator = null, $preferColumnCondition = true)
     {
@@ -2471,7 +2472,7 @@ class Criteria
      *
      * @param boolean $cond
      *
-     * @return PropelConditionalProxy|Criteria
+     * @return PropelConditionalProxy|$this|Criteria
      */
     public function _if($cond)
     {
@@ -2486,7 +2487,7 @@ class Criteria
      *
      * @param boolean $cond ignored
      *
-     * @return PropelConditionalProxy|Criteria
+     * @return PropelConditionalProxy|$this|Criteria
      */
     public function _elseif($cond)
     {
@@ -2501,7 +2502,7 @@ class Criteria
      * Returns a PropelConditionalProxy instance.
      * Allows for conditional statements in a fluid interface.
      *
-     * @return PropelConditionalProxy|Criteria
+     * @return PropelConditionalProxy|$this|Criteria
      */
     public function _else()
     {
@@ -2516,7 +2517,7 @@ class Criteria
      * Returns the current object
      * Allows for conditional statements in a fluid interface.
      *
-     * @return Criteria
+     * @return $this|Criteria
      */
     public function _endif()
     {

--- a/src/Propel/Runtime/ActiveQuery/Criterion/AbstractCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/AbstractCriterion.php
@@ -229,6 +229,9 @@ abstract class AbstractCriterion
 
     /**
      * Append an AND Criterion onto this Criterion's list.
+     *
+     * @param AbstractCriterion $criterion
+     * @return $this|AbstractCriterion
      */
     public function addAnd(AbstractCriterion $criterion)
     {
@@ -242,7 +245,7 @@ abstract class AbstractCriterion
      * Append an OR Criterion onto this Criterion's list.
      *
      * @param AbstractCriterion $criterion
-     * @return AbstractCriterion
+     * @return $this|AbstractCriterion
      */
     public function addOr(AbstractCriterion $criterion)
     {

--- a/src/Propel/Runtime/ActiveQuery/Criterion/BasicCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/BasicCriterion.php
@@ -39,7 +39,7 @@ class BasicCriterion extends AbstractCriterion
      * Sets ignore case.
      *
      * @param  boolean   $b True if case should be ignored.
-     * @return BasicCriterion A modified Criterion object.
+     * @return $this|BasicCriterion A modified Criterion object.
      */
     public function setIgnoreCase($b)
     {

--- a/src/Propel/Runtime/ActiveQuery/Criterion/LikeCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/LikeCriterion.php
@@ -39,7 +39,7 @@ class LikeCriterion extends AbstractCriterion
      * Sets ignore case.
      *
      * @param  boolean   $b True if case should be ignored.
-     * @return LikeCriterion A modified Criterion object.
+     * @return $this|LikeCriterion A modified Criterion object.
      */
     public function setIgnoreCase($b)
     {

--- a/src/Propel/Runtime/ActiveQuery/Criterion/LikeModelCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/LikeModelCriterion.php
@@ -26,7 +26,7 @@ class LikeModelCriterion extends BasicModelCriterion
      * Sets ignore case.
      *
      * @param  boolean            $b True if case should be ignored.
-     * @return LikeModelCriterion A modified Criterion object.
+     * @return $this|LikeModelCriterion A modified Criterion object.
      */
     public function setIgnoreCase($b)
     {

--- a/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
@@ -91,7 +91,7 @@ class ModelCriteria extends BaseModelCriteria
      * @param mixed  $value         A value for the condition
      * @param mixed  $bindingType   A value for the condition
      *
-     * @return ModelCriteria The current object, for fluid interface
+     * @return $this|ModelCriteria The current object, for fluid interface
      */
     public function condition($conditionName, $clause, $value = null, $bindingType = null)
     {
@@ -114,7 +114,7 @@ class ModelCriteria extends BaseModelCriteria
      * @param mixed  $value      A value for the condition
      * @param string $comparison What to use for the column comparison, defaults to Criteria::EQUAL
      *
-     * @return ModelCriteria The current object, for fluid interface
+     * @return $this|ModelCriteria The current object, for fluid interface
      */
     public function filterBy($column, $value, $comparison = Criteria::EQUAL)
     {
@@ -136,7 +136,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @param mixed $conditions An array of conditions, using column phpNames as key
      *
-     * @return ModelCriteria The current object, for fluid interface
+     * @return $this|ModelCriteria The current object, for fluid interface
      */
     public function filterByArray($conditions)
     {
@@ -165,7 +165,7 @@ class ModelCriteria extends BaseModelCriteria
      *                           Or an array of condition names
      * @param mixed $value A value for the condition
      *
-     * @return ModelCriteria The current object, for fluid interface
+     * @return $this|ModelCriteria The current object, for fluid interface
      */
     public function where($clause, $value = null, $bindingType = null)
     {
@@ -200,7 +200,7 @@ class ModelCriteria extends BaseModelCriteria
      *                           Or an array of condition names
      * @param mixed $value A value for the condition
      *
-     * @return ModelCriteria The current object, for fluid interface
+     * @return $this|ModelCriteria The current object, for fluid interface
      */
     public function having($clause, $value = null, $bindingType = null)
     {
@@ -230,7 +230,7 @@ class ModelCriteria extends BaseModelCriteria
      * @param string $columnName The column to order by
      * @param string $order      The sorting order. Criteria::ASC by default, also accepts Criteria::DESC
      *
-     * @return ModelCriteria The current object, for fluid interface
+     * @return $this|ModelCriteria The current object, for fluid interface
      */
     public function orderBy($columnName, $order = Criteria::ASC)
     {
@@ -260,7 +260,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @param string $columnName The column to group by
      *
-     * @return ModelCriteria The current object, for fluid interface
+     * @return $this|ModelCriteria The current object, for fluid interface
      */
     public function groupBy($columnName)
     {
@@ -281,7 +281,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @param string $class The class name or alias
      *
-     * @return ModelCriteria The current object, for fluid interface
+     * @return $this|ModelCriteria The current object, for fluid interface
      */
     public function groupByClass($class)
     {
@@ -310,7 +310,7 @@ class ModelCriteria extends BaseModelCriteria
      * Adds a DISTINCT clause to the query
      * Alias for Criteria::setDistinct()
      *
-     * @return ModelCriteria The current object, for fluid interface
+     * @return $this|ModelCriteria The current object, for fluid interface
      */
     public function distinct()
     {
@@ -325,7 +325,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @param int $limit Maximum number of results to return by the query
      *
-     * @return ModelCriteria The current object, for fluid interface
+     * @return $this|ModelCriteria The current object, for fluid interface
      */
     public function limit($limit)
     {
@@ -340,7 +340,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @param int $offset Offset of the first result to return
      *
-     * @return ModelCriteria The current object, for fluid interface
+     * @return $this|ModelCriteria The current object, for fluid interface
      */
     public function offset($offset)
     {
@@ -369,7 +369,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @param mixed $columnArray A list of column names (e.g. array('Title', 'Category.Name', 'c.Content')) or a single column name (e.g. 'Name')
      *
-     * @return ModelCriteria The current object, for fluid interface
+     * @return $this|ModelCriteria The current object, for fluid interface
      */
     public function select($columnArray)
     {
@@ -453,7 +453,7 @@ class ModelCriteria extends BaseModelCriteria
      * @param string $relation Relation to use for the join
      * @param string $joinType Accepted values are null, 'left join', 'right join', 'inner join'
      *
-     * @return ModelCriteria The current object, for fluid interface
+     * @return $this|ModelCriteria The current object, for fluid interface
      */
     public function join($relation, $joinType = Criteria::INNER_JOIN)
     {
@@ -522,7 +522,7 @@ class ModelCriteria extends BaseModelCriteria
      * @param mixed  $value    An optional value to bind to the clause
      * @param string $operator The operator to use to add the condition. Defaults to 'AND'
      *
-     * @return ModelCriteria The current object, for fluid interface
+     * @return $this|ModelCriteria The current object, for fluid interface
      */
     public function addJoinCondition($name, $clause, $value = null, $operator = null, $bindingType = null)
     {
@@ -554,7 +554,7 @@ class ModelCriteria extends BaseModelCriteria
      * @param string $name      The relation name or alias on which the join was created
      * @param mixed  $condition A Criterion object, or a condition name
      *
-     * @return ModelCriteria The current object, for fluid interface
+     * @return $this|ModelCriteria The current object, for fluid interface
      */
     public function setJoinCondition($name, $condition)
     {
@@ -578,7 +578,7 @@ class ModelCriteria extends BaseModelCriteria
      * @see Criteria::addJoinObject()
      * @param Join $join A join object
      *
-     * @return ModelCriteria The current object, for fluid interface
+     * @return $this|ModelCriteria The current object, for fluid interface
      */
     public function addJoinObject(Join $join, $name = null)
     {
@@ -608,7 +608,7 @@ class ModelCriteria extends BaseModelCriteria
      * @param string $relation Relation to use for the join
      * @param string $joinType Accepted values are null, 'left join', 'right join', 'inner join'
      *
-     * @return ModelCriteria The current object, for fluid interface
+     * @return $this|ModelCriteria The current object, for fluid interface
      */
     public function joinWith($relation, $joinType = Criteria::INNER_JOIN)
     {
@@ -634,7 +634,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @param string $relation Relation to use for the join
      *
-     * @return ModelCriteria The current object, for fluid interface
+     * @return $this|ModelCriteria The current object, for fluid interface
      */
     public function with($relation)
     {
@@ -678,7 +678,7 @@ class ModelCriteria extends BaseModelCriteria
      *                           If no alias is provided, the clause is used as a column alias
      *                           This alias is used for retrieving the column via BaseObject::getVirtualColumn($alias)
      *
-     * @return ModelCriteria The current object, for fluid interface
+     * @return $this|ModelCriteria The current object, for fluid interface
      */
     public function withColumn($clause, $name = null)
     {
@@ -701,8 +701,8 @@ class ModelCriteria extends BaseModelCriteria
      * Initializes a secondary ModelCriteria object, to be later merged with the current object
      *
      * @see ModelCriteria::endUse()
-     * @param string $relationName        Relation name or alias
-     * @param string $secondCriteriaClass ClassName for the ModelCriteria to be used
+     * @param string $relationName           Relation name or alias
+     * @param string $secondaryCriteriaClass ClassName for the ModelCriteria to be used
      *
      * @return ModelCriteria The secondary criteria object
      */
@@ -757,7 +757,7 @@ class ModelCriteria extends BaseModelCriteria
      * @param string   $operator The logical operator used to combine conditions
      *              Defaults to Criteria::LOGICAL_AND, also accepts Criteria::LOGICAL_OR
      *
-     * @return ModelCriteria The primary criteria object
+     * @return $this|ModelCriteria The primary criteria object
      */
     public function mergeWith(Criteria $criteria, $operator = null)
     {
@@ -775,7 +775,7 @@ class ModelCriteria extends BaseModelCriteria
      * Clear the conditions to allow the reuse of the query object.
      * The ModelCriteria's Model and alias 'all the properties set by construct) will remain.
      *
-     * @return ModelCriteria The primary criteria object
+     * @return $this|ModelCriteria The primary criteria object
      */
     public function clear()
     {
@@ -818,7 +818,7 @@ class ModelCriteria extends BaseModelCriteria
      * @param string   $alias                    alias for the subQuery
      * @param boolean  $addAliasAndSelectColumns Set to false if you want to manually add the aliased select columns
      *
-     * @return ModelCriteria The current object, for fluid interface
+     * @return $this|ModelCriteria The current object, for fluid interface
      */
     public function addSelectQuery(Criteria $subQueryCriteria, $alias = null, $addAliasAndSelectColumns = true)
     {
@@ -845,7 +845,7 @@ class ModelCriteria extends BaseModelCriteria
     /**
      * Adds the select columns for a the current table
      *
-     * @return ModelCriteria The current object, for fluid interface
+     * @return $this|ModelCriteria The current object, for fluid interface
      */
     public function addSelfSelectColumns()
     {
@@ -860,7 +860,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @param string $relation The relation name or alias, as defined in join()
      *
-     * @return ModelCriteria The current object, for fluid interface
+     * @return $this|ModelCriteria The current object, for fluid interface
      */
     public function addRelationSelectColumns($relation)
     {
@@ -923,7 +923,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @param boolean $isKeepQuery
      *
-     * @return ModelCriteria The current object, for fluid interface
+     * @return $this|ModelCriteria The current object, for fluid interface
      */
     public function keepQuery($isKeepQuery = true)
     {
@@ -1949,7 +1949,7 @@ class ModelCriteria extends BaseModelCriteria
      * @param mixed  $value
      * @param string $operator A String, like Criteria::EQUAL.
      *
-     * @return ModelCriteria A modified Criteria object.
+     * @return $this|ModelCriteria A modified Criteria object.
      */
     public function addUsingAlias($p1, $value = null, $operator = null)
     {

--- a/src/Propel/Runtime/ActiveQuery/ModelJoin.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelJoin.php
@@ -56,7 +56,7 @@ class ModelJoin extends Join
      *
      * @param TableMap $tableMap The table map to use
      *
-     * @return ModelJoin The current join object, for fluid interface
+     * @return $this|ModelJoin The current join object, for fluid interface
      */
     public function setTableMap(TableMap $tableMap)
     {

--- a/src/Propel/Runtime/Formatter/AbstractFormatter.php
+++ b/src/Propel/Runtime/Formatter/AbstractFormatter.php
@@ -87,7 +87,7 @@ abstract class AbstractFormatter
      * @param BaseModelCriteria    $criteria
      * @param DataFetcherInterface $dataFetcher
      *
-     * @return AbstractFormatter The current formatter object
+     * @return $this|AbstractFormatter The current formatter object
      */
     public function init(BaseModelCriteria $criteria, DataFetcherInterface $dataFetcher = null)
     {

--- a/src/Propel/Runtime/Util/PropelConditionalProxy.php
+++ b/src/Propel/Runtime/Util/PropelConditionalProxy.php
@@ -66,7 +66,7 @@ class PropelConditionalProxy
      *
      * @param boolean $cond
      *
-     * @return PropelConditionalProxy
+     * @return $this|PropelConditionalProxy|Criteria
      */
     public function _if($cond)
     {
@@ -78,7 +78,7 @@ class PropelConditionalProxy
      *
      * @param boolean $cond ignored
      *
-     * @return PropelConditionalProxy
+     * @return $this|PropelConditionalProxy|Criteria
      */
     public function _elseif($cond)
     {
@@ -88,7 +88,7 @@ class PropelConditionalProxy
     /**
      * Allows for conditional statements in a fluid interface.
      *
-     * @return PropelConditionalProxy
+     * @return $this|PropelConditionalProxy|Criteria
      */
     public function _else()
     {
@@ -99,7 +99,7 @@ class PropelConditionalProxy
      * Returns the parent object
      * Allows for conditional statements in a fluid interface.
      *
-     * @return PropelConditionalProxy|Criteria
+     * @return $this|PropelConditionalProxy|Criteria
      */
     public function _endif()
     {


### PR DESCRIPTION
I would like to change the return type of all fluent style methods to `@return $this` (instead of `@return ClassName`). Look here for more infos: https://github.com/phpDocumentor/fig-standards/blob/master/proposed/phpdoc.md#keyword, 15.

PhpStorm is supporting this very well, but I don't know for the other main PHP IDEs.
So maybe we should use a compat notation: `@return ClassName|$this`.

What do you think about this?
### Example:

Before:

![bildschirmfoto 2014-03-02 um 20 01 25](https://f.cloud.github.com/assets/330436/2304938/491020da-a23d-11e3-8710-c9cdb0689389.png)

After:

![bildschirmfoto 2014-03-02 um 20 02 21](https://f.cloud.github.com/assets/330436/2304939/5144498e-a23d-11e3-8b19-2f39c46e3fc3.png)
