### PR TITLE
Now filename of build.properties may be specified

### DIFF
--- a/src/Propel/Generator/Command/AbstractCommand.php
+++ b/src/Propel/Generator/Command/AbstractCommand.php
@@ -54,8 +54,9 @@ abstract class AbstractCommand extends Command
      */
     protected function getGeneratorConfig(array $properties, InputInterface $input = null)
     {
-        $buildfile = $input->getOption('build-properties');
-        if(empty($buildfile))
+        if($input && $input->hasOption('build-properties'))
+            $buildfile = $input->getOption('build-properties');
+        else
             $buildfile = self::DEFAULT_BUILD_PROPERTIES_FILE_NAME;
         
         $options = $properties;


### PR DESCRIPTION
Added the option to tell the generator commands a custom name of the project's "build.properties". This brings the advantage of being able to have build.properties for each project like "project1.build.properties", "project2.build.properties" and so on. You can now build the project according to the custom build.props via 
"propel anyPropelCommand --build-properties=project1.build.properties"
That makes generation of stuff much more comfortable when using one and the same propel installation for different projects which all reference the same propel dir and the generated classes within it.
