### PR TITLE
Fixed diff generator when several identical tables or columns were renamed

### DIFF
--- a/src/Propel/Generator/Model/Diff/DatabaseComparator.php
+++ b/src/Propel/Generator/Model/Diff/DatabaseComparator.php
@@ -152,17 +152,17 @@ class DatabaseComparator
             }
         }
 
-        $renamed = [];
         // check for table renamings
         foreach ($this->databaseDiff->getAddedTables() as $addedTableName => $addedTable) {
             foreach ($this->databaseDiff->getRemovedTables() as $removedTableName => $removedTable) {
-                if (!in_array($addedTableName, $renamed) && !TableComparator::computeDiff($addedTable, $removedTable, $caseInsensitive)) {
+                if (!TableComparator::computeDiff($addedTable, $removedTable, $caseInsensitive)) {
                     // no difference except the name, that's probably a renaming
-                    $renamed[] = $addedTableName;
                     $this->databaseDiff->addRenamedTable($removedTableName, $addedTableName);
                     $this->databaseDiff->removeAddedTable($addedTableName);
                     $this->databaseDiff->removeRemovedTable($removedTableName);
                     $databaseDifferences--;
+                    // skip to the next added table
+                    break;
                 }
             }
         }

--- a/src/Propel/Generator/Model/Diff/TableComparator.php
+++ b/src/Propel/Generator/Model/Diff/TableComparator.php
@@ -161,17 +161,17 @@ class TableComparator
             }
         }
 
-        $renamed = [];
         // check for column renamings
         foreach ($this->tableDiff->getAddedColumns() as $addedColumnName => $addedColumn) {
             foreach ($this->tableDiff->getRemovedColumns() as $removedColumnName => $removedColumn) {
-                if (!in_array($addedColumnName, $renamed) && !ColumnComparator::computeDiff($addedColumn, $removedColumn, $caseInsensitive)) {
+                if (!ColumnComparator::computeDiff($addedColumn, $removedColumn, $caseInsensitive)) {
                     // no difference except the name, that's probably a renaming
-                    $renamed[] = $addedColumnName;
                     $this->tableDiff->addRenamedColumn($removedColumn, $addedColumn);
                     $this->tableDiff->removeAddedColumn($addedColumnName);
                     $this->tableDiff->removeRemovedColumn($removedColumnName);
                     $columnDifferences--;
+                    // skip to the next added column
+                    break;
                 }
             }
         }
@@ -221,6 +221,8 @@ class TableComparator
                     $this->tableDiff->removeAddedPkColumn($addedColumnName);
                     $this->tableDiff->removeRemovedPkColumn($removedColumnName);
                     $pkDifferences--;
+                    // skip to the next added column
+                    break;
                 }
             }
         }

--- a/tests/Propel/Tests/Generator/Model/Diff/PropelDatabaseTableComparatorTest.php
+++ b/tests/Propel/Tests/Generator/Model/Diff/PropelDatabaseTableComparatorTest.php
@@ -365,4 +365,53 @@ class PropelDatabaseTableComparatorTest extends TestCase
         $this->assertEquals(array('Foo_Table' => $tableDiff), $databaseDiff->getModifiedTables());
     }
 
+    public function testCompareSeveralRenamedSameTables()
+    {
+        $d1 = new Database();
+        $t1 = new Table('table1');
+        $c1 = new Column('col1');
+        $c1->getDomain()->copy($this->platform->getDomainForType('INTEGER'));
+        $t1->addColumn($c1);
+        $d1->addTable($t1);
+        $t2 = new Table('table2');
+        $c2 = new Column('col1');
+        $c2->getDomain()->copy($this->platform->getDomainForType('INTEGER'));
+        $t2->addColumn($c2);
+        $d1->addTable($t2);
+        $t3 = new Table('table3');
+        $c3 = new Column('col1');
+        $c3->getDomain()->copy($this->platform->getDomainForType('INTEGER'));
+        $t3->addColumn($c3);
+        $d1->addTable($t3);
+
+        $d2 = new Database();
+        $t4 = new Table('table4');
+        $c4 = new Column('col1');
+        $c4->getDomain()->copy($this->platform->getDomainForType('INTEGER'));
+        $t4->addColumn($c4);
+        $d2->addTable($t4);
+        $t5 = new Table('table5');
+        $c5 = new Column('col1');
+        $c5->getDomain()->copy($this->platform->getDomainForType('INTEGER'));
+        $t5->addColumn($c5);
+        $d2->addTable($t5);
+        $t6 = new Table('table3');
+        $c6 = new Column('col1');
+        $c6->getDomain()->copy($this->platform->getDomainForType('INTEGER'));
+        $t6->addColumn($c6);
+        $d2->addTable($t6);
+
+        // table1 and table2 were renamed
+        $dc = new DatabaseComparator();
+        $dc->setFromDatabase($d1);
+        $dc->setToDatabase($d2);
+        $nbDiffs = $dc->compareTables();
+        $databaseDiff = $dc->getDatabaseDiff();
+        $this->assertEquals(2, $nbDiffs);
+        $this->assertEquals(2, count($databaseDiff->getRenamedTables()));
+        $this->assertEquals(array('table1' => 'table4', 'table2' => 'table5'), $databaseDiff->getRenamedTables());
+        $this->assertEquals(array(), $databaseDiff->getAddedTables());
+        $this->assertEquals(array(), $databaseDiff->getRemovedTables());
+    }
+
 }

--- a/tests/Propel/Tests/Generator/Model/Diff/PropelTableColumnComparatorTest.php
+++ b/tests/Propel/Tests/Generator/Model/Diff/PropelTableColumnComparatorTest.php
@@ -230,4 +230,47 @@ class PropelTableColumnComparatorTest extends TestCase
         $this->assertEquals(array('col1' => $columnDiff), $tableDiff->getModifiedColumns());
     }
 
+    public function testCompareSeveralRenamedSameColumns()
+    {
+        $t1 = new Table();
+        $c1 = new Column('col1');
+        $c1->getDomain()->copy($this->platform->getDomainForType('VARCHAR'));
+        $c1->getDomain()->replaceSize(255);
+        $t1->addColumn($c1);
+        $c2 = new Column('col2');
+        $c2->getDomain()->copy($this->platform->getDomainForType('VARCHAR'));
+        $c2->getDomain()->replaceSize(255);
+        $t1->addColumn($c2);
+        $c3 = new Column('col3');
+        $c3->getDomain()->copy($this->platform->getDomainForType('VARCHAR'));
+        $c3->getDomain()->replaceSize(255);
+        $t1->addColumn($c3);
+
+        $t2 = new Table();
+        $c4 = new Column('col4');
+        $c4->getDomain()->copy($this->platform->getDomainForType('VARCHAR'));
+        $c4->getDomain()->replaceSize(255);
+        $t2->addColumn($c4);
+        $c5 = new Column('col5');
+        $c5->getDomain()->copy($this->platform->getDomainForType('VARCHAR'));
+        $c5->getDomain()->replaceSize(255);
+        $t2->addColumn($c5);
+        $c6 = new Column('col3');
+        $c6->getDomain()->copy($this->platform->getDomainForType('VARCHAR'));
+        $c6->getDomain()->replaceSize(255);
+        $t2->addColumn($c6);
+
+        // col1 and col2 were renamed
+        $tc = new TableComparator();
+        $tc->setFromTable($t1);
+        $tc->setToTable($t2);
+        $nbDiffs = $tc->compareColumns();
+        $tableDiff = $tc->getTableDiff();
+        $this->assertEquals(2, $nbDiffs);
+        $this->assertEquals(array(array($c1, $c4), array($c2, $c5)), $tableDiff->getRenamedColumns());
+        $this->assertEquals(array(), $tableDiff->getAddedColumns());
+        $this->assertEquals(array(), $tableDiff->getRemovedColumns());
+        $this->assertEquals(array(), $tableDiff->getModifiedColumns());
+    }
+
 }

--- a/tests/Propel/Tests/Generator/Model/Diff/PropelTablePkColumnComparatorTest.php
+++ b/tests/Propel/Tests/Generator/Model/Diff/PropelTablePkColumnComparatorTest.php
@@ -185,4 +185,52 @@ class PropelTablePkColumnComparatorTest extends TestCase
         $this->assertEquals(array('col3' => $c3), $tableDiff->getRemovedPkColumns());
     }
 
+    public function testCompareSeveralRenamedSamePrimaryKeys()
+    {
+        $t1 = new Table();
+        $c1 = new Column('col1');
+        $c1->getDomain()->copy($this->platform->getDomainForType('INTEGER'));
+        $c1->setNotNull(true);
+        $c1->setPrimaryKey(true);
+        $t1->addColumn($c1);
+        $c2 = new Column('col2');
+        $c2->getDomain()->copy($this->platform->getDomainForType('INTEGER'));
+        $c2->setNotNull(true);
+        $c2->setPrimaryKey(true);
+        $t1->addColumn($c2);
+        $c3 = new Column('col3');
+        $c3->getDomain()->copy($this->platform->getDomainForType('INTEGER'));
+        $c3->setNotNull(true);
+        $c3->setPrimaryKey(true);
+        $t1->addColumn($c3);
+
+        $t2 = new Table();
+        $c4 = new Column('col4');
+        $c4->getDomain()->copy($this->platform->getDomainForType('INTEGER'));
+        $c4->setNotNull(true);
+        $c4->setPrimaryKey(true);
+        $t2->addColumn($c4);
+        $c5 = new Column('col5');
+        $c5->getDomain()->copy($this->platform->getDomainForType('INTEGER'));
+        $c5->setNotNull(true);
+        $c5->setPrimaryKey(true);
+        $t2->addColumn($c5);
+        $c6 = new Column('col3');
+        $c6->getDomain()->copy($this->platform->getDomainForType('INTEGER'));
+        $c6->setNotNull(true);
+        $c6->setPrimaryKey(true);
+        $t2->addColumn($c6);
+
+        // col1 and col2 were renamed
+        $tc = new TableComparator();
+        $tc->setFromTable($t1);
+        $tc->setToTable($t2);
+        $nbDiffs = $tc->comparePrimaryKeys();
+        $tableDiff = $tc->getTableDiff();
+        $this->assertEquals(2, $nbDiffs);
+        $this->assertEquals(array(array($c1, $c4), array($c2, $c5)), $tableDiff->getRenamedPkColumns());
+        $this->assertEquals(array(), $tableDiff->getAddedPkColumns());
+        $this->assertEquals(array(), $tableDiff->getRemovedPkColumns());
+    }
+
 }


### PR DESCRIPTION
Fixed diff generator when databases have several tables with identical DDL and several of them were renamed.

Fixed diff generator when two tables have several columns or primary keys with identical DDL and several of them were renamed.

Port PR https://github.com/propelorm/Propel/pull/839 from Propel1.
