### PR TITLE
Fix getting option value from configuration

### DIFF
--- a/src/Propel/Runtime/Adapter/Pdo/PdoAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/PdoAdapter.php
@@ -54,7 +54,7 @@ abstract class PdoAdapter
         $driver_options = array();
         if (isset($conparams['options']) && is_array($conparams['options'])) {
             foreach ($conparams['options'] as $option => $optiondata) {
-                $value = $optiondata['value'];
+                $value = $optiondata;
                 if (is_string($value) && false !== strpos($value, '::')) {
                     if (!defined($value)) {
                         throw new InvalidArgumentException(sprintf('Error processing driver options for dsn "%s"', $dsn));


### PR DESCRIPTION
Configuration tries to read ['value'] from an array but it throws a PHP Warning:  Illegal string offset 'value'.

Configuration file containing

```
<options>
    <option id="PDO::MYSQL_ATTR_INIT_COMMAND">SET NAMES utf8</option>
</options>
```

Generates the following PHP configuration file:

```
'options' =>
  array (
    'PDO::MYSQL_ATTR_INIT_COMMAND' => 'SET NAMES utf8',
  ),
```
