### PR TITLE
fixed declaration of methods on Profiler classes

### DIFF
--- a/src/Propel/Runtime/Connection/ProfilerConnectionWrapper.php
+++ b/src/Propel/Runtime/Connection/ProfilerConnectionWrapper.php
@@ -78,7 +78,7 @@ class ProfilerConnectionWrapper extends ConnectionWrapper
     /**
      * {@inheritDoc}
      */
-    public function prepare($statement, array $driver_options = array())
+    public function prepare($statement, $driver_options = null)
     {
         $this->getProfiler()->start();
 

--- a/src/Propel/Runtime/Connection/ProfilerStatementWrapper.php
+++ b/src/Propel/Runtime/Connection/ProfilerStatementWrapper.php
@@ -60,7 +60,7 @@ class ProfilerStatementWrapper extends StatementWrapper
      * @param  string  $input_parameters
      * @return boolean
      */
-    public function execute(array $input_parameters = null)
+    public function execute($input_parameters = null)
     {
         $this->connection->getProfiler()->start();
 


### PR DESCRIPTION
The declaration of methods ProfilerConnectionWrapper->prepare and ProfilerStatementWrapper->execute weren't compatible with the declaration on their respective superclasses, causing Compiler Error.
