### PR TITLE
use IteratorAggregate for Collections, so nested iterations are possible

### DIFF
--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -3822,8 +3822,6 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
                         \$this->{$collName}Partial = true;
                     }
 
-                    \${$collName}->rewind();
-
                     return \$$collName;
                 }
 

--- a/src/Propel/Runtime/ActiveQuery/Criterion/InCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/InCriterion.php
@@ -41,7 +41,7 @@ class InCriterion extends AbstractCriterion
     {
         $bindParams = array();
         $index = count($params); // to avoid counting the number of parameters for each element in the array
-        $values = ($this->value instanceof \Iterator) ? iterator_to_array($this->value) : (array) $this->value;
+        $values = ($this->value instanceof \Traversable) ? iterator_to_array($this->value) : (array) $this->value;
         foreach ($values as $value) {
             $params[] = array('table' => $this->realtable, 'column' => $this->column, 'value' => $value);
             $index++; // increment this first to correct for wanting bind params to start with :p1

--- a/src/Propel/Runtime/ActiveQuery/Criterion/InModelCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/InModelCriterion.php
@@ -26,7 +26,7 @@ class InModelCriterion extends AbstractModelCriterion
     {
         $bindParams = array(); // the param names used in query building
         $index = count($params);
-        $values = ($this->value instanceof \Iterator) ? iterator_to_array($this->value) : (array) $this->value;
+        $values = ($this->value instanceof \Traversable) ? iterator_to_array($this->value) : (array) $this->value;
         foreach ($values as $value) {
             $params[] = array(
                 'table'  => $this->realtable,

--- a/src/Propel/Runtime/Collection/CollectionIterator.php
+++ b/src/Propel/Runtime/Collection/CollectionIterator.php
@@ -1,0 +1,249 @@
+<?php
+
+/**
+ * This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT License
+ */
+
+namespace Propel\Runtime\Collection;
+
+use Propel\Runtime\Exception\BadMethodCallException;
+
+/**
+ * Iterator class for iterating over Collection data
+ */
+class CollectionIterator extends \ArrayIterator
+{
+    /** @var Collection */
+    protected $collection;
+
+    /** @var array */
+    protected $positions = [];
+
+    /**
+     * Constructor
+     *
+     * @param Collection $collection
+     */
+    public function __construct(Collection $collection)
+    {
+        parent::__construct($collection->getData());
+
+        $this->collection = $collection;
+        $this->refreshPositions();
+    }
+
+    /**
+     * Returns the collection instance
+     *
+     * @return Collection
+     */
+    public function getCollection()
+    {
+        return $this->collection;
+    }
+
+    /**
+     * Check if the collection is empty
+     *
+     * @return boolean
+     */
+    public function isEmpty()
+    {
+        return 0 === $this->count();
+    }
+
+    /**
+     * Gets the position of the internal pointer
+     * This position can be later used in seek()
+     *
+     * @return integer
+     */
+    public function getPosition()
+    {
+        if (null === $this->key()) {
+            return 0;
+        }
+
+        return $this->positions[$this->key()];
+    }
+
+    /**
+     * Move the internal pointer to the beginning of the list
+     * And get the first element in the collection
+     *
+     * @return mixed
+     */
+    public function getFirst()
+    {
+        if ($this->isEmpty()) {
+            return null;
+        }
+        $this->rewind();
+        return $this->current();
+    }
+
+    /**
+     * Check whether the internal pointer is at the beginning of the list
+     *
+     * @return boolean
+     */
+    public function isFirst()
+    {
+        return 0 === $this->getPosition();
+    }
+
+    /**
+     * Move the internal pointer backward
+     * And get the previous element in the collection
+     *
+     * @return mixed
+     */
+    public function getPrevious()
+    {
+        if ($this->isFirst()) {
+            return null;
+        }
+
+        $this->seek($this->getPosition() - 1);
+        return $this->current();
+    }
+
+    /**
+     * Get the current element in the collection
+     *
+     * @return mixed
+     */
+    public function getCurrent()
+    {
+        return $this->current();
+    }
+
+    /**
+     * Move the internal pointer forward
+     * And get the next element in the collection
+     *
+     * @return mixed
+     */
+    public function getNext()
+    {
+        $this->next();
+        return $this->current();
+    }
+
+    /**
+     * Move the internal pointer to the end of the list
+     * And get the last element in the collection
+     *
+     * @return mixed
+     */
+    public function getLast()
+    {
+        if ($this->isEmpty()) {
+            return null;
+        }
+
+        $this->seek(count($this->positions) - 1);
+        return $this->current();
+    }
+
+    /**
+     * Check whether the internal pointer is at the end of the list
+     *
+     * @return boolean
+     */
+    public function isLast()
+    {
+        if ($this->isEmpty()) {
+            // empty list... so yes, this is the last
+            return true;
+        }
+
+        return $this->getPosition() === count($this->positions) - 1;
+    }
+
+    /**
+     * Check if the current index is an odd integer
+     *
+     * @return boolean
+     */
+    public function isOdd()
+    {
+        return (boolean)($this->getPosition() % 2);
+    }
+
+    /**
+     * Check if the current index is an even integer
+     *
+     * @return boolean
+     */
+    public function isEven()
+    {
+        return !$this->isOdd();
+    }
+
+    public function offsetSet($index, $newval)
+    {
+        $this->collection->offsetSet($index, $newval);
+        parent::offsetSet($index, $newval);
+        $this->refreshPositions();
+    }
+
+    public function offsetUnset($index)
+    {
+        $this->collection->offsetUnset($index);
+        parent::offsetUnset($index);
+        $this->refreshPositions();
+    }
+
+    public function append($value)
+    {
+        $this->collection->append($value);
+        parent::append($value);
+        $this->refreshPositions();
+    }
+
+    public function asort()
+    {
+        parent::asort();
+        $this->refreshPositions();
+    }
+
+    public function ksort()
+    {
+        parent::ksort();
+        $this->refreshPositions();
+    }
+
+    public function uasort($cmp_function)
+    {
+        parent::uasort($cmp_function);
+        $this->refreshPositions();
+    }
+
+    public function uksort($cmp_function)
+    {
+        parent::uksort($cmp_function);
+        $this->refreshPositions();
+    }
+
+    public function natsort()
+    {
+        parent::natsort();
+        $this->refreshPositions();
+    }
+
+    public function natcasesort()
+    {
+        parent::natcasesort();
+        $this->refreshPositions();
+    }
+
+    private function refreshPositions()
+    {
+        $this->positions = array_flip(array_keys($this->getArrayCopy()));
+    }
+}

--- a/src/Propel/Runtime/Collection/ObjectCollection.php
+++ b/src/Propel/Runtime/Collection/ObjectCollection.php
@@ -15,7 +15,6 @@ use Propel\Runtime\Propel;
 use Propel\Runtime\Collection\Exception\ReadOnlyModelException;
 use Propel\Runtime\Collection\Exception\UnsupportedRelationException;
 use Propel\Runtime\Connection\ConnectionInterface;
-use Propel\Runtime\Exception\PropelException;
 use Propel\Runtime\Exception\RuntimeException;
 use Propel\Runtime\Map\RelationMap;
 use Propel\Runtime\Map\TableMap;

--- a/src/Propel/Runtime/Formatter/OnDemandFormatter.php
+++ b/src/Propel/Runtime/Formatter/OnDemandFormatter.php
@@ -12,6 +12,7 @@ namespace Propel\Runtime\Formatter;
 
 use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
 use Propel\Runtime\Collection\Collection;
+use Propel\Runtime\Collection\OnDemandCollection;
 use Propel\Runtime\Exception\LogicException;
 use Propel\Runtime\ActiveQuery\BaseModelCriteria;
 use Propel\Runtime\DataFetcher\DataFetcherInterface;
@@ -61,13 +62,13 @@ class OnDemandFormatter extends ObjectFormatter
     }
 
     /**
-     * @return Collection
+     * @return OnDemandCollection
      */
     public function getCollection()
     {
         $class = $this->getCollectionClassName();
 
-        /** @var Collection $collection */
+        /** @var OnDemandCollection $collection */
         $collection = new $class();
         $collection->setModel($this->class);
 

--- a/src/Propel/Runtime/Util/PropelModelPager.php
+++ b/src/Propel/Runtime/Util/PropelModelPager.php
@@ -13,6 +13,7 @@ namespace Propel\Runtime\Util;
 use Propel\Runtime\ActiveQuery\ModelCriteria;
 use Propel\Runtime\Collection\Collection;
 use Propel\Runtime\Connection\ConnectionInterface;
+use Propel\Runtime\Exception\BadMethodCallException;
 
 /**
  * Implements a pager based on a ModelCriteria
@@ -376,28 +377,6 @@ class PropelModelPager implements \IteratorAggregate, \Countable
     }
 
     /**
-     * Check whether the internal pointer is at the beginning of the list
-     * @see Collection
-     *
-     * @return boolean
-     */
-    public function isFirst()
-    {
-        return $this->getResults()->isFirst();
-    }
-
-    /**
-     * Check whether the internal pointer is at the end of the list
-     * @see Collection
-     *
-     * @return boolean
-     */
-    public function isLast()
-    {
-        return $this->getResults()->isLast();
-    }
-
-    /**
      * Check if the collection is empty
      * @see Collection
      *
@@ -408,31 +387,9 @@ class PropelModelPager implements \IteratorAggregate, \Countable
         return $this->getResults()->isEmpty();
     }
 
-    /**
-     * Check if the current index is an odd integer
-     * @see Collection
-     *
-     * @return boolean
-     */
-    public function isOdd()
-    {
-        return $this->getResults()->isOdd();
-    }
-
-    /**
-     * Check if the current index is an even integer
-     * @see Collection
-     *
-     * @return boolean
-     */
-    public function isEven()
-    {
-        return $this->getResults()->isEven();
-    }
-
     public function getIterator()
     {
-        return $this->getResults();
+        return $this->getResults()->getIterator();
     }
 
     /**
@@ -444,6 +401,15 @@ class PropelModelPager implements \IteratorAggregate, \Countable
     public function count()
     {
         return count($this->getResults());
+    }
+
+    public function __call($name, $params)
+    {
+        try {
+            return call_user_func_array([$this->getResults(), $name], $params);
+        } catch (BadMethodCallException $exception) {
+            throw new BadMethodCallException('Call to undefined method: ' . $name);
+        }
     }
 
 }

--- a/tests/Propel/Tests/Runtime/Collection/CollectionConvertTest.php
+++ b/tests/Propel/Tests/Runtime/Collection/CollectionConvertTest.php
@@ -98,7 +98,7 @@ EOF;
             $book->resetModified();
         }
 
-        $this->assertEquals($this->coll, $coll);
+        $this->assertEquals($this->coll->getData(), $coll->getData());
     }
 
     public function toYamlDataProvider()
@@ -145,7 +145,7 @@ EOF;
             $book->resetModified();
         }
 
-        $this->assertEquals($this->coll, $coll);
+        $this->assertEquals($this->coll->getData(), $coll->getData());
     }
 
     public function toJsonDataProvider()
@@ -178,7 +178,7 @@ EOF;
             $book->resetModified();
         }
 
-        $this->assertEquals($this->coll, $coll);
+        $this->assertEquals($this->coll->getData(), $coll->getData());
     }
 
     public function toCsvDataProvider()
@@ -209,7 +209,7 @@ EOF;
             $book->resetModified();
         }
 
-        $this->assertEquals($this->coll, $coll);
+        $this->assertEquals($this->coll->getData(), $coll->getData());
     }
 
     /**

--- a/tests/Propel/Tests/Runtime/Collection/CollectionIteratorTest.php
+++ b/tests/Propel/Tests/Runtime/Collection/CollectionIteratorTest.php
@@ -1,0 +1,145 @@
+<?php
+
+/**
+ * This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT License
+ */
+
+namespace Propel\Tests\Runtime\Collection;
+
+use Propel\Runtime\Collection\Collection;
+use Propel\Runtime\Collection\CollectionIterator;
+use Propel\Tests\Helpers\Bookstore\BookstoreTestBase;
+
+class CollectionIteratorTest extends BookstoreTestBase
+{
+    public function testIsEmpty()
+    {
+        $iterator = new CollectionIterator(new Collection());
+        $this->assertTrue($iterator->isEmpty(), 'isEmpty() returns true on an empty collection');
+        $data = array('bar1', 'bar2', 'bar3');
+        $iterator = new CollectionIterator(new Collection($data));
+        $this->assertFalse($iterator->isEmpty(), 'isEmpty() returns false on a non empty collection');
+    }
+
+    public function testGetPosition()
+    {
+        $iterator = new CollectionIterator(new Collection());
+        $this->assertEquals(0, $iterator->getPosition(), 'getPosition() returns 0 on an empty collection');
+        $data = array('bar1', 'bar2', 'bar3');
+        $iterator = new CollectionIterator(new Collection($data));
+        $expectedPositions = array(0, 1, 2);
+        foreach ($iterator as $k => $element) {
+            $this->assertEquals(array_shift($expectedPositions), $iterator->getPosition(), 'getPosition() returns the current position');
+            $this->assertEquals($element, $iterator->getCurrent(), 'getPosition() does not change the current position');
+        }
+    }
+
+    public function testGetFirst()
+    {
+        $iterator = new CollectionIterator(new Collection());
+        $this->assertNull($iterator->getFirst(), 'getFirst() returns null on an empty collection');
+        $data = array('bar1', 'bar2', 'bar3');
+        $iterator = new CollectionIterator(new Collection($data));
+        $this->assertEquals('bar1', $iterator->getFirst(), 'getFirst() returns value of the first element in the collection');
+    }
+
+    public function testIsFirst()
+    {
+        $iterator = new CollectionIterator(new Collection());
+        $this->assertTrue($iterator->isFirst(), 'isFirst() returns true on an empty collection');
+        $data = array('bar1', 'bar2', 'bar3');
+        $iterator = new CollectionIterator(new Collection($data));
+        $expectedRes = array(true, false, false);
+
+        foreach ($iterator as $element) {
+            $this->assertEquals(array_shift($expectedRes), $iterator->isFirst(), 'isFirst() returns true only for the first element');
+            $this->assertEquals($element, $iterator->getCurrent(), 'isFirst() does not change the current position');
+        }
+    }
+
+    public function testGetPrevious()
+    {
+        $iterator = new CollectionIterator(new Collection());
+        $this->assertNull($iterator->getPrevious(), 'getPrevious() returns null on an empty collection');
+        $data = array('bar1', 'bar2', 'bar3');
+        $iterator = new CollectionIterator(new Collection($data));
+        $this->assertNull($iterator->getPrevious(), 'getPrevious() returns null when the internal pointer is at the beginning of the list');
+        $iterator->getNext();
+        $this->assertEquals('bar1', $iterator->getPrevious(), 'getPrevious() returns the previous element');
+        $this->assertEquals('bar1', $iterator->getCurrent(), 'getPrevious() decrements the internal pointer');
+    }
+
+    public function testGetCurrent()
+    {
+        $iterator = new CollectionIterator(new Collection());
+        $this->assertNull($iterator->getCurrent(), 'getCurrent() returns null on an empty collection');
+        $data = array('bar1', 'bar2', 'bar3');
+        $iterator = new CollectionIterator(new Collection($data));
+        $this->assertEquals('bar1', $iterator->getCurrent(), 'getCurrent() returns the value of the first element when the internal pointer is at the beginning of the list');
+        foreach ($iterator as $key => $value) {
+            $this->assertEquals($value, $iterator->getCurrent(), 'getCurrent() returns the value of the current element in the collection');
+        }
+    }
+
+    public function testGetNext()
+    {
+        $iterator = new CollectionIterator(new Collection());
+        $this->assertNull($iterator->getNext(), 'getNext() returns null on an empty collection');
+        $data = array('bar1', 'bar2', 'bar3');
+        $iterator = new CollectionIterator(new Collection($data));
+        $this->assertEquals('bar2', $iterator->getNext(), 'getNext() returns the second element when the internal pointer is at the beginning of the list');
+        $this->assertEquals('bar2', $iterator->getCurrent(), 'getNext() increments the internal pointer');
+        $iterator->getNext();
+        $this->assertNull($iterator->getNext(), 'getNext() returns null when the internal pointer is at the end of the list');
+    }
+
+    public function testGetLast()
+    {
+        $iterator = new CollectionIterator(new Collection());
+        $this->assertNull($iterator->getLast(), 'getLast() returns null on an empty collection');
+        $data = array('bar1', 'bar2', 'bar3');
+        $iterator = new CollectionIterator(new Collection($data));
+        $this->assertEquals('bar3', $iterator->getLast(), 'getLast() returns the last element');
+        $this->assertEquals('bar3', $iterator->getCurrent(), 'getLast() moves the internal pointer to the last element');
+    }
+
+    public function testIsLast()
+    {
+        $iterator = new CollectionIterator(new Collection());
+        $this->assertTrue($iterator->isLast(), 'isLast() returns true on an empty collection');
+        $data = array('bar1', 'bar2', 'bar3');
+        $iterator = new CollectionIterator(new Collection($data));
+        $expectedRes = array(false, false, true);
+        foreach ($iterator as $element) {
+            $this->assertEquals(array_shift($expectedRes), $iterator->isLast(), 'isLast() returns true only for the last element');
+            $this->assertEquals($element, $iterator->getCurrent(), 'isLast() does not change the current position');
+        }
+    }
+
+    public function testIsOdd()
+    {
+        $iterator = new CollectionIterator(new Collection());
+        $this->assertFalse($iterator->isOdd(), 'isOdd() returns false on an empty collection');
+        $data = array('bar1', 'bar2', 'bar3');
+        $iterator = new CollectionIterator(new Collection($data));
+        foreach ($iterator as $key => $value) {
+            $this->assertEquals((boolean) ($key % 2), $iterator->isOdd(), 'isOdd() returns true only when the key is odd');
+        }
+    }
+
+    public function testIsEven()
+    {
+        $iterator = new CollectionIterator(new Collection());
+        $this->assertTrue($iterator->isEven(), 'isEven() returns true on an empty collection');
+        $data = array('bar1', 'bar2', 'bar3');
+        $iterator = new CollectionIterator(new Collection($data));
+        foreach ($iterator as $key => $value) {
+            $this->assertEquals(!(boolean) ($key % 2), $iterator->isEven(), 'isEven() returns true only when the key is even');
+        }
+    }
+
+}

--- a/tests/Propel/Tests/Runtime/Collection/CollectionTest.php
+++ b/tests/Propel/Tests/Runtime/Collection/CollectionTest.php
@@ -66,101 +66,6 @@ class CollectionTest extends BookstoreTestBase
         $this->assertEquals($data, $col->getArrayCopy(), 'setData() sets the collection data');
     }
 
-    public function testGetPosition()
-    {
-        $col = new Collection();
-        $this->assertEquals(0, $col->getPosition(), 'getPosition() returns 0 on an empty collection');
-        $data = array('bar1', 'bar2', 'bar3');
-        $col = new Collection($data);
-        $expectedPositions = array(0, 1, 2);
-        foreach ($col as $k => $element) {
-            $this->assertEquals(array_shift($expectedPositions), $col->getPosition(), 'getPosition() returns the current position');
-            $this->assertEquals($element, $col->getCurrent(), 'getPosition() does not change the current position');
-        }
-    }
-
-    public function testGetFirst()
-    {
-        $col = new Collection();
-        $this->assertNull($col->getFirst(), 'getFirst() returns null on an empty collection');
-        $data = array('bar1', 'bar2', 'bar3');
-        $col = new Collection($data);
-        $this->assertEquals('bar1', $col->getFirst(), 'getFirst() returns value of the first element in the collection');
-    }
-
-    public function testIsFirst()
-    {
-        $col = new Collection();
-        $this->assertTrue($col->isFirst(), 'isFirst() returns true on an empty collection');
-        $data = array('bar1', 'bar2', 'bar3');
-        $col = new Collection($data);
-        $expectedRes = array(true, false, false);
-
-        foreach ($col as $element) {
-            $this->assertEquals(array_shift($expectedRes), $col->isFirst(), 'isFirst() returns true only for the first element');
-            $this->assertEquals($element, $col->getCurrent(), 'isFirst() does not change the current position');
-        }
-    }
-
-    public function testGetPrevious()
-    {
-        $col = new Collection();
-        $this->assertNull($col->getPrevious(), 'getPrevious() returns null on an empty collection');
-        $data = array('bar1', 'bar2', 'bar3');
-        $col = new Collection($data);
-        $this->assertNull($col->getPrevious(), 'getPrevious() returns null when the internal pointer is at the beginning of the list');
-        $col->getNext();
-        $this->assertEquals('bar1', $col->getPrevious(), 'getPrevious() returns the previous element');
-        $this->assertEquals('bar1', $col->getCurrent(), 'getPrevious() decrements the internal pointer');
-    }
-
-    public function testGetCurrent()
-    {
-        $col = new Collection();
-        $this->assertNull($col->getCurrent(), 'getCurrent() returns null on an empty collection');
-        $data = array('bar1', 'bar2', 'bar3');
-        $col = new Collection($data);
-        $this->assertEquals('bar1', $col->getCurrent(), 'getCurrent() returns the value of the first element when the internal pointer is at the beginning of the list');
-        foreach ($col as $key => $value) {
-            $this->assertEquals($value, $col->getCurrent(), 'getCurrent() returns the value of the current element in the collection');
-        }
-    }
-
-    public function testGetNext()
-    {
-        $col = new Collection();
-        $this->assertNull($col->getNext(), 'getNext() returns null on an empty collection');
-        $data = array('bar1', 'bar2', 'bar3');
-        $col = new Collection($data);
-        $this->assertEquals('bar2', $col->getNext(), 'getNext() returns the second element when the internal pointer is at the beginning of the list');
-        $this->assertEquals('bar2', $col->getCurrent(), 'getNext() increments the internal pointer');
-        $col->getNext();
-        $this->assertNull($col->getNext(), 'getNext() returns null when the internal pointer is at the end of the list');
-    }
-
-    public function testGetLast()
-    {
-        $col = new Collection();
-        $this->assertNull($col->getLast(), 'getLast() returns null on an empty collection');
-        $data = array('bar1', 'bar2', 'bar3');
-        $col = new Collection($data);
-        $this->assertEquals('bar3', $col->getLast(), 'getLast() returns the last element');
-        $this->assertEquals('bar3', $col->getCurrent(), 'getLast() moves the internal pointer to the last element');
-    }
-
-    public function testIsLAst()
-    {
-        $col = new Collection();
-        $this->assertTrue($col->isLast(), 'isLast() returns true on an empty collection');
-        $data = array('bar1', 'bar2', 'bar3');
-        $col = new Collection($data);
-        $expectedRes = array(false, false, true);
-        foreach ($col as $element) {
-            $this->assertEquals(array_shift($expectedRes), $col->isLast(), 'isLast() returns true only for the last element');
-            $this->assertEquals($element, $col->getCurrent(), 'isLast() does not change the current position');
-        }
-    }
-
     public function testIsEmpty()
     {
         $col = new Collection();
@@ -170,28 +75,35 @@ class CollectionTest extends BookstoreTestBase
         $this->assertFalse($col->isEmpty(), 'isEmpty() returns false on a non empty collection');
     }
 
-    public function testIsOdd()
+    public function testCallIteratorMethods()
     {
-        $col = new Collection();
-        $this->assertFalse($col->isOdd(), 'isOdd() returns false on an empty collection');
+        $methods = ['getPosition', 'isFirst', 'isLast', 'isOdd', 'isEven'];
         $data = array('bar1', 'bar2', 'bar3');
-        $col = new Collection();
-        $col->setData($data);
-        foreach ($col as $key => $value) {
-            $this->assertEquals((boolean) ($key % 2), $col->isOdd(), 'isOdd() returns true only when the key is odd');
+        $col = new Collection($data);
+        $it = $col->getIterator();
+        foreach ($it as $item) {
+            foreach ($methods as $method) {
+                $this->assertEquals(
+                    $it->$method(),
+                    $col->$method(),
+                    $method . '() returns same value for collection and iterator instance'
+                );
+            }
         }
     }
 
-    public function testIsEven()
+    public function testNestedIteration()
     {
-        $col = new Collection();
-        $this->assertTrue($col->isEven(), 'isEven() returns true on an empty collection');
         $data = array('bar1', 'bar2', 'bar3');
-        $col = new Collection();
-        $col->setData($data);
-        foreach ($col as $key => $value) {
-            $this->assertEquals(!(boolean) ($key % 2), $col->isEven(), 'isEven() returns true only when the key is even');
+        $col = new Collection($data);
+        $sequence = '';
+        foreach ($col as $i => $element) {
+            $sequence .= "i$i;";
+            foreach ($col as $k => $element2) {
+                $sequence .= "k$k;";
+            }
         }
+        $this->assertEquals('i0;k0;k1;k2;i1;k0;k1;k2;i2;k0;k1;k2;', $sequence);
     }
 
     public function testGet()

--- a/tests/Propel/Tests/Runtime/Formatter/OnDemandFormatterTest.php
+++ b/tests/Propel/Tests/Runtime/Formatter/OnDemandFormatterTest.php
@@ -59,7 +59,7 @@ class OnDemandFormatterTest extends BookstoreEmptyTestBase
         $this->assertTrue(Propel::isInstancePoolingEnabled());
         $books = $formatter->format($stmt);
         $this->assertFalse(Propel::isInstancePoolingEnabled());
-        $books->closeCursor();
+        $books->getIterator()->closeCursor();
         $this->assertTrue(Propel::isInstancePoolingEnabled());
     }
 
@@ -74,7 +74,7 @@ class OnDemandFormatterTest extends BookstoreEmptyTestBase
         $this->assertFalse(Propel::isInstancePoolingEnabled());
         $books = $formatter->format($stmt);
         $this->assertFalse(Propel::isInstancePoolingEnabled());
-        $books->closeCursor();
+        $books->getIterator()->closeCursor();
         $this->assertFalse(Propel::isInstancePoolingEnabled());
         Propel::enableInstancePooling();
     }

--- a/tests/Propel/Tests/Runtime/Util/PropelModelPagerTest.php
+++ b/tests/Propel/Tests/Runtime/Util/PropelModelPagerTest.php
@@ -176,58 +176,6 @@ class PropelModelPagerTest extends BookstoreEmptyTestBase
         $this->assertInternalType('integer', $pager->getLastPage(), 'getLastPage() returns an integer');
     }
 
-    public function testIsFirstOnFirstPage()
-    {
-        $this->createBooks(5);
-        $pager = $this->getPager(3, 1);
-        foreach ($pager as $index => $book) {
-            if ($index == 0) {
-                $this->assertTrue($pager->isFirst());
-            } else {
-                $this->assertFalse($pager->isFirst());
-            }
-        }
-    }
-
-    public function testIsFirstOnNonFirstPage()
-    {
-        $this->createBooks(5);
-        $pager = $this->getPager(3, 2);
-        foreach ($pager as $index => $book) {
-            if ($index == 0) {
-                $this->assertTrue($pager->isFirst());
-            } else {
-                $this->assertFalse($pager->isFirst());
-            }
-        }
-    }
-
-    public function testIsLastOnNonLastPage()
-    {
-        $this->createBooks(5);
-        $pager = $this->getPager(3, 1);
-        foreach ($pager as $index => $book) {
-            if ($index == 2) {
-                $this->assertTrue($pager->isLast());
-            } else {
-                $this->assertFalse($pager->isLast());
-            }
-        }
-    }
-
-    public function testIsLastOnLastPage()
-    {
-        $this->createBooks(5);
-        $pager = $this->getPager(3, 2);
-        foreach ($pager as $index => $book) {
-            if ($index == 1) {
-                $this->assertTrue($pager->isLast());
-            } else {
-                $this->assertFalse($pager->isLast());
-            }
-        }
-    }
-
     public function testIsEmptyIsTrueOnEmptyPagers()
     {
         $pager = $this->getPager(4, 1);
@@ -239,21 +187,6 @@ class PropelModelPagerTest extends BookstoreEmptyTestBase
         $this->createBooks(1);
         $pager = $this->getPager(4, 1);
         $this->assertFalse($pager->isEmpty());
-    }
-
-    public function testIsOddAndIsEven()
-    {
-        $this->createBooks(5);
-        $pager = $this->getPager(4, 1);
-        foreach ($pager as $index => $book) {
-            if ($index % 2) {
-                $this->assertTrue($pager->isOdd());
-                $this->assertFalse($pager->isEven());
-            } else {
-                $this->assertFalse($pager->isOdd());
-                $this->assertTrue($pager->isEven());
-            }
-        }
     }
 
     public function testCountableInterface()
@@ -268,6 +201,23 @@ class PropelModelPagerTest extends BookstoreEmptyTestBase
 
         $pager = $this->getPager(10, 2);
         $this->assertCount(5, $pager);
+    }
+
+    public function testCallIteratorMethods()
+    {
+        $this->createBooks(5);
+        $pager = $this->getPager(10);
+        $methods = ['getPosition', 'isFirst', 'isLast', 'isOdd', 'isEven'];
+        $it = $pager->getIterator();
+        foreach ($it as $item) {
+            foreach ($methods as $method) {
+                $this->assertEquals(
+                    $it->$method(),
+                    $pager->$method(),
+                    $method . '() returns same value for pager and iterator instance'
+                );
+            }
+        }
     }
 
 }


### PR DESCRIPTION
At the moment nested iteration over the same collection is not possible because the Collection is the Iterator itself and so there is only one array pointer for current position.
I suggest to use the `IteratorAggregate` interface instead.

I came up to this by using a `preSave` hook where I iterate over a collection. But at call time Propel was iterating over the same collection in the `doSave` method of a relational object. So my foreach-loop was modifying the internal pointer of the Collection and some objects were not saved.
