### PR TITLE
Add sql-dir option for sql:insert command

### DIFF
--- a/src/Propel/Generator/Command/SqlInsertCommand.php
+++ b/src/Propel/Generator/Command/SqlInsertCommand.php
@@ -28,7 +28,8 @@ class SqlInsertCommand extends AbstractCommand
     protected function configure()
     {
         $this
-            ->addOption('input-dir', null, InputOption::VALUE_REQUIRED,  'The input directory', self::DEFAULT_OUTPUT_DIRECTORY)
+            ->addOption('input-dir', null, InputOption::VALUE_REQUIRED, 'The input directory', self::DEFAULT_OUTPUT_DIRECTORY)
+            ->addOption('sql-dir', null, InputOption::VALUE_REQUIRED, 'The SQL files directory', self::DEFAULT_OUTPUT_DIRECTORY)
             ->addOption('connection', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Connection to use. Example: bookstore=mysql:host=127.0.0.1;dbname=test;user=root;password=foobar')
             ->setName('sql:insert')
             ->setAliases(array('insert-sql'))
@@ -62,7 +63,7 @@ class SqlInsertCommand extends AbstractCommand
                 $output->writeln($message);
             }
         });
-        $manager->setWorkingDirectory($input->getOption('input-dir'));
+        $manager->setWorkingDirectory($input->getOption('sql-dir'));
 
         $manager->insertSql();
     }

--- a/src/Propel/Generator/Command/TestPrepareCommand.php
+++ b/src/Propel/Generator/Command/TestPrepareCommand.php
@@ -166,7 +166,8 @@ class TestPrepareCommand extends AbstractCommand
 
             $in = new ArrayInput(array(
                 'command'      => 'sql:insert',
-                '--input-dir' => 'build/sql/',
+                '--input-dir'  => '.',
+                '--sql-dir'    => 'build/sql/',
                 '--connection' => $conParams,
                 '--verbose'    => $input->getOption('verbose'),
             ));


### PR DESCRIPTION
SqlInsert command overrides input-dir property (as sql source location).
So getGeneratorConfig method looks for database configuration in generated-sql folder.

I've changed input-dir property to sql-dir property, so sql scripts would be look up there, and connection settings are looking in default input-dir (as other console commands).
