### PR TITLE
Fix QuickBuilder classTargets initialization

### DIFF
--- a/src/Propel/Generator/Util/QuickBuilder.php
+++ b/src/Propel/Generator/Util/QuickBuilder.php
@@ -303,7 +303,7 @@ class QuickBuilder
      */
     public function buildClasses(array $classTargets = null, $separate = false)
     {
-        $classes = $classTargets ? : array('tablemap', 'object', 'query', 'objectstub', 'querystub');
+        $classes = $classTargets === null ? array('tablemap', 'object', 'query', 'objectstub', 'querystub') : $classTargets;
 
         $dirHash = substr(sha1(getcwd()), 0, 10);
         $dir = sys_get_temp_dir() . "/propelQuickBuild-$dirHash/";


### PR DESCRIPTION
Defining the classTargets as null (build all) or as an empty array (do
not build any classes) isn't the same thing.

This will fix the PropelBundle's test suite (https://travis-ci.org/propelorm/PropelBundle/builds/23321036)
