### PR TITLE
Throw an exception when no connection has been defined for a database (fixes #620)

### DIFF
--- a/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
+++ b/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
@@ -14,6 +14,7 @@ use Propel\Runtime\Adapter\AdapterFactory;
 use Propel\Runtime\Adapter\AdapterInterface;
 use Propel\Runtime\Adapter\Exception\AdapterException;
 use Propel\Runtime\Exception\UnexpectedValueException;
+use Propel\Runtime\Exception\RuntimeException;
 use Propel\Runtime\Connection\ConnectionInterface;
 use Propel\Runtime\Connection\ConnectionManagerInterface;
 use Propel\Runtime\Connection\ConnectionManagerSingle;
@@ -270,9 +271,14 @@ class StandardServiceContainer implements ServiceContainerInterface
      * @param string $name The datasource name
      *
      * @return \Propel\Runtime\Connection\ConnectionManagerInterface
+     * @throws \Propel\Runtime\Exception\RuntimeException - if the datasource doesn't exist
      */
     public function getConnectionManager($name)
     {
+        if (!isset($this->connectionManagers[$name])) {
+            throw new RuntimeException(sprintf('No connection defined for database "%s". Did you forget to define a connection or is it wrong written?', $name));
+        }
+
         return $this->connectionManagers[$name];
     }
 

--- a/tests/Propel/Tests/Runtime/ServiceContainer/StandardServiceContainerTest.php
+++ b/tests/Propel/Tests/Runtime/ServiceContainer/StandardServiceContainerTest.php
@@ -242,6 +242,14 @@ class StandardServiceContainerTest extends BaseTestCase
         $this->assertEquals($expected, $this->sc->getConnectionManagers());
     }
 
+    /**
+     * @expectedException Propel\Runtime\Exception\RuntimeException
+     */
+    public function testGetConnectionManagerWithUnknownDatasource()
+    {
+        $this->sc->getConnectionManager('unknown');
+    }
+
     public function testCloseConnectionsClosesConnectionsOnAllConnectionManagers()
     {
         $manager1 = new TestableConnectionManagerSingle();


### PR DESCRIPTION
Is a RuntimeException ok or a more specific exception would be better?
