### PR TITLE
ActiveRecordObject->save() returns wrong results

### DIFF
--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -5247,7 +5247,8 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
             if (\$this->isNew() || \$this->isModified()) {
                 // persist changes
                 if (\$this->isNew()) {
-                    \$this->doInsert(\$con);";
+                    \$this->doInsert(\$con);
+                    \$affectedRows += 1;";
         if ($reloadOnInsert) {
             $script .= "
                     if (!\$skipReload) {
@@ -5256,7 +5257,7 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
         }
         $script .= "
                 } else {
-                    \$this->doUpdate(\$con);";
+                    \$affectedRows += \$this->doUpdate(\$con);";
         if ($reloadOnUpdate) {
             $script .= "
                     if (!\$skipReload) {
@@ -5264,8 +5265,7 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
                     }";
         }
         $script .= "
-                }
-                \$affectedRows += 1;";
+                }";
 
         // We need to rewind any LOB columns
         foreach ($table->getColumns() as $col) {


### PR DESCRIPTION
Hello,

When I wish to update a certain ActiveRecord object in my database(without SELECTing it),
I perform the following code:

$myObj = new ActiveRecordObject();
$myObj->setId(123); //The PK of the object which I wish to update
$myObj->setField("NewFieldValue");
$myObj->setNew(false);
$affectedRows = $myObj->save(); //<-- Returns wrong results when such PK doesn't exist.

The following edit fixes the problem.

Thank you.
