### PR TITLE
Fixed ActiveRecordObject->save() returning wrong results, Fixed concrete inheritence save-loop-bug 

### DIFF
--- a/tests/Propel/Tests/Generator/Behavior/ConcreteInheritance/ConcreteArticleLoopSaveCheckerMock.php
+++ b/tests/Propel/Tests/Generator/Behavior/ConcreteInheritance/ConcreteArticleLoopSaveCheckerMock.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Propel\Tests\Generator\Behavior\ConcreteInheritance;
+
+/**
+    * @brief This class' purpose is to find out whether there's a save which occurrs
+    * without setting $this->alreadyInSave = true,
+    * which causes loop-saving to occure in the inherited classes as before the fix.
+    *
+    * Let's take a look at the following flow:
+    * 
+    * Article->save() {
+    *   //Without setting "$this->alreadyInSave = true"
+    * 
+    *   content->save()  {
+    *     doSave() {
+    *       if(!$this->alreadyInSave) {
+    *         $this->alreadyInSave = true;
+    *         
+    *         category->save() {
+    *           doSave() {
+    *             if(!$this->alreadyInSave) {
+    *               //INSERT INTO category...
+    *               
+    *               content->save(); //Does nothing! because content->alreadyInSave = true.
+    *               
+    *               article->save()  {
+    *                 content::save(); //Does nothing & content isn't saved yet
+    *                 
+    *                 $this->setPrimaryKey(content->getPrimaryKey()); 
+    *                 //sets NULL, because content isn't saved
+    *                 
+    *                 doSave(); 
+    *                 //Error! Content's foreign key constraint fails because it is NULL.
+    * 
+    * @how_to_use Simply, call ConcreteArticleLoopSaveChecker->save(),
+    * and then take the result from getDoesLoopParentSaveHappen().
+ */
+class ConcreteArticleLoopSaveCheckerMock extends \Propel\Tests\Bookstore\Behavior\ConcreteArticle
+{    
+	public function getDoesLoopSavingOccur()
+	{
+		return $this->doesLoopSavingOccur;
+	}
+
+	public function save(\Propel\Runtime\Connection\ConnectionInterface $con = null)
+	{
+		$this->amountOfSavers++;
+
+		try {
+			parent::save($con);
+		} catch(\Exception $e) {
+			//Usually, a huge exception will be thrown from save()
+			//if loop-saving occurs (problems with the parent primary key set to null),
+			//so we catch it in order to not spam test results.
+		}
+
+		$this->amountOfSavers--;
+	}
+
+	protected function doSave(\Propel\Runtime\Connection\ConnectionInterface $con)
+	{
+		if(!$this->alreadyInSave) {
+			$this->alreadyInSave = true;
+
+			if($this->amountOfSavers > 1) {
+				$this->doesLoopSavingOccur = true;
+			}
+
+			$this->alreadyInSave = false;
+		}
+
+		return 1;
+	}
+
+	protected $amountOfSavers = 0;
+	protected $doesLoopSavingOccur = false;
+}

--- a/tests/Propel/Tests/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceBehaviorTest.php
@@ -309,4 +309,97 @@ EOF;
         }
     }
 
+    public function testGetSyncParentReturnsTheSameParent()
+    {
+        $article = new ConcreteArticle();
+        $articleParent1 = $article->getSyncParent(); //Create the parent
+        $articleParent2 = $article->getSyncParent(); //Get the parent
+
+        //Verify that the parent created is the same object (same instance)
+        //As the one gotten in the second getSyncParent().
+        $this->assertTrue($articleParent1 === $articleParent2,
+                          "getSyncParent() doesn't return sequentially the same parent object.");
+    }
+    
+    public function testDoesLoopSavingOccur()
+    {
+        $article = new ConcreteArticleLoopSaveChecker();
+        $article->save();
+        $this->assertFalse($article->getDoesLoopSavingOccur(), "Object loop saving occurs.");
+    }
+}
+
+/**
+ * @brief This class' purpose is to find out whether there's a save which occurrs
+ * without setting $this->alreadyInSave = true,
+ * which causes loop-saving to occure in the inherited classes as before the fix.
+ *
+ * Let's take a look at the following flow:
+ * 
+ * Article->save() {
+ *   //Without setting "$this->alreadyInSave = true"
+ * 
+ *   content->save()  {
+ *     doSave() {
+ *       if(!$this->alreadyInSave) {
+ *         $this->alreadyInSave = true;
+ *         
+ *         category->save() {
+ *           doSave() {
+ *             if(!$this->alreadyInSave) {
+ *               //INSERT INTO category...
+ *               
+ *               content->save(); //Does nothing! because content->alreadyInSave = true.
+ *               
+ *               article->save()  {
+ *                 content::save(); //Does nothing & content isn't saved yet
+ *                 
+ *                 $this->setPrimaryKey(content->getPrimaryKey()); 
+ *                 //sets NULL, because content isn't saved
+ *                 
+ *                 doSave(); 
+ *                 //Error! Content's foreign key constraint fails because it is NULL.
+ * 
+ * @how_to_use Simply, call ConcreteArticleLoopSaveChecker->save(),
+ * and then take the result from getDoesLoopParentSaveHappen().
+ */
+class ConcreteArticleLoopSaveChecker extends ConcreteArticle
+{    
+    public function getDoesLoopSavingOccur()
+    {
+        return $this->doesLoopSavingOccur;
+    }
+    
+    public function save(\Propel\Runtime\Connection\ConnectionInterface $con = null)
+    {
+        $this->amountOfSavers++;
+        
+        try {
+            parent::save($con);
+        } catch(\Exception $e) {
+            //Usually, a huge exception will be thrown from save()
+            //if loop-saving occurs (problems with the parent primary key set to null),
+            //so we catch it in order to not spam test results.
+        }
+        
+        $this->amountOfSavers--;
+    }
+    
+    protected function doSave(\Propel\Runtime\Connection\ConnectionInterface $con)
+    {
+        if(!$this->alreadyInSave) {
+            $this->alreadyInSave = true;
+
+            if($this->amountOfSavers > 1) {
+                $this->doesLoopSavingOccur = true;
+            }
+
+            $this->alreadyInSave = false;
+        }
+        
+        return 1;
+    }
+    
+    protected $amountOfSavers = 0;
+    protected $doesLoopSavingOccur = false;
 }

--- a/tests/Propel/Tests/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceBehaviorTest.php
@@ -24,6 +24,7 @@ use Propel\Tests\Bookstore\Behavior\Map\ConcreteContentTableMap;
 use Propel\Tests\Bookstore\Behavior\ConcreteQuizz;
 use Propel\Tests\Bookstore\Behavior\Map\ConcreteQuizzTableMap;
 use Propel\Tests\Bookstore\Behavior\ConcreteQuizzQuery;
+use Propel\Tests\Generator\Behavior\ConcreteInheritance\ConcreteArticleLoopSaveCheckerMock;
 
 use Propel\Runtime\Exception\PropelException;
 use Propel\Runtime\Map\RelationMap;
@@ -323,83 +324,8 @@ EOF;
     
     public function testDoesLoopSavingOccur()
     {
-        $article = new ConcreteArticleLoopSaveChecker();
+        $article = new ConcreteArticleLoopSaveCheckerMock();
         $article->save();
         $this->assertFalse($article->getDoesLoopSavingOccur(), "Object loop saving occurs.");
     }
-}
-
-/**
- * @brief This class' purpose is to find out whether there's a save which occurrs
- * without setting $this->alreadyInSave = true,
- * which causes loop-saving to occure in the inherited classes as before the fix.
- *
- * Let's take a look at the following flow:
- * 
- * Article->save() {
- *   //Without setting "$this->alreadyInSave = true"
- * 
- *   content->save()  {
- *     doSave() {
- *       if(!$this->alreadyInSave) {
- *         $this->alreadyInSave = true;
- *         
- *         category->save() {
- *           doSave() {
- *             if(!$this->alreadyInSave) {
- *               //INSERT INTO category...
- *               
- *               content->save(); //Does nothing! because content->alreadyInSave = true.
- *               
- *               article->save()  {
- *                 content::save(); //Does nothing & content isn't saved yet
- *                 
- *                 $this->setPrimaryKey(content->getPrimaryKey()); 
- *                 //sets NULL, because content isn't saved
- *                 
- *                 doSave(); 
- *                 //Error! Content's foreign key constraint fails because it is NULL.
- * 
- * @how_to_use Simply, call ConcreteArticleLoopSaveChecker->save(),
- * and then take the result from getDoesLoopParentSaveHappen().
- */
-class ConcreteArticleLoopSaveChecker extends \Propel\Tests\Bookstore\Behavior\ConcreteArticle
-{    
-    public function getDoesLoopSavingOccur()
-    {
-        return $this->doesLoopSavingOccur;
-    }
-    
-    public function save(\Propel\Runtime\Connection\ConnectionInterface $con = null)
-    {
-        $this->amountOfSavers++;
-        
-        try {
-            parent::save($con);
-        } catch(\Exception $e) {
-            //Usually, a huge exception will be thrown from save()
-            //if loop-saving occurs (problems with the parent primary key set to null),
-            //so we catch it in order to not spam test results.
-        }
-        
-        $this->amountOfSavers--;
-    }
-    
-    protected function doSave(\Propel\Runtime\Connection\ConnectionInterface $con)
-    {
-        if(!$this->alreadyInSave) {
-            $this->alreadyInSave = true;
-
-            if($this->amountOfSavers > 1) {
-                $this->doesLoopSavingOccur = true;
-            }
-
-            $this->alreadyInSave = false;
-        }
-        
-        return 1;
-    }
-    
-    protected $amountOfSavers = 0;
-    protected $doesLoopSavingOccur = false;
 }

--- a/tests/Propel/Tests/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceBehaviorTest.php
@@ -363,7 +363,7 @@ EOF;
  * @how_to_use Simply, call ConcreteArticleLoopSaveChecker->save(),
  * and then take the result from getDoesLoopParentSaveHappen().
  */
-class ConcreteArticleLoopSaveChecker extends ConcreteArticle
+class ConcreteArticleLoopSaveChecker extends \Propel\Tests\Bookstore\Behavior\ConcreteArticle
 {    
     public function getDoesLoopSavingOccur()
     {


### PR DESCRIPTION
I have added code to ObjectBuilder.php which fixes returning wrong results when performing updates,
and now throwing an exception when trying to update non-existant objects.

Also, 2 bugs in concrete inheritence were fixed:
1.getSyncParent() - now the inherited object stores its parent, and returns the same one when the parent object has been created \ retrieved.

2.Loop-saving when saving parent - a quite massive bug causing 2 parent objects to be saved, due to loop-saving in inherited objects, and extra non-required SQL statements to be performed.
