### PR TITLE
toArray with includedForeignObjects should not prefix the arrays of foreignObjects

### DIFF
--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -16,6 +16,7 @@ use Propel\Generator\Model\CrossForeignKeys;
 use Propel\Generator\Model\ForeignKey;
 use Propel\Generator\Model\IdMethod;
 use Propel\Generator\Model\PropelTypes;
+use Propel\Generator\Model\Table;
 use Propel\Generator\Platform\MssqlPlatform;
 use Propel\Generator\Platform\MysqlPlatform;
 use Propel\Generator\Platform\OraclePlatform;
@@ -2357,19 +2358,22 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
             foreach ($fks as $fk) {
                 $script .= "
             if (null !== \$this->" . $this->getFKVarName($fk) . ") {
-                \$result['" . $this->getFKPhpNameAffix($fk, false) . "'] = \$this->" . $this->getFKVarName($fk) . "->toArray(\$keyType, \$includeLazyLoadColumns,  \$alreadyDumpedObjects, true);
+                {$this->addToArrayKeyLookUp($fk->getForeignTable(), false)}
+                \$result[\$key] = \$this->" . $this->getFKVarName($fk) . "->toArray(\$keyType, \$includeLazyLoadColumns,  \$alreadyDumpedObjects, true);
             }";
             }
             foreach ($referrers as $fk) {
                 if ($fk->isLocalPrimaryKey()) {
                     $script .= "
             if (null !== \$this->" . $this->getPKRefFKVarName($fk) . ") {
-                \$result['" . $this->getRefFKPhpNameAffix($fk, false) . "'] = \$this->" . $this->getPKRefFKVarName($fk) . "->toArray(\$keyType, \$includeLazyLoadColumns, \$alreadyDumpedObjects, true);
+                {$this->addToArrayKeyLookUp($fk->getTable(), false)}
+                \$result[\$key] = \$this->" . $this->getPKRefFKVarName($fk) . "->toArray(\$keyType, \$includeLazyLoadColumns, \$alreadyDumpedObjects, true);
             }";
                 } else {
                     $script .= "
             if (null !== \$this->" . $this->getRefFKCollVarName($fk) . ") {
-                \$result['" . $this->getRefFKPhpNameAffix($fk, true) . "'] = \$this->" . $this->getRefFKCollVarName($fk) . "->toArray(null, true, \$keyType, \$includeLazyLoadColumns, \$alreadyDumpedObjects);
+                {$this->addToArrayKeyLookUp($fk->getTable(), true)}
+                \$result[\$key] = \$this->" . $this->getRefFKCollVarName($fk) . "->toArray(null, false, \$keyType, \$includeLazyLoadColumns, \$alreadyDumpedObjects);
             }";
                 }
             }
@@ -2382,6 +2386,36 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
     }
 ";
     } // addToArray()
+
+    /**
+     * Adds the switch-statement for looking up the array-key name for toArray
+     * @see toArray
+     */
+    protected function addToArrayKeyLookUp(Table $table, $plural)
+    {
+        $phpName = $table->getPhpName();
+        $studlyPhpName = $table->getStudlyPhpName();
+        $fieldName = $table->getName();
+
+        if ($plural) {
+            $phpName = $this->getPluralizer()->getPluralForm($phpName);
+            $studlyPhpName = $this->getPluralizer()->getPluralForm($studlyPhpName);
+            $fieldName = $this->getPluralizer()->getPluralForm($fieldName);
+        }
+
+        return "
+                switch (\$keyType) {
+                    case TableMap::TYPE_STUDLYPHPNAME:
+                        \$key = '" . $studlyPhpName . "';
+                        break;
+                    case TableMap::TYPE_FIELDNAME:
+                        \$key = '" . $fieldName . "';
+                        break;
+                    default:
+                        \$key = '" . $phpName . "';
+                }
+        ";
+    }
 
     /**
      * Adds the getByName method

--- a/src/Propel/Runtime/Parser/AbstractParser.php
+++ b/src/Propel/Runtime/Parser/AbstractParser.php
@@ -10,6 +10,8 @@
 
 namespace Propel\Runtime\Parser;
 
+use Propel\Common\Pluralizer\PluralizerInterface;
+use Propel\Common\Pluralizer\StandardEnglishPluralizer;
 use Propel\Runtime\Exception\FileNotFoundException;
 
 /**
@@ -26,9 +28,10 @@ abstract class AbstractParser
      * Override in the parser driver.
      *
      * @param  array $array Source data to convert
+     * @param string $rootKey The parser might use this for naming the root key of the parser format
      * @return mixed Converted data, depending on the parser format
      */
-    abstract public function fromArray($array);
+    abstract public function fromArray($array, $rootKey = 'data');
 
     /**
      * Converts data from the parser format to an associative array.
@@ -36,18 +39,19 @@ abstract class AbstractParser
      * Override in the parser driver.
      *
      * @param  mixed $data Source data to convert, depending on the parser format
+     * @param string $rootKey The parser might use this name for converting from parser format
      * @return array Converted data
      */
-    abstract public function toArray($data);
+    abstract public function toArray($data, $rootKey = 'data');
 
-    public function listFromArray($data)
+    public function listFromArray($data, $rootKey = 'data')
     {
-        return $this->fromArray($data);
+        return $this->fromArray($data, $rootKey);
     }
 
-    public function listToArray($data)
+    public function listToArray($data, $rootKey = 'data')
     {
-        return $this->toArray($data);
+        return $this->toArray($data, $rootKey);
     }
 
     /**

--- a/src/Propel/Runtime/Parser/CsvParser.php
+++ b/src/Propel/Runtime/Parser/CsvParser.php
@@ -35,13 +35,14 @@ class CsvParser extends AbstractParser
     /**
      * Converts data from an associative array to CSV.
      *
-     * @param array   $array          Source data to convert
-     * @param boolean $isList         Whether the input data contains more than one row
+     * @param array $array Source data to convert
+     * @param string $rootKey Will not be used for converting because csv is flat
+     * @param boolean $isList Whether the input data contains more than one row
      * @param boolean $includeHeading Whether the output should contain a heading line
      *
      * @return string Converted data, as a CSV string
      */
-    public function fromArray($array, $isList = false, $includeHeading = true)
+    public function fromArray($array, $rootKey = null, $isList = false, $includeHeading = true)
     {
         $rows = array();
         if ($isList) {
@@ -61,9 +62,9 @@ class CsvParser extends AbstractParser
         return implode($rows, $this->lineTerminator) . $this->lineTerminator;
     }
 
-    public function listFromArray($array)
+    public function listFromArray($array, $rootKey = null)
     {
-        return $this->fromArray($array, true);
+        return $this->fromArray($array, $rootKey, true);
     }
 
     /**
@@ -168,19 +169,20 @@ class CsvParser extends AbstractParser
      */
     public function toCSV($array, $isList = false, $includeHeading = true)
     {
-        return $this->fromArray($array, $isList, $includeHeading);
+        return $this->fromArray($array, null, $isList, $includeHeading);
     }
 
     /**
      * Converts data from CSV to an associative array.
      *
-     * @param string  $data           Source data to convert, as a CSV string
-     * @param boolean $isList         Whether the input data contains more than one row
+     * @param string $data Source data to convert, as a CSV string
+     * @param string|null $rootKey Will not be used for converting because csv is flat
+     * @param boolean $isList Whether the input data contains more than one row
      * @param boolean $includeHeading Whether the input contains a heading line
      *
      * @return array Converted data
      */
-    public function toArray($data, $isList = false, $includeHeading = true)
+    public function toArray($data, $rootKey = null, $isList = false, $includeHeading = true)
     {
         $rows = explode($this->lineTerminator, $data);
         if ($includeHeading) {
@@ -213,9 +215,9 @@ class CsvParser extends AbstractParser
         return $array;
     }
 
-    public function listToArray($array)
+    public function listToArray($array, $rootKey = null)
     {
-        return $this->toArray($array, true);
+        return $this->toArray($array, $rootKey, true);
     }
 
     protected function getColumns($row)
@@ -301,6 +303,6 @@ class CsvParser extends AbstractParser
      */
     public function fromCSV($data, $isList = false, $includeHeading = true)
     {
-        return $this->toArray($data, $isList, $includeHeading);
+        return $this->toArray($data, null, $isList, $includeHeading);
     }
 }

--- a/src/Propel/Runtime/Parser/JsonParser.php
+++ b/src/Propel/Runtime/Parser/JsonParser.php
@@ -21,43 +21,57 @@ class JsonParser extends AbstractParser
      * Converts data from an associative array to JSON.
      *
      * @param  array  $array Source data to convert
+     * @param string $rootKey
      * @return string Converted data, as a JSON string
      */
-    public function fromArray($array)
+    public function fromArray($array, $rootKey = null)
     {
-        return json_encode($array);
+        return json_encode($rootKey === null ? $array : [$rootKey => $array]);
     }
 
     /**
      * Alias for JsonParser::fromArray()
      *
-     * @param  array  $array Source data to convert
+     * @param  array $array Source data to convert
+     * @param string $rootKey
      * @return string Converted data, as a JSON string
      */
-    public function toJSON($array)
+    public function toJSON($array, $rootKey = null)
     {
-        return $this->fromArray($array);
+        return $this->fromArray($array, $rootKey);
     }
 
     /**
      * Converts data from JSON to an associative array.
      *
      * @param  string $data Source data to convert, as a JSON string
+     * @param string $rootKey
      * @return array  Converted data
      */
-    public function toArray($data)
+    public function toArray($data, $rootKey = null)
     {
-        return json_decode($data, true);
+        $data = json_decode($data, true);
+
+        if ($rootKey === null) {
+            return $data;
+        }
+
+        if (!isset($data[$rootKey])) {
+            return [];
+        }
+
+        return $data[$rootKey];
     }
 
     /**
      * Alias for JsonParser::toArray()
      *
      * @param  string $data Source data to convert, as a JSON string
+     * @param string $rootKey
      * @return array  Converted data
      */
-    public function fromJSON($data)
+    public function fromJSON($data, $rootKey = null)
     {
-        return $this->toArray($data);
+        return $this->toArray($data, $rootKey);
     }
 }

--- a/src/Propel/Runtime/Parser/XmlParser.php
+++ b/src/Propel/Runtime/Parser/XmlParser.php
@@ -20,23 +20,23 @@ class XmlParser extends AbstractParser
     /**
      * Converts data from an associative array to XML.
      *
-     * @param array  $array           Source data to convert
-     * @param string $rootElementName Name of the root element of the XML document
-     * @param string $charset         Character set of the input data. Defaults to UTF-8.
+     * @param array $array Source data to convert
+     * @param string $rootKey Will be used for naming the root node
+     * @param string $charset Character set of the input data. Defaults to UTF-8.
      *
      * @return string Converted data, as an XML string
      */
-    public function fromArray($array, $rootElementName = 'data', $charset = null)
+    public function fromArray($array, $rootKey = 'data', $charset = null)
     {
-        $rootNode = $this->getRootNode($rootElementName);
+        $rootNode = $this->getRootNode($rootKey);
         $this->arrayToDOM($array, $rootNode, $charset, false);
 
         return $rootNode->ownerDocument->saveXML();
     }
 
-    public function listFromArray($array, $rootElementName = 'data', $charset = null)
+    public function listFromArray($array, $rootKey = 'data', $charset = null)
     {
-        $rootNode = $this->getRootNode($rootElementName);
+        $rootNode = $this->getRootNode($rootKey);
         $this->arrayToDOM($array, $rootNode, $charset, true);
 
         return $rootNode->ownerDocument->saveXML();
@@ -49,7 +49,7 @@ class XmlParser extends AbstractParser
      *
      * @return \DOMElement The root DOMNode
      */
-    protected function getRootNode($rootElementName = 'data')
+    protected function getRootNode($rootElementName)
     {
         $xml = new \DOMDocument('1.0', 'UTF-8');
         $xml->preserveWhiteSpace = false;
@@ -92,16 +92,21 @@ class XmlParser extends AbstractParser
      * @param array       $array
      * @param \DOMElement $rootElement
      * @param string      $charset
-     * @param boolean     $removeNumbersFromKeys
      *
      * @return \DOMElement
      */
-    protected function arrayToDOM($array, $rootElement, $charset = null, $removeNumbersFromKeys = false)
+    protected function arrayToDOM($array, $rootElement, $charset = null)
     {
         foreach ($array as $key => $value) {
-            if ($removeNumbersFromKeys) {
-                $key = preg_replace('/[^a-z]/i', '', $key);
+            if (is_numeric($key)) {
+                $key = $rootElement->nodeName;
+
+                // Books => Book
+                if (substr($key, -1, 1) === 's') {
+                    $key = substr($key, 0, strlen($key) - 1);
+                }
             }
+
             $element = $rootElement->ownerDocument->createElement($key);
             if (is_array($value)) {
                 if (!empty($value)) {
@@ -129,9 +134,10 @@ class XmlParser extends AbstractParser
      * Converts data from XML to an associative array.
      *
      * @param  string $data Source data to convert, as an XML string
+     * @param string $rootKey
      * @return array  Converted data
      */
-    public function toArray($data)
+    public function toArray($data, $rootKey = 'data')
     {
         $doc = new \DOMDocument('1.0', 'UTF-8');
         $doc->loadXML($data);
@@ -144,11 +150,12 @@ class XmlParser extends AbstractParser
      * Alias for XmlParser::toArray()
      *
      * @param  string $data Source data to convert, as an XML string
+     * @param string $rootKey
      * @return array  Converted data
      */
-    public function fromXML($data)
+    public function fromXML($data, $rootKey = 'data')
     {
-        return $this->toArray($data);
+        return $this->toArray($data, $rootKey);
     }
 
     /**
@@ -166,16 +173,17 @@ class XmlParser extends AbstractParser
             $name = $element->nodeName;
             if (isset($elementNames[$name])) {
                 if (isset($array[$name])) {
-                    // change the first 'book' to 'book0'
-                    $array[$name . $elementNames[$name]] = $array[$name];
+                    // change the first 'book' to 0
+                    $array[$elementNames[$name]] = $array[$name];
                     unset($array[$name]);
                 }
                 $elementNames[$name] += 1;
-                $index = $name . $elementNames[$name];
+                $index = $elementNames[$name];
             } else {
-                $index = $name;
                 $elementNames[$name] = 0;
+                $index = $name;
             }
+
             if ($element->hasChildNodes() && !$this->hasOnlyTextNodes($element)) {
                 $array[$index] = $this->convertDOMElementToArray($element);
             } elseif ($element->hasChildNodes() && $element->firstChild->nodeType == XML_CDATA_SECTION_NODE) {

--- a/src/Propel/Runtime/Parser/YamlParser.php
+++ b/src/Propel/Runtime/Parser/YamlParser.php
@@ -22,44 +22,58 @@ class YamlParser extends AbstractParser
     /**
      * Converts data from an associative array to YAML.
      *
-     * @param  array  $array Source data to convert
+     * @param  array $array Source data to convert
+     * @param string $rootKey
      * @return string Converted data, as a YAML string
      */
-    public function fromArray($array)
+    public function fromArray($array, $rootKey = null)
     {
-        return Yaml::dump($array, 3);
+        return Yaml::dump($rootKey === null ? $array : [$rootKey => $array], 3);
     }
 
     /**
      * Alias for YamlParser::fromArray()
      *
-     * @param  array  $array Source data to convert
+     * @param  array $array Source data to convert
+     * @param string $rootKey
      * @return string Converted data, as a YAML string
      */
-    public function toYAML($array)
+    public function toYAML($array, $rootKey = null)
     {
-        return $this->fromArray($array);
+        return $this->fromArray($array, $rootKey);
     }
 
     /**
      * Converts data from YAML to an associative array.
      *
      * @param  string $data Source data to convert, as a YAML string
+     * @param string $rootKey
      * @return array  Converted data
      */
-    public function toArray($data)
+    public function toArray($data, $rootKey = null)
     {
-        return Yaml::parse($data);
+        $data = Yaml::parse($data);
+
+        if ($rootKey === null) {
+            return $data;
+        }
+
+        if (!isset($data[$rootKey])) {
+            return [];
+        }
+
+        return $data[$rootKey];
     }
 
     /**
      * Alias for YamlParser::toArray()
      *
      * @param  string $data Source data to convert, as a YAML string
+     * @param string $rootKey
      * @return array  Converted data
      */
-    public function fromYAML($data)
+    public function fromYAML($data, $rootKey = null)
     {
-        return $this->toArray($data);
+        return $this->toArray($data, $rootKey);
     }
 }

--- a/tests/Propel/Tests/FieldnameRelatedTest.php
+++ b/tests/Propel/Tests/FieldnameRelatedTest.php
@@ -14,6 +14,8 @@ use Propel\Tests\Bookstore\Map\BookTableMap;
 
 use Propel\Runtime\Map\TableMap;
 use Propel\Tests\Bookstore\Book;
+use Propel\Tests\Bookstore\Map\ReviewTableMap;
+use Propel\Tests\Bookstore\Review;
 
 /**
  * Tests some of the methods of generated Object classes. These are:
@@ -380,6 +382,150 @@ class FieldnameRelatedTest extends TestCaseFixtures
             $result = $book->toArray($type);
             // remove ID since its autoincremented at each test iteration
             $result = array_slice($result, 1, 2, true);
+            $this->assertEquals(
+                $expected,
+                $result,
+                'expected was: ' . print_r($expected, 1) .
+                'but toArray() returned ' . print_r($result, 1)
+            );
+        }
+    }
+
+    /**
+     * @see https://github.com/propelorm/Propel2/issues/648
+     */
+    public function testToArrayWithForeignObjectsDoesNotHavePrefix()
+    {
+        $book = new Book();
+        $book->addReview(new Review());
+
+        $array = $book->toArray(TableMap::TYPE_PHPNAME, false, [], true);
+
+        $this->assertArrayHasKey('Reviews', $array);
+        $this->assertArrayNotHasKey('Review_0', $array['Reviews']);
+        $this->assertArrayHasKey(0, $array['Reviews']);
+    }
+
+    public function testToArrayWithForeignObjects()
+    {
+        $types = [
+            TableMap::TYPE_PHPNAME,
+            TableMap::TYPE_STUDLYPHPNAME,
+            TableMap::TYPE_COLNAME,
+            TableMap::TYPE_FIELDNAME,
+            TableMap::TYPE_NUM
+        ];
+
+        $review = new Review();
+        $review->setRecommended(true)->setReviewedBy('Someone')->setReviewDate(null);
+
+        $book = new Book();
+        $book->setTitle('Harry Potter and the Order of the Phoenix')
+            ->setISBN('043935806X')
+            ->addReview($review)
+            ->setPrice(10);
+
+        $expecteds = array (
+            TableMap::TYPE_PHPNAME => [
+                'Id' => null,
+                'Title' => 'Harry Potter and the Order of the Phoenix',
+                'ISBN' => '043935806X',
+                'Price' => 10.0,
+                'PublisherId' => null,
+                'AuthorId' => null,
+                'Reviews' => [
+                    [
+                        'Id' => null,
+                        'ReviewedBy' => 'Someone',
+                        'ReviewDate' => null,
+                        'Recommended' => true,
+                        'Status' => null,
+                        'BookId' => null,
+                        'Book' => '*RECURSION*'
+                    ]
+                ]
+            ],
+            TableMap::TYPE_STUDLYPHPNAME => array (
+                'id' => null,
+                'title' => 'Harry Potter and the Order of the Phoenix',
+                'iSBN' => '043935806X',
+                'price' => 10.0,
+                'publisherId' => null,
+                'authorId' => null,
+                'reviews' => [
+                    [
+                        'id' => null,
+                        'reviewedBy' => 'Someone',
+                        'reviewDate' => null,
+                        'recommended' => true,
+                        'status' => null,
+                        'bookId' => null,
+                        'book' => '*RECURSION*'
+                    ]
+                ]
+            ),
+            TableMap::TYPE_COLNAME => array (
+                'book.ID' => null,
+                'book.TITLE' => 'Harry Potter and the Order of the Phoenix',
+                'book.ISBN' => '043935806X',
+                'book.PRICE' => 10.0,
+                'book.PUBLISHER_ID' => null,
+                'book.AUTHOR_ID' => null,
+                'Reviews' => [
+                    [
+                        'review.ID' => null,
+                        'review.REVIEWED_BY' => 'Someone',
+                        'review.REVIEW_DATE' => null,
+                        'review.RECOMMENDED' => true,
+                        'review.STATUS' => null,
+                        'review.BOOK_ID' => null,
+                        'Book' => '*RECURSION*'
+                    ]
+                ]
+            ),
+            TableMap::TYPE_FIELDNAME => array (
+                'id' => null,
+                'title' => 'Harry Potter and the Order of the Phoenix',
+                'isbn' => '043935806X',
+                'price' => 10.0,
+                'publisher_id' => null,
+                'author_id' => null,
+                'reviews' => [
+                    [
+                        'id' => null,
+                        'reviewed_by' => 'Someone',
+                        'review_date' => null,
+                        'recommended' => true,
+                        'status' => null,
+                        'book_id' => null,
+                        'book' => '*RECURSION*'
+                    ]
+                ]
+            ),
+            TableMap::TYPE_NUM => array (
+                '0' => null,
+                '1' => 'Harry Potter and the Order of the Phoenix',
+                '2' => '043935806X',
+                '3' => 10.0,
+                '4' => null,
+                '5' => null,
+                'Reviews' => [
+                    [
+                        '0' => null,
+                        '1' => 'Someone',
+                        '2' => null,
+                        '3' => 1,
+                        '4' => null,
+                        '5' => null,
+                        'Book' => '*RECURSION*',
+                    ]
+                ]
+            )
+        );
+
+        foreach ($types as $type) {
+            $expected = $expecteds[$type];
+            $result = $book->toArray($type, true, [], true);
             $this->assertEquals(
                 $expected,
                 $result,

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectWithFixturesTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectWithFixturesTest.php
@@ -356,9 +356,9 @@ class GeneratedObjectWithFixturesTest extends BookstoreEmptyTestBase
         $arr = $a1->toArray(TableMap::TYPE_PHPNAME, null, array(), true);
         $this->assertTrue(array_key_exists('Books', $arr));
         $this->assertEquals(2, count($arr['Books']));
-        $this->assertEquals('War and Peace', $arr['Books']['Book_0']['Title']);
-        $this->assertEquals('Anna Karenina', $arr['Books']['Book_1']['Title']);
-        $this->assertEquals('*RECURSION*', $arr['Books']['Book_0']['Author']);
+        $this->assertEquals('War and Peace', $arr['Books'][0]['Title']);
+        $this->assertEquals('Anna Karenina', $arr['Books'][1]['Title']);
+        $this->assertEquals('*RECURSION*', $arr['Books'][0]['Author']);
     }
 
 }

--- a/tests/Propel/Tests/Runtime/ActiveRecordConvertTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveRecordConvertTest.php
@@ -22,6 +22,8 @@ use Propel\Tests\TestCaseFixtures;
  */
 class ActiveRecordConvertTest extends TestCaseFixtures
 {
+    private $book;
+
     protected function setUp()
     {
         parent::setUp();
@@ -57,7 +59,7 @@ class ActiveRecordConvertTest extends TestCaseFixtures
     <Id>1234</Id>
     <Name><![CDATA[Penguin]]></Name>
     <Books>
-      <Book_0><![CDATA[*RECURSION*]]></Book_0>
+      <Book><![CDATA[*RECURSION*]]></Book>
     </Books>
   </Publisher>
   <Author>
@@ -67,7 +69,7 @@ class ActiveRecordConvertTest extends TestCaseFixtures
     <Email></Email>
     <Age></Age>
     <Books>
-      <Book_0><![CDATA[*RECURSION*]]></Book_0>
+      <Book><![CDATA[*RECURSION*]]></Book>
     </Books>
   </Author>
 </data>
@@ -118,7 +120,7 @@ Publisher:
     Id: 1234
     Name: Penguin
     Books:
-        Book_0: '*RECURSION*'
+        - '*RECURSION*'
 Author:
     Id: 5678
     FirstName: George
@@ -126,7 +128,7 @@ Author:
     Email: null
     Age: null
     Books:
-        Book_0: '*RECURSION*'
+        - '*RECURSION*'
 
 EOF;
 
@@ -164,7 +166,7 @@ EOF;
     public function toJsonDataProvider()
     {
         $expected = <<<EOF
-{"Id":9012,"Title":"Don Juan","ISBN":"0140422161","Price":12.99,"PublisherId":1234,"AuthorId":5678,"Publisher":{"Id":1234,"Name":"Penguin","Books":{"Book_0":"*RECURSION*"}},"Author":{"Id":5678,"FirstName":"George","LastName":"Byron","Email":null,"Age":null,"Books":{"Book_0":"*RECURSION*"}}}
+{"Id":9012,"Title":"Don Juan","ISBN":"0140422161","Price":12.99,"PublisherId":1234,"AuthorId":5678,"Publisher":{"Id":1234,"Name":"Penguin","Books":["*RECURSION*"]},"Author":{"Id":5678,"FirstName":"George","LastName":"Byron","Email":null,"Age":null,"Books":["*RECURSION*"]}}
 EOF;
 
         return array(array($expected));
@@ -200,7 +202,7 @@ EOF;
 
     public function toCsvDataProvider()
     {
-        $expected = "Id,Title,ISBN,Price,PublisherId,AuthorId,Publisher,Author\r\n9012,Don Juan,0140422161,12.99,1234,5678,\"a:3:{s:2:\\\"Id\\\";i:1234;s:4:\\\"Name\\\";s:7:\\\"Penguin\\\";s:5:\\\"Books\\\";a:1:{s:6:\\\"Book_0\\\";s:11:\\\"*RECURSION*\\\";}}\",\"a:6:{s:2:\\\"Id\\\";i:5678;s:9:\\\"FirstName\\\";s:6:\\\"George\\\";s:8:\\\"LastName\\\";s:5:\\\"Byron\\\";s:5:\\\"Email\\\";N;s:3:\\\"Age\\\";N;s:5:\\\"Books\\\";a:1:{s:6:\\\"Book_0\\\";s:11:\\\"*RECURSION*\\\";}}\"\r\n";
+        $expected = "Id,Title,ISBN,Price,PublisherId,AuthorId,Publisher,Author\r\n9012,Don Juan,0140422161,12.99,1234,5678,\"a:3:{s:2:\\\"Id\\\";i:1234;s:4:\\\"Name\\\";s:7:\\\"Penguin\\\";s:5:\\\"Books\\\";a:1:{i:0;s:11:\\\"*RECURSION*\\\";}}\",\"a:6:{s:2:\\\"Id\\\";i:5678;s:9:\\\"FirstName\\\";s:6:\\\"George\\\";s:8:\\\"LastName\\\";s:5:\\\"Byron\\\";s:5:\\\"Email\\\";N;s:3:\\\"Age\\\";N;s:5:\\\"Books\\\";a:1:{i:0;s:11:\\\"*RECURSION*\\\";}}\"\r\n";
 
         return array(array($expected));
     }

--- a/tests/Propel/Tests/Runtime/Collection/ArrayCollectionTest.php
+++ b/tests/Propel/Tests/Runtime/Collection/ArrayCollectionTest.php
@@ -205,7 +205,7 @@ class ArrayCollectionTest extends BookstoreEmptyTestBase
                 'Email' => null,
                 'Age' => null,
                 'Books' => array(
-                    'Book_0' => '*RECURSION*',
+                    0 => '*RECURSION*',
                 )
             ),
         ));

--- a/tests/Propel/Tests/Runtime/Collection/CollectionConvertTest.php
+++ b/tests/Propel/Tests/Runtime/Collection/CollectionConvertTest.php
@@ -25,6 +25,8 @@ use Propel\Tests\TestCaseFixtures;
  */
 class CollectionConvertTest extends TestCaseFixtures
 {
+    private $coll;
+
     protected function setUp()
     {
         parent::setUp();
@@ -53,7 +55,7 @@ class CollectionConvertTest extends TestCaseFixtures
     {
         $expected = <<<EOF
 <?xml version="1.0" encoding="UTF-8"?>
-<data>
+<Books>
   <Book>
     <Id>9012</Id>
     <Title><![CDATA[Don Juan]]></Title>
@@ -70,7 +72,7 @@ class CollectionConvertTest extends TestCaseFixtures
     <PublisherId></PublisherId>
     <AuthorId></AuthorId>
   </Book>
-</data>
+</Books>
 
 EOF;
 
@@ -104,20 +106,21 @@ EOF;
     public function toYamlDataProvider()
     {
         $expected = <<<EOF
-Book_0:
-    Id: 9012
-    Title: 'Don Juan'
-    ISBN: '0140422161'
-    Price: 12.99
-    PublisherId: 1234
-    AuthorId: 5678
-Book_1:
-    Id: 58
-    Title: 'Harry Potter and the Order of the Phoenix'
-    ISBN: 043935806X
-    Price: 10.99
-    PublisherId: null
-    AuthorId: null
+Books:
+    -
+        Id: 9012
+        Title: 'Don Juan'
+        ISBN: '0140422161'
+        Price: 12.99
+        PublisherId: 1234
+        AuthorId: 5678
+    -
+        Id: 58
+        Title: 'Harry Potter and the Order of the Phoenix'
+        ISBN: 043935806X
+        Price: 10.99
+        PublisherId: null
+        AuthorId: null
 
 EOF;
 
@@ -151,7 +154,7 @@ EOF;
     public function toJsonDataProvider()
     {
         $expected = <<<EOF
-{"Book_0":{"Id":9012,"Title":"Don Juan","ISBN":"0140422161","Price":12.99,"PublisherId":1234,"AuthorId":5678},"Book_1":{"Id":58,"Title":"Harry Potter and the Order of the Phoenix","ISBN":"043935806X","Price":10.99,"PublisherId":null,"AuthorId":null}}
+{"Books":[{"Id":9012,"Title":"Don Juan","ISBN":"0140422161","Price":12.99,"PublisherId":1234,"AuthorId":5678},{"Id":58,"Title":"Harry Potter and the Order of the Phoenix","ISBN":"043935806X","Price":10.99,"PublisherId":null,"AuthorId":null}]}
 EOF;
 
         return array(array($expected));
@@ -230,12 +233,12 @@ EOF;
         $coll[]= $publisher;
         $expected = <<<EOF
 <?xml version="1.0" encoding="UTF-8"?>
-<data>
+<Publishers>
   <Publisher>
     <Id>12345</Id>
     <Name><![CDATA[Penguinoo]]></Name>
   </Publisher>
-</data>
+</Publishers>
 
 EOF;
         $this->assertEquals($expected, (string) $coll);

--- a/tests/Propel/Tests/Runtime/Collection/ObjectCollectionTest.php
+++ b/tests/Propel/Tests/Runtime/Collection/ObjectCollectionTest.php
@@ -131,7 +131,7 @@ class ObjectCollectionTest extends BookstoreTestBase
                 'Email' => null,
                 'Age' => null,
                 'Books' => array(
-                    'Book_0' => '*RECURSION*',
+                    0 => '*RECURSION*',
                 )
             ),
         ));

--- a/tests/Propel/Tests/Runtime/Parser/XmlParserTest.php
+++ b/tests/Propel/Tests/Runtime/Parser/XmlParserTest.php
@@ -132,14 +132,14 @@ class XmlParserTest extends TestCase
     public static function listToXMLDataProvider()
     {
         $list = array(
-            'book0' => array('Id' => 123, 'Title' => 'Pride and Prejudice', 'AuthorId' => 456, 'ISBN' => '0553213105', 'Author' => array('Id' => 456, 'FirstName' => 'Jane', 'LastName' => 'Austen')),
-            'book1' => array('Id' => 82, 'Title' => 'Anna Karenina', 'AuthorId' => 543, 'ISBN' => '0143035002', 'Author' => array('Id' => 543, 'FirstName' => 'Leo', 'LastName' => 'Tolstoi')),
-            'book2' => array('Id' => 567, 'Title' => 'War and Peace', 'AuthorId' => 543, 'ISBN' => '067003469X', 'Author' => array('Id' => 543, 'FirstName' => 'Leo', 'LastName' => 'Tolstoi')),
+            ['Id' => 123, 'Title' => 'Pride and Prejudice', 'AuthorId' => 456, 'ISBN' => '0553213105', 'Author' => ['Id' => 456, 'FirstName' => 'Jane', 'LastName' => 'Austen']],
+            ['Id' => 82, 'Title' => 'Anna Karenina', 'AuthorId' => 543, 'ISBN' => '0143035002', 'Author' => ['Id' => 543, 'FirstName' => 'Leo', 'LastName' => 'Tolstoi']],
+            ['Id' => 567, 'Title' => 'War and Peace', 'AuthorId' => 543, 'ISBN' => '067003469X', 'Author' => ['Id' => 543, 'FirstName' => 'Leo', 'LastName' => 'Tolstoi']],
         );
         $xml = <<<EOF
 <?xml version="1.0" encoding="UTF-8"?>
-<data>
-  <book>
+<Books>
+  <Book>
     <Id>123</Id>
     <Title><![CDATA[Pride and Prejudice]]></Title>
     <AuthorId>456</AuthorId>
@@ -149,8 +149,8 @@ class XmlParserTest extends TestCase
       <FirstName><![CDATA[Jane]]></FirstName>
       <LastName><![CDATA[Austen]]></LastName>
     </Author>
-  </book>
-  <book>
+  </Book>
+  <Book>
     <Id>82</Id>
     <Title><![CDATA[Anna Karenina]]></Title>
     <AuthorId>543</AuthorId>
@@ -160,8 +160,8 @@ class XmlParserTest extends TestCase
       <FirstName><![CDATA[Leo]]></FirstName>
       <LastName><![CDATA[Tolstoi]]></LastName>
     </Author>
-  </book>
-  <book>
+  </Book>
+  <Book>
     <Id>567</Id>
     <Title><![CDATA[War and Peace]]></Title>
     <AuthorId>543</AuthorId>
@@ -171,8 +171,8 @@ class XmlParserTest extends TestCase
       <FirstName><![CDATA[Leo]]></FirstName>
       <LastName><![CDATA[Tolstoi]]></LastName>
     </Author>
-  </book>
-</data>
+  </Book>
+</Books>
 
 EOF;
 
@@ -185,7 +185,7 @@ EOF;
     public function testListToXML($list, $xml)
     {
         $parser = new XmlParser();
-        $this->assertEquals($xml, $parser->listToXML($list));
+        $this->assertEquals($xml, $parser->listToXML($list, 'Books'));
     }
 
     /**


### PR DESCRIPTION
Fix for #649 and #648

Now the result of toArray is much more natural. You expect the foreign-objects to have a numeric index instead of being prefixed with the foreign-object-name.

`$book->toArray(...);` before this pr:

```
(
    [Id] => 
    ....
    [Reviews] => Array
        (
            [Review_0] => Array
                (
                    [Id] => 
                    ....
                )

        )

)
```

After this pr:

```
(
    [Id] => 
    ....
    [Reviews] => Array
        (
            [0] => Array
                (
                    [Id] => 
                    ....
                )

        )

)
```
