### PR TITLE
Fix issue #669

### DIFF
--- a/src/Propel/Common/Config/PropelConfiguration.php
+++ b/src/Propel/Common/Config/PropelConfiguration.php
@@ -84,7 +84,7 @@ class PropelConfiguration implements ConfigurationInterface
                                     ->arrayNode('settings')
                                         ->children()
                                             ->scalarNode('charset')->defaultValue('utf8')->end()
-                                            ->arrayNode('query')
+                                            ->arrayNode('queries')
                                                 ->prototype('scalar')->end()
                                             ->end()
                                         ->end()

--- a/src/Propel/Runtime/Adapter/Pdo/PdoAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/PdoAdapter.php
@@ -127,10 +127,8 @@ abstract class PdoAdapter
         }
 
         if (isset($settings['queries']) && is_array($settings['queries'])) {
-            foreach ($settings['queries'] as $queries) {
-                foreach ((array) $queries as $query) {
-                    $con->exec($query);
-                }
+            foreach ($settings['queries'] as $query) {
+                $con->exec($query);
             }
         }
     }


### PR DESCRIPTION
Fix for issue #669. Refactor `query` configuration parameter.
Now the right configuration section is the following:

``` yaml
propel:
  database:
    connections:
      default:
        settings:
          charset: utf8
          queries:
            - "sql query number 1"
            - "sql query number 2"
```

which is translated into the following php, by running `config:convert` command:

``` php
<?php

$manager->setConfiguration(array(
    'settings' => array (
        'charset' => 'utf8',
        'queries' => array(
            0 => 'sql query number 1',
            1 => 'sql query number 2
        ),
    ),
));
```
