### PR TITLE
Fixed XmlParser not recognising DateTime objects when dumping to XML

### DIFF
--- a/src/Propel/Runtime/Parser/XmlParser.php
+++ b/src/Propel/Runtime/Parser/XmlParser.php
@@ -115,6 +115,10 @@ class XmlParser extends AbstractParser
                 $value = htmlspecialchars($value, ENT_COMPAT, 'UTF-8');
                 $child = $element->ownerDocument->createCDATASection($value);
                 $element->appendChild($child);
+            } elseif ($value instanceof \DateTime) {
+                $element->setAttribute('type', 'xsd:dateTime');
+                $child = $element->ownerDocument->createTextNode($value->format(\DateTime::ISO8601));
+                $element->appendChild($child);
             } else {
                 $child = $element->ownerDocument->createTextNode($value);
                 $element->appendChild($child);
@@ -182,6 +186,8 @@ class XmlParser extends AbstractParser
                 $array[$index] = htmlspecialchars_decode($element->firstChild->textContent);
             } elseif (!$element->hasChildNodes()) {
                 $array[$index] = null;
+            } elseif ($element->hasAttribute('type') && $element->getAttribute('type') === 'xsd:dateTime') {
+                $array[$index] = new \DateTime($element->textContent);
             } else {
                 $array[$index] = $element->textContent;
             }

--- a/tests/Propel/Tests/Runtime/Parser/XmlParserTest.php
+++ b/tests/Propel/Tests/Runtime/Parser/XmlParserTest.php
@@ -77,6 +77,11 @@ class XmlParserTest extends TestCase
   <b2>2</b2>
 </data>
 ", 'keys with numbers'),
+            [['time' => new \DateTime('2014-07-23T22:27:17+0200')], "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<data>
+  <time type=\"xsd:dateTime\">2014-07-23T22:27:17+0200</time>
+</data>
+", '\\DateTime objects']
         );
     }
 


### PR DESCRIPTION
#643

The XmlParser now generates the following xml for \DateTime instances:

``` xml
<data>
  <time type="xsd:dateTime">2014-07-23T22:27:17+0200</time>
</data>
```

I'm not sure if setting `type` to `xsd:dateTime` is the right solution, but without setting a `type` attribute we cannot use `fromXML` with the generated xml because we cannot know if a dom node should map to a `\DateTime`.
