### PR TITLE
Added propel init command

### DIFF
--- a/bin/propel.php
+++ b/bin/propel.php
@@ -14,7 +14,7 @@ use Symfony\Component\Finder\Finder;
 use Propel\Runtime\Propel;
 
 $finder = new Finder();
-$finder->files()->name('*.php')->in(__DIR__.'/../src/Propel/Generator/Command');
+$finder->files()->name('*.php')->in(__DIR__.'/../src/Propel/Generator/Command')->depth(0);
 
 $app = new Application('Propel', Propel::VERSION);
 

--- a/src/Propel/Generator/Command/Helper/DialogHelper.php
+++ b/src/Propel/Generator/Command/Helper/DialogHelper.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Propel\Generator\Command\Helper;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+class DialogHelper extends \Symfony\Component\Console\Helper\DialogHelper
+{
+    public function ask(OutputInterface $output, $question, $default = null, array $autocomplete = null)
+    {
+        return parent::ask($output, $this->formatQuestion($question, $default), $default, $autocomplete);
+    }
+
+    public function askHiddenResponse(OutputInterface $output, $question, $fallback = true)
+    {
+        return parent::askHiddenResponse($output, $this->formatQuestion($question), $fallback);
+    }
+
+    public function writeSection(OutputInterface $output, $text)
+    {
+        $output->writeln([
+            '',
+            $text,
+        ]);
+    }
+
+    public function writeBlock(OutputInterface $output, $text, $style = 'bg=blue;fg=white')
+    {
+        $formatter = $this->getHelperSet()->get('formatter');
+        $block = $formatter->formatBlock($text, $style, true);
+
+        $this->writeSection($output, $block);
+    }
+
+    public function writeSummary(OutputInterface $output, $items)
+    {
+        $output->writeln('');
+        foreach ($items as $name => $value) {
+            $output->writeln(sprintf('<info>%s</info>: <comment>%s</comment>', $name, $value));
+        }
+    }
+
+    private function formatQuestion($question, $default = null)
+    {
+        if ($default) {
+            return sprintf('<info>%s</info> [<comment>%s</comment>]: ', $question, $default);
+        } else {
+            return sprintf('<info>%s</info>: ', $question);
+        }
+    }
+
+    public function select(OutputInterface $output, $question, $choices, $default = null, $attempts = false, $errorMessage = 'Value "%s" is invalid', $multiselect = false)
+    {
+        return parent::select($output, $this->formatQuestion($question, $default), $choices, $default, $attempts, $errorMessage, $multiselect);
+    }
+
+    public function askConfirmation(OutputInterface $output, $question, $default = true)
+    {
+        return parent::askConfirmation($output, $this->formatQuestion($question, $default ? 'yes' : 'no'), $default);
+    }
+}

--- a/src/Propel/Generator/Command/InitCommand.php
+++ b/src/Propel/Generator/Command/InitCommand.php
@@ -1,0 +1,296 @@
+<?php
+
+/**
+ * This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
+namespace Propel\Generator\Command;
+
+use Propel\Generator\Builder\Util\PropelTemplate;
+use Propel\Generator\Command\Helper\DialogHelper;
+use Propel\Runtime\Adapter\AdapterFactory;
+use Propel\Runtime\Connection\ConnectionFactory;
+use Propel\Runtime\Connection\Exception\ConnectionException;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\Output;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * @author Marc Scholten <marcphilipscholten@gmail.com>
+ */
+class InitCommand extends AbstractCommand
+{
+    private $defaultSchemaDir;
+    private $defaultPhpDir;
+
+    public function __construct($name = null)
+    {
+        parent::__construct($name);
+        $this->defaultSchemaDir = getcwd();
+        $this->defaultPhpDir = $this->detectDefaultPhpDir();
+    }
+
+
+    protected function configure()
+    {
+        parent::configure();
+
+        $this
+            ->setName('init')
+            ->setDescription('Initializes a new project')
+            ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->getHelperSet()->set(new DialogHelper());
+
+        /** @var $dialog DialogHelper */
+        $dialog = $this->getHelper('dialog');
+
+        $options = [];
+
+        $dialog->writeBlock($output, 'Propel 2 Initializer');
+
+        $dialog->writeSection($output, 'First we need to set up your database connection.');
+        $output->writeln('');
+
+        $supportedRdbms = [
+            'mysql' => 'MySQL',
+            'sqlite' => 'SQLite',
+            'pgsql' => 'PostgreSQL',
+            'oracle' => 'Oracle',
+            'sqlsrv' => 'MSSQL (via pdo-sqlsrv)',
+            'mssql' => 'MSSQL (via pdo-mssql)'
+        ];
+
+        $options['rdbms'] = $dialog->select($output, 'Please pick your favorite database management system', $supportedRdbms);
+
+        $output->writeln('');
+
+        do {
+            switch ($options['rdbms']) {
+                case 'mysql':
+                    $options['dsn'] = $this->initMysql($output, $dialog);
+                    break;
+                case 'sqlite':
+                    $options['dsn'] = $this->initSqlite($output, $dialog);
+                    break;
+                case 'pgsql':
+                    $options['dsn'] = $this->initPgsql($output, $dialog);
+                    break;
+                default:
+                    $options['dsn'] = $this->initDsn($output, $dialog, $options['rdbms']);
+                    break;
+            }
+
+
+            $options['user'] = $dialog->ask($output, 'Please enter your database user', 'root');
+            $options['password'] = $dialog->askHiddenResponse($output, 'Please enter your database password');
+
+            $options['charset'] = $dialog->ask($output, 'Which charset would you like to use?', 'utf8');
+        } while (!$this->testConnection($output, $dialog, $options));
+
+        $dialog->writeSection($output, 'The initial step in every Propel project is the "build". During build time, a developer describes the structure of the datamodel in a XML file called the "schema".');
+        $dialog->writeSection($output, 'From this schema, Propel generates PHP classes, called "model classes", made of object-oriented PHP code optimized for a given RDMBS. The model classes are the primary interface to find and manipulate data in the database in Propel.');
+        $dialog->writeSection($output, 'The XML schema can also be used to generate SQL code to setup your database. Alternatively, you can generate the schema from an existing database.');
+        $output->writeln('');
+
+        if ($dialog->askConfirmation($output, 'Do you have an existing database you want to use with propel?', false)) {
+            $options['schema'] = $this->reverseEngineerSchema($output, $options);
+        }
+
+        $options['schemaDir'] = $dialog->ask($output, 'Where do you want to store your schema.xml?', $this->defaultSchemaDir);
+        $options['phpDir'] = $dialog->ask($output, 'Where do you want propel to save the generated php models?', $this->defaultPhpDir);
+        $options['namespace'] = $dialog->ask($output, 'Which namespace should the generated php models use?');
+
+        $dialog->writeSection($output, 'Propel asks you to define some data to work properly, for instance: connection parameters, working directories, flags to take decisions and so on. You can pass these data via a configuration file.');
+        $dialog->writeSection($output, 'The name of the configuration file is <comment>propel</comment>, with one of the supported extensions (yml, xml, json, ini, php). E.g. <comment>propel.yml</comment> or <comment>propel.json</comment>.');
+        $output->writeln('');
+
+        $options['format'] = $dialog->askAndValidate($output, 'Please enter the format to use for the generated configuration file (yml, xml, json, ini, php)', [$this, 'validateFormat'], false, 'yml');
+
+        $dialog->writeBlock($output, 'Propel 2 Initializer - Summary');
+        $dialog->writeSection($output, 'The Propel 2 Initializer will set up your project with the following settings:');
+
+        $dialog->writeSummary($output, [
+            'Path to schema.xml' => $options['schemaDir'] . '/schema.xml',
+            'Path to config file' => sprintf('%s/propel.%s', getcwd(), $options['format']),
+            'Path to generated php models' => $options['phpDir'],
+            'Namespace of generated php models' => $options['namespace'],
+        ]);
+
+        $dialog->writeSummary($output, [
+            'Database management system' => $options['rdbms'],
+            'Charset' => $options['charset'],
+            'User' => $options['user'],
+        ]);
+
+        $output->writeln('');
+
+        if (!$dialog->askConfirmation($output, 'Is everything correct?')) {
+            $output->writeln('<error>Process aborted.</error>');
+            return 1;
+        }
+
+        $output->writeln('');
+
+        $this->generateProject($output, $options);
+
+        $dialog->writeSection($output, sprintf('Propel 2 is ready to be used!'));
+    }
+
+    private function detectDefaultPhpDir()
+    {
+        if (file_exists(getcwd() . '/src/')) {
+            $vendors = Finder::create()->directories()->in(getcwd() . '/src/')->depth(1);
+
+            if ($vendors->count() > 1) {
+                $iterator = $vendors->getIterator();
+                $iterator->next();
+
+                return $iterator->current() . '/Model/';
+            }
+        }
+
+        return getcwd();
+    }
+
+    private function initMysql(OutputInterface $output, DialogHelper $dialog)
+    {
+        $host = $dialog->ask($output, 'Please enter your database host', 'localhost');
+        $database = $dialog->ask($output, 'Please enter your database name');
+
+        return sprintf('mysql:host=%s;dbname=%s', $host, $database);
+    }
+
+    private function initSqlite(OutputInterface $output, DialogHelper $dialog)
+    {
+        $path = $dialog->ask($output, 'Where should the sqlite database be stored?', getcwd() . '/my.app.sq3');
+
+        return sprintf('sqlite:', $path);
+    }
+
+    private function initPgsql(OutputInterface $output, DialogHelper $dialog)
+    {
+        $host = $dialog->ask($output, 'Please enter your database host (without port)', 'localhost');
+        $port = $dialog->ask($output, 'Please enter your database port', '3306');
+        $database = $dialog->ask($output, 'Please enter your database name');
+
+        return sprintf('pgsql:host=%s;port=%s;dbname=%s', $host, $port, $database);
+    }
+
+    private function initDsn(OutputInterface $output, DialogHelper $dialog, $rdbms)
+    {
+        switch ($rdbms) {
+            case 'oracle':
+                $help = 'https://php.net/manual/en/ref.pdo-oci.connection.php#refsect1-ref.pdo-oci.connection-description';
+                break;
+            case 'sqlsrv':
+                $help = 'https://php.net/manual/en/ref.pdo-sqlsrv.connection.php#refsect1-ref.pdo-sqlsrv.connection-description';
+                break;
+            case 'mssql':
+                $help = 'https://php.net/manual/en/ref.pdo-dblib.connection.php#refsect1-ref.pdo-dblib.connection-description';
+                break;
+            default:
+                $help = 'https://php.net/manual/en/pdo.drivers.php';
+        }
+
+        return $dialog->ask($output, sprintf('Please enter the dsn (see <comment>%s</comment>) for your database connection', $help));
+    }
+
+    private function generateProject(OutputInterface $output, array $options)
+    {
+        $schema = new PropelTemplate();
+        $schema->setTemplateFile(__DIR__ . '/templates/schema.xml.php');
+
+        $config = new PropelTemplate();
+        $config->setTemplateFile(__DIR__ . '/templates/propel.' . $options['format'] . '.php');
+
+        $distConfig = new PropelTemplate();
+        $distConfig->setTemplateFile(__DIR__ . '/templates/propel.' . $options['format'] . '.dist.php');
+
+        if (!isset($options['schema'])) {
+            $options['schema'] = $schema->render($options);
+        }
+
+        $this->writeFile($output, sprintf('%s/schema.xml', $options['schemaDir']), $options['schema']);
+        $this->writeFile($output, sprintf('%s/propel.%s', getcwd(), $options['format']), $config->render($options));
+        $this->writeFile($output, sprintf('%s/propel.%s.dist', getcwd(), $options['format']), $distConfig->render($options));
+    }
+
+    private function writeFile(OutputInterface $output, $filename, $content)
+    {
+        $this->getFilesystem()->dumpFile($filename, $content);
+
+        $output->writeln(sprintf('<info> + %s</info>', $filename));
+    }
+
+    public function validateFormat($format)
+    {
+        $format = strtolower($format);
+
+        if ($format === 'yaml') {
+            $format = 'yml';
+        }
+
+        $validFormats = ['php', 'ini', 'yml', 'xml', 'json'];
+        if (!in_array($format, $validFormats)) {
+            throw new \InvalidArgumentException(sprintf('The specified format "%s" is invalid. Use one of %s',
+                $format,
+                implode(', ', $validFormats)
+            ));
+        }
+
+        return $format;
+    }
+
+    private function testConnection(OutputInterface $output, DialogHelper $dialog, array $options)
+    {
+        $adapter = AdapterFactory::create($options['rdbms']);
+
+        try {
+            ConnectionFactory::create($options, $adapter);
+
+            $dialog->writeBlock($output, 'Connected to sql server successful!');
+            return true;
+        } catch (ConnectionException $e) {
+            // get the "real" wrapped exception message
+            do {
+                $message = $e->getMessage();
+            } while (($e = $e->getPrevious()) !== null);
+
+            $dialog->writeBlock($output, 'Unable to connect to the specific sql server: ' . $message, 'error');
+            $dialog->writeSection($output, 'Make sure the specified credentials are correct and try it again.');
+            $output->writeln('');
+
+            if ($output->getVerbosity() === OutputInterface::VERBOSITY_DEBUG) {
+                $output->writeln($e);
+            }
+
+            return false;
+        }
+    }
+
+    private function reverseEngineerSchema(OutputInterface $output, array $options)
+    {
+        $outputDir = sys_get_temp_dir();
+
+        $this->getApplication()->setAutoExit(false);
+        if (0 === $this->getApplication()->run(new StringInput(sprintf('reverse %s --output-dir %s', escapeshellarg($options['dsn']), $outputDir)), $output)) {
+            $schema = file_get_contents($outputDir . '/schema.xml');
+        } else {
+            exit(1);
+        }
+
+        $this->getApplication()->setAutoExit(true);
+
+        return $schema;
+    }
+}

--- a/src/Propel/Generator/Command/templates/propel.ini.dist.php
+++ b/src/Propel/Generator/Command/templates/propel.ini.dist.php
@@ -1,0 +1,19 @@
+; When you're part of a team, you could want to define a common configuration file and commit it into your VCS. But, of
+; course, there can be some properties you don't want to share, e.g. database passwords. Propel helps you and looks for
+; a propel.yml.dist file too, merging its properties with propel.yml ones. So you can define shared configuration
+; properties in propel.yml.dist, committing it in your VCS, and keep propel.yml as private. The properties loaded from
+; propel.yml overwrite the ones with the same name, loaded from propel.yml.dist.
+;
+; For a complete references see: http://propelorm.org/documentation/reference/configuration-file.html
+
+; The directory where Propel expects to find your `schema.xml` file.
+propel.paths.schemaDir: <?php echo $schemaDir . PHP_EOL; ?>
+
+; The directory where Propel should output generated object model classes.
+propel.paths.phpDir: <?php echo $phpDir . PHP_EOL; ?>
+
+; propel.database.connections.default.adapter: <?php echo $rdbms . PHP_EOL ?>
+; propel.database.connections.default.dsn: <?php echo $dsn . PHP_EOL ?>
+; propel.database.connections.default.user: <?php echo $user . PHP_EOL ?>
+; propel.database.connections.default.password:
+; propel.database.connections.default.settings.charset: <?php echo $charset . PHP_EOL ?>

--- a/src/Propel/Generator/Command/templates/propel.ini.php
+++ b/src/Propel/Generator/Command/templates/propel.ini.php
@@ -1,0 +1,5 @@
+propel.database.connections.default.adapter: <?php echo $rdbms . PHP_EOL ?>
+propel.database.connections.default.dsn: <?php echo $dsn . PHP_EOL ?>
+propel.database.connections.default.user: <?php echo $user . PHP_EOL ?>
+propel.database.connections.default.password: <?php echo $password . PHP_EOL ?>
+propel.database.connections.default.settings.charset: <?php echo $charset . PHP_EOL ?>

--- a/src/Propel/Generator/Command/templates/propel.json.dist.php
+++ b/src/Propel/Generator/Command/templates/propel.json.dist.php
@@ -1,0 +1,9 @@
+<?php
+echo json_encode([
+    'propel' => [
+        'paths' => [
+            'schemaDir' => $schemaDir,
+            'phpDir' => $phpDir,
+        ],
+    ]
+], JSON_PRETTY_PRINT);

--- a/src/Propel/Generator/Command/templates/propel.json.php
+++ b/src/Propel/Generator/Command/templates/propel.json.php
@@ -1,0 +1,17 @@
+<?php echo json_encode([
+    'propel' => [
+        'database' => [
+            'connections' => [
+                'default' => [
+                    'adapter' => $rdbms,
+                    'dsn' => $dsn,
+                    'user' => $user,
+                    'password' => '',
+                    'settings' => [
+                        'charset' => $charset
+                    ]
+                ]
+            ]
+        ]
+    ]
+], JSON_PRETTY_PRINT);

--- a/src/Propel/Generator/Command/templates/propel.php.dist.php
+++ b/src/Propel/Generator/Command/templates/propel.php.dist.php
@@ -1,0 +1,35 @@
+<?php echo "<?php\n"; ?>
+// When you're part of a team, you could want to define a common configuration file and commit it into your VCS. But, of
+// course, there can be some properties you don't want to share, e.g. database passwords. Propel helps you and looks for
+// a propel.yml.dist file too, merging its properties with propel.yml ones. So you can define shared configuration
+// properties in propel.yml.dist, committing it in your VCS, and keep propel.yml as private. The properties loaded from
+// propel.yml overwrite the ones with the same name, loaded from propel.yml.dist.
+//
+// For a complete references see: http://propelorm.org/documentation/reference/configuration-file.html
+
+return [
+    'propel' => [
+        'paths' => [
+            // The directory where Propel expects to find your `schema.xml` file.
+            'schemaDir' => '<?php echo $schemaDir ?>',
+
+            // The directory where Propel should output generated object model classes.
+            'phpDir' => '<?php echo $phpDir ?>',
+        ],
+        /*
+        'database' => [
+            'connections' => [
+                'default' => [
+                    'adapter' => '<?php echo $rdbms ?>',
+                    'dsn' => '<?php echo $dsn ?>',
+                    'user' => '<?php echo $user ?>',
+                    'password' => '',
+                    'settings' => [
+                        'charset' => '<?php echo $charset ?>'
+                    ]
+                ]
+            ]
+        ]
+        */
+    ]
+];

--- a/src/Propel/Generator/Command/templates/propel.php.php
+++ b/src/Propel/Generator/Command/templates/propel.php.php
@@ -1,0 +1,18 @@
+<?php echo "<?php\n"; ?>
+return [
+    'propel' => [
+        'database' => [
+            'connections' => [
+                'default' => [
+                    'adapter' => '<?php echo $rdbms ?>',
+                    'dsn' => '<?php echo $dsn ?>',
+                    'user' => '<?php echo $user ?>',
+                    'password' => '',
+                    'settings' => [
+                        'charset' => '<?php echo $charset ?>'
+                    ]
+                ]
+            ]
+        ]
+    ]
+];

--- a/src/Propel/Generator/Command/templates/propel.xml.dist.php
+++ b/src/Propel/Generator/Command/templates/propel.xml.dist.php
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="ISO-8859-1" standalone="no"?>
+<!--
+    When you're part of a team, you could want to define a common configuration file and commit it into your VCS. But, of
+    course, there can be some properties you don't want to share, e.g. database passwords. Propel helps you and looks for
+    a propel.yml.dist file too, merging its properties with propel.yml ones. So you can define shared configuration
+    properties in propel.yml.dist, committing it in your VCS, and keep propel.yml as private. The properties loaded from
+    propel.yml overwrite the ones with the same name, loaded from propel.yml.dist.
+
+    For a complete references see: http://propelorm.org/documentation/reference/configuration-file.html
+-->
+<config>
+    <propel>
+        <paths>
+            <!-- The directory where Propel expects to find your `schema.xml` file. -->
+            <schemaDir><?php echo $schemaDir ?></schemaDir>
+            <!-- The directory where Propel should output generated object model classes. -->
+            <phpDir><?php echo $phpDir ?></phpDir>
+        </paths>
+
+        <!--
+        <database>
+            <connections>
+                <connection id="default">
+                    <adapter><?php echo $rdbms ?></adapter>
+                    <dsn><?php echo $dsn ?></dsn>
+                    <user><?php echo $user ?></user>
+                    <password></password>
+                    <settings>
+                        <charset><?php echo $charset ?></charset>
+                    </settings>
+                </connection>
+            </connections>
+        </database>
+        -->
+    </propel>
+</config>

--- a/src/Propel/Generator/Command/templates/propel.xml.php
+++ b/src/Propel/Generator/Command/templates/propel.xml.php
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="ISO-8859-1" standalone="no"?>
+<config>
+    <propel>
+        <database>
+            <connections>
+                <connection id="default">
+                    <adapter><?php echo $rdbms ?></adapter>
+                    <dsn><?php echo $dsn ?></dsn>
+                    <user><?php echo $user ?></user>
+                    <password><?php echo $password ?></password>
+                    <settings>
+                        <charset><?php echo $charset ?></charset>
+                    </settings>
+                </connection>
+            </connections>
+        </database>
+    </propel>
+</config>

--- a/src/Propel/Generator/Command/templates/propel.yml.dist.php
+++ b/src/Propel/Generator/Command/templates/propel.yml.dist.php
@@ -1,0 +1,25 @@
+# When you're part of a team, you could want to define a common configuration file and commit it into your VCS. But, of
+# course, there can be some properties you don't want to share, e.g. database passwords. Propel helps you and looks for
+# a propel.yml.dist file too, merging its properties with propel.yml ones. So you can define shared configuration
+# properties in propel.yml.dist, committing it in your VCS, and keep propel.yml as private. The properties loaded from
+# propel.yml overwrite the ones with the same name, loaded from propel.yml.dist.
+#
+# For a complete references see: http://propelorm.org/documentation/reference/configuration-file.html
+
+propel:
+    paths:
+        # The directory where Propel expects to find your `schema.xml` file.
+        schemaDir: <?php echo $schemaDir . PHP_EOL; ?>
+
+        # The directory where Propel should output generated object model classes.
+        phpDir: <?php echo $phpDir . PHP_EOL; ?>
+
+#   database:
+#       connections:
+#           default:
+#               adapter: <?php echo $rdbms . PHP_EOL ?>
+#               dsn: <?php echo $dsn . PHP_EOL ?>
+#               user: <?php echo $user . PHP_EOL ?>
+#               password:
+#               settings:
+#                   charset: <?php echo $charset . PHP_EOL ?>

--- a/src/Propel/Generator/Command/templates/propel.yml.php
+++ b/src/Propel/Generator/Command/templates/propel.yml.php
@@ -1,0 +1,10 @@
+propel:
+    database:
+        connections:
+            default:
+                adapter: <?php echo $rdbms . PHP_EOL ?>
+                dsn: <?php echo $dsn . PHP_EOL ?>
+                user: <?php echo $user . PHP_EOL ?>
+                password: <?php echo $password  . PHP_EOL ?>
+                settings:
+                    charset: <?php echo $charset . PHP_EOL ?>

--- a/src/Propel/Generator/Command/templates/schema.xml.php
+++ b/src/Propel/Generator/Command/templates/schema.xml.php
@@ -1,0 +1,96 @@
+<!--
+    Awesome, your propel set up is nearly done! You just have to describe how you want your database to look like.
+
+    You can let propel set up your <?php echo $rdbms ?> database by running `vendor/bin/propel database:create && vendor/bin/propel database:insert-sql`.
+    This will create your database including all the tables.
+-->
+
+<!--
+    The root tag of the XML schema is the <database> tag.
+
+    The `name` attribute defines the name of the connection that Propel uses for the tables in this schema. It is not
+    necessarily the name of the actual database. In fact, Propel uses some configuration properties to link a connection
+    name with real connection settings (like database name, user and password).
+
+    The `defaultIdMethod` attribute indicates that the tables in this schema use the database's "native"
+    auto-increment/sequence features to handle id columns that are set to auto-increment.
+
+   [TIP]: You can define several schemas for a single project. Just make sure that each of the schema
+          filenames end with schema.xml.
+-->
+<database name="default" defaultIdMethod="native"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="http://xsd.propelorm.org/1.6/database.xsd"
+          namespace="<?php echo $namespace?>"
+        >
+    <!-- Within the <database> tag, Propel expects one <table> tag for each table -->
+
+
+    <!--
+        Each table element should have a `name` attribute. It will be used for naming the sql table.
+
+        The `phpName` is the name that Propel will use for the generated PHP class. By default, Propel uses a
+        CamelCase version of the table name as its phpName - that means that you could omit the `phpName` attribute
+        on our `book` table.
+    -->
+    <table name="book" phpName="Book">
+        <!--
+            Each column has a `name` (the one used by the database), and an optional `phpName` attribute. Once again,
+            the Propel default behavior is to use a CamelCase version of the name as `phpName` when not specified.
+
+            Each column also requires a `type`. The XML schema is database agnostic, so the column types and attributes
+            are probably not exactly the same as the one you use in your own database. But Propel knows how to map the
+            schema types with SQL types for many database vendors. Existing Propel column types are:
+            `boolean`, `tinyint`, `smallint`, `integer`, `bigint`, `double`, `float`, `real`, `decimal`, `char`,
+            `varchar`, `longvarchar`, `date`, `time`, `timestamp`, `blob`, `clob`, `object`, and `array`.
+
+            Some column types use a size (like `varchar` and `int`), some have unlimited size (`longvarchar`, `clob`,
+            `blob`).
+
+            Check the (schema reference)[http://propelorm.org/reference/schema.html] for more details
+            on each column type.
+
+            As for the other column attributes, `required`, `primaryKey`, and `autoIncrement`, they mean exactly
+            what their names imply.
+        -->
+        <column name="id" type="integer" required="true" primaryKey="true" autoIncrement="true"/>
+        <column name="title" type="varchar" size="255" required="true"/>
+        <column name="isbn" type="varchar" size="24" required="true" phpName="ISBN"/>
+        <column name="publisher_id" type="integer" required="true"/>
+        <column name="author_id" type="integer" required="true"/>
+
+        <!--
+            A foreign key represents a relationship. Just like a table or a column, a relationship has a `phpName`.
+            By default, Propel uses the `phpName` of the foreign table as the `phpName` of the relation.
+
+            The `refPhpName` defines the name of the relation as seen from the foreign table.
+        -->
+        <foreign-key foreignTable="publisher" phpName="Publisher" refPhpName="Book">
+            <reference local="publisher_id" foreign="id"/>
+        </foreign-key>
+        <foreign-key foreignTable="author">
+            <reference local="author_id" foreign="id"/>
+        </foreign-key>
+    </table>
+
+    <table name="author" phpName="Author">
+        <column name="id" type="integer" required="true" primaryKey="true" autoIncrement="true"/>
+        <column name="first_name" type="varchar" size="128" required="true"/>
+        <column name="last_name" type="varchar" size="128" required="true"/>
+    </table>
+
+    <table name="publisher" phpName="Publisher">
+        <column name="id" type="integer" required="true" primaryKey="true" autoIncrement="true"/>
+        <column name="name" type="varchar" size="128" required="true"/>
+    </table>
+
+    <!--
+        When you're done with editing, open a terminal and run
+            `$ cd <?php echo $schemaDir ?>`
+            `$ vendor/bin/propel build`
+        to generate the model classes.
+
+        You should now be able to perform basic crud operations with your models. To learn how to use these models
+        please look into our documentation: http://propelorm.org/documentation/03-basic-crud.html
+    -->
+</database>

--- a/tests/Propel/Tests/TestCaseFixtures.php
+++ b/tests/Propel/Tests/TestCaseFixtures.php
@@ -83,7 +83,7 @@ class TestCaseFixtures extends TestCase
         }
 
         $finder = new Finder();
-        $finder->files()->name('*.php')->in(__DIR__.'/../../../src/Propel/Generator/Command');
+        $finder->files()->name('*.php')->in(__DIR__.'/../../../src/Propel/Generator/Command')->depth(0);
 
         $app = new Application('Propel', Propel::VERSION);
 


### PR DESCRIPTION
![bildschirmfoto 2014-08-04 um 19 02 31](https://cloud.githubusercontent.com/assets/2072185/3800496/26f1a7ea-1bf9-11e4-95b6-d89b62169735.png)

Based on the discussion in #679.
This is currently work in progress but I want to get some early feedback.

Still to do:
- [x] Check if we can connect to the db with the credentials provided by the user
- [x] Allow running reverse-task on existing databases via init command (suggested by @BunnyHolder)
- [x] Add DSN generation for all rdbms's (currently only mysql)
- [x] Add prod/dev context to generated `propel.yml` (we should probably generate a `propel.yml.dist` instead of a `propel.yml`, or we could use env-vars for passing the credentials, not sure on this)
- [x] Add missing templates for config formats other than yml and xml

So what do you think of this? Let me know if you have some suggestions :)
