### PR TITLE
Propel2-619 Propel Query limit(0) not working

### DIFF
--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -218,10 +218,10 @@ class Criteria
     protected $originalDbName;
 
     /**
-     * To limit the number of rows to return.  <code>0</code> means return all
+     * To limit the number of rows to return.  <code>-1</code> means return all
      * rows.
      */
-    protected $limit = 0;
+    protected $limit = -1;
 
     /** To start the results at a row other than the first one. */
     protected $offset = 0;
@@ -1560,7 +1560,7 @@ class Criteria
     {
         // merge limit
         $limit = $criteria->getLimit();
-        if (0 != $limit && 0 === $this->getLimit()) {
+        if (0 != $limit && -1 === $this->getLimit()) {
             $this->limit = $limit;
         }
 
@@ -1971,7 +1971,7 @@ class Criteria
         $sql .= ($havingString ? ' HAVING '.$havingString : '')
              .($orderByClause ? ' ORDER BY '.implode(',', $orderByClause) : '');
 
-        if ($this->getLimit() || $this->getOffset()) {
+        if ($this->getLimit() >= 0 || $this->getOffset()) {
             $db->applyLimit($sql, $this->getOffset(), $this->getLimit(), $this);
         }
 
@@ -2296,7 +2296,7 @@ class Criteria
 
         $needsComplexCount = $this->getGroupByColumns()
             || $this->getOffset()
-            || $this->getLimit()
+            || $this->getLimit() >= 0
             || $this->getHaving()
             || in_array(Criteria::DISTINCT, $this->getSelectModifiers())
             || count($this->selectQueries) > 0

--- a/src/Propel/Runtime/Adapter/Pdo/MysqlAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/MysqlAdapter.php
@@ -132,7 +132,7 @@ class MysqlAdapter extends PdoAdapter implements SqlAdapterInterface
      */
     public function applyLimit(&$sql, $offset, $limit)
     {
-        if ($limit > 0) {
+        if ($limit >= 0) {
             $sql .= ' LIMIT ' . ($offset > 0 ? $offset . ', ' : '') . $limit;
         } elseif ($offset > 0) {
             $sql .= ' LIMIT ' . $offset . ', 18446744073709551615';

--- a/src/Propel/Runtime/Adapter/Pdo/PgsqlAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/PgsqlAdapter.php
@@ -128,7 +128,7 @@ class PgsqlAdapter extends PdoAdapter implements SqlAdapterInterface
      */
     public function applyLimit(&$sql, $offset, $limit)
     {
-        if ($limit > 0) {
+        if ($limit >= 0) {
             $sql .= sprintf(' LIMIT %u', $limit);
         }
         if ($offset > 0) {

--- a/src/Propel/Runtime/Adapter/Pdo/SqliteAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/SqliteAdapter.php
@@ -115,7 +115,7 @@ class SqliteAdapter extends PdoAdapter implements SqlAdapterInterface
      */
     public function applyLimit(&$sql, $offset, $limit)
     {
-        if ($limit > 0) {
+        if ($limit >= 0) {
             $sql .= ' LIMIT ' . $limit . ($offset > 0 ? ' OFFSET ' . $offset : '');
         } elseif ($offset > 0) {
             $sql .= sprintf(' LIMIT -1 OFFSET %i', $offset);

--- a/src/Propel/Runtime/Formatter/AbstractFormatter.php
+++ b/src/Propel/Runtime/Formatter/AbstractFormatter.php
@@ -95,7 +95,7 @@ abstract class AbstractFormatter
         $this->setClass($criteria->getModelName());
         $this->setWith($criteria->getWith());
         $this->asColumns = $criteria->getAsColumns();
-        $this->hasLimit = $criteria->getLimit() != 0;
+        $this->hasLimit = $criteria->getLimit() != -1;
         if ($dataFetcher) {
             $this->setDataFetcher($dataFetcher);
         }

--- a/src/Propel/Runtime/Util/PropelModelPager.php
+++ b/src/Propel/Runtime/Util/PropelModelPager.php
@@ -100,7 +100,7 @@ class PropelModelPager implements \IteratorAggregate, \Countable
         $qForCount = clone $this->getQuery();
         $count = $qForCount
             ->offset(0)
-            ->limit(0)
+            ->limit(-1)
             ->count($this->con)
         ;
 
@@ -108,7 +108,7 @@ class PropelModelPager implements \IteratorAggregate, \Countable
 
         $q = $this->getQuery()
             ->offset(0)
-            ->limit(0)
+            ->limit(-1)
         ;
 
         if (0 === $this->getPage() || 0 === $this->getMaxPerPage()) {

--- a/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaTest.php
@@ -1077,7 +1077,7 @@ class CriteriaTest extends BookstoreTestBase
     public function testLimit()
     {
         $c = new Criteria();
-        $this->assertEquals(0, $c->getLimit(), 'Limit is 0 by default');
+        $this->assertEquals(-1, $c->getLimit(), 'Limit is -1 by default');
 
         $c2 = $c->setLimit(1);
         $this->assertEquals(1, $c->getLimit(), 'Limit is set by setLimit');

--- a/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaTest.php
@@ -740,6 +740,12 @@ class ModelCriteriaTest extends BookstoreTestBase
         $sql = 'SELECT  FROM  LIMIT 10';
         $params = array();
         $this->assertCriteriaTranslation($c, $sql, $params, 'limit() adds a LIMIT clause');
+        //test that limit 0 also works
+        $c->limit(0);
+        $sql = 'SELECT  FROM  LIMIT 0';
+        $params = array();
+        $this->assertCriteriaTranslation($c, $sql, $params, 'limit() adds a LIMIT clause');
+
     }
 
     public function testOffset()
@@ -1479,7 +1485,7 @@ class ModelCriteriaTest extends BookstoreTestBase
         $c = BookQuery::create();
         $c->filterByTitle('foo');
         $c->findOne();
-        $this->assertEquals(0, $c->getLimit(), 'findOne() clones the query by default');
+        $this->assertEquals(-1, $c->getLimit(), 'findOne() clones the query by default');
 
         $c = BookQuery::create();
         $c->filterByTitle('foo');


### PR DESCRIPTION
changed default value for limit to -1 in order to allow limit clause with 0.
Fixed some unit tests which failed because they expected a default value for limit with 0. Changed this to -1 because otherwise we can't use limit(0) clause.

fixes #619
