### PR TITLE
Update database.dtd

### DIFF
--- a/resources/dtd/database.dtd
+++ b/resources/dtd/database.dtd
@@ -132,7 +132,7 @@ PHP class or method name.
   foreign CDATA #REQUIRED
 >
 
-<!ELEMENT index (index-column+)>
+<!ELEMENT index (index-column+,vendor*)>
 <!ATTLIST index
   name CDATA #IMPLIED
 >


### PR DESCRIPTION
Added missing reference of attribute `allowPkInsert` in the `table` element.
Also allow `behavior` to not have `parameter` children, like in timestampable behavior.
