### PR TITLE
Optional config file

### DIFF
--- a/src/Propel/Common/Config/ConfigurationManager.php
+++ b/src/Propel/Common/Config/ConfigurationManager.php
@@ -230,5 +230,15 @@ class ConfigurationManager
                 unset($this->config['database']['connections'][$name]['slaves']);
             }
         }
+
+        foreach (['runtime', 'generator'] as $section) {
+            if (!isset($this->config[$section]['connections']) || count($this->config[$section]['connections']) === 0) {
+                $this->config[$section]['connections'] = array_keys($this->config['database']['connections']);
+            }
+
+            if (!isset($this->config[$section]['defaultConnection'])) {
+                $this->config[$section]['defaultConnection'] = key($this->config['database']['connections']);
+            }
+        }
     }
 }

--- a/src/Propel/Common/Config/PropelConfiguration.php
+++ b/src/Propel/Common/Config/PropelConfiguration.php
@@ -142,7 +142,6 @@ class PropelConfiguration implements ConfigurationInterface
                     ->end()
                 ->end() //reverse
                 ->arrayNode('runtime')
-                    ->isRequired()
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->scalarNode('defaultConnection')->isRequired()->end()
@@ -201,7 +200,6 @@ class PropelConfiguration implements ConfigurationInterface
                     ->end()
                 ->end() //runtime
                 ->arrayNode('generator')
-                    ->isRequired()
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->scalarNode('defaultConnection')->isRequired()->end()

--- a/tests/Propel/Tests/Common/Config/ConfigurationManagerTest.php
+++ b/tests/Propel/Tests/Common/Config/ConfigurationManagerTest.php
@@ -85,11 +85,7 @@ EOF;
         $this->assertEquals('baz', $actual['bar']);
     }
 
-    /**
-     * @expectedException Propel\Common\Config\Exception\InvalidArgumentException
-     * @exceptionMessage Propel configuration file not found
-     */
-    public function testWrongConfigFileThrowsException()
+    public function testNotExistingConfigFileLoadsDefaultSettingsAndDoesNotThrowExceptions()
     {
         $yamlConf = <<<EOF
 foo: bar
@@ -320,11 +316,7 @@ EOF;
         $manager = new ConfigurationManager();
     }
 
-    /**
-     * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedMessage The child node "runtime" at path "propel" must be configured
-     */
-    public function testNotDefineRuntimeSectionTrowsException()
+    public function testNotDefineRuntimeAndGeneratorSectionUsesDefaultConnections()
     {
         $yamlConf = <<<EOF
 propel:
@@ -343,6 +335,15 @@ EOF;
         $this->getFilesystem()->dumpFile('propel.yaml', $yamlConf);
 
         $manager = new ConfigurationManager();
+
+        $this->assertArrayHasKey('runtime', $manager->get());
+        $this->assertArrayHasKey('generator', $manager->get());
+
+        $this->assertArrayHasKey('connections', $manager->getSection('runtime'));
+        $this->assertArrayHasKey('connections', $manager->getSection('generator'));
+
+        $this->assertEquals(['default'], $manager->get()['runtime']['connections']);
+        $this->assertEquals(['default'], $manager->get()['generator']['connections']);
     }
 
     /**


### PR DESCRIPTION
Fixes #680 and #679.

Basically if we don't find any config files we just pass the `$extraConf` to `$this->config`. After that the config file was still not really "optional" because the `PropelConfiguration` requires the `{runtime,generator}.connections` to bet set. Therefore I had to fix the other issue too.
