### PR TITLE
Propel2-710 Propel compatibility with Symfony 2.5 components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
     ],
     "require": {
         "php": ">=5.4",
-        "symfony/yaml": "~2.4.0",
-        "symfony/console": "~2.4.0",
-        "symfony/finder": "~2.4.0",
-        "symfony/validator": "~2.4.0",
-        "symfony/filesystem": "~2.4.0",
-        "symfony/config": "~2.4.0",
+        "symfony/yaml": "~2.3",
+        "symfony/console": "~2.3",
+        "symfony/finder": "~2.3",
+        "symfony/validator": "~2.3",
+        "symfony/filesystem": "~2.3",
+        "symfony/config": "~2.3",
         "psr/log": "~1.0"
     },
     "require-dev": {

--- a/src/Propel/Generator/Behavior/Validate/ValidateBehavior.php
+++ b/src/Propel/Generator/Behavior/Validate/ValidateBehavior.php
@@ -43,13 +43,26 @@ class ValidateBehavior extends Behavior
         $this->builder = $builder;
         $this->builder->declareClasses(
             'Symfony\\Component\\Validator\\Mapping\\ClassMetadata',
-            'Symfony\\Component\\Validator\\Validator',
             'Symfony\\Component\\Validator\\DefaultTranslator',
             'Symfony\\Component\\Validator\\Mapping\\Loader\\StaticMethodLoader',
             'Symfony\\Component\\Validator\\ConstraintValidatorFactory',
             'Symfony\\Component\\Validator\\Mapping\\ClassMetadataFactory',
             'Symfony\\Component\\Validator\\ConstraintViolationList'
         );
+
+        //if SF >= 5.3 use new validator classes
+        if(class_exists('Symfony\\Component\\Validator\\Validator\\LegacyValidator')){
+            $this->builder->declareClasses(
+                'Symfony\\Component\\Validator\\Validator\\LegacyValidator',
+                'Symfony\\Component\\Validator\\Context\\ExecutionContextFactory',
+                'Symfony\\Component\\Validator\\Validator\\ValidatorInterface'
+            );
+        }else{
+            $this->builder->declareClasses(
+                'Symfony\\Component\\Validator\\Validator',
+                'Symfony\\Component\\Validator\\ValidatorInterface'
+            );
+        }
 
         $script = $this->addLoadValidatorMetadataMethod();
         $script .= $this->addValidateMethod();

--- a/src/Propel/Generator/Behavior/Validate/templates/objectValidate.php
+++ b/src/Propel/Generator/Behavior/Validate/templates/objectValidate.php
@@ -6,10 +6,22 @@
  * @param      object $validator A Validator class instance
  * @return     boolean Whether all objects pass validation.
  */
-public function validate(Validator $validator = null)
+public function validate(ValidatorInterface $validator = null)
 {
     if (null === $validator) {
-        $validator = new Validator(new ClassMetadataFactory(new StaticMethodLoader()), new ConstraintValidatorFactory(), new DefaultTranslator());
+        if(class_exists('Symfony\\Component\\Validator\\Validator\\LegacyValidator')){
+            $validator = new LegacyValidator(
+                        new ExecutionContextFactory(new DefaultTranslator()),
+                        new ClassMetaDataFactory(new StaticMethodLoader()),
+                        new ConstraintValidatorFactory()
+            );
+        }else{
+            $validator = new Validator(
+                        new ClassMetadataFactory(new StaticMethodLoader()),
+                        new ConstraintValidatorFactory(),
+                        new DefaultTranslator()
+            );
+        }
     }
 
     $failureMap = new ConstraintViolationList();

--- a/tests/Propel/Tests/Generator/Command/DatabaseReverseTest.php
+++ b/tests/Propel/Tests/Generator/Command/DatabaseReverseTest.php
@@ -32,14 +32,15 @@ class DatabaseReverseTest extends TestCaseFixturesDatabase
             'connection' => $this->getConnectionDsn('bookstore-schemas', true)
         ));
 
-        $output = new \Symfony\Component\Console\Output\BufferedOutput();
+        $output = new \Symfony\Component\Console\Output\StreamOutput(fopen("php://temp", 'r+'));
         $app->setAutoExit(false);
         $result = $app->run($input, $output);
 
 	chdir($currentDir);
 
         if (0 !== $result) {
-            echo $output->fetch();
+            rewind($output->getStream());
+            echo stream_get_contents($output->getStream());
         }
         $this->assertEquals(0, $result, 'database:reverse tests exited successfully');
 

--- a/tests/Propel/Tests/Generator/Command/GraphvizGenerateTest.php
+++ b/tests/Propel/Tests/Generator/Command/GraphvizGenerateTest.php
@@ -24,12 +24,13 @@ class GraphvizGenerateTest extends TestCaseFixtures
             '--verbose' => true
         ));
 
-        $output = new \Symfony\Component\Console\Output\BufferedOutput();
+        $output = new \Symfony\Component\Console\Output\StreamOutput(fopen("php://temp", 'r+'));
         $app->setAutoExit(false);
         $result = $app->run($input, $output);
 
         if (0 !== $result) {
-            echo $output->fetch();
+            rewind($output->getStream());
+            echo stream_get_contents($output->getStream());
         }
 
         $this->assertEquals(0, $result, 'graphviz:generate tests exited successfully');

--- a/tests/Propel/Tests/Generator/Command/MigrationTest.php
+++ b/tests/Propel/Tests/Generator/Command/MigrationTest.php
@@ -50,12 +50,13 @@ class MigrationTest extends TestCaseFixturesDatabase
             '--verbose' => true
         ));
 
-        $output = new \Symfony\Component\Console\Output\BufferedOutput();
+        $output = new \Symfony\Component\Console\Output\StreamOutput(fopen("php://temp", 'r+'));
         $app->setAutoExit(false);
         $result = $app->run($input, $output);
 
         if (0 !== $result) {
-            echo $output->fetch();
+            rewind($output->getStream());
+            echo stream_get_contents($output->getStream());
         }
 
         $this->assertEquals(0, $result, 'migration:diff tests exited successfully');
@@ -84,16 +85,17 @@ class MigrationTest extends TestCaseFixturesDatabase
             '--verbose' => true
         ));
 
-        $output = new \Symfony\Component\Console\Output\BufferedOutput();
+        $output = new \Symfony\Component\Console\Output\StreamOutput(fopen("php://temp", 'r+'));
         $app->setAutoExit(false);
         $result = $app->run($input, $output);
 
+        rewind($output->getStream());
         if (0 !== $result) {
-            echo $output->fetch();
+            echo stream_get_contents($output->getStream());
         }
 
         $this->assertEquals(0, $result, 'migration:up tests exited successfully');
-        $outputString = $output->fetch();
+        $outputString = stream_get_contents($output->getStream());
         $this->assertContains('Migration complete.', $outputString);
     }
 
@@ -112,16 +114,17 @@ class MigrationTest extends TestCaseFixturesDatabase
             '--verbose' => true
         ));
 
-        $output = new \Symfony\Component\Console\Output\BufferedOutput();
+        $output = new \Symfony\Component\Console\Output\StreamOutput(fopen("php://temp", 'r+'));
         $app->setAutoExit(false);
         $result = $app->run($input, $output);
 
+        rewind($output->getStream());
         if (0 !== $result) {
-            echo $output->fetch();
+            echo stream_get_contents($output->getStream());
         }
 
         $this->assertEquals(0, $result, 'migration:down tests exited successfully');
-        $outputString = $output->fetch();
+        $outputString = stream_get_contents($output->getStream());
         $this->assertContains('Reverse migration complete.', $outputString);
     }
 
@@ -140,16 +143,17 @@ class MigrationTest extends TestCaseFixturesDatabase
             '--verbose' => true
         ));
 
-        $output = new \Symfony\Component\Console\Output\BufferedOutput();
+        $output = new \Symfony\Component\Console\Output\StreamOutput(fopen("php://temp", 'r+'));
         $app->setAutoExit(false);
         $result = $app->run($input, $output);
 
+        rewind($output->getStream());
         if (0 !== $result) {
-            echo $output->fetch();
+            echo stream_get_contents($output->getStream());
         }
 
         $this->assertEquals(0, $result, 'migration:down tests exited successfully');
-        $outputString = $output->fetch();
+        $outputString = stream_get_contents($output->getStream());
         $this->assertContains('Migration complete.', $outputString);
 
         //revert this migration change so we have the same database structure as before this test


### PR DESCRIPTION
replaced deprecated validator class with new recursive one introduced in symfony 2.5
in order to make propel2 usable with symfony 2.5

fixes #710
