### PR TITLE
Fix issue #697

### DIFF
--- a/src/Propel/Common/Config/PropelConfiguration.php
+++ b/src/Propel/Common/Config/PropelConfiguration.php
@@ -152,6 +152,7 @@ class PropelConfiguration implements ConfigurationInterface
                             ->prototype('scalar')->end()
                         ->end()
                         ->arrayNode('log')
+                            ->useAttributeAsKey('name')
                             ->prototype('array')
                                 ->children()
                                     ->scalarNode('type')->end()

--- a/src/Propel/Common/Config/XmlToArrayConverter.php
+++ b/src/Propel/Common/Config/XmlToArrayConverter.php
@@ -131,6 +131,16 @@ class XmlToArrayConverter
     private static function getConvertedXmlValue($value)
     {
         $value = (string) $value; // convert from simplexml to string
+
+        //handle numeric values
+        if (is_numeric($value)) {
+            if (ctype_digit($value)) {
+                $value = intval($value);
+            } else {
+                $value = floatval($value);
+            }
+        }
+
         // handle booleans specially
         $lwr = strtolower($value);
         if ($lwr === "false") {


### PR DESCRIPTION
Adjust Propel Configuration TreeBuilder to correctly parse associative arrays, in `propel:runtime:log` key.
Adjust `Propel\Common\Config\XmlToArrayConverter` class to correctly convert numeric values.
This PR fixes #697.
