### PR TITLE
Fixed psr2 violation: There must be one blank line after the last use statement; two found

### DIFF
--- a/src/Propel/Generator/Builder/Om/ExtensionObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ExtensionObjectBuilder.php
@@ -43,7 +43,6 @@ class ExtensionObjectBuilder extends AbstractObjectBuilder
 
         if ($this->getBuildProperty('generator.objectModel.addClassLevelComment')) {
             $script .= "
-
 /**
  * Skeleton subclass for representing a row from the '$tableName' table.
  *

--- a/src/Propel/Generator/Builder/Om/ExtensionQueryBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ExtensionQueryBuilder.php
@@ -42,7 +42,6 @@ class ExtensionQueryBuilder extends AbstractOMBuilder
         $baseClassName = $this->getClassNameFromBuilder($this->getQueryBuilder());
 
         $script .= "
-
 /**
  * Skeleton subclass for performing query and update operations on the '$tableName' table.
  *


### PR DESCRIPTION
![bildschirmfoto 2014-09-21 um 15 37 39](https://cloud.githubusercontent.com/assets/2072185/4348613/83c0b8b0-4194-11e4-87f1-5ed7614c73a1.png)

There's one blank line two much after the use statement and before the php doc of the class definition.

See psr2: `There MUST be one blank line after the namespace declaration, and there MUST be one blank line after the block of use declarations.` (https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)
