### PR TITLE
Fix issue 766

### DIFF
--- a/src/Propel/Common/Config/ConfigurationManager.php
+++ b/src/Propel/Common/Config/ConfigurationManager.php
@@ -161,11 +161,11 @@ class ConfigurationManager
             }
 
             $finder = new Finder();
-            $finder->in($dirs)->depth(0)->files()->name($fileName . '.*')->notName('*.dist');
+            $finder->in($dirs)->depth(0)->files()->name($fileName . '.{php,inc,ini,properties,yaml,yml,xml,json}');
             $files = iterator_to_array($finder);
 
             $distfinder = new Finder();
-            $distfinder->in($dirs)->depth(0)->files()->name($fileName . '.*.dist');
+            $distfinder->in($dirs)->depth(0)->files()->name($fileName . '.{php,inc,ini,properties,yaml,yml,xml,json}.dist');
             $distfiles = iterator_to_array($distfinder);
 
             $numFiles = count($files);

--- a/tests/Propel/Tests/Common/Config/ConfigurationManagerTest.php
+++ b/tests/Propel/Tests/Common/Config/ConfigurationManagerTest.php
@@ -96,6 +96,37 @@ EOF;
         $manager = new TestableConfigurationManager();
     }
 
+    public function testBackupConfigFilesAreIgnored()
+    {
+        $yamlConf = <<<EOF
+foo: bar
+bar: baz
+EOF;
+        $this->getFilesystem()->dumpFile('propel.yaml.bak', $yamlConf);
+        $this->getFilesystem()->dumpFile('propel.yaml~', $yamlConf);
+
+        $manager = new TestableConfigurationManager();
+        $actual = $manager->get();
+
+        $this->assertArrayNotHasKey('bar', $actual);
+        $this->assertArrayNotHasKey('baz', $actual);
+    }
+
+    public function testUnsupportedExtensionsAreIgnored()
+    {
+        $yamlConf = <<<EOF
+foo: bar
+bar: baz
+EOF;
+        $this->getFilesystem()->dumpFile('propel.log', $yamlConf);
+
+        $manager = new TestableConfigurationManager();
+        $actual = $manager->get();
+
+        $this->assertArrayNotHasKey('bar', $actual);
+        $this->assertArrayNotHasKey('baz', $actual);
+    }
+
     /**
      * @expectedException Propel\Common\Config\Exception\InvalidArgumentException
      * @exceptionMessage Propel expects only one configuration file


### PR DESCRIPTION
Load only configuration files having one of the supported extensions.
This commit fixes issue #766.
