### PR TITLE
Misconfigured connections throw exception

### DIFF
--- a/src/Propel/Common/Config/ConfigurationManager.php
+++ b/src/Propel/Common/Config/ConfigurationManager.php
@@ -11,6 +11,7 @@
 namespace Propel\Common\Config;
 
 use Propel\Common\Config\Exception\InvalidArgumentException;
+use Propel\Common\Config\Exception\InvalidConfigurationException;
 use Propel\Common\Config\Loader\DelegatingLoader;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Config\Definition\Processor;
@@ -238,6 +239,18 @@ class ConfigurationManager
 
             if (!isset($this->config[$section]['defaultConnection'])) {
                 $this->config[$section]['defaultConnection'] = key($this->config['database']['connections']);
+            }
+
+            foreach ($this->config[$section]['connections'] as $connection) {
+                if (!array_key_exists($connection, $this->config['database']['connections'])) {
+                    throw new InvalidConfigurationException("`$connection` isn't a valid configured connection (Section: propel.$section.connections). " .
+                    "Please, check your configured connections in `propel.database.connections` section of your configuration file.");
+                }
+            }
+
+            if (!array_key_exists($defaultConnection = $this->config[$section]['defaultConnection'], $this->config['database']['connections'])) {
+                throw new InvalidConfigurationException("`$defaultConnection` isn't a valid configured connection (Section: propel.$section.defaultConnection). " .
+                "Please, check your configured connections in `propel.database.connections` section of your configuration file.");
             }
         }
     }

--- a/src/Propel/Common/Config/Exception/InvalidConfigurationException.php
+++ b/src/Propel/Common/Config/Exception/InvalidConfigurationException.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT License
+ */
+
+namespace Propel\Common\Config\Exception;
+
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException as BaseConfigurationException;
+
+class InvalidConfigurationException extends BaseConfigurationException implements ExceptionInterface
+{
+}

--- a/tests/Propel/Tests/Common/Config/ConfigurationManagerTest.php
+++ b/tests/Propel/Tests/Common/Config/ConfigurationManagerTest.php
@@ -14,6 +14,8 @@ use Propel\Common\Config\ConfigurationManager;
 
 class ConfigurationManagerTest extends ConfigTestCase
 {
+    use DataProviderTrait;
+
     /**
      * Current working directory
      */
@@ -422,6 +424,30 @@ propel:
 EOF;
         $this->getFilesystem()->dumpFile('propel.yaml', $yamlConf);
 
+        $manager = new ConfigurationManager();
+    }
+
+    /**
+     * @dataProvider providerForInvalidConnections
+     */
+    public function testRuntimeOrGeneratorConnectionIsNotInConfiguredConnectionsThrowsException($yamlConf, $section)
+    {
+        $this->setExpectedException("Propel\Common\Config\Exception\InvalidConfigurationException",
+            "`wrongsource` isn't a valid configured connection (Section: propel.$section.connections).");
+
+        $this->getFilesystem()->dumpFile('propel.yaml', $yamlConf);
+        $manager = new ConfigurationManager();
+    }
+
+    /**
+     * @dataProvider providerForInvalidDefaultConnection
+     */
+    public function testRuntimeOrGeneratorDefaultConnectionIsNotInConfiguredConnectionsThrowsException($yamlConf, $section)
+    {
+        $this->setExpectedException("Propel\Common\Config\Exception\InvalidConfigurationException",
+            "`wrongsource` isn't a valid configured connection (Section: propel.$section.defaultConnection).");
+
+        $this->getFilesystem()->dumpFile('propel.yaml', $yamlConf);
         $manager = new ConfigurationManager();
     }
 

--- a/tests/Propel/Tests/Common/Config/DataProviderTrait.php
+++ b/tests/Propel/Tests/Common/Config/DataProviderTrait.php
@@ -1,0 +1,179 @@
+<?php
+
+/**
+ * This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT License
+ */
+
+namespace Propel\Tests\Common\Config;
+
+/**
+ * This trait contains the data providers for ConfigurationManagerTest class.
+ */
+trait DataProviderTrait
+{
+    public function providerForInvalidConnections()
+    {
+        return array(
+            array("
+propel:
+  database:
+      connections:
+          mysource:
+              adapter: mysql
+              classname: Propel\Runtime\Connection\DebugPDO
+              dsn: mysql:host=localhost;dbname=mydb
+              user: root
+              password:
+  runtime:
+      defaultConnection: wrongsource
+      connections:
+          - wrongsource
+
+"
+            , 'runtime'),
+            array("
+propel:
+  database:
+      connections:
+          mysource:
+              adapter: mysql
+              classname: Propel\Runtime\Connection\DebugPDO
+              dsn: mysql:host=localhost;dbname=mydb
+              user: root
+              password:
+  runtime:
+      defaultConnection: wrongsource
+      connections:
+          - mysource
+          - wrongsource
+
+"
+            , 'runtime'),
+            array("
+propel:
+  database:
+      connections:
+          mysource:
+              adapter: mysql
+              classname: Propel\Runtime\Connection\DebugPDO
+              dsn: mysql:host=localhost;dbname=mydb
+              user: root
+              password:
+  generator:
+      defaultConnection: wrongsource
+      connections:
+          - wrongsource
+
+"
+            , 'generator'),
+            array("
+propel:
+  database:
+      connections:
+          mysource:
+              adapter: mysql
+              classname: Propel\Runtime\Connection\DebugPDO
+              dsn: mysql:host=localhost;dbname=mydb
+              user: root
+              password:
+  generator:
+      defaultConnection: wrongsource
+      connections:
+          - wrongsource
+          - mysource
+
+"
+            , 'generator'),
+            array("
+propel:
+  database:
+      connections:
+          mysource:
+              adapter: mysql
+              classname: Propel\Runtime\Connection\DebugPDO
+              dsn: mysql:host=localhost;dbname=mydb
+              user: root
+              password:
+  generator:
+      defaultConnection: wrongsource
+      connections:
+          - wrongsource
+
+  runtime:
+      defaultConnection: wrongsource
+      connections:
+          - wrongsource
+
+
+"
+            , 'runtime'),
+        );
+    }
+
+    public function providerForInvalidDefaultConnection()
+    {
+        return array(
+            array("
+propel:
+  database:
+      connections:
+          mysource:
+              adapter: mysql
+              classname: Propel\Runtime\Connection\DebugPDO
+              dsn: mysql:host=localhost;dbname=mydb
+              user: root
+              password:
+  runtime:
+      defaultConnection: wrongsource
+      connections:
+          - mysource
+
+"
+            , 'runtime'),
+            array("
+propel:
+  database:
+      connections:
+          mysource:
+              adapter: mysql
+              classname: Propel\Runtime\Connection\DebugPDO
+              dsn: mysql:host=localhost;dbname=mydb
+              user: root
+              password:
+  generator:
+      defaultConnection: wrongsource
+      connections:
+          - mysource
+
+"
+            , 'generator'),
+            array("
+propel:
+  database:
+      connections:
+          mysource:
+              adapter: mysql
+              classname: Propel\Runtime\Connection\DebugPDO
+              dsn: mysql:host=localhost;dbname=mydb
+              user: root
+              password:
+  generator:
+      defaultConnection: wrongsource
+      connections:
+          - mysource
+
+  runtime:
+      defaultConnection: wrongsource
+      connections:
+          - mysource
+
+
+"
+            , 'runtime'),
+        );
+    }
+}

--- a/tests/Propel/Tests/Generator/Config/QuickGeneratorConfigTest.php
+++ b/tests/Propel/Tests/Generator/Config/QuickGeneratorConfigTest.php
@@ -63,6 +63,16 @@ class QuickGeneratorConfigTest extends TestCase
     {
         $extraConf = array(
             'propel' => array(
+                'database' => array(
+                    'connections' => array(
+                        'fakeConn' => array(
+                            'adapter' => 'sqlite',
+                            'dsn' => 'sqlite:fakeDb.sqlite',
+                            'user'=> '',
+                            'password' => ''
+                        )
+                    )
+                ),
                 'runtime' => array(
                     'defaultConnection' => 'fakeConn',
                     'connections' => array('fakeConn', 'default')
@@ -77,6 +87,8 @@ class QuickGeneratorConfigTest extends TestCase
         $this->assertEquals('path/to/composer', $generatorConfig->get()['paths']['composerDir']);
         $this->assertEquals('fakeConn', $generatorConfig->get()['runtime']['defaultConnection']);
         $this->assertEquals(array('fakeConn', 'default'), $generatorConfig->get()['runtime']['connections']);
+        $this->assertEquals(array('adapter' => 'sqlite', 'classname' => '\Propel\Runtime\Connection\ConnectionWrapper',
+            'dsn' => 'sqlite:fakeDb.sqlite', 'user' => '', 'password' => ''), $generatorConfig->get()['database']['connections']['fakeConn']);
         $this->assertEquals(array('adapter' => 'sqlite','classname' => 'Propel\Runtime\Connection\DebugPDO','dsn' => 'sqlite::memory:','user' => '',
         'password' => ''), $generatorConfig->get()['database']['connections']['default']);
     }


### PR DESCRIPTION
Issues #738 and #779 showed that if a connection, in runtime or generator sections, isn't configured in
`propel.database.connections` section, Propel throws an exception with a cryptic message.
With this PR, we cover this use case by throwing a specific exception with a more explaining message.
