### PR TITLE
String values in native ENUM column

### DIFF
--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -185,6 +185,8 @@ class ObjectBuilder extends AbstractObjectBuilder
                 throw new EngineException(sprintf('Default Value "%s" is not among the enumerated values', $val));
             }
             $defaultValue = array_search($val, $valueSet);
+            settype($defaultValue, $column->getPhpType());
+            $defaultValue = var_export($defaultValue, true);
         } elseif ($column->isPhpPrimitiveType()) {
             settype($val, $column->getPhpType());
             $defaultValue = var_export($val, true);
@@ -1794,8 +1796,9 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
 
         $script .= "
         if (\$v !== null) {
+            \$v = (string) \$v;
             \$valueSet = " . $this->getTableMapClassName() . "::getValueSet(" . $this->getColumnConstant($col) . ");
-            if (!in_array(\$v, \$valueSet)) {
+            if (!in_array(\$v, \$valueSet, true)) {
                 throw new PropelException(sprintf('Value \"%s\" is not accepted in this enumerated column', \$v));
             }
             \$v = array_search(\$v, \$valueSet);

--- a/src/Propel/Generator/Builder/Om/QueryBuilder.php
+++ b/src/Propel/Generator/Builder/Om/QueryBuilder.php
@@ -1029,14 +1029,14 @@ abstract class ".$this->getUnqualifiedClassName()." extends " . $parentClass . "
             $script .= "
         \$valueSet = " . $this->getTableMapClassName() . "::getValueSet(" . $this->getColumnConstant($col) . ");
         if (is_scalar(\$$variableName)) {
-            if (!in_array(\$$variableName, \$valueSet)) {
+            if (!in_array(\$$variableName, \$valueSet, true)) {
                 throw new PropelException(sprintf('Value \"%s\" is not accepted in this enumerated column', \$$variableName));
             }
             \$$variableName = array_search(\$$variableName, \$valueSet);
         } elseif (is_array(\$$variableName)) {
             \$convertedValues = array();
             foreach (\$$variableName as \$value) {
-                if (!in_array(\$value, \$valueSet)) {
+                if (!in_array(\$value, \$valueSet, true)) {
                     throw new PropelException(sprintf('Value \"%s\" is not accepted in this enumerated column', \$value));
                 }
                 \$convertedValues []= array_search(\$value, \$valueSet);

--- a/src/Propel/Generator/Builder/Om/TableMapBuilder.php
+++ b/src/Propel/Generator/Builder/Om/TableMapBuilder.php
@@ -246,8 +246,10 @@ class ".$this->getUnqualifiedClassName()." extends TableMap
                 $script .= "
                 {$col->getFQConstantName()} => array(
                 ";
-                foreach ($col->getValueSet() as $value) {
-                    $script .= "            self::" . $col->getConstantName() . '_' . $this->getEnumValueConstant($value) . ",
+                foreach ($col->getValueSet() as $key => $value) {
+					$value = "self::" . $col->getConstantName() . '_' . $this->getEnumValueConstant($value);
+					$key = $col->getPhpType() === 'string' ? $value . " => " : '';
+                    $script .= "            ".$key.$value . ",
 ";
                 }
                 $script .= "        ),";

--- a/src/Propel/Generator/Model/Column.php
+++ b/src/Propel/Generator/Model/Column.php
@@ -1180,6 +1180,11 @@ class Column extends MappingModel
             $valueSet = array_map('trim', $valueSet);
         }
 
+        // when using native enum type, make the array indices respect the actual string values defined in DDL
+        if (strtoupper(substr(trim($this->getDomain()->getSqlType()), 0, 4)) === 'ENUM') {
+            $valueSet = array_combine($valueSet, $valueSet);
+        }
+
         $this->valueSet = $valueSet;
     }
 

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedTableMapEnumColumnTypeStringTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedTableMapEnumColumnTypeStringTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT License
+ */
+
+namespace Propel\Tests\Generator\Builder\Om;
+
+use Propel\Generator\Util\QuickBuilder;
+
+use Propel\Runtime\Propel;
+use Propel\Tests\TestCase;
+
+/**
+ * Tests the generated TableMap classes for enum column type constants when using native ENUM string values
+ *
+ * @author Francois Zaninotto
+ * @author Miroslav Oujesky
+ */
+class GeneratedTableMapEnumColumnTypeStringTest extends TestCase
+{
+    public function setUp()
+    {
+        if (!class_exists('ComplexColumnTypeEntity104')) {
+            $schema = <<<EOF
+<database name="generated_object_complex_type_test_104">
+    <table name="complex_column_type_entity_104">
+        <column name="id" primaryKey="true" type="INTEGER" autoIncrement="true" />
+        <column name="bar" type="ENUM" valueSet="foo, bar, baz, 1, 4,(, foo bar " phpType="string" sqlType="ENUM('foo', 'bar', 'baz', '1', '4', '(', 'foo bar')" />
+    </table>
+</database>
+EOF;
+
+            $builder = new QuickBuilder();
+            $builder->setSchema($schema);
+            $builder->buildClasses();
+        }
+    }
+
+    public function valueSetConstantProvider()
+    {
+        return array(
+            array('\Map\ComplexColumnTypeEntity104TableMap::COL_BAR_FOO', 'foo'),
+            array('\Map\ComplexColumnTypeEntity104TableMap::COL_BAR_BAR', 'bar'),
+            array('\Map\ComplexColumnTypeEntity104TableMap::COL_BAR_BAZ', 'baz'),
+            array('\Map\ComplexColumnTypeEntity104TableMap::COL_BAR_1', '1'),
+            array('\Map\ComplexColumnTypeEntity104TableMap::COL_BAR_4', '4'),
+            array('\Map\ComplexColumnTypeEntity104TableMap::COL_BAR__', '('),
+            array('\Map\ComplexColumnTypeEntity104TableMap::COL_BAR_FOO_BAR', 'foo bar'),
+        );
+    }
+
+    /**
+     * @dataProvider valueSetConstantProvider
+     */
+    public function testValueSetConstants($constantName, $value)
+    {
+        $this->assertTrue(defined($constantName));
+        $this->assertEquals($value, constant($constantName));
+    }
+
+    public function testGetValueSets()
+    {
+        $expected = array(\Map\ComplexColumnTypeEntity104TableMap::COL_BAR => array('foo' => 'foo', 'bar' => 'bar',
+            'baz' => 'baz', '1' => '1', '4' => '4', '(' => '(', 'foo bar' => 'foo bar'));
+        $this->assertEquals($expected, \Map\ComplexColumnTypeEntity104TableMap::getValueSets());
+
+    }
+
+    public function testGetValueSet()
+    {
+        $expected = array('foo' => 'foo', 'bar' => 'bar',
+            'baz' => 'baz', '1' => '1', '4' => '4', '(' => '(', 'foo bar' => 'foo bar');
+        $this->assertEquals($expected, \Map\ComplexColumnTypeEntity104TableMap::getValueSet(\Map\ComplexColumnTypeEntity104TableMap::COL_BAR));
+    }
+}


### PR DESCRIPTION
Some RDBMS (e.g. MySQL) provides native ENUM column type. Propel however keeps using numeric values internally for the enumerated column even if you force the column type with `sqlType="ENUM('one', 'two', 'three')"` and `phpType="string"` in `schema.xml`.

Back in the day the solution was to modify the value set in Peer class (as discussed here: https://groups.google.com/forum/#!msg/propel-development/3DhvA-9bUDg/Q0Z3zY39DUkJ). With the advent of Peer classes, there is no such simple solution. 

This PR modifies the behaviour of ENUM columns which are also set as native ENUM through `sqlType` attribute in schema by allowing the values actually inserted from Propel to database to be string.

The solution is bit hackish for my taste, but I am not very familiar with Propel internals, so I would use some guidance to see if there is a better place for doing this ENUM "magic". 

Example column definition:

``` xml
<column name="status" type="ENUM" valueSet="NEW,OPEN,COMPLETED,CANCELLED" sqlType="enum('NEW','OPEN','COMPLETED','CANCELLED')" phpType="string" />
```

It would be also nice to have `sqlType` ENUM values automatically filled from `valueSet` to avoid repetition, but since this is RDBMS specific, I don't know how it fits in Propel's philosophy (Behavior?).
