### PR TITLE
fix 763 renamed command sql to build-sql to avoid ambiguous

### DIFF
--- a/src/Propel/Generator/Command/SqlBuildCommand.php
+++ b/src/Propel/Generator/Command/SqlBuildCommand.php
@@ -36,7 +36,7 @@ class SqlBuildCommand extends AbstractCommand
             //->addOption('encoding',     null, InputOption::VALUE_REQUIRED,  'The encoding to use for the database')
             ->addOption('table-prefix', null, InputOption::VALUE_REQUIRED,  'Add a prefix to all the table names in the database', '')
             ->setName('sql:build')
-            ->setAliases(array('sql'))
+            ->setAliases(array('build-sql'))
             ->setDescription('Build SQL files')
         ;
     }


### PR DESCRIPTION
Should fix #763. I chose the same nomenclature as the  insert-sql command.
