### PR TITLE
Fix ignore `generator.platformClass` property

### DIFF
--- a/src/Propel/Generator/Command/AbstractCommand.php
+++ b/src/Propel/Generator/Command/AbstractCommand.php
@@ -33,7 +33,7 @@ abstract class AbstractCommand extends Command
     protected function configure()
     {
         $this
-            ->addOption('platform',  null, InputOption::VALUE_REQUIRED,  'The platform to use. Define a full qualified class name or mysql|pgsql|sqlite|mssql|oracle.', 'mysql')
+            ->addOption('platform',  null, InputOption::VALUE_REQUIRED,  'The platform to use. Define a full qualified class name or mysql|pgsql|sqlite|mssql|oracle.')
             ->addOption('config-dir', null, InputOption::VALUE_REQUIRED,  'The directory where the configuration file is placed.', self::DEFAULT_CONFIG_DIRECTORY)
             ->addOption('recursive', null, InputOption::VALUE_NONE, 'Search recursive for *schema.xml inside the input directory')
         ;
@@ -54,8 +54,8 @@ abstract class AbstractCommand extends Command
             return new GeneratorConfig(null, $properties);
         }
 
-        if ($input->hasOption('platform') && ($platformClass = $input->getOption('platform'))) {
-            $properties['propel']['generator']['platformClass'] = $platformClass;
+        if ($this->hasInputOption('platform', $input)) {
+            $properties['propel']['generator']['platformClass'] = $input->getOption('platform');
         }
 
         return new GeneratorConfig($input->getOption('config-dir'), $properties);


### PR DESCRIPTION
`generator.platformClass` property, in the configuration file, is always overwritten by the default value of `platform` option, in `Propel\Generator\Command\AbstractCommand` class.

This commit fixes that behavior. Now, Propel takes correctly the configuration file property and overwrites it only if it'sexplicitly passed to the command line.
