### PR TITLE
allow whitespace folders for setup database scripts

### DIFF
--- a/tests/bin/setup.mysql.sh
+++ b/tests/bin/setup.mysql.sh
@@ -25,7 +25,7 @@ fi
 
 DB_HOSTNAME=${DB_HOSTNAME-127.0.0.1};
 
-$mysql --host=$DB_HOSTNAME -u$DB_USER $pw_option -e '
+"$mysql" --host="$DB_HOSTNAME" -u"$DB_USER" "$pw_option" -e '
 SET FOREIGN_KEY_CHECKS = 0;
 DROP DATABASE IF EXISTS test;
 DROP SCHEMA IF EXISTS second_hand_books;
@@ -36,7 +36,7 @@ SET FOREIGN_KEY_CHECKS = 1;
 '
 check;
 
-$mysql --host=$DB_HOSTNAME -u$DB_USER $pw_option -e '
+"$mysql" --host="$DB_HOSTNAME" -u"$DB_USER" "$pw_option" -e '
 CREATE DATABASE test;
 CREATE SCHEMA bookstore_schemas;
 CREATE SCHEMA contest;

--- a/tests/bin/setup.pgsql.sh
+++ b/tests/bin/setup.pgsql.sh
@@ -22,17 +22,17 @@ fi
 
 DB_HOSTNAME=${DB_HOSTNAME-127.0.0.1};
 
-$psql --version;
+"$psql" --version;
 
-dropdb --host=$DB_HOSTNAME --username=$DB_USER $DB_NAME;
+dropdb --host="$DB_HOSTNAME" --username="$DB_USER" "$DB_NAME";
 
-createdb --host=$DB_HOSTNAME --username=$DB_USER $DB_NAME;
+createdb --host="$DB_HOSTNAME" --username="$DB_USER" "$DB_NAME";
 check;
 
-$psql --host=$DB_HOSTNAME --username=$DB_USER -c '
+"$psql" --host="$DB_HOSTNAME" --username="$DB_USER" -c '
 CREATE SCHEMA bookstore_schemas;
 CREATE SCHEMA contest;
 CREATE SCHEMA second_hand_books;
 CREATE SCHEMA migration;
-' $DB_NAME;
+' "$DB_NAME";
 check;


### PR DESCRIPTION
When installing for example MySQL to a folder path with whitespaces (C:\Program Files.....) this script won't work properly. Wrapping the command in quotes fixes the problem.
