### PR TITLE
Removed comment at the closing brace of Extension Query Classes to conform psr-1/psr-2

### DIFF
--- a/src/Propel/Generator/Builder/Om/ExtensionQueryBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ExtensionQueryBuilder.php
@@ -86,7 +86,7 @@ class ".$this->getUnqualifiedClassName()." extends $baseClassName
     protected function addClassClose(&$script)
     {
         $script .= "
-} // " . $this->getUnqualifiedClassName() . "
+}
 ";
         $this->applyBehaviorModifier('extensionQueryFilter', $script, "");
     }


### PR DESCRIPTION
Currently the Extension Query class will be generated like this:

``` php
<?php

namespace MyApp;

use MyApp\Base\UserQuery as BaseUserQuery;

class UserQuery extends BaseUserQuery
{
} // ClientQuery
```

php codesniffer with the psr2 ruleset complains about the the last line. There should be no comment because the closing brace must be on a line by itself.

It's also inconsistent with the ExtensionObjectBuilder: The Extension Objects don't have a comment at the closing brace of the class definition.

With this patch the generate code above will look like this:

``` php
<?php

namespace MyApp;

use MyApp\Base\UserQuery as BaseUserQuery;

class UserQuery extends BaseUserQuery
{
}
```
