### PR TITLE
ENUM: "IS NULL" check with where()

### DIFF
--- a/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
@@ -1614,7 +1614,7 @@ class ModelCriteria extends BaseModelCriteria
             }
         } elseif ('ARRAY' === $colMap->getType() && is_array($value)) {
             $value = '| ' . implode(' | ', $value) . ' |';
-        } elseif ('ENUM' === $colMap->getType()) {
+        } elseif ('ENUM' === $colMap->getType() && !is_null($value)) {
             if (is_array($value)) {
                 $value = array_map(array($colMap, 'getValueSetKey'), $value);
             } else {


### PR DESCRIPTION
When I try this:

``` php
BookQuery::create()
  ->where('book.type IS NULL')
  ->find();
```

.. I get this InvalidClauseException: 
`A clause must contain a question mark in order to be bound to a value`.

`type` is an ENUM column.

http://sandbox.propelorm.org/a9d21c3
