### PR TITLE
Fix migration of unique/index keys

### DIFF
--- a/src/Propel/Generator/Builder/Util/SchemaReader.php
+++ b/src/Propel/Generator/Builder/Util/SchemaReader.php
@@ -293,7 +293,8 @@ class SchemaReader
 
             switch ($name) {
                 case 'index-column':
-                    $this->currIndex->addColumn($attributes);
+                    $column = $this->currIndex->getTable()->getColumn($attributes['name']);
+                    $this->currIndex->addColumn($column);
                     break;
 
                 case 'vendor':
@@ -308,7 +309,8 @@ class SchemaReader
 
             switch ($name) {
                 case 'unique-column':
-                    $this->currUnique->addColumn($attributes);
+                    $column = $this->currUnique->getTable()->getColumn($attributes['name']);
+                    $this->currUnique->addColumn($column);
                     break;
 
                 case 'vendor':


### PR DESCRIPTION
`propel diff` always generate change of unique/index keys, even if there's no change.
It's because `SchemaReader` passes XML attributes of the `unique-column` so `IndexComperator` compares size of the `unique-column` (which is mostly `null`) with the size of indexed columns.
