### PR TITLE
require-api: requireOne, requireOneByXXX, requireByArray

### DIFF
--- a/src/Propel/Common/Config/PropelConfiguration.php
+++ b/src/Propel/Common/Config/PropelConfiguration.php
@@ -326,6 +326,7 @@ class PropelConfiguration implements ConfigurationInterface
                                 ->scalarNode('classPrefix')->defaultNull()->end()
                                 ->booleanNode('useLeftJoinsInDoJoinMethods')->defaultTrue()->end()
                                 ->scalarNode('pluralizerClass')->defaultValue('\Propel\Common\Pluralizer\StandardEnglishPluralizer')->end()
+                                ->scalarNode('entityNotFoundExceptionClass')->defaultValue('\Propel\Runtime\Exception\EntityNotFoundException')->end()
                                 ->arrayNode('builders')
                                     ->addDefaultsIfNotSet()
                                     ->children()

--- a/src/Propel/Generator/Builder/Om/QueryBuilder.php
+++ b/src/Propel/Generator/Builder/Om/QueryBuilder.php
@@ -159,6 +159,15 @@ class QueryBuilder extends AbstractOMBuilder
             $script .= "
  * @method     $modelClass findOneBy" . $column->getPhpName() . "(" . $column->getPhpType() . " \$" . $column->getName() . ") Return the first $modelClass filtered by the " . $column->getName() . " column";
         }
+
+        $script .= " * \n";
+
+        // magic requireOneBy() methods, for IDE completion
+        foreach ($this->getTable()->getColumns() as $column) {
+            $script .= "
+ * @method     $modelClass requireOneBy" . $column->getPhpName() . "(" . $column->getPhpType() . " \$" . $column->getName() . ") Return the first $modelClass filtered by the " . $column->getName() . " column and throws {$this->getEntityNotFoundExceptionClass()} when not found";
+        }
+
         $script .= "
  *
  * @method     {$modelClass}[]|ObjectCollection find(ConnectionInterface \$con = null) Return $modelClass objects based on current ModelCriteria";
@@ -202,6 +211,7 @@ abstract class ".$this->getUnqualifiedClassName()." extends " . $parentClass . "
 
         // apply behaviors
         $this->applyBehaviorModifier('queryAttributes', $script, "    ");
+        $this->addEntityNotFoundExceptionClass($script);
         $this->addConstructor($script);
         $this->addFactory($script);
         $this->addFindPk($script);
@@ -246,6 +256,20 @@ abstract class ".$this->getUnqualifiedClassName()." extends " . $parentClass . "
         $this->applyBehaviorModifier('staticAttributes', $script, "    ");
         $this->applyBehaviorModifier('staticMethods', $script, "    ");
         $this->applyBehaviorModifier('queryMethods', $script, "    ");
+    }
+
+    /**
+     * Adds the entityNotFoundExceptionClass property which is necessary for the `requireOne` method
+     * of the `ModelCriteria`
+     */
+    protected function addEntityNotFoundExceptionClass(&$script)
+    {
+        $script .= "protected \$entityNotFoundExceptionClass = '" . addslashes($this->getEntityNotFoundExceptionClass()) . "';\n";
+    }
+
+    private function getEntityNotFoundExceptionClass()
+    {
+        return $this->getBuildProperty('generator.objectModel.entityNotFoundExceptionClass');
     }
 
     /**

--- a/src/Propel/Runtime/Exception/EntityNotFoundException.php
+++ b/src/Propel/Runtime/Exception/EntityNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Propel\Runtime\Exception;
+
+/**
+ * This is the default exception which gets thrown when using the `requireOne` method. It indicates
+ * that a model which is required to processed in the application flow could not be found by the
+ * ModelCriteria.
+ *
+ * You can catch this exception in your applications front-controller to display a generic not-found
+ * error message.
+ */
+class EntityNotFoundException extends RuntimeException
+{
+}

--- a/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaTest.php
@@ -2704,4 +2704,43 @@ class ModelCriteriaTest extends BookstoreTestBase
         $expectedSQL = $this->getSql("SELECT book.id, book.title, book.isbn, book.price, book.publisher_id, book.author_id FROM book WHERE book.author_id=" . $testAuthor->getId() . " AND book.isbn=1234");
         $this->assertEquals($expectedSQL, $con->getLastExecutedQuery(), 'findByXXXAndYYY($value) is turned into findBy(array(XXX, YYY), $value)');
     }
+
+    public function testRequireOneReturnsModel()
+    {
+        $book = BookQuery::create()->orderByTitle()->requireOne();
+        $this->assertInstanceOf(BookTableMap::OM_CLASS, $book);
+    }
+
+    public function testRequireOneThrowsException()
+    {
+        $this->setExpectedException('\Propel\Runtime\Exception\EntityNotFoundException', 'Book could not be found');
+
+        BookQuery::create()->filterByTitle('Not existing title')->requireOne();
+    }
+
+    public function testMagicRequireOneReturnsModel()
+    {
+        $book = BookQuery::create()->requireOneByTitle('Harry Potter and the Order of the Phoenix');
+        $this->assertInstanceOf(BookTableMap::OM_CLASS, $book);
+    }
+
+    public function testMagicRequireOneThrowsException()
+    {
+        $this->setExpectedException('\Propel\Runtime\Exception\EntityNotFoundException', 'Book could not be found');
+
+        BookQuery::create()->requireOneById(-1337);
+    }
+
+    public function testMagicRequireOneWithAndReturnsModel()
+    {
+        $book = BookQuery::create()->requireOneByIsbnAndTitle('043935806X', 'Harry Potter and the Order of the Phoenix');
+        $this->assertInstanceOf(BookTableMap::OM_CLASS, $book);
+    }
+
+    public function testMagicRequireOneWithAndThrowsException()
+    {
+        $this->setExpectedException('\Propel\Runtime\Exception\EntityNotFoundException', 'Book could not be found');
+
+        BookQuery::create()->requireOneByTitleAndId('Not Existing Book', -1337);
+    }
 }


### PR DESCRIPTION
Implementation of #803 

This adds `requireOne()`, `requireOneBy($column, $value)` and `requireOneByArray($values)` to `ModelCriteria`. The `ModelCriteria` also provides magic methods for `requireOneByXXX` and `requireOneByXXXAndXXX`. The generated query classes have `@method`-annotations for these magic methods to support autocompletion. 

---

You can now do something like:

```php
<?php
// ...
try {
  echo 'Hello ' . UserQuery::create()->requireOneById($_GET['id'])->getName();
} catch (\Propel\Runtime\Exception\ModelNotFoundException $e) {
  echo $e->getMessage();
}
```

Which will output 'Hello Marc' or 'User could not be found'  depending on whenever the given user-id exists.

---

You can customize the exception class in the propel config:
```yaml
propel
    generator:
        objectModel:
            notFoundExceptionClass: \Vendor\Project\ResourceNotFoundException
```
or by overwriting the `modelNotFoundExceptionClass` attribute in your query class (or you can overwrite the `createModelNotFoundException` method to customize your exception even more, e.g. when you use a custom constructor signature)

