### PR TITLE
Fixes #715 IDE warning cast in generated crosslink methods

### DIFF
--- a/src/Propel/Generator/Builder/Om/AbstractOMBuilder.php
+++ b/src/Propel/Generator/Builder/Om/AbstractOMBuilder.php
@@ -147,6 +147,22 @@ abstract class AbstractOMBuilder extends DataModelBuilder
     }
 
     /**
+     * Returns the qualified base classname (e.g. Model\Base\Book)
+     *
+     * @return string
+     */
+    public function getFullyQualifiedBaseClassName()
+    {
+
+        if ($namespace = $this->getNamespace()) {
+            return '\\' . $namespace . '\\Base\\' . $this->getUnqualifiedClassName();
+        }
+
+        return $this->getUnqualifiedClassName();
+
+    }
+
+    /**
      * Returns the fully qualified classname (e.g. \Model\Book)
      *
      * @return string

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -3677,12 +3677,15 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
 
         $collName = $this->getRefFKCollVarName($refFK);
 
+        $fkStub = $tblFK->getGeneratorConfig()->getConfiguredBuilder($tblFK, 'objectstub');
+        $fkClassName = $fkStub->getFullyQualifiedBaseClassName();
+
         $script .= "
     /**
      * Method called to associate a $className object to this object
      * through the $className foreign key attribute.
      *
-     * @param  $className \$l $className
+     * @param  $className|$fkClassName \$l $className
      * @return \$this|".$this->getObjectClassName(true)." The current object (for fluent API support)
      */
     public function add".$this->getRefFKPhpNameAffix($refFK, false)."($className \$l)


### PR DESCRIPTION
#715 
I added the base class as a second param in the phpdoc. I did this because when I changed the typehint of the passed parameter to be our base class then the IDE has thrown another warning (see picture). I couldn't find any clear method to get the base class so I created a new method in AbstracOMBuilder. If there is a better way please let me know.

![warning](https://cloud.githubusercontent.com/assets/884833/5382167/352d751e-80a8-11e4-89d0-63064ed2629d.jpg)

