### PR TITLE
Add an API for exists().

### DIFF
--- a/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaTest.php
@@ -1968,6 +1968,20 @@ class ModelCriteriaTest extends BookstoreTestBase
         $this->assertEquals(1, $nbBooks, 'count() returns the number of results in the query');
     }
 
+    public function testExists()
+    {
+        $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book', 'b');
+        $c->where('b.Title = ?', 'foo');
+        $booksExists = $c->exists();
+        $this->assertFalse($booksExists, 'exists() returns false when there are are matching results');
+
+        $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book', 'b');
+        $c->join('b.Author a');
+        $c->where('a.FirstName = ?', 'Neal');
+        $booksExists = $c->exists();
+        $this->assertTrue($booksExists, 'exists() returns true when there are matching results');
+    }
+
     public function testPaginate()
     {
         $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book', 'b');


### PR DESCRIPTION
If I want to check if something exists currently I would do something like this:

```php
CmsCompanyQuery::create()->count() > 1;
```

Executes

````sql
SELECT COUNT(*) FROM cms_company;
````

But `count()` is expensive on larger tables, so I'd need to keep in mind to limit it:

````php
CmsCompanyQuery::create()->limit(1)->count() > 1;
````
Which surprisingly produces
```sql
SELECT COUNT(*) FROM (SELECT cms_company.com_id, cms_company.media_id, cms_company.admin_id, cms_company.com_name, cms_company.com_email, cms_company.com_address, cms_company.com_address2, cms_company.com_postal, cms_company.com_country, cms_company.com_employee, cms_company.com_skin, cms_company.com_theme, cms_company.com_activity, cms_company.com_status, cms_company.com_created, cms_company.com_modified, cms_company.com_creator, cms_company.pay_id, cms_company.pay_amount, cms_company.com_last_payment, cms_company.com_next_payment, cms_company.is_reward, cms_company.vote_start, cms_company.vote_end, cms_company.is_banner, cms_company.is_goal, cms_company.skin_path FROM cms_company LIMIT 1) propelmatch4cnt
```
Limiting the select column
```php
CmsCompanyQuery::create()->select(['com_id'])->limit(1)->count();
```

Turns into:

```sql
SELECT COUNT(*) FROM (SELECT cms_company.com_id AS "com_id" FROM cms_company LIMIT 1) propelmatch4cnt
```

Which is still not ideal because it's quite convoluted and the SQL query is still getting table data unnecessarily. A faster way would be to add an `exists()`:

```php
CmsCompanyQuery::create()->exists();
```
Produce.
```sql
SELECT 1 FROM cms_company LIMIT 1;
```
Which should be the fastest query to check for existence since we aren't interested in retrieving any data.