### PR TITLE
Improved error message when external schema cannot be found

### DIFF
--- a/src/Propel/Generator/Manager/AbstractManager.php
+++ b/src/Propel/Generator/Manager/AbstractManager.php
@@ -364,6 +364,10 @@ abstract class AbstractManager
 
             $externalSchema->parentNode->removeChild($externalSchema);
 
+            if (!is_readable($include)) {
+                throw new BuildException("External schema '$include' does not exist");
+            }
+
             $externalSchemaDom = new \DOMDocument('1.0', 'UTF-8');
             $externalSchemaDom->load(realpath($include));
 


### PR DESCRIPTION
This improves the error message when you include an external schema which could not be found by propel. Currently you get the following error:

```
Warning: DOMDocument::load(): Empty string supplied as input
```

Now you get

```
Unable to find external schema 'my-external-schema.xml'
```

Propel applies `realpath` to the path given by the user. If `realpath` cannot resolve the given path it'll return `false`. Now `false` is given to `DOMDocument::load`, which logs a php warning because of invalid input.
