### PR TITLE
Add method requirePk() to Query classes

### DIFF
--- a/src/Propel/Generator/Builder/Om/QueryBuilder.php
+++ b/src/Propel/Generator/Builder/Om/QueryBuilder.php
@@ -162,6 +162,12 @@ class QueryBuilder extends AbstractOMBuilder
 
         $script .= " * \n";
 
+        // override the signature of ModelCriteria::require*() to specify the class of the returned object, for IDE completion
+        $script .= "
+ * @method     $modelClass requirePk(\$key, ConnectionInterface \$con = null) Return the $modelClass by primary key and throws {$this->getEntityNotFoundExceptionClass()} when not found
+ * @method     $modelClass requireOne(ConnectionInterface \$con = null) Return the first $modelClass matching the query and throws {$this->getEntityNotFoundExceptionClass()} when not found
+ *";
+
         // magic requireOneBy() methods, for IDE completion
         foreach ($this->getTable()->getColumns() as $column) {
             $script .= "

--- a/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
@@ -998,6 +998,35 @@ class ModelCriteria extends BaseModelCriteria
     }
 
     /**
+     * Find object by primary key
+     * Behaves differently if the model has simple or composite primary key
+     * <code>
+     * // simple primary key
+     * $book  = $c->requirePk(12, $con);
+     * // composite primary key
+     * $bookOpinion = $c->requirePk(array(34, 634), $con);
+     * </code>
+     *
+     * Throws an exception when nothing was found.
+     *
+     * @param mixed               $key Primary key to use for the query
+     * @param ConnectionInterface $con an optional connection object
+     *
+     * @return mixed the result, formatted by the current formatter
+     * @throws EntityNotFoundException|\Exception When nothing is found
+     */
+    public function requirePk($key, ConnectionInterface $con = null)
+    {
+        $result = $this->findPk($key, $con);
+
+        if ($result === null) {
+            throw $this->createEntityNotFoundException();
+        }
+
+        return $result;
+    }
+
+    /**
      * Issue a SELECT ... LIMIT 1 query based on the current ModelCriteria
      * and format the result with the current formatter
      * By default, returns a model object.

--- a/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaTest.php
@@ -2719,6 +2719,23 @@ class ModelCriteriaTest extends BookstoreTestBase
         $this->assertEquals($expectedSQL, $con->getLastExecutedQuery(), 'findByXXXAndYYY($value) is turned into findBy(array(XXX, YYY), $value)');
     }
 
+    public function testRequirePkReturnsModel()
+    {
+        // retrieve the test data
+        $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
+        $testBook = $c->findOne();
+
+        $book = BookQuery::create()->requirePk($testBook->getId());
+        $this->assertInstanceOf(BookTableMap::OM_CLASS, $book);
+    }
+
+    public function testRequirePkThrowsException()
+    {
+        $this->setExpectedException('\Propel\Runtime\Exception\EntityNotFoundException', 'Book could not be found');
+
+        BookQuery::create()->requirePk(-1337);
+    }
+
     public function testRequireOneReturnsModel()
     {
         $book = BookQuery::create()->orderByTitle()->requireOne();


### PR DESCRIPTION
Thanks for the require* methods! :+1: 

I would like to have a `requirePk` method (like `findPk`). Is there a reason why this method was not added?