### PR TITLE
groupByArray

### DIFF
--- a/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
@@ -270,6 +270,26 @@ class ModelCriteria extends BaseModelCriteria
 
         return $this;
     }
+    
+    /**
+     * Adds a GROUP BY clause for certain columns to the query
+     * Examples:
+     *   $c->groupByArray(array('Book.AuthorId', 'Book.AuthorName'))
+     *    => $c->addGroupByColumn(BookTableMap::AUTHOR_ID)
+     *    => $c->addGroupByColumn(BookTableMap::AUTHOR_NAME)  
+     *
+     * @param array $columns The column to group by
+     *
+     * @return $this|ModelCriteria The current object, for fluid interface
+     */
+    public function groupByArray(array $columns)
+    {
+        foreach ($columns as $column) {
+            $this->groupBy($column);
+        }
+        
+        return $this;
+    }
 
     /**
      * Adds a GROUP BY clause for all columns of a model to the query

--- a/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaGroupByArrayTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaGroupByArrayTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT License
+ */
+
+namespace Propel\Tests\Runtime\ActiveQuery;
+
+use Propel\Tests\Helpers\Bookstore\BookstoreEmptyTestBase;
+use Propel\Tests\Bookstore\Book;
+use Propel\Tests\Bookstore\Author;
+use Propel\Tests\Bookstore\AuthorQuery;
+
+class ModelCriteriaGroupByArrayTest extends BookstoreEmptyTestBase
+{
+    public function testGroupByArray()
+    {
+        $stephenson = new Author();
+        $stephenson->setFirstName("Neal");
+        $stephenson->setLastName("Stephenson");
+        $stephenson->save();
+
+        $byron = new Author();
+        $byron->setFirstName("George");
+        $byron->setLastName("Byron");
+        $byron->save();
+        
+        $phoenix = new Book();
+        $phoenix->setTitle("Harry Potter and the Order of the Phoenix");
+        $phoenix->setISBN("043935806X");
+        $phoenix->setAuthor($stephenson);
+        $phoenix->save();
+        
+        $qs = new Book();
+        $qs->setISBN("0380977427");
+        $qs->setTitle("Quicksilver");
+        $qs->setAuthor($stephenson);
+        $qs->save();
+
+        $dj = new Book();
+        $dj->setISBN("0140422161");
+        $dj->setTitle("Don Juan");
+        $dj->setAuthor($stephenson);
+        $dj->save();
+
+        $td = new Book();
+        $td->setISBN("067972575X");
+        $td->setTitle("The Tin Drum");
+        $td->setAuthor($byron);
+        $td->save();
+        
+        $authors = AuthorQuery::create()
+            ->leftJoinBook()
+            ->select(array('FirstName', 'LastName'))
+            ->withColumn('COUNT(Book.Id)', 'nbBooks')
+            ->groupByArray(array('FirstName', 'LastName'))
+            ->orderByLastName()
+            ->find();
+        
+        $expectedSql = 'SELECT COUNT(book.id) AS nbBooks, author.first_name AS "FirstName", author.last_name AS "LastName" FROM author LEFT JOIN book ON (author.id=book.author_id) GROUP BY author.first_name,author.last_name ORDER BY author.last_name ASC';
+        
+        $this->assertEquals($expectedSql, $this->con->getLastExecutedQuery());
+        
+        $this->assertEquals(2, count($authors));
+        
+        $this->assertEquals('George', $authors[0]['FirstName']);
+        $this->assertEquals(1, $authors[0]['nbBooks']);
+        
+        $this->assertEquals('Neal', $authors[1]['FirstName']);
+        $this->assertEquals(3, $authors[1]['nbBooks']);
+    }
+}


### PR DESCRIPTION
Currently, if we want to do grouping by multiple columns, we have to write *groupBy* for each column. For example: 
```php
FooBarQuery::create()
   ->joinBaz()
   ->select(['Foo', 'Bar'])
   ->withColumn('COUNT(Baz.Id)', 'nbBazs')
   ->groupBy('Foo')
   ->groupBy('Bar')
```

with this PR, we just simply write:
```php
FooBarQuery::create()
   ->joinBaz()
   ->select(['Foo', 'Bar'])
   ->withColumn('COUNT(Baz.Id)', 'nbBazs')
   ->groupByArray(['Foo', 'Bar'])
```