### PR TITLE
fix typehining on generated doc blocks by adding default 'mixed'' value

### DIFF
--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -1189,7 +1189,7 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
      * @param      ConnectionInterface \$con An optional ConnectionInterface connection to use for fetching this lazy-loaded column.";
         }
         $script .= "
-     * @return ".($column->getTypeHint() ?: $column->getPhpType())."
+     * @return ".($column->getTypeHint() ?: ($column->getPhpType() ?: 'mixed'))."
      */";
     }
 
@@ -1404,7 +1404,7 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
     /**
      * Set the value of [$clo] column.
      * ".$column->getDescription()."
-     * @param  ".$column->getPhpType()." \$v new value
+     * @param ".($column->getPhpType() ?: 'mixed')." \$v new value
      * @return \$this|".$this->getObjectClassName(true)." The current object (for fluent API support)
      */";
     }


### PR DESCRIPTION
On columns without explicit type hinting, like PropelType::Object, no param type was set:

```php
/**
     * Set the value of [sms_per_day] column.
     *
     * @param $v new value
     * @return \Valid\NameSpace\Model The current object (for fluent API support)
     */
```

 Leading to wrong IDE assumption for param type equals `Base\new`. By adding this fix doc block generation results in:

```php
/**
     * Set the value of [sms_per_day] column.
     *
     * @param $v mixed new value
     * @return \Valid\NameSpace\Model The current object (for fluent API support)
     */
```