### PR TITLE
Fix performance issues on OnDemandFormatter as in ObjectFormatter

### DIFF
--- a/src/Propel/Runtime/Collection/OnDemandCollection.php
+++ b/src/Propel/Runtime/Collection/OnDemandCollection.php
@@ -24,6 +24,10 @@ use Propel\Runtime\Map\TableMap;
  */
 class OnDemandCollection extends Collection
 {
+    /**
+     * @var \Iterator
+     */
+    private $lastIterator;
 
     /**
      * @param AbstractFormatter    $formatter

--- a/src/Propel/Runtime/Formatter/AbstractFormatter.php
+++ b/src/Propel/Runtime/Formatter/AbstractFormatter.php
@@ -222,32 +222,6 @@ abstract class AbstractFormatter
     }
 
     /**
-     * Gets the worker object for the class.
-     * To save memory, we don't create a new object for each row,
-     * But we keep hydrating a single object per class.
-     * The column offset in the row is used to index the array of classes
-     * As there may be more than one object of the same class in the chain
-     *
-     * @param int    $col   Offset of the object in the list of objects to hydrate
-     * @param string $class Propel model object class
-     *
-     * @return ActiveRecordInterface
-     */
-    protected function getWorkerObject($col, $class)
-    {
-        if (isset($this->currentObjects[$col])) {
-            $this->currentObjects[$col]->clearAllReferences();
-            $this->currentObjects[$col]->clear();
-            
-            // TODO: also consider to return always a new $class(), it's a little fast that clear the previous and is must secure to clear all data/references!
-        } else {
-            $this->currentObjects[$col] = new $class();
-        }
-
-        return $this->currentObjects[$col];
-    }
-
-    /**
      * Gets a Propel object hydrated from a selection of columns in statement row
      *
      * @param array  $row   associative array indexed by column number,
@@ -259,7 +233,7 @@ abstract class AbstractFormatter
      */
     public function getSingleObjectFromRow($row, $class, &$col = 0)
     {
-        $obj = $this->getWorkerObject($col, $class);
+        $obj = new $class();
         $col = $obj->hydrate($row, $col, false, $this->getDataFetcher()->getIndexType());
 
         return $obj;


### PR DESCRIPTION
Thus we don't fill our local instance collection inside the OnDemandFormatter we don't get into filling memory issues over time.