### PR TITLE
`ModelCriteria::clear()` resets the `$select` value

### DIFF
--- a/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
@@ -779,7 +779,8 @@ class ModelCriteria extends BaseModelCriteria
 
         $this->with = array();
         $this->primaryCriteria = null;
-        $this->formatter=null;
+        $this->formatter = null;
+        $this->select = null;
 
         return $this;
     }


### PR DESCRIPTION
Please merge if it’s the desired behaviour. There is no other way of reseting the `select` field, since the `select()` method doesn’t allow `null`.