### PR TITLE
Fix PgsqlPlatform::getMaxColumnNameLength()

### DIFF
--- a/src/Propel/Generator/Platform/PgsqlPlatform.php
+++ b/src/Propel/Generator/Platform/PgsqlPlatform.php
@@ -86,7 +86,7 @@ class PgsqlPlatform extends DefaultPlatform
 
     public function getMaxColumnNameLength()
     {
-        return 32;
+        return 63;
     }
 
     public function getBooleanString($b)


### PR DESCRIPTION
According to http://www.postgresql.org/docs/current/interactive/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
> The system uses no more than NAMEDATALEN-1 bytes of an identifier; longer names can be written in commands, but they will be truncated. By default, NAMEDATALEN is 64 so the maximum identifier length is 63 bytes. If this limit is problematic, it can be raised by changing the NAMEDATALEN constant in src/include/pg_config_manual.h.