### PR TITLE
Fix #915  serialize custom properties in __sleep

### DIFF
--- a/src/Propel/Generator/Builder/Om/templates/baseObjectMethods.php
+++ b/src/Propel/Generator/Builder/Om/templates/baseObjectMethods.php
@@ -206,5 +206,10 @@
     {
         $this->clearAllReferences();
 
-        return array_keys(get_object_vars($this));
+        $cls = new \ReflectionClass($this);
+        $propertyNames = [];
+        foreach($cls->getProperties() as $property) {
+            $propertyNames[] = $property->getName();
+        }
+        return $propertyNames;
     }

--- a/tests/Propel/Tests/Issues/Issue915Book.php
+++ b/tests/Propel/Tests/Issues/Issue915Book.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Propel\Tests\Issues;
+
+
+class Issue915Book extends \Base\Issue915Book
+{
+    private $color;
+
+    public function setColor($color)
+    {
+        $this->color = $color;
+    }
+
+    public function getColor()
+    {
+        return $this->color;
+    }
+}

--- a/tests/Propel/Tests/Issues/Issue915Test.php
+++ b/tests/Propel/Tests/Issues/Issue915Test.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Propel\Tests\Issues;
+
+use Propel\Generator\Util\QuickBuilder;
+use Propel\Tests\Helpers\Bookstore\BookstoreTestBase;
+
+
+
+/**
+ * This test proves the bug described in https://github.com/propelorm/Propel2/issues/915.
+ * @group database
+ */
+class Issue915Test extends BookstoreTestBase
+{
+    public function setUp()
+    {
+        if (!class_exists('\Base\Issue915Book')) {
+            $schema = <<<EOF
+<database>
+    <table name="Issue915Book">
+        <column name="id" required="true" primaryKey="true" autoIncrement="true" type="INTEGER" description="Book Id" />
+        <column name="title" type="VARCHAR" required="true" description="Book Title" primaryString="true" />
+    </table>
+</database>
+EOF;
+            $builder = new QuickBuilder();
+            $builder->setSchema($schema);
+            $builder->buildClasses(null, true);
+        }
+    }
+
+    public function testSerialize()
+    {
+        $o = new Issue915Book();
+        $o->setColor('blue');
+
+        $unserializedBook = unserialize(serialize($o));
+        $this->assertEquals('blue', $unserializedBook->getColor());
+    }
+
+}


### PR DESCRIPTION
I did not find a good way to place the test fixture, so i included it in the testcases file.