### PR TITLE
Fix PostgreSQL's default port running the init command

### DIFF
--- a/src/Propel/Generator/Command/InitCommand.php
+++ b/src/Propel/Generator/Command/InitCommand.php
@@ -180,7 +180,7 @@ class InitCommand extends AbstractCommand
     private function initPgsql(OutputInterface $output, DialogHelper $dialog)
     {
         $host = $dialog->ask($output, 'Please enter your database host (without port)', 'localhost');
-        $port = $dialog->ask($output, 'Please enter your database port', '3306');
+        $port = $dialog->ask($output, 'Please enter your database port', '5432');
         $database = $dialog->ask($output, 'Please enter your database name');
 
         return sprintf('pgsql:host=%s;port=%s;dbname=%s', $host, $port, $database);


### PR DESCRIPTION
Hello,

This pull request fixes PostgreSQL's default port number to 5432 when running the `propel init` command. 3306 is actually MySQL's default port number.

http://www.postgresql.org/docs/9.4/static/runtime-config-connection.html

Have a nice day.