### PR TITLE
PDO Statement Wrapper not correctly return getExecutedQueryString with parameter

### DIFF
--- a/src/Propel/Runtime/Connection/StatementWrapper.php
+++ b/src/Propel/Runtime/Connection/StatementWrapper.php
@@ -193,7 +193,7 @@ class StatementWrapper implements StatementInterface, \IteratorAggregate
     {
         $return = $this->statement->execute($input_parameters);
         if ($this->connection->useDebug) {
-            $sql = $this->getExecutedQueryString();
+            $sql = $this->getExecutedQueryString($input_parameters);
             $this->connection->log($sql);
             $this->connection->setLastExecutedQuery($sql);
             $this->connection->incrementQueryCount();
@@ -205,7 +205,7 @@ class StatementWrapper implements StatementInterface, \IteratorAggregate
     /**
      * @return string
      */
-    public function getExecutedQueryString()
+    public function getExecutedQueryString($input_parameters = null)
     {
         $sql = $this->statement->queryString;
         $matches = array();
@@ -213,7 +213,10 @@ class StatementWrapper implements StatementInterface, \IteratorAggregate
             $size = count($matches[1]);
             for ($i = $size-1; $i >= 0; $i--) {
                 $pos = $matches[1][$i];
-                $sql = str_replace($pos, $this->boundValues[$pos], $sql);
+                if (isset($this->boundValues[$pos]))
+                    $sql = str_replace($pos, $this->boundValues[$pos], $sql);
+                if (isset($input_parameters[$pos]))
+                    $sql = str_replace($pos, $input_parameters[$pos], $sql);
             }
         }
 


### PR DESCRIPTION
Hi,

I find a bug in wrapper, if we execute PDO Statement with input_parameters into a debug context, the workaround for fetch getExecutedQueryString is based on boundValues (and in this case they don't set).

I propose following pull request for support this (with a silent fallback)

Best 