### PR TITLE
Fix referenceOnly bug

### DIFF
--- a/src/Propel/Generator/Manager/AbstractManager.php
+++ b/src/Propel/Generator/Manager/AbstractManager.php
@@ -374,7 +374,7 @@ abstract class AbstractManager
             // The external schema may have external schemas of its own ; recurs
             $this->includeExternalSchemas($externalSchemaDom, $srcDir);
             foreach ($externalSchemaDom->getElementsByTagName('table') as $tableNode) {
-                if ($referenceOnly) {
+                if ("true" === $referenceOnly) {
                     $tableNode->setAttribute("skipSql", "true");
                 }
                 $databaseNode->appendChild($dom->importNode($tableNode, true));


### PR DESCRIPTION
The propel XML schema definition allows to reference external models,
which then are included the generation of the php source code. The
resulting classes can then be used in the application.

The 'referenceOnly' parameter indicates if the model should be included
in sql schema generation or not.

The current implementation does not check the value of this parameter,
it checks only if it is set. Because of a default value, the current
check evaluates always to true. This causes the sql generation to be
skipped.