### PR TITLE
Fixed #950. Now magic {left|right|inner}Join{Relation}() methods and …

### DIFF
--- a/src/Propel/Generator/Builder/Om/QueryBuilder.php
+++ b/src/Propel/Generator/Builder/Om/QueryBuilder.php
@@ -1317,6 +1317,7 @@ abstract class ".$this->getUnqualifiedClassName()." extends " . $parentClass . "
     {
         \$tableMap = \$this->getTableMap();
         \$relationMap = \$tableMap->getRelation('" . $relationName . "');
+        \$relationAlias = \$relationAlias ?: '" . $relationName . "';
 
         // create a ModelJoin object for this join
         \$join = new ModelJoin();

--- a/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
@@ -449,12 +449,17 @@ class ModelCriteria extends BaseModelCriteria
      * @param string $relation Relation to use for the join
      * @param string $joinType Accepted values are null, 'left join', 'right join', 'inner join'
      *
+     * @throws PropelException Unknown table or alias
+     * @throws UnknownRelationException Unknown relation %s on the %s table
+     *
      * @return $this|ModelCriteria The current object, for fluid interface
      */
     public function join($relation, $joinType = Criteria::INNER_JOIN)
     {
         // relation looks like '$leftName.$relationName $relationAlias'
         list($fullName, $relationAlias) = self::getClassAndAlias($relation);
+        $relationAlias = $relationAlias ?: $fullName;
+
         if (false === strpos($fullName, '.')) {
             // simple relation name, refers to the current table
             $leftName = $this->getModelAliasOrName();


### PR DESCRIPTION
…joinWith() works correct on self-referenced relations.
