### PR TITLE
Alter comparison so that an int(-1) value for getLimit() evaluates correctly

### DIFF
--- a/src/Propel/Generator/Behavior/QueryCache/QueryCacheBehavior.php
+++ b/src/Propel/Generator/Behavior/QueryCache/QueryCacheBehavior.php
@@ -228,9 +228,11 @@ public function doCount(ConnectionInterface \$con = null)
 
         \$needsComplexCount = \$this->getGroupByColumns()
             || \$this->getOffset()
-            || \$this->getLimit()
+            || \$this->getLimit() >= 0
             || \$this->getHaving()
-            || in_array(Criteria::DISTINCT, \$this->getSelectModifiers());
+            || in_array(Criteria::DISTINCT, \$this->getSelectModifiers())
+            || count(\$this->selectQueries) > 0
+        ;
 
         \$params = array();
         if (\$needsComplexCount) {

--- a/tests/Propel/Tests/Generator/Behavior/QueryCache/QueryCacheTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/QueryCache/QueryCacheTest.php
@@ -62,4 +62,18 @@ class QueryCacheTest extends BookstoreTestBase
         $this->assertTrue(QuerycacheTable1Query::create()->cacheContains('test2'), ' cache contains "test2" key');
         $this->assertEquals($expectedSql, $q->cacheFetch('test2'));
     }
+
+    public function testSimpleCountSql()
+    {
+        $con = \Propel\Runtime\Propel::getConnection();
+        $con->useDebug(true);
+
+        $exec = QuerycacheTable1Query::create()
+            ->count($con);
+
+        $expectedSql = $this->getSql("SELECT COUNT(*) FROM querycache_table1");
+        $renderedSql = \Propel\Runtime\Propel::getConnection()->getLastExecutedQuery();
+
+        $this->assertEquals($expectedSql, $renderedSql);
+    }
 }


### PR DESCRIPTION
Simple fix for #960. This one-liner updates this comparison to be consistent with other comparisons for this method.