### PR TITLE
Fix #954 - Sortable behavior on enum scope

### DIFF
--- a/src/Propel/Generator/Behavior/Sortable/SortableBehaviorObjectBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/Sortable/SortableBehaviorObjectBuilderModifier.php
@@ -313,6 +313,11 @@ public function getScopeValue(\$returnNulls = true)
 
     return \$onlyNulls && \$returnNulls ? null : \$result;
 ";
+        } else if ($this->behavior->getColumnForParameter('scope_column')->isEnumType()){
+            $columnConstant = strtoupper(preg_replace('/[^a-zA-Z0-9_\x7f-\xff]/', '_', $this->getColumnAttribute('scope_column')));
+            $script .= "
+    return array_search(\$this->{$this->getColumnGetter('scope_column')}(), {$this->tableMapClassName}::getValueSet({$this->tableMapClassName}::COL_{$columnConstant}));
+            ";
         } else {
 
             $script .= "

--- a/tests/Fixtures/bookstore/behavior-sortable-schema.xml
+++ b/tests/Fixtures/bookstore/behavior-sortable-schema.xml
@@ -20,6 +20,17 @@
         </behavior>
     </table>
 
+    <table name="sortable_table13">
+        <column name="id" required="true" primaryKey="true" autoIncrement="true" type="INTEGER" />
+        <column name="title" type="VARCHAR" size="100" primaryString="true" />
+        <column name="style" type="ENUM" valueSet="novel, essay" />
+
+        <behavior name="sortable">
+            <parameter name="use_scope" value="true" />
+            <parameter name="scope_column" value="style" />
+        </behavior>
+    </table>
+
     <table name="sortable_multi_scopes">
         <column name="id" required="true" primaryKey="true" autoIncrement="true" type="INTEGER" />
         <column name="category_id" required="true" type="INTEGER" />

--- a/tests/Propel/Tests/Generator/Behavior/Sortable/SortableBehaviorWithEnumScopeTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Sortable/SortableBehaviorWithEnumScopeTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT License
+ */
+
+namespace Propel\Tests\Generator\Behavior\Sortable;
+
+use Propel\Tests\Bookstore\Behavior\SortableTable13Query;
+use Propel\Tests\Bookstore\Behavior\Map\SortableTable13TableMap;
+use Propel\Tests\Bookstore\Behavior\SortableTable13 as Table13;
+
+/**
+ * Tests for SortableBehavior class
+ *
+ * @author Arnaud Lejosne
+ *
+ * @group database
+ */
+class SortableBehaviorWithEnumScopeTest extends TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->populateTable13();
+    }
+
+    public function testEnumRank()
+    {
+        $entries = SortableTable13Query::create()->find();
+        $this->assertEquals($entries[0]->getRank(), 1);
+        $this->assertEquals($entries[1]->getRank(), 2);
+        $this->assertEquals($entries[2]->getRank(), 1);
+        $this->assertEquals($entries[3]->getRank(), 2);
+    }
+}

--- a/tests/Propel/Tests/Generator/Behavior/Sortable/TestCase.php
+++ b/tests/Propel/Tests/Generator/Behavior/Sortable/TestCase.php
@@ -16,6 +16,9 @@ use Propel\Tests\Bookstore\Behavior\SortableTable11;
 use Propel\Tests\Bookstore\Behavior\SortableTable11Query;
 use Propel\Tests\Bookstore\Behavior\SortableTable12;
 use Propel\Tests\Bookstore\Behavior\SortableTable12Query;
+use Propel\Tests\Bookstore\Behavior\SortableTable13;
+use Propel\Tests\Bookstore\Behavior\SortableTable13Query;
+use Propel\Tests\Bookstore\Behavior\Map\SortableTable13TableMap;
 use Propel\Tests\Bookstore\Behavior\Map\SortableTable12TableMap;
 use Propel\Tests\Bookstore\Behavior\Map\SortableTable11TableMap;
 use Propel\Tests\TestCaseFixturesDatabase;
@@ -115,6 +118,31 @@ class TestCase extends TestCaseFixturesDatabase
         $t10->setRank(4);
         $t10->setTitle('row10');
         $t10->save();
+    }
+
+    protected function populateTable13()
+    {
+        SortableTable13TableMap::doDeleteAll();
+
+        $t1 = new SortableTable13();
+        $t1->setTitle('row1');
+        $t1->setStyle(SortableTable13TableMap::COL_STYLE_NOVEL);
+        $t1->save();
+
+        $t2 = new SortableTable13();
+        $t2->setTitle('row2');
+        $t2->setStyle(SortableTable13TableMap::COL_STYLE_NOVEL);
+        $t2->save();
+
+        $t3 = new SortableTable13();
+        $t3->setTitle('row3');
+        $t3->setStyle(SortableTable13TableMap::COL_STYLE_ESSAY);
+        $t3->save();
+
+        $t4 = new SortableTable13();
+        $t4->setTitle('row4');
+        $t4->setStyle(SortableTable13TableMap::COL_STYLE_ESSAY);
+        $t4->save();
     }
 
     protected function getFixturesArray()


### PR DESCRIPTION
Here is a fix for the enum scope issue on Sortable behavior
It might not be perfect but at least it illustrates the issue and provides a test for it.

Here are the things that, to me, are arguable in this PR:
- I had to copy the regexp for the enum constants from the table map generator in the sortable generator
- I created the objects in the fixtures (you might prefer having them directly in the test case)