### PR TITLE
Allow ObjectCollections->toArray() to serialise without foreign objects.

### DIFF
--- a/src/Propel/Runtime/Collection/ObjectCollection.php
+++ b/src/Propel/Runtime/Collection/ObjectCollection.php
@@ -139,6 +139,7 @@ class ObjectCollection extends Collection
      *                                        TableMap::TYPE_NUM. Defaults to TableMap::TYPE_PHPNAME.
      * @param boolean $includeLazyLoadColumns (optional) Whether to include lazy loaded columns. Defaults to TRUE.
      * @param array   $alreadyDumpedObjects   List of objects to skip to avoid recursion
+     * @param boolean $includeForeignObjects  (optional) Whether to include hydrated related objects. Default to FALSE.
      *
      * <code>
      * $bookCollection->toArray();

--- a/src/Propel/Runtime/Collection/ObjectCollection.php
+++ b/src/Propel/Runtime/Collection/ObjectCollection.php
@@ -160,7 +160,7 @@ class ObjectCollection extends Collection
      *
      * @return array
      */
-    public function toArray($keyColumn = null, $usePrefix = false, $keyType = TableMap::TYPE_PHPNAME, $includeLazyLoadColumns = true, $alreadyDumpedObjects = array())
+    public function toArray($keyColumn = null, $usePrefix = false, $keyType = TableMap::TYPE_PHPNAME, $includeLazyLoadColumns = true, $alreadyDumpedObjects = array(), $includeForeignObjects = false)
     {
         $ret = array();
         $keyGetterMethod = 'get' . $keyColumn;
@@ -169,7 +169,7 @@ class ObjectCollection extends Collection
         foreach ($this->data as $key => $obj) {
             $key = null === $keyColumn ? $key : $obj->$keyGetterMethod();
             $key = $usePrefix ? ($this->getModel() . '_' . $key) : $key;
-            $ret[$key] = $obj->toArray($keyType, $includeLazyLoadColumns, $alreadyDumpedObjects, true);
+            $ret[$key] = $obj->toArray($keyType, $includeLazyLoadColumns, $alreadyDumpedObjects, $includeForeignObjects);
         }
 
         return $ret;


### PR DESCRIPTION
The default for `ObjectCollections->toArray()` was also to **always** serialise foreign objects. But the default for `Model->toArray()` was to **not** serialise foreign objects. I've put the `ObjectCollections->toArray()` to not serialise foreign objects by default to keep the API consistent.
