### PR TITLE
Use generated slug instead of stored value when querying existence

### DIFF
--- a/src/Propel/Generator/Behavior/Sluggable/SluggableBehavior.php
+++ b/src/Propel/Generator/Behavior/Sluggable/SluggableBehavior.php
@@ -285,18 +285,19 @@ protected function makeSlugUnique(\$slug, \$separator = '" . $this->getParameter
     if (!\$alreadyExists) {
         \$slug2 = \$slug;
     } else {
-        \$slug2 = \$slug . \$separator;";
+        \$slug2 = \$slug . \$separator;
+        \$filterSlug = (\$this->$getter()) ? \$this->$getter() : \$slug;";
 
         if (null == $this->getParameter('slug_pattern')) {
             $script .= "
 
         \$count = " . $this->builder->getStubQueryBuilder()->getClassname() . "::create()
-            ->filterBySlug(\$this->$getter())
+            ->filterBySlug(\$filterSlug)
             ->filterByPrimaryKey(\$this->getPrimaryKey())
         ->count();
 
         if (1 == \$count) {
-            return \$this->$getter();
+            return \$filterSlug;
         }";
         }
 


### PR DESCRIPTION
I can't think of any reason why $getter() should be preferred over $slug in this function. 

$getter() causes problems as described in #982.

Any thoughts or feedback would be appreciated :)
