### PR TITLE
Added option --composer-dir to the sql:build command

### DIFF
--- a/src/Propel/Generator/Command/SqlBuildCommand.php
+++ b/src/Propel/Generator/Command/SqlBuildCommand.php
@@ -37,6 +37,7 @@ class SqlBuildCommand extends AbstractCommand
             ->addOption('schema-name',  null, InputOption::VALUE_REQUIRED,  'The schema name for RDBMS supporting them', '')
             //->addOption('encoding',     null, InputOption::VALUE_REQUIRED,  'The encoding to use for the database')
             ->addOption('table-prefix', null, InputOption::VALUE_REQUIRED,  'Add a prefix to all the table names in the database')
+            ->addOption('composer-dir', null, InputOption::VALUE_REQUIRED, 'Directory in which your composer.json resides', null)
             ->setName('sql:build')
             ->setAliases(array('build-sql'))
             ->setDescription('Build SQL files')
@@ -67,6 +68,9 @@ class SqlBuildCommand extends AbstractCommand
                         break;
                     case 'mysql-engine';
                         $configOptions['propel']['database']['adapters']['mysql']['tableType'] = $option;
+                        break;
+                    case 'composer-dir':
+                        $configOptions['propel']['paths']['composerDir'] = $option;
                         break;
                 }
             }


### PR DESCRIPTION
Hi There

I ran into a situation where I have a behaviour thats part of of my main project, and when I ran the sql:build command, it complained about not being able to find my behaviour because it was using a different composer directory, and therefore wanted me to provide the composer-dir option (I have a fairly complex project structure, with modules and plugins). Upon adding the composer-dir option, Propel told me that it wasn't an option for the command sql:build. So upon inspecting the command, lone behold it doesn't exist. After adding it and running the sql:build command again with --composer-dir, everything worked as expected.

Im aware you are in the process of making a massive change with the internals of propel, but I'm offering this small fix anyway (in case someone ran into a similar issue :) ).

Cheers