### PR TITLE
Fix no drop table and constraint when migrate:diff (PostgreSQL)

### DIFF
--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -469,7 +469,8 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
 
         $script .= "
     /**
-     * The value for the $clo field.";
+     * The value for the $clo field.
+     * ".$column->getDescription();
         if ($column->getDefaultValue()) {
             if ($column->getDefaultValue()->isExpression()) {
                 $script .= "


### PR DESCRIPTION
Removed tables was not retrieved from the current database state.
Therefore the two variables ```$fromDatabaseTables``` and ```$toDatabaseTables``` had the same tables at the moment of the comparison in the DatabaseComparator... 