### PR TITLE
Use absolute path to include propel.php

### DIFF
--- a/bin/propel
+++ b/bin/propel
@@ -1,4 +1,4 @@
 #!/usr/bin/env php
 <?php
 
-include('propel.php');
+require(__DIR__ . '/propel.php');


### PR DESCRIPTION
`include('propel.php')` can include the propel configuration file, so an absolute path should be used.