### PR TITLE
Fix several errors when using mssql plattform

### DIFF
--- a/src/Propel/Generator/Model/PropelTypes.php
+++ b/src/Propel/Generator/Model/PropelTypes.php
@@ -49,6 +49,7 @@ class PropelTypes
     const OBJECT        = 'OBJECT';
     const PHP_ARRAY     = 'ARRAY';
     const ENUM          = 'ENUM';
+    const GEOMETRY      = 'GEOMETRY';
 
     const CHAR_NATIVE_TYPE          = 'string';
     const VARCHAR_NATIVE_TYPE       = 'string';
@@ -78,6 +79,7 @@ class PropelTypes
     const OBJECT_NATIVE_TYPE        = '';
     const PHP_ARRAY_NATIVE_TYPE     = 'array';
     const ENUM_NATIVE_TYPE          = 'int';
+    const GEOMETRY_NATIVE_TYPE      = 'resource';
 
     /**
      * Propel mapping types.
@@ -110,6 +112,7 @@ class PropelTypes
         self::OBJECT,
         self::PHP_ARRAY,
         self::ENUM,
+        self::GEOMETRY,
         // These are pre-epoch dates, which we need to map to String type
         // since they cannot be properly handled using strtotime() -- or
         // even numeric timestamps on Windows.
@@ -151,6 +154,7 @@ class PropelTypes
         self::OBJECT        => self::OBJECT_NATIVE_TYPE,
         self::PHP_ARRAY     => self::PHP_ARRAY_NATIVE_TYPE,
         self::ENUM          => self::ENUM_NATIVE_TYPE,
+        self::GEOMETRY      => self::GEOMETRY,
     ];
 
     /**
@@ -188,6 +192,7 @@ class PropelTypes
         self::OBJECT        => \PDO::PARAM_LOB,
         self::PHP_ARRAY     => \PDO::PARAM_STR,
         self::ENUM          => \PDO::PARAM_INT,
+        self::GEOMETRY      => \PDO::PARAM_LOB,
 
         // These are pre-epoch dates, which we need to map to String type
         // since they cannot be properly handled using strtotime() -- or even
@@ -324,7 +329,7 @@ class PropelTypes
      */
     public static function isLobType($mappingType)
     {
-        return in_array($mappingType, [ self::VARBINARY, self::LONGVARBINARY, self::BLOB, self::OBJECT ]);
+        return in_array($mappingType, [ self::VARBINARY, self::LONGVARBINARY, self::BLOB, self::OBJECT, self::GEOMETRY ]);
     }
 
     /**

--- a/src/Propel/Generator/Platform/MssqlPlatform.php
+++ b/src/Propel/Generator/Platform/MssqlPlatform.php
@@ -10,6 +10,7 @@
 
 namespace Propel\Generator\Platform;
 
+use Propel\Generator\Model\Database;
 use Propel\Generator\Model\Domain;
 use Propel\Generator\Model\ForeignKey;
 use Propel\Generator\Model\PropelTypes;
@@ -20,6 +21,7 @@ use Propel\Generator\Model\Table;
  *
  * @author Hans Lellelid <hans@xmpl.org> (Propel)
  * @author Martin Poeschl <mpoeschl@marmot.at> (Torque)
+ * @author Dominic Winkler <d.winkler@flexarts.at> (Flexarts)
  */
 class MssqlPlatform extends DefaultPlatform
 {
@@ -69,6 +71,34 @@ class MssqlPlatform extends DefaultPlatform
     public function supportsInsertNullPk()
     {
         return false;
+    }
+
+    /**
+     * Returns the DDL SQL to add the tables of a database
+     * together with index and foreign keys. 
+     * Since MSSQL always checks it the tables in foreign key definitions exist, 
+     * the foreign key DDLs are moved after all tables are created
+     *
+     * @return string
+     */
+    public function getAddTablesDDL(Database $database)
+    {
+        $ret = $this->getBeginDDL();
+        foreach ($database->getTablesForSql() as $table) {
+            $this->normalizeTable($table);
+        }
+        foreach ($database->getTablesForSql() as $table) {
+            $ret .= $this->getCommentBlockDDL($table->getName());
+            $ret .= $this->getDropTableDDL($table);
+            $ret .= $this->getAddTableDDL($table);
+            $ret .= $this->getAddIndicesDDL($table);
+        }
+        foreach ($database->getTablesForSql() as $table) {
+            $ret .= $this->getAddForeignKeysDDL($table);
+        }
+        $ret .= $this->getEndDDL();
+
+        return $ret;
     }
 
     public function getDropTableDDL(Table $table)
@@ -175,7 +205,8 @@ END
 
     public function hasSize($sqlType)
     {
-        return !('INT' === $sqlType || 'TEXT' === $sqlType);
+        $nosize = array('INT', 'TEXT', 'GEOMETRY', 'VARCHAR(MAX)', 'VARBINARY(MAX)', 'SMALLINT', 'DATETIME', 'TINYINT', 'REAL', 'BIGINT');
+        return !(in_array($sqlType, $nosize));
     }
 
     /**

--- a/src/Propel/Generator/Platform/MssqlPlatform.php
+++ b/src/Propel/Generator/Platform/MssqlPlatform.php
@@ -15,6 +15,7 @@ use Propel\Generator\Model\Domain;
 use Propel\Generator\Model\ForeignKey;
 use Propel\Generator\Model\PropelTypes;
 use Propel\Generator\Model\Table;
+use Propel\Generator\Model\Unique;
 
 /**
  * MS SQL PlatformInterface implementation.
@@ -170,6 +171,21 @@ END
         return sprintf($pattern,
             $this->quoteIdentifier($fk->getTable()->getName()),
             $this->getForeignKeyDDL($fk)
+        );
+    }
+
+    /**
+     * Builds the DDL SQL for a Unique constraint object. MS SQL Server CONTRAINT specific
+     *
+     * @param  Unique $unique
+     * @return string
+     */
+    public function getUniqueDDL(Unique $unique)
+    {
+        $pattern = 'CONSTRAINT %s UNIQUE NONCLUSTERED (%s) ON [PRIMARY]';
+        return sprintf($pattern,
+            $this->quoteIdentifier($unique->getName()),
+            $this->getColumnListDDL($unique->getColumnObjects())
         );
     }
 

--- a/src/Propel/Generator/Reverse/MssqlSchemaParser.php
+++ b/src/Propel/Generator/Reverse/MssqlSchemaParser.php
@@ -15,7 +15,7 @@ use Propel\Generator\Model\Column;
 use Propel\Generator\Model\ColumnDefaultValue;
 use Propel\Generator\Model\ForeignKey;
 use Propel\Generator\Model\Index;
-
+use Propel\Generator\Model\Unique;
 use Propel\Generator\Model\Table;
 use Propel\Generator\Model\Database;
 use Propel\Generator\Model\PropelTypes;
@@ -218,19 +218,29 @@ class MssqlSchemaParser extends AbstractSchemaParser
 
             $localColumn   = $table->getColumn($colName);
 
-            // FIXME -- Add UNIQUE support
-            if ($isPk || $isUnique) {
+            // ignore PRIMARY index
+            if ($isPk) {
                 continue;
             }
-            
+
             if (!isset($indexes[$name])) {
-                $indexes[$name] = new Index($name);
+                if ($isUnique) {
+                    $indexes[$name] = new Unique($name);
+                } else {
+                    $indexes[$name] = new Index($name);
+                }
+                $indexes[$name]->setTable($table);
             }
+
             $indexes[$name]->addColumn($localColumn);
         }
 
-        foreach ($indexes as $name => $index) {
-            $table->addIndex($index);
+        foreach ($indexes as $index) {
+            if ($index instanceof Unique) {
+                $table->addUnique($index);
+            } else {
+                $table->addIndex($index);
+            }
         }
     }
 

--- a/src/Propel/Runtime/DataFetcher/PDODataFetcher.php
+++ b/src/Propel/Runtime/DataFetcher/PDODataFetcher.php
@@ -30,10 +30,37 @@ class PDODataFetcher extends AbstractDataFetcher
     private $cachedCount;
 
     /**
+     * fetch style (default FETCH_NUM)
+     * @var integer
+     */
+    private $style = \PDO::FETCH_NUM;
+
+    /**
+     * Sets a new fetch style (FETCH_NUM, FETCH_ASSOC or FETCH_BOTH). Returns previous fetch style.
+     * @var integer
+     */
+    public function setStyle($style) {
+        $old_style = $this->style;
+        $this->style = $style;
+        return $old_style;
+    }
+
+    /**
+     * Returns current fetch style (FETCH_NUM, FETCH_ASSOC or FETCH_BOTH).
+     * @var integer
+     */
+    public function getStyle() {
+        return $this->style;
+    }
+
+    /**
      * {@inheritDoc}
      */
-    public function fetch($style = \PDO::FETCH_NUM)
+    public function fetch($style = null)
     {
+        if (is_null($style)) {
+            $style = $this->style;
+        }
         return $this->getDataObject()->fetch($style);
     }
 
@@ -43,7 +70,7 @@ class PDODataFetcher extends AbstractDataFetcher
     public function next()
     {
         if (null !== $this->dataObject) {
-            $this->current = $this->dataObject->fetch(\PDO::FETCH_NUM);
+            $this->current = $this->dataObject->fetch($this->style);
             if ($this->current) {
                 $this->index++;
             }
@@ -81,7 +108,7 @@ class PDODataFetcher extends AbstractDataFetcher
      */
     public function rewind()
     {
-        $this->current = $this->dataObject->fetch(\PDO::FETCH_NUM);
+        $this->current = $this->dataObject->fetch($this->style);
     }
 
     /**

--- a/tests/Propel/Tests/Generator/Platform/MssqlPlatformTest.php
+++ b/tests/Propel/Tests/Generator/Platform/MssqlPlatformTest.php
@@ -347,7 +347,7 @@ CREATE TABLE [foo]
     [id] INT NOT NULL IDENTITY,
     [bar] INT NULL,
     CONSTRAINT [foo_pk] PRIMARY KEY ([id]),
-    UNIQUE ([bar])
+    CONSTRAINT [foo_u_14f552] UNIQUE NONCLUSTERED ([bar]) ON [PRIMARY]
 );
 ";
         $this->assertEquals($expected, $this->getPlatform()->getAddTableDDL($table));
@@ -544,7 +544,7 @@ DROP INDEX [babar];
      */
     public function testGetUniqueDDL($index)
     {
-        $expected = 'UNIQUE ([bar1],[bar2])';
+        $expected = 'CONSTRAINT [babar] UNIQUE NONCLUSTERED ([bar1],[bar2]) ON [PRIMARY]';
         $this->assertEquals($expected, $this->getPlatform()->getUniqueDDL($index));
     }
 

--- a/tests/Propel/Tests/Generator/Platform/MssqlPlatformTest.php
+++ b/tests/Propel/Tests/Generator/Platform/MssqlPlatformTest.php
@@ -102,11 +102,6 @@ CREATE TABLE [book]
 
 CREATE INDEX [book_i_639136] ON [book] ([title]);
 
-BEGIN
-ALTER TABLE [book] ADD CONSTRAINT [book_fk_ea464c] FOREIGN KEY ([author_id]) REFERENCES [author] ([id])
-END
-;
-
 -----------------------------------------------------------------------
 -- author
 -----------------------------------------------------------------------
@@ -143,6 +138,11 @@ CREATE TABLE [author]
     [last_name] VARCHAR(100) NULL,
     CONSTRAINT [author_pk] PRIMARY KEY ([id])
 );
+
+BEGIN
+ALTER TABLE [book] ADD CONSTRAINT [book_fk_ea464c] FOREIGN KEY ([author_id]) REFERENCES [author] ([id])
+END
+;
 
 EOF;
         $this->assertEquals($expected, $this->getPlatform()->getAddTablesDDL($database));
@@ -197,11 +197,6 @@ CREATE TABLE [x].[book]
 );
 
 CREATE INDEX [book_i_639136] ON [x].[book] ([title]);
-
-BEGIN
-ALTER TABLE [x].[book] ADD CONSTRAINT [book_fk_4444ca] FOREIGN KEY ([author_id]) REFERENCES [y].[author] ([id])
-END
-;
 
 -----------------------------------------------------------------------
 -- y.author
@@ -279,6 +274,11 @@ CREATE TABLE [x].[book_summary]
     [summary] VARCHAR(MAX) NOT NULL,
     CONSTRAINT [book_summary_pk] PRIMARY KEY ([id])
 );
+
+BEGIN
+ALTER TABLE [x].[book] ADD CONSTRAINT [book_fk_4444ca] FOREIGN KEY ([author_id]) REFERENCES [y].[author] ([id])
+END
+;
 
 BEGIN
 ALTER TABLE [x].[book_summary] ADD CONSTRAINT [book_summary_fk_23450f] FOREIGN KEY ([book_id]) REFERENCES [x].[book] ([id]) ON DELETE CASCADE


### PR DESCRIPTION
This fix concerns reverse engineering, building sql files and creating sql migrations scripts.
It was needed to add support for `FETCH_ASSOC` in `PDODataFetcher` (see #863).
Also schema support for `GEOMETRY`column type was added.

Please be kind, this is my first contribution on GitHub ever :)