### PR TITLE
Proposal for implement a ParentClass for query objects at database or table level

### DIFF
--- a/resources/dtd/database.dtd
+++ b/resources/dtd/database.dtd
@@ -29,6 +29,7 @@ PHP class or method name.
   schema CDATA #IMPLIED
   namespace CDATA #IMPLIED
   baseClass CDATA #IMPLIED
+  baseQueryClass CDATA #IMPLIED
   defaultPhpNamingMethod (nochange|underscore|phpname) "underscore"
   heavyIndexing (true|false) "false"
   identifierQuoting (true|false) "false"
@@ -61,6 +62,7 @@ PHP class or method name.
   schema CDATA #IMPLIED
   namespace CDATA #IMPLIED
   baseClass CDATA #IMPLIED
+  baseQueryClass CDATA #IMPLIED
   alias CDATA #IMPLIED
   interface CDATA #IMPLIED
   phpNamingMethod (nochange|underscore|phpname) #IMPLIED

--- a/resources/xsd/database.xsd
+++ b/resources/xsd/database.xsd
@@ -699,6 +699,13 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="baseQueryClass" type="php_class" use="optional">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    Allows you to specify a class that the generated Propel Query Objects should extend (in place of ModelCriteria) this class should extend ModelCriteria
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="alias" type="table_name" use="optional"/>
         <xs:attribute name="package" type="xs:string" use="optional">
             <xs:annotation>
@@ -843,6 +850,13 @@
             <xs:annotation>
                 <xs:documentation xml:lang="en">
                     Allows to specify a default base class that all generated Propel objects should extend (in place of propel.om.BaseObject)
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="baseQueryClass" type="php_class" use="optional">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    Allows you to specify a class that the generated Propel Query objects should extend (in place of ModelCriteria) this class should extend ModelCriteria
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/src/Propel/Generator/Builder/Om/QueryBuilder.php
+++ b/src/Propel/Generator/Builder/Om/QueryBuilder.php
@@ -66,7 +66,7 @@ class QueryBuilder extends AbstractOMBuilder
     public function getParentClass()
     {
         $parentClass = $this->getBehaviorContent('parentClass');
-        return null === $parentClass ? ($this->getTable()->getParentClass() != "" ? $this->getTable()->getParentClass() : 'ModelCriteria') : $parentClass;
+        return null === $parentClass ? ($this->getTable()->getBaseQueryClass() != "" ? $this->getTable()->getBaseQueryClass() : 'ModelCriteria') : $parentClass;
     }
 
     /**

--- a/src/Propel/Generator/Builder/Om/QueryBuilder.php
+++ b/src/Propel/Generator/Builder/Om/QueryBuilder.php
@@ -59,11 +59,14 @@ class QueryBuilder extends AbstractOMBuilder
         return $this->getStubQueryBuilder()->getUnprefixedClassName();
     }
 
+    /**
+     * Returns parent class name that extends TableQuery Object if is set this class must extends ModelCriteria for be compatible
+     * @return string
+     */
     public function getParentClass()
     {
         $parentClass = $this->getBehaviorContent('parentClass');
-
-        return null === $parentClass ? 'ModelCriteria' : $parentClass;
+        return null === $parentClass ? ($this->getDatabase()->getParentClass() != "" ? $this->getDatabase()->getParentClass() : 'ModelCriteria') : $parentClass;
     }
 
     /**

--- a/src/Propel/Generator/Builder/Om/QueryBuilder.php
+++ b/src/Propel/Generator/Builder/Om/QueryBuilder.php
@@ -66,7 +66,7 @@ class QueryBuilder extends AbstractOMBuilder
     public function getParentClass()
     {
         $parentClass = $this->getBehaviorContent('parentClass');
-        return null === $parentClass ? ($this->getDatabase()->getParentClass() != "" ? $this->getDatabase()->getParentClass() : 'ModelCriteria') : $parentClass;
+        return null === $parentClass ? ($this->getTable()->getParentClass() != "" ? $this->getTable()->getParentClass() : 'ModelCriteria') : $parentClass;
     }
 
     /**

--- a/src/Propel/Generator/Model/Database.php
+++ b/src/Propel/Generator/Model/Database.php
@@ -49,7 +49,7 @@ class Database extends ScopedMappingModel
     private $name;
 
     private $baseClass;
-    private $parentClass;
+    private $baseQueryClass;
     private $defaultIdMethod;
     private $defaultPhpNamingMethod;
 
@@ -143,7 +143,7 @@ class Database extends ScopedMappingModel
 
         $this->name = $this->getAttribute('name');
         $this->baseClass = $this->getAttribute('baseClass');
-        $this->parentClass = $this->getAttribute('parentClass');
+        $this->baseQueryClass = $this->getAttribute('baseQueryClass');
         $this->defaultIdMethod = $this->getAttribute('defaultIdMethod', IdMethod::NATIVE);
         $this->defaultPhpNamingMethod = $this->getAttribute('defaultPhpNamingMethod', NameGeneratorInterface::CONV_METHOD_UNDERSCORE);
         $this->heavyIndexing = $this->booleanValue($this->getAttribute('heavyIndexing'));
@@ -219,9 +219,9 @@ class Database extends ScopedMappingModel
      *
      * @return string
      */
-    public function getParentClass()
+    public function getBaseQueryClass()
     {
-        return $this->parentClass;
+        return $this->baseQueryClass;
     }
 
     /**
@@ -241,9 +241,9 @@ class Database extends ScopedMappingModel
      *
      * @param string $class.
      */
-    public function setParentClass($class)
+    public function setBaseQueryClass($class)
     {
-        $this->parentClass = $class;
+        $this->baseQueryClass = $class;
     }
 
     /**

--- a/src/Propel/Generator/Model/Database.php
+++ b/src/Propel/Generator/Model/Database.php
@@ -49,6 +49,7 @@ class Database extends ScopedMappingModel
     private $name;
 
     private $baseClass;
+    private $parentClass;
     private $defaultIdMethod;
     private $defaultPhpNamingMethod;
 
@@ -142,6 +143,7 @@ class Database extends ScopedMappingModel
 
         $this->name = $this->getAttribute('name');
         $this->baseClass = $this->getAttribute('baseClass');
+        $this->parentClass = $this->getAttribute('parentClass');
         $this->defaultIdMethod = $this->getAttribute('defaultIdMethod', IdMethod::NATIVE);
         $this->defaultPhpNamingMethod = $this->getAttribute('defaultPhpNamingMethod', NameGeneratorInterface::CONV_METHOD_UNDERSCORE);
         $this->heavyIndexing = $this->booleanValue($this->getAttribute('heavyIndexing'));
@@ -212,6 +214,17 @@ class Database extends ScopedMappingModel
     }
 
     /**
+     * Returns the name of the base super class inherited by query
+     * objects. This parameter is overridden at the table level.
+     *
+     * @return string
+     */
+    public function getParentClass()
+    {
+        return $this->parentClass;
+    }
+
+    /**
      * Sets the name of the base super class inherited by active record objects.
      * This parameter is overridden at the table level.
      *
@@ -220,6 +233,17 @@ class Database extends ScopedMappingModel
     public function setBaseClass($class)
     {
         $this->baseClass = $class;
+    }
+
+    /**
+     * Sets the name of the base super class inherited by query objects.
+     * This parameter is overridden at the table level.
+     *
+     * @param string $class.
+     */
+    public function setParentClass($class)
+    {
+        $this->parentClass = $class;
     }
 
     /**

--- a/src/Propel/Generator/Model/Table.php
+++ b/src/Propel/Generator/Model/Table.php
@@ -84,7 +84,7 @@ class Table extends ScopedMappingModel implements IdMethod
     private $alias;
     private $interface;
     private $baseClass;
-    private $parentClass;
+    private $baseQueryClass;
     private $columnsByName;
     private $columnsByLowercaseName;
     private $columnsByPhpName;
@@ -201,7 +201,7 @@ class Table extends ScopedMappingModel implements IdMethod
 
         $this->isAbstract = $this->booleanValue($this->getAttribute('abstract'));
         $this->baseClass = $this->getAttribute('baseClass');
-        $this->parentClass = $this->getAttribute('parentClass');
+        $this->baseQueryClass = $this->getAttribute('baseQueryClass');
         $this->alias = $this->getAttribute('alias');
 
         $this->heavyIndexing = (
@@ -479,22 +479,18 @@ class Table extends ScopedMappingModel implements IdMethod
     }
 
     /**
-     * Returns the name of the parent class used for superclass of all query objects
+     * Returns the name of the base query class used for superclass of all query objects
      * of this table.
      *
      * @return string
      */
-    public function getParentClass()
+    public function getBaseQueryClass()
     {
-        if ($this->isAlias() && null === $this->parentClass) {
-            return $this->alias;
+        if (null === $this->baseQueryClass) {
+            return $this->database->getBaseQueryClass();
         }
 
-        if (null === $this->parentClass) {
-            return $this->database->getParentClass();
-        }
-
-        return $this->parentClass;
+        return $this->baseQueryClass;
     }
 
     /**
@@ -508,13 +504,13 @@ class Table extends ScopedMappingModel implements IdMethod
     }
 
     /**
-     * Sets the parent class name.
+     * Sets the base query class name.
      *
      * @param string $class
      */
-    public function setParentClass($class)
+    public function setBaseQueryClass($class)
     {
-        $this->parentClass = $class;
+        $this->baseQueryClass = $class;
     }
 
     /**

--- a/src/Propel/Generator/Model/Table.php
+++ b/src/Propel/Generator/Model/Table.php
@@ -84,6 +84,7 @@ class Table extends ScopedMappingModel implements IdMethod
     private $alias;
     private $interface;
     private $baseClass;
+    private $parentClass;
     private $columnsByName;
     private $columnsByLowercaseName;
     private $columnsByPhpName;
@@ -200,6 +201,7 @@ class Table extends ScopedMappingModel implements IdMethod
 
         $this->isAbstract = $this->booleanValue($this->getAttribute('abstract'));
         $this->baseClass = $this->getAttribute('baseClass');
+        $this->parentClass = $this->getAttribute('parentClass');
         $this->alias = $this->getAttribute('alias');
 
         $this->heavyIndexing = (
@@ -477,6 +479,25 @@ class Table extends ScopedMappingModel implements IdMethod
     }
 
     /**
+     * Returns the name of the parent class used for superclass of all query objects
+     * of this table.
+     *
+     * @return string
+     */
+    public function getParentClass()
+    {
+        if ($this->isAlias() && null === $this->parentClass) {
+            return $this->alias;
+        }
+
+        if (null === $this->parentClass) {
+            return $this->database->getParentClass();
+        }
+
+        return $this->parentClass;
+    }
+
+    /**
      * Sets the base class name.
      *
      * @param string $class
@@ -484,6 +505,16 @@ class Table extends ScopedMappingModel implements IdMethod
     public function setBaseClass($class)
     {
         $this->baseClass = $class;
+    }
+
+    /**
+     * Sets the parent class name.
+     *
+     * @param string $class
+     */
+    public function setParentClass($class)
+    {
+        $this->parentClass = $class;
     }
 
     /**

--- a/src/Propel/Generator/Schema/Dumper/XmlDumper.php
+++ b/src/Propel/Generator/Schema/Dumper/XmlDumper.php
@@ -112,6 +112,10 @@ class XmlDumper implements DumperInterface
             $databaseNode->setAttribute('baseClass', $baseClass);
         }
 
+        if ($baseQueryClass = $database->getBaseQueryClass()) {
+            $databaseNode->setAttribute('baseQueryClass', $baseQueryClass);
+        }
+
         if ($defaultNamingMethod = $database->getDefaultPhpNamingMethod()) {
             $databaseNode->setAttribute('defaultPhpNamingMethod', $defaultNamingMethod);
         }
@@ -233,6 +237,10 @@ class XmlDumper implements DumperInterface
 
         if ($baseClass = $table->getBaseClass()) {
             $tableNode->setAttribute('baseClass', $baseClass);
+        }
+
+        if ($baseQueryClass = $table->getBaseQueryClass()) {
+            $tableNode->setAttribute('baseQueryClass', $baseQueryClass);
         }
 
         if ($table->isReadOnly()) {

--- a/tests/Propel/Tests/Generator/Model/DatabaseTest.php
+++ b/tests/Propel/Tests/Generator/Model/DatabaseTest.php
@@ -49,6 +49,7 @@ class DatabaseTest extends ModelTestCase
         $database->loadMapping(array(
             'name'                   => 'bookstore',
             'baseClass'              => 'CustomBaseObject',
+            'baseQueryClass'         => 'CustomBaseQueryObject',
             'defaultIdMethod'        => 'native',
             'defaultPhpNamingMethod' => 'underscore',
             'heavyIndexing'          => 'true',
@@ -58,6 +59,7 @@ class DatabaseTest extends ModelTestCase
 
         $this->assertSame('bookstore', $database->getName());
         $this->assertSame('CustomBaseObject', $database->getBaseClass());
+        $this->assertSame('CustomBaseQueryObject', $database->getBaseQueryClass());
         $this->assertSame('XML', $database->getDefaultStringFormat());
         $this->assertSame('native', $database->getDefaultIdMethod());
         $this->assertSame('underscore', $database->getDefaultPhpNamingMethod());
@@ -397,6 +399,14 @@ class DatabaseTest extends ModelTestCase
         $database->setBaseClass('CustomBaseObject');
 
         $this->assertSame('CustomBaseObject', $database->getBaseClass());
+    }
+
+    public function testSetBaseQueryClasses()
+    {
+        $database = new Database();
+        $database->setBaseQueryClass('CustomBaseQueryObject');
+
+        $this->assertSame('CustomBaseQueryObject', $database->getBaseQueryClass());
     }
 
     public function testSetDefaultIdMethod()


### PR DESCRIPTION
I need to extends TableQuery objects with common methods, so I propose to add parameter similar to baseClass named parentClass for custom builder generator  extends "class name" ...

The class should extends ModelCriteria for be compatible (php doesn't support multiple extends)