### PR TITLE
fixed question mark recognition

### DIFF
--- a/src/Propel/Runtime/ActiveQuery/Criterion/BasicModelCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/BasicModelCriterion.php
@@ -27,7 +27,7 @@ class BasicModelCriterion extends AbstractModelCriterion
     protected function appendPsForUniqueClauseTo(&$sb, array &$params)
     {
         if (null !== $this->value) {
-            if (!strpos($this->clause, '?')) {
+            if (false === strpos($this->clause, '?')) {
                 throw new InvalidClauseException('A clause must contain a question mark in order to be bound to a value');
             }
             $params[] = array(


### PR DESCRIPTION
Fails because of invalid usage of `strpos` function.
Throws an exception when `$this->clause` will be started with question mark, f.ex. `'? in (col1, col2, col3)'`