### PR TITLE
save timezone in result of toArray method

### DIFF
--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -2385,20 +2385,11 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
         $script .= "
         );";
 
-        $timezoneDefined = false;
         foreach ($this->getTable()->getColumns() as $num => $col) {
             if ($col->isTemporalType()) {
-                if (!$timezoneDefined) {
-                    $script .= "
-
-        \$utc = new \DateTimeZone('utc');";
-                    $timezoneDefined = true;
-                }
-        $script .= "
+                $script .= "
         if (\$result[\$keys[$num]] instanceof \DateTime) {
-            // When changing timezone we don't want to change existing instances
-            \$dateTime = clone \$result[\$keys[$num]];
-            \$result[\$keys[$num]] = \$dateTime->setTimezone(\$utc)->format('Y-m-d\TH:i:s\Z');
+            \$result[\$keys[$num]] = \$result[\$keys[$num]]->format('c');
         }
         ";
             }

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectTest.php
@@ -745,7 +745,7 @@ class GeneratedObjectTest extends BookstoreTestBase
         $review = new Review();
         $review->setReviewDate($date);
 
-        $this->assertEquals('2015-01-04T16:00:02Z', $review->toArray()['ReviewDate'], 'toArray() format temporal colums as ISO8601');
+        $this->assertEquals('2015-01-04T16:00:02+00:00', $review->toArray()['ReviewDate'], 'toArray() format temporal colums as ISO8601');
     }
 
     public function testWithColumn()


### PR DESCRIPTION
Keeps timezone of original object. 
Previously, if you had `\DateTime` object in f.ex 'Europe/warsaw' timezone, as a result of `toArray` you received always Zulu timezone :)