### PR TITLE
#968 - Fix the child deletion issue in many-to-one form

### DIFF
--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -3745,6 +3745,8 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
 
         $collName = $this->getRefFKCollVarName($refFK);
 
+        $scheduledForDeletion = lcfirst($this->getRefFKPhpNameAffix($refFK, $plural = true)) . "ScheduledForDeletion";
+
         $script .= "
     /**
      * Method called to associate a $className object to this object
@@ -3762,6 +3764,10 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
 
         if (!\$this->{$collName}->contains(\$l)) {
             \$this->doAdd" . $this->getRefFKPhpNameAffix($refFK, $plural = false) . "(\$l);
+
+            if (\$this->{$scheduledForDeletion} and \$this->{$scheduledForDeletion}->contains(\$l)) {
+                \$this->{$scheduledForDeletion}->remove(\$this->{$scheduledForDeletion}->search(\$l));
+            }
         }
 
         return \$this;

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectRelTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectRelTest.php
@@ -859,6 +859,39 @@ class GeneratedObjectRelTest extends BookstoreEmptyTestBase
         $this->assertEquals(1, BookListRelQuery::create()->count(), 'One BookClubList has been remove');
     }
 
+    public function testSymfonyFormManyToOne()
+    {
+        BookQuery::create()->deleteAll();
+        AuthorQuery::create()->deleteAll();
+
+        // We create a simple book and a simple Author and simply link them to each other before reloading them
+        $book = new Book();
+        $book->setISBN('012345');
+        $book->setTitle('Propel Book');
+
+        $author = new Author();
+        $author->setFirstName('François');
+        $author->setLastName('Z');
+        $author->addBook($book);
+        $author->save();
+        $book->save();
+
+        $author->reload(true);
+        $book->reload(true);
+
+        // Symfony is cloning the book object in a ManyToOne form with by_reference = false
+        $book2 = clone $book;
+
+        $author->removeBook($book);
+        $author->addBook($book2);
+        $author->save();
+
+        $author->reload(true);
+
+        $books = $author->getBooks();
+        $this->assertCount(1, $books);
+    }
+
     public function testRemoveObjectOneToMany()
     {
         BookQuery::create()->deleteAll();


### PR DESCRIPTION
Here is a fix for the Child deletion issue in many-to-one form issue.

Because this issue is caused mainly by Symfony not comparing the collection objects like Propel is made for, I unfortunately did not manage to provide any tests, though this fix does not break any existing ones...