### PR TITLE
Add timestamptz for postgres

### DIFF
--- a/resources/dtd/database.dtd
+++ b/resources/dtd/database.dtd
@@ -90,7 +90,7 @@ PHP class or method name.
         | DATE   | TIME    | TIMESTAMP   | BINARY     | VARBINARY | LONGVARBINARY
         | NULL   | OTHER   | PHP_OBJECT  | DISTINCT   | STRUCT    | ARRAY
         | BLOB   | CLOB    | REF         | BOOLEANINT | BOOLEANCHAR
-        | DOUBLE | BOOLEAN | OBJECT      | ENUM
+        | DOUBLE | BOOLEAN | OBJECT      | ENUM       | TIMESTAMPTZ
     ) "VARCHAR"
   phpType CDATA #IMPLIED
   sqlType CDATA #IMPLIED

--- a/resources/xsd/database.xsd
+++ b/resources/xsd/database.xsd
@@ -34,6 +34,7 @@
             <xs:enumeration value="DATE"/>
             <xs:enumeration value="TIME"/>
             <xs:enumeration value="TIMESTAMP"/>
+            <xs:enumeration value="TIMESTAMPTZ"/>
             <xs:enumeration value="BINARY"/>
             <xs:enumeration value="VARBINARY"/>
             <xs:enumeration value="LONGVARBINARY"/>

--- a/src/Propel/Common/Config/PropelConfiguration.php
+++ b/src/Propel/Common/Config/PropelConfiguration.php
@@ -323,6 +323,7 @@ class PropelConfiguration implements ConfigurationInterface
                                 ->booleanNode('useDateTimeClass')->defaultTrue()->end()
                                 ->scalarNode('dateTimeClass')->defaultValue('DateTime')->end()
                                 ->scalarNode('defaultTimeStampFormat')->end()
+                                ->scalarNode('defaultTimeStampTzFormat')->end()
                                 ->scalarNode('defaultTimeFormat')->end()
                                 ->scalarNode('defaultDateFormat')->end()
                             ->end()

--- a/src/Propel/Generator/Behavior/I18n/I18nBehaviorObjectBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/I18n/I18nBehaviorObjectBuilderModifier.php
@@ -231,7 +231,8 @@ class I18nBehaviorObjectBuilderModifier
         return in_array($columnType, [
             PropelTypes::DATE,
             PropelTypes::TIME,
-            PropelTypes::TIMESTAMP
+            PropelTypes::TIMESTAMP,
+            PropelTypes::TIMESTAMPTZ
         ]);
     }
 }

--- a/src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
@@ -39,6 +39,7 @@ abstract class AbstractObjectBuilder extends AbstractOMBuilder
             if (PropelTypes::DATE === $col->getType()
                 || PropelTypes::TIME === $col->getType()
                 || PropelTypes::TIMESTAMP === $col->getType()
+                || PropelTypes::TIMESTAMPTZ === $col->getType()
             ) {
                 $this->addTemporalAccessor($script, $col);
             } elseif (PropelTypes::OBJECT === $col->getType()) {
@@ -80,6 +81,7 @@ abstract class AbstractObjectBuilder extends AbstractOMBuilder
                 PropelTypes::DATE === $col->getType()
                 || PropelTypes::TIME === $col->getType()
                 || PropelTypes::TIMESTAMP === $col->getType()
+                || PropelTypes::TIMESTAMPTZ === $col->getType()
             ) {
                 $this->addTemporalMutator($script, $col);
             } elseif (PropelTypes::PHP_ARRAY === $col->getType()) {

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -143,6 +143,8 @@ class ObjectBuilder extends AbstractObjectBuilder
             $fmt = $this->getPlatform()->getTimeFormatter();
         } elseif ($column->getType() === PropelTypes::TIMESTAMP) {
             $fmt = $this->getPlatform()->getTimestampFormatter();
+        } elseif ($column->getType() === PropelTypes::TIMESTAMPTZ) {
+            $fmt = $this->getPlatform()->getTimestampTzFormatter();
         }
 
         return $fmt;
@@ -778,7 +780,7 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
 
         $handleMysqlDate = false;
         if ($this->getPlatform() instanceof MysqlPlatform) {
-            if ($column->getType() === PropelTypes::TIMESTAMP) {
+            if ($column->getType() === PropelTypes::TIMESTAMP || $column->getType() === PropelTypes::TIMESTAMPTZ) {
                 $handleMysqlDate = true;
                 $mysqlInvalidDateString = '0000-00-00 00:00:00';
             } elseif ($column->getType() === PropelTypes::DATE) {
@@ -822,6 +824,8 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
             $defaultfmt = $this->getBuildProperty('generator.dateTime.defaultTimeFormat');
         } elseif ($column->getType() === PropelTypes::TIMESTAMP) {
             $defaultfmt = $this->getBuildProperty('generator.dateTime.defaultTimeStampFormat');
+        } elseif ($column->getType() === PropelTypes::TIMESTAMPTZ) {
+            $defaultfmt = $this->getBuildProperty('generator.dateTime.defaultTimeStampTzFormat');
         }
 
         if (empty($defaultfmt)) {
@@ -887,6 +891,8 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
             $defaultfmt = $this->getBuildProperty('generator.dateTime.defaultTimeFormat');
         } elseif ($column->getType() === PropelTypes::TIMESTAMP) {
             $defaultfmt = $this->getBuildProperty('generator.dateTime.defaultTimeStampFormat');
+        } elseif ($column->getType() === PropelTypes::TIMESTAMPTZ) {
+            $defaultfmt = $this->getBuildProperty('generator.dateTime.defaultTimeStampTzFormat');
         }
 
         if (empty($defaultfmt)) {
@@ -1616,16 +1622,7 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
                 || (\$dt->format($fmt) === $defaultValue) // or the entered value matches the default
                  ) {";
         } else {
-            switch ($col->getType()) {
-                case 'DATE':
-                    $format = 'Y-m-d';
-                    break;
-                case 'TIME':
-                    $format = 'H:i:s';
-                    break;
-                default:
-                    $format = 'Y-m-d H:i:s';
-            }
+            $format =  $this->getTemporalFormatter($col);
             $script .= "
             if (\$this->{$clo} === null || \$dt === null || \$dt->format(\"$format\") !== \$this->{$clo}->format(\"$format\")) {";
         }

--- a/src/Propel/Generator/Model/PropelTypes.php
+++ b/src/Propel/Generator/Model/PropelTypes.php
@@ -42,6 +42,7 @@ class PropelTypes
     const DATE          = 'DATE';
     const TIME          = 'TIME';
     const TIMESTAMP     = 'TIMESTAMP';
+    const TIMESTAMPTZ   = 'TIMESTAMPTZ';
     const BU_DATE       = 'BU_DATE';
     const BU_TIMESTAMP  = 'BU_TIMESTAMP';
     const BOOLEAN       = 'BOOLEAN';
@@ -73,6 +74,7 @@ class PropelTypes
     const DATE_NATIVE_TYPE          = 'string';
     const TIME_NATIVE_TYPE          = 'string';
     const TIMESTAMP_NATIVE_TYPE     = 'string';
+    const TIMESTAMPTZ_NATIVE_TYPE   = 'string';
     const BU_TIMESTAMP_NATIVE_TYPE  = 'string';
     const BOOLEAN_NATIVE_TYPE       = 'boolean';
     const BOOLEAN_EMU_NATIVE_TYPE   = 'boolean';
@@ -107,6 +109,7 @@ class PropelTypes
         self::DATE,
         self::TIME,
         self::TIMESTAMP,
+        self::TIMESTAMPTZ,
         self::BOOLEAN,
         self::BOOLEAN_EMU,
         self::OBJECT,
@@ -148,6 +151,7 @@ class PropelTypes
         self::BU_DATE       => self::BU_DATE_NATIVE_TYPE,
         self::TIME          => self::TIME_NATIVE_TYPE,
         self::TIMESTAMP     => self::TIMESTAMP_NATIVE_TYPE,
+        self::TIMESTAMPTZ   => self::TIMESTAMPTZ_NATIVE_TYPE,
         self::BU_TIMESTAMP  => self::BU_TIMESTAMP_NATIVE_TYPE,
         self::BOOLEAN       => self::BOOLEAN_NATIVE_TYPE,
         self::BOOLEAN_EMU   => self::BOOLEAN_EMU_NATIVE_TYPE,
@@ -185,6 +189,7 @@ class PropelTypes
         self::DATE          => \PDO::PARAM_STR,
         self::TIME          => \PDO::PARAM_STR,
         self::TIMESTAMP     => \PDO::PARAM_STR,
+        self::TIMESTAMPTZ   => \PDO::PARAM_STR,
         self::BU_DATE       => \PDO::PARAM_STR,
         self::BU_TIMESTAMP  => \PDO::PARAM_STR,
         self::BOOLEAN       => \PDO::PARAM_BOOL,
@@ -263,6 +268,7 @@ class PropelTypes
             self::DATE,
             self::TIME,
             self::TIMESTAMP,
+            self::TIMESTAMPTZ,
             self::BU_DATE,
             self::BU_TIMESTAMP,
         ]);
@@ -284,6 +290,7 @@ class PropelTypes
             self::DATE,
             self::TIME,
             self::TIMESTAMP,
+            self::TIMESTAMPTZ,
             self::BU_DATE,
             self::BU_TIMESTAMP,
         ]);

--- a/src/Propel/Generator/Platform/PgsqlPlatform.php
+++ b/src/Propel/Generator/Platform/PgsqlPlatform.php
@@ -60,6 +60,7 @@ class PgsqlPlatform extends DefaultPlatform
         $this->setSchemaDomainMapping(new Domain(PropelTypes::PHP_ARRAY, 'TEXT'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::ENUM, 'INT2'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::DECIMAL, 'NUMERIC'));
+        $this->setSchemaDomainMapping(new Domain(PropelTypes::TIMESTAMPTZ, 'TIMESTAMPTZ'));
     }
 
     public function getNativeIdMethod()
@@ -671,6 +672,16 @@ DROP SEQUENCE %s CASCADE;
         );
 
         return preg_replace('/^/m', $tab, $script);
+    }
+
+    /**
+     * Gets the preferred timestamp formatter for setting date/time values.
+     * For postgres, this is an isodate
+     * @return string
+     */
+    public function getTimestampTzFormatter()
+    {
+        return 'c';
     }
 
 }

--- a/src/Propel/Generator/Reverse/PgsqlSchemaParser.php
+++ b/src/Propel/Generator/Reverse/PgsqlSchemaParser.php
@@ -63,11 +63,12 @@ class PgsqlSchemaParser extends AbstractSchemaParser
         //'year' => PropelTypes::YEAR,  PropelTypes::YEAR does not exist... does this need to be mapped to a different propel type?
         'datetime'    => PropelTypes::TIMESTAMP,
         'timestamp'   => PropelTypes::TIMESTAMP,
-        'timestamptz' => PropelTypes::TIMESTAMP,
+        'timestamptz' => PropelTypes::TIMESTAMPTZ,
         'bytea'       => PropelTypes::BLOB,
         'text'        => PropelTypes::LONGVARCHAR,
         'time without time zone' => PropelTypes::TIME,
         'timestamp without time zone' => PropelTypes::TIMESTAMP,
+        'timestamp with time zone' => PropelTypes::TIMESTAMPTZ,
         'double precision' => PropelTypes::DOUBLE,
     ];
 

--- a/src/Propel/Runtime/Adapter/Pdo/PdoAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/PdoAdapter.php
@@ -308,6 +308,9 @@ abstract class PdoAdapter
                 case PropelTypes::BU_TIMESTAMP:
                     $value = $dt->format($this->getTimestampFormatter());
                     break;
+                case PropelTypes::TIMESTAMPTZ:
+                    $value = $dt->format($this->getTimestampTzFormatter());
+                    break;
                 case PropelTypes::DATE:
                 case PropelTypes::BU_DATE:
                     $value = $dt->format($this->getDateFormatter());
@@ -327,6 +330,16 @@ abstract class PdoAdapter
      * @return string
      */
     public function getTimestampFormatter()
+    {
+        return 'Y-m-d H:i:s';
+    }
+
+    /**
+     * Returns timestamptz formatter string for use in date() function.
+     *
+     * @return string
+     */
+    public function getTimestampTzFormatter()
     {
         return 'Y-m-d H:i:s';
     }

--- a/src/Propel/Runtime/Adapter/Pdo/PgsqlAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/PgsqlAdapter.php
@@ -110,6 +110,16 @@ class PgsqlAdapter extends PdoAdapter implements SqlAdapterInterface
     }
 
     /**
+     * Returns timestamptz formatter string for use in date() function.
+     *
+     * @return string
+     */
+    public function getTimestampTzFormatter()
+    {
+        return 'c';
+    }
+
+    /**
      * Returns timestamp formatter string for use in date() function.
      *
      * @return string

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilderTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilderTest.php
@@ -41,19 +41,27 @@ class ObjectBuilderTest extends TestCase
         $col1->setDomain(new Domain('VARCHAR'));
         $col1->setDefaultValue(new ColumnDefaultValue('abc', ColumnDefaultValue::TYPE_VALUE));
         $val1 = "'abc'";
+
         $col2 = new Column('Bar');
         $col2->setDomain(new Domain('INTEGER'));
         $col2->setDefaultValue(new ColumnDefaultValue(1234, ColumnDefaultValue::TYPE_VALUE));
         $val2 = "1234";
+
         $col3 = new Column('Bar');
         $col3->setDomain(new Domain('DATE'));
         $col3->setDefaultValue(new ColumnDefaultValue('0000-00-00', ColumnDefaultValue::TYPE_VALUE));
         $val3 = "NULL";
 
+        $col4 = new Column('Bar');
+        $col4->setDomain(new Domain('TIMESTAMPTZ'));
+        $col4->setDefaultValue(new ColumnDefaultValue('0000-00-00 00:00:00', ColumnDefaultValue::TYPE_VALUE));
+        $val4 = "NULL";
+
         return [
             [$col1, $val1],
             [$col2, $val2],
             [$col3, $val3],
+            [$col4, $val4],
         ];
     }
 

--- a/tests/Propel/Tests/Generator/Model/ColumnTest.php
+++ b/tests/Propel/Tests/Generator/Model/ColumnTest.php
@@ -447,6 +447,7 @@ class ColumnTest extends ModelTestCase
             ['DATE', \PDO::PARAM_STR],
             ['TIME', \PDO::PARAM_STR],
             ['TIMESTAMP', \PDO::PARAM_STR],
+            ['TIMESTAMPTZ', \PDO::PARAM_STR],
             ['BOOLEAN', \PDO::PARAM_BOOL],
             ['BOOLEAN_EMU', \PDO::PARAM_INT],
             ['OBJECT', \PDO::PARAM_LOB],
@@ -538,6 +539,7 @@ class ColumnTest extends ModelTestCase
             ['DATE'],
             ['TIME'],
             ['TIMESTAMP'],
+            ['TIMESTAMPTZ'],
             ['BU_DATE'],
             ['BU_TIMESTAMP'],
         ];
@@ -694,6 +696,7 @@ class ColumnTest extends ModelTestCase
             ['DATE'],
             ['TIME'],
             ['TIMESTAMP'],
+            ['TIMESTAMPTZ'],
             ['BU_DATE'],
             ['BU_TIMESTAMP'],
         ];

--- a/tests/Propel/Tests/Generator/Platform/MysqlPlatformTest.php
+++ b/tests/Propel/Tests/Generator/Platform/MysqlPlatformTest.php
@@ -799,6 +799,27 @@ CREATE TABLE `foo`
         $this->assertEquals($expected, $this->getPlatform()->getAddTableDDL($table));
     }
 
+    public function testGetAddTableDDLTimestampTzTypeMysqlConsideredTimestamp()
+    {
+        $schema = <<<EOF
+<database name="test">
+    <table name="foo">
+        <column name="bar" type="TIMESTAMPTZ"/>
+    </table>
+</database>
+EOF;
+        $table = $this->getTableFromSchema($schema);
+        $expected = <<<EOF
+
+CREATE TABLE `foo`
+(
+    `bar` TIMESTAMP NULL
+) ENGINE=InnoDB;
+
+EOF;
+        $this->assertEquals($expected, $this->getPlatform()->getAddTableDDL($table));
+    }
+
     public function testVendorOptionsQuoting()
     {
 

--- a/tests/Propel/Tests/Generator/Platform/PgsqlPlatformTest.php
+++ b/tests/Propel/Tests/Generator/Platform/PgsqlPlatformTest.php
@@ -429,6 +429,27 @@ EOF;
         $this->assertEquals($expected, $this->getPlatform()->getAddTableDDL($table));
     }
 
+    public function testGetAddTableDDLTimestampTzType()
+    {
+        $schema = <<<EOF
+<database name="test">
+    <table name="foo">
+        <column name="bar" type="TIMESTAMPTZ"/>
+    </table>
+</database>
+EOF;
+        $table = $this->getTableFromSchema($schema);
+        $expected = <<<EOF
+
+CREATE TABLE "foo"
+(
+    "bar" TIMESTAMPTZ
+);
+
+EOF;
+        $this->assertEquals($expected, $this->getPlatform()->getAddTableDDL($table));
+    }
+
     public function testGetDropTableDDL()
     {
         $table = new Table('foo');


### PR DESCRIPTION
This basically fixes #589 by adding support for timestamptz. For pgsql, this means use timestamptz. For other databases, it should behave like timestamp (I may have gone overkill in ensuring that bit too, heh).

I don't consider this ready to ship yet. Looking for some feedback because I've never contributed to the code base (and PHP is not my forté). Also would like suggestions as to exactly which parts should get specific tests (An answer of `all of it` is totally groovy.)