### PR TITLE
Include identifierQuoting in the reverse-engineered schema.xml

### DIFF
--- a/src/Propel/Generator/Schema/Dumper/XmlDumper.php
+++ b/src/Propel/Generator/Schema/Dumper/XmlDumper.php
@@ -139,6 +139,10 @@ class XmlDumper implements DumperInterface
             $databaseNode->setAttribute('tablePrefix', $tablePrefix);
         }
 
+        if ($database->isIdentifierQuotingEnabled()) {
+            $databaseNode->setAttribute('identifierQuoting', 'true');
+        }
+
         /*
             FIXME - Before we can add support for domains in the schema, we need
             to have a method of the Column that indicates whether the column was mapped


### PR DESCRIPTION
I am working on a new SchemaParser using which the need for identifier quoting is detectable at the schema level. Without this PR however, the identifierQuoting attribute is not included in the reverse-engineered schema.xml

Let me know if there are any underlying reasons as to NOT include identifierQuoting.

Thanks