### PR TITLE
Added migration create command for creating empty migration classes

### DIFF
--- a/src/Propel/Generator/Command/MigrationCreateCommand.php
+++ b/src/Propel/Generator/Command/MigrationCreateCommand.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
+namespace Propel\Generator\Command;
+
+use Propel\Common\Config\ConfigurationManager;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\Output;
+use Propel\Generator\Exception\RuntimeException;
+use Propel\Generator\Manager\MigrationManager;
+
+/**
+ * @author William Durand <william.durand1@gmail.com>
+ * @author Fredrik Wollsén <fredrik@neam.se>
+ */
+class MigrationCreateCommand extends AbstractCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        parent::configure();
+
+        $this
+            ->addOption('schema-dir',         null, InputOption::VALUE_REQUIRED,  'The directory where the schema files are placed')
+            ->addOption('output-dir',         null, InputOption::VALUE_REQUIRED,  'The output directory where the migration files are located')
+            ->addOption('connection',         null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Connection to use. Example: \'bookstore=mysql:host=127.0.0.1;dbname=test;user=root;password=foobar\' where "bookstore" is your propel database name (used in your schema.xml)', [])
+            ->addOption('editor',             null, InputOption::VALUE_OPTIONAL,  'The text editor to use to open diff files', null)
+            ->addOption('comment',            "m",  InputOption::VALUE_OPTIONAL,  'A comment for the migration', '')
+            ->setName('migration:create')
+            ->setDescription('Create an empty migration class')
+            ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $configOptions = [];
+
+        if ($this->hasInputOption('connection', $input)) {
+            foreach ($input->getOption('connection') as $conn) {
+                $configOptions += $this->connectionToProperties($conn);
+            }
+        }
+
+        if ($this->hasInputOption('schema-dir', $input)) {
+            $configOptions['propel']['paths']['schemaDir'] = $input->getOption('schema-dir');
+        }
+
+        if ($this->hasInputOption('output-dir', $input)) {
+            $configOptions['propel']['paths']['migrationDir'] = $input->getOption('output-dir');
+        }
+
+        $generatorConfig = $this->getGeneratorConfig($configOptions, $input);
+
+        $this->createDirectory($generatorConfig->getSection('paths')['migrationDir']);
+
+        $manager = new MigrationManager();
+        $manager->setGeneratorConfig($generatorConfig);
+        $manager->setSchemas($this->getSchemas($generatorConfig->getSection('paths')['schemaDir'], $input->getOption('recursive')));
+
+        $migrationsUp   = [];
+        $migrationsDown = [];
+        foreach ($manager->getDatabases() as $appDatabase) {
+            $name = $appDatabase->getName();
+            $migrationsUp[$name]    = '';
+            $migrationsDown[$name]  = '';
+        }
+
+        $timestamp = time();
+        $migrationFileName  = $manager->getMigrationFileName($timestamp);
+        $migrationClassBody = $manager->getMigrationClassBody($migrationsUp, $migrationsDown, $timestamp, $input->getOption('comment'));
+
+        $file = $generatorConfig->getSection('paths')['migrationDir'] . DIRECTORY_SEPARATOR . $migrationFileName;
+        file_put_contents($file, $migrationClassBody);
+
+        $output->writeln(sprintf('"%s" file successfully created.', $file));
+
+        if (null !== $editorCmd = $input->getOption('editor')) {
+            $output->writeln(sprintf('Using "%s" as text editor', $editorCmd));
+            shell_exec($editorCmd . ' ' . escapeshellarg($file));
+        } else {
+            $output->writeln('Now add SQL statements and data migration code as necessary.');
+            $output->writeln('Once the migration class is valid, call the "migrate" task to execute it.');
+        }
+    }
+
+}

--- a/tests/Propel/Tests/Generator/Command/MigrationTest.php
+++ b/tests/Propel/Tests/Generator/Command/MigrationTest.php
@@ -6,6 +6,7 @@ use Propel\Generator\Command\MigrationDiffCommand;
 use Propel\Generator\Command\MigrationDownCommand;
 use Propel\Generator\Command\MigrationMigrateCommand;
 use Propel\Generator\Command\MigrationUpCommand;
+use Propel\Generator\Command\MigrationCreateCommand;
 use Propel\Runtime\Propel;
 use Propel\Tests\TestCaseFixturesDatabase;
 use Symfony\Component\Console\Application;
@@ -161,6 +162,46 @@ class MigrationTest extends TestCaseFixturesDatabase
 
         //revert this migration change so we have the same database structure as before this test
         $this->testDownCommand();
+    }
+
+    public function testCreateCommand()
+    {
+        $app = new Application('Propel', Propel::VERSION);
+        $command = new MigrationCreateCommand();
+        $app->add($command);
+
+        $files = glob($this->outputDir . '/PropelMigration_*.php');
+        foreach ($files as $file) {
+            unlink($file);
+        }
+
+        $input = new \Symfony\Component\Console\Input\ArrayInput([
+            'command' => 'migration:create',
+            '--schema-dir' => $this->schemaDir,
+            '--config-dir' => $this->configDir,
+            '--output-dir' => $this->outputDir,
+            '--platform' => ucfirst($this->getDriver()) . 'Platform',
+            '--connection' => $this->connectionOption,
+            '--verbose' => true
+        ]);
+
+        $output = new \Symfony\Component\Console\Output\StreamOutput(fopen("php://temp", 'r+'));
+        $app->setAutoExit(false);
+        $result = $app->run($input, $output);
+
+        if (0 !== $result) {
+            rewind($output->getStream());
+            echo stream_get_contents($output->getStream());
+        }
+
+        $this->assertEquals(0, $result, 'migration:create tests exited successfully');
+
+        $files = glob($this->outputDir . '/PropelMigration_*.php');
+        $this->assertGreaterThanOrEqual(1, count($files));
+        $file = $files[0];
+
+        $content = file_get_contents($file);
+        $this->assertNotContains('CREATE TABLE ', $content);
     }
 
 }


### PR DESCRIPTION
Fixes https://github.com/propelorm/Propel2/issues/832

For semantic reasons, I chose to implement it as a separate command instead of an "--empty" command to migration:diff.

Usage and verbose output:
```
# vendor/bin/propel migration:create -vvv
"/app/dna/generated-migrations/PropelMigration_1449320135.php" file successfully created.
Now add SQL statements and data migration code as necessary.
Once the migration class is valid, call the "migrate" task to execute it.
```