### PR TITLE
Fixes fatal error in test suites.

### DIFF
--- a/tests/Propel/Tests/Generator/Behavior/Versionable/VersionableBehaviorObjectBuilderModifierTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Versionable/VersionableBehaviorObjectBuilderModifierTest.php
@@ -21,10 +21,9 @@ use Propel\Runtime\Collection\ObjectCollection;
 class VersionableBehaviorObjectBuilderModifierTest extends TestCase
 {
 
-    public function setUp()
+    public static function setUpBeforeClass()
     {
-        if (!class_exists('VersionableBehaviorTest1')) {
-            $schema = <<<EOF
+        $schema = <<<EOF
 <database name="versionable_behavior_test_1">
     <table name="versionable_behavior_test_1">
         <column name="id" primaryKey="true" type="INTEGER" autoIncrement="true" />
@@ -65,10 +64,9 @@ class VersionableBehaviorObjectBuilderModifierTest extends TestCase
     </table>
 </database>
 EOF;
-            QuickBuilder::buildSchema($schema);
-        }
-        if (!class_exists('VersionableBehaviorTest6')) {
-            $schema2 = <<<EOF
+        QuickBuilder::buildSchema($schema);
+
+        $schema2 = <<<EOF
 <database name="versionable_behavior_test_2" defaultPhpNamingMethod="nochange">
     <table name="VersionableBehaviorTest6">
         <column name="Id" primaryKey="true" type="INTEGER" autoIncrement="true" />
@@ -98,11 +96,9 @@ EOF;
     </table>
 </database>
 EOF;
-            QuickBuilder::buildSchema($schema2);
-        }
+        QuickBuilder::buildSchema($schema2);
 
-        if (!class_exists('VersionableBehaviorTest8')) {
-            $schema2 = <<<EOF
+        $schema3 = <<<EOF
 <database name="versionable_behavior_test_3" defaultPhpNamingMethod="nochange">
     <table name="VersionableBehaviorTest8">
         <column name="Id" primaryKey="true" type="INTEGER" autoIncrement="true" />
@@ -117,12 +113,10 @@ EOF;
     </table>
 </database>
 EOF;
-            QuickBuilder::buildSchema($schema2);
-        }
+        QuickBuilder::buildSchema($schema3);
 
 
-        if (!class_exists('VersionableBehaviorTest10')) {
-            $schema4 = <<<EOF
+        $schema4 = <<<EOF
 <database name="versionable_behavior_test_4">
     <table name="VersionableBehaviorTest10">
         <column name="id" primaryKey="true" type="INTEGER" autoIncrement="true" />
@@ -153,8 +147,7 @@ EOF;
     </table>
 </database>
 EOF;
-            QuickBuilder::buildSchema($schema4);
-        }
+        QuickBuilder::buildSchema($schema4);
     }
 
     public function testGetVersionExists()


### PR DESCRIPTION
Original commit message: Fixed php7 test suites

Fixes fatal error described in https://github.com/propelorm/Propel2/issues/1052

The following warnings remain:

```
PHP Warning:  The use statement with non-compound name 'VersionableBehaviorTest8' has no effect in /tmp/propelQuickBuild-2.0.0-dev-7a1e019deb/VersionableBehaviorTest8_VersionableBehaviorTest8Version.php on line 3136
PHP Warning:  The use statement with non-compound name 'VersionableBehaviorTest8Foo' has no effect in /tmp/propelQuickBuild-2.0.0-dev-7a1e019deb/VersionableBehaviorTest8_VersionableBehaviorTest8Version.php on line 3281
```