### PR TITLE
fixing serialization issues

### DIFF
--- a/src/Propel/Generator/Builder/Om/TableMapBuilder.php
+++ b/src/Propel/Generator/Builder/Om/TableMapBuilder.php
@@ -646,14 +646,14 @@ class ".$this->getUnqualifiedClassName()." extends TableMap
         $pkphp = (array) $pkphp; // make it an array if it is not.
         $script = '';
         if (count($pkphp) > 1) {
-            $script .= "serialize(array(";
+            $script .= "serialize([";
             $i = 0;
             foreach ($pkphp as $pkvar) {
-                $script .= ($i++ ? ', ' : '') . "(string) $pkvar";
+                $script .= ($i++ ? ', ' : '') . "(null === {$pkvar} || is_scalar({$pkvar}) || is_callable([{$pkvar}, '__toString']) ? (string) {$pkvar} : {$pkvar})";
             }
-            $script .= "))";
+            $script .= "])";
         } else {
-            $script .= "(string) " . $pkphp[0];
+            $script .= "null === {$pkphp[0]} || is_scalar({$pkphp[0]}) || is_callable([{$pkphp[0]}, '__toString']) ? (string) {$pkphp[0]} : {$pkphp[0]}";
         }
 
         return $script;

--- a/tests/Propel/Tests/Issues/Issue829Test.php
+++ b/tests/Propel/Tests/Issues/Issue829Test.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT License
+ */
+namespace Propel\Tests\Issues;
+
+use Propel\Generator\Util\QuickBuilder;
+use Propel\Tests\TestCase;
+
+/**
+ * Regression test for https://github.com/propelorm/Propel2/issues/829
+ *
+ * @group database
+ */
+class Issue829Test extends TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        if (!class_exists('\Table829')) {
+            $schema = '
+            <database name="issue_829" defaultIdMethod="native">
+                <table name="table829">
+                    <column name="id" primaryKey="true" type="INTEGER" />
+                    <column name="date" primaryKey="true" type="DATE" />
+                </table>
+            </database>
+            ';
+            QuickBuilder::buildSchema($schema);
+        }
+    }
+
+    /*
+     * Test if adding to instance pool doesn't throw an exception when primary key is composed of fields of types
+     * that can be serialized but cannot be casted to a string (f.in. \DateTime)
+     */
+    public function testAddingToInstancePool()
+    {
+        $date = new \DateTime;
+        $test = new \Table829();
+
+        $test
+            ->setId(1)
+            ->setDate($date)
+        ;
+
+        \Map\Table829TableMap::addInstanceToPool($test);
+    }
+}


### PR DESCRIPTION
whenever a key that could be serialized couldn't be casted to a `string` at the same time (f.in. `\DateTime`) an exception was thrown

fixes #829