### PR TITLE
Unit tests on Windows

### DIFF
--- a/tests/Propel/Tests/Common/Config/ConfigurationManagerTest.php
+++ b/tests/Propel/Tests/Common/Config/ConfigurationManagerTest.php
@@ -37,9 +37,8 @@ class ConfigurationManagerTest extends ConfigTestCase
 
     public function tearDown()
     {
-        $this->getFileSystem()->remove($this->fixturesDir);
-
         chdir($this->currentDir);
+        $this->getFileSystem()->remove($this->fixturesDir);
     }
 
     public function testLoadConfigFileInCurrentDirectory()

--- a/tests/Propel/Tests/Common/Config/Loader/IniFileLoaderTest.php
+++ b/tests/Propel/Tests/Common/Config/Loader/IniFileLoaderTest.php
@@ -196,6 +196,7 @@ EOF;
     /**
      * @expectedException Propel\Common\Config\Exception\InputOutputException
      * @expectedExceptionMessage You don't have permissions to access configuration file notreadable.ini.
+     * @requires OS ^(?!Win.*)
      */
     public function testIniFileNotReadableThrowsException()
     {

--- a/tests/Propel/Tests/Common/Config/Loader/JsonFileLoaderTest.php
+++ b/tests/Propel/Tests/Common/Config/Loader/JsonFileLoaderTest.php
@@ -83,6 +83,7 @@ EOF;
     /**
      * @expectedException Propel\Common\Config\Exception\InputOutputException
      * @expectedExceptionMessage You don't have permissions to access configuration file notreadable.json.
+     * @requires OS ^(?!Win.*)
      */
     public function testJsonFileNotReadableThrowsException()
     {

--- a/tests/Propel/Tests/Common/Config/Loader/PhpFileLoaderTest.php
+++ b/tests/Propel/Tests/Common/Config/Loader/PhpFileLoaderTest.php
@@ -86,6 +86,7 @@ EOF;
     /**
      * @expectedException Propel\Common\Config\Exception\InputOutputException
      * @expectedExceptionMessage You don't have permissions to access configuration file notreadable.php.
+     * @requires OS ^(?!Win.*)
      */
     public function testConfigFileNotReadableThrowsException()
     {

--- a/tests/Propel/Tests/Common/Config/Loader/XmlFileLoaderTest.php
+++ b/tests/Propel/Tests/Common/Config/Loader/XmlFileLoaderTest.php
@@ -86,6 +86,7 @@ EOF;
     /**
      * @expectedException Propel\Common\Config\Exception\InputOutputException
      * @expectedExceptionMessage You don't have permissions to access configuration file notreadable.xml.
+     * @requires OS ^(?!Win.*)
      */
     public function testXmlFileNotReadableThrowsException()
     {

--- a/tests/Propel/Tests/Common/Config/Loader/YamlFileLoaderTest.php
+++ b/tests/Propel/Tests/Common/Config/Loader/YamlFileLoaderTest.php
@@ -85,6 +85,7 @@ EOF;
     /**
      * @expectedException Propel\Common\Config\Exception\InputOutputException
      * @expectedExceptionMessage You don't have permissions to access configuration file notreadable.yaml.
+     * @requires OS ^(?!Win.*)
      */
     public function testYamlFileNotReadableThrowsException()
     {

--- a/tests/bin/base.bat
+++ b/tests/bin/base.bat
@@ -1,0 +1,24 @@
+@echo off
+
+call %*
+exit /b
+
+:check
+
+if not "%errorlevel%" == "0" (
+    echo Aborted.
+    exit /B 1
+)
+
+goto :eof
+
+
+:init
+
+if "%PHPUNIT_COVERAGE%"=="1" (
+    set PHPUNIT=.\vendor\bin\phpunit.bat --coverage-php=tests\clover.cov
+) else (
+    set PHPUNIT=.\vendor\bin\phpunit.bat
+)
+
+goto :eof

--- a/tests/bin/setup.mysql.bat
+++ b/tests/bin/setup.mysql.bat
@@ -1,0 +1,53 @@
+@echo off
+
+setlocal
+
+set DIR=%~dp0
+call %DIR%\base.bat :init
+
+set mysql=
+@for %%e in (%PATHEXT%) do @for %%i in (mysql%%e) do @if NOT "%%~$PATH:i"=="" set mysql=%%~$PATH:i
+if "%mysql%" == "" (
+    @for %%e in (%PATHEXT%) do @for %%i in (mysql5%%e) do @if NOT "%%~$PATH:i"=="" set mysql=%%~$PATH:i
+)       
+
+if "%mysql%" == "" (
+    echo Can not find mysql binary. Is it installed?
+    exit /B 1
+)
+
+if "%DB_USER%" == "" (
+    echo DB_USER not set. Using 'root'.
+    set DB_USER=root
+)
+
+set pw_option= 
+if not "%DB_PW" == "" (
+    set pw_option= -p"%DB_PW%"
+)
+
+if "%DB_HOSTNAME%" == "" (
+    set DB_HOSTNAME=127.0.0.1
+)
+
+"%mysql%" --host="%DB_HOSTNAME%" -u"%DB_USER%" %pw_option% -e ^"^
+SET FOREIGN_KEY_CHECKS = 0;^
+DROP DATABASE IF EXISTS test;^
+DROP SCHEMA IF EXISTS second_hand_books;^
+DROP SCHEMA IF EXISTS contest;^
+DROP SCHEMA IF EXISTS bookstore_schemas;^
+DROP SCHEMA IF EXISTS migration;^
+SET FOREIGN_KEY_CHECKS = 1;^
+"
+call %DIR%\base.bat :check
+if "%errorlevel%" == "1" exit /B 1
+
+"%mysql%" --host="%DB_HOSTNAME%" -u"%DB_USER%" %pw_option% -e ^"^
+CREATE DATABASE test;^
+CREATE SCHEMA bookstore_schemas;^
+CREATE SCHEMA contest;^
+CREATE SCHEMA second_hand_books;^
+CREATE SCHEMA migration;^
+"
+call %DIR%\base.bat :check
+if "%errorlevel%" == "1" exit /B 1

--- a/tests/bin/setup.pgsql.bat
+++ b/tests/bin/setup.pgsql.bat
@@ -1,0 +1,47 @@
+@echo off
+
+setlocal
+
+set DIR=%~dp0
+call %DIR%\base.bat :init
+
+set psql=
+@for %%e in (%PATHEXT%) do @for %%i in (psql%%e) do @if NOT "%%~$PATH:i"=="" set psql=%%~$PATH:i
+
+if "%psql%" == "" (
+    echo Can not find psql binary. Is it installed?
+    exit /B 1
+)
+
+if "%DB_USER%" == "" (
+    echo DB_USER not set. Using 'postgres'.
+    set DB_USER=postgres
+)
+
+if "%DB_NAME%" == "" (
+    echo DB_NAME not set. Using 'postgres'.
+    set DB_NAME=postgres
+)
+
+if "%DB_HOSTNAME%" == "" (
+    set DB_HOSTNAME=127.0.0.1
+)
+
+"%psql%" --version
+
+dropdb --host="%DB_HOSTNAME%" --username="%DB_USER%" "%DB_NAME%"
+
+createdb --host="%DB_HOSTNAME%" --username="%DB_USER%" "%DB_NAME%"
+
+call %DIR%\base.bat :check
+if "%errorlevel%" == "1" exit /B 1
+
+"%psql%" --host="%DB_HOSTNAME%" --username="%DB_USER%" -c ^"^
+CREATE SCHEMA bookstore_schemas;^
+CREATE SCHEMA contest;^
+CREATE SCHEMA second_hand_books;^
+CREATE SCHEMA migration;^
+" "%DB_NAME%"
+
+call %DIR%\base.bat :check
+if "%errorlevel%" == "1" exit /B 1

--- a/tests/bin/setup.sqlite.bat
+++ b/tests/bin/setup.sqlite.bat
@@ -1,0 +1,15 @@
+@echo off
+
+setlocal
+
+set DIR=%~dp0
+call %DIR%\base.bat :init
+
+if exist .\test.sq3 (
+    del /F .\test.sq3
+)
+
+if exist "%dir%..\test.sq3" (
+    del /F "%dir%..\test.sq3"
+)
+


### PR DESCRIPTION
I made few adjustments for running unit tests on Windows machine. 

Tests are passing green without DB, with MySQL and with SQLite on Windows 7, PHP 5.6. 

---

PostrgreSQL however for some weird reason fails few tests - mostly because different quoting - looks like the Windows version ignores binding values as integers and treats them as strings instead. 

That leads to following type of errors:
```
Failed asserting that two strings are equal.
Expected :'INSERT INTO "group" ("id", "title", "as") VALUES (1, 'Test Group', 3)'
Actual   :'INSERT INTO "group" ("id", "title", "as") VALUES ('1', 'Test Group', 3)'
```

Any PostgreSQL expert who can give any insights? Is this some kind of known limitation or just misconfiguration? On linux, this works out of the box.