### PR TITLE
Remove a unnecessary fucntion call on the hot path while model generation.

### DIFF
--- a/src/Propel/Generator/Model/Database.php
+++ b/src/Propel/Generator/Model/Database.php
@@ -760,8 +760,8 @@ class Database extends ScopedMappingModel
                 }
             }
         }
-        ksort($behaviors);
         if (count($behaviors)) {
+            ksort($behaviors);
             $nextBehavior = $behaviors[key($behaviors)][0];
         }
 


### PR DESCRIPTION
per https://blackfire.io/profiles/35114fdc-8aec-4ea2-ba31-e88d8bec865e/graph?callname=Propel\Generator\Model\Database%3A%3AgetNextTableBehavior&selected=Propel\Generator\Model\Database%3A%3AgetNextTableBehavior&settings[dimension]=wt&settings[display]=focused&settings[tabPane]=nodes this method is on the hot path, and this PR removes an unnecessary function call.

easy catch. sorting only necessary when we have behaviours.