### PR TITLE
Speedup Database->getNextTableBehavior().

### DIFF
--- a/src/Propel/Generator/Model/Database.php
+++ b/src/Propel/Generator/Model/Database.php
@@ -753,16 +753,17 @@ class Database extends ScopedMappingModel
         // order the behaviors according to Behavior::$tableModificationOrder
         $behaviors = [];
         $nextBehavior = null;
+        $lowestModificationOrder = PHP_INT_MAX;
         foreach ($this->tables as $table) {
             foreach ($table->getBehaviors() as $behavior) {
                 if (!$behavior->isTableModified()) {
-                    $behaviors[$behavior->getTableModificationOrder()][] = $behavior;
+                    $modificationOrder = $behavior->getTableModificationOrder();
+                    if ($modificationOrder < $lowestModificationOrder) {
+                        $lowestModificationOrder = $modificationOrder;
+                        $nextBehavior = $behavior;
+                    }
                 }
             }
-        }
-        ksort($behaviors);
-        if (count($behaviors)) {
-            $nextBehavior = $behaviors[key($behaviors)][0];
         }
 
         return $nextBehavior;


### PR DESCRIPTION
This is more or less an experiment. could please someone double check I did not overlook something.

`GetNextTableBehaviour` is on the hot path of https://blackfire.io/profiles/35114fdc-8aec-4ea2-ba31-e88d8bec865e/graph?callname=Propel\Generator\Model\Database%3A%3AgetNextTableBehavior&selected=Propel\Generator\Model\Database%3A%3AgetNextTableBehavior&settings[dimension]=wt&settings[display]=focused&settings[tabPane]=nodes and this change tries to reduce the costs of it by getting rid of the `ksort`.

refs #1066