### PR TITLE
added a warning when xdebug is loaded in cli

### DIFF
--- a/bin/propel.php
+++ b/bin/propel.php
@@ -8,10 +8,10 @@ if (!class_exists('\Symfony\Component\Console\Application')) {
     }
 }
 
-use Symfony\Component\Console\Application;
 use Symfony\Component\Finder\Finder;
 
 use Propel\Runtime\Propel;
+use Propel\Generator\Application;
 
 $finder = new Finder();
 $finder->files()->name('*.php')->in(__DIR__.'/../src/Propel/Generator/Command')->depth(0);

--- a/src/Propel/Generator/Application.php
+++ b/src/Propel/Generator/Application.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Propel\Generator;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Application extends \Symfony\Component\Console\Application
+{
+    public function doRun(InputInterface $input, OutputInterface $output)
+    {
+        if (extension_loaded('xdebug')) {
+            $output->writeln(
+                '<comment>You are running propel with xdebug enabled. This has a major impact on runtime performance.</comment>'."\n"
+            );
+        }
+        return parent::doRun($input, $output);
+    }
+}


### PR DESCRIPTION
Xdebug being loaded reduces the runtime performance considerably (a factor up to 3). inform the user about it. refs #1066.

This was also a major problem when running composer, therefore we added this warning there like we do here.

see it in action: (Warning in the very first line after invoking the command)
![xdebug](https://cloud.githubusercontent.com/assets/120441/11714080/b1f17b6e-9f37-11e5-9902-feb8327e2329.png)
