### PR TITLE
bug fix multiple 'XML Schema' with different 'database schema'

### DIFF
--- a/src/Propel/Generator/Builder/Util/SchemaReader.php
+++ b/src/Propel/Generator/Builder/Util/SchemaReader.php
@@ -202,6 +202,12 @@ class SchemaReader
                     break;
 
                 case 'table':
+                    if (!isset($attributes['schema']) 
+                        && $this->currDB->getSchema() && $this->currDB->getPlatform()->supportsSchemas()
+                        && false === strpos($attributes['name'], $this->currDB->getPlatform()->getSchemaDelimiter())) {
+                        $attributes['schema'] = $this->currDB->getSchema();
+                    }
+                    
                     $this->currTable = $this->currDB->addTable($attributes);
                     if ($this->isExternalSchema()) {
                         $this->currTable->setForReferenceOnly($this->isForReferenceOnly);

--- a/tests/Propel/Tests/Generator/Builder/Util/SchemaReaderJoinSchemaTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Util/SchemaReaderJoinSchemaTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT License
+ */
+
+namespace Propel\Tests\Generator\Builder\Util;
+
+use Propel\Generator\Builder\Util\SchemaReader;
+use Propel\Tests\TestCase;
+use Propel\Generator\Platform\PgsqlPlatform;
+
+class SchemaReaderJoinSchemaTest extends TestCase
+{
+    public function testJoinXmlSchemaWithMultipleDatabaseSchema()
+    {
+        $expectedSchema = <<<EOF
+<?xml version="1.0" encoding="utf-8"?>
+<app-data>
+  <database name="default" defaultIdMethod="native" schema="foo" defaultPhpNamingMethod="underscore">
+    <table name="table1" idMethod="native" phpName="Table1">
+      <column name="id" phpName="Id" type="INTEGER" primaryKey="true" autoIncrement="true" required="true"/>
+    </table>
+    <table name="table2" schema="bar" idMethod="native" phpName="Table2">
+      <column name="id" phpName="Id" type="INTEGER" primaryKey="true" autoIncrement="true" required="true"/>
+      <column name="table1_id" phpName="Table1Id" type="INTEGER"/>
+      <foreign-key foreignTable="table1" foreignSchema="foo" name="table2_fk_6e7121">
+        <reference local="table1_id" foreign="id"/>
+      </foreign-key>
+    </table>
+  </database>
+</app-data>
+EOF;
+        
+        $fooReader = new SchemaReader(new PgsqlPlatform());
+        $barReader = new SchemaReader(new PgsqlPlatform());
+        
+        $fooSchema = $fooReader->parseFile($this->getSchemaFile('fooSchema.xml'));
+        $barSchema = $barReader->parseFile($this->getSchemaFile('barSchema.xml'));
+        $fooSchema->joinSchemas([$barSchema]);
+        
+        $this->assertEquals($expectedSchema, $fooSchema->toString());
+    }
+    
+    protected function getSchemaFile($filename)
+    {
+        return realpath(dirname(__FILE__) . DIRECTORY_SEPARATOR . $filename);
+    }
+}

--- a/tests/Propel/Tests/Generator/Builder/Util/barSchema.xml
+++ b/tests/Propel/Tests/Generator/Builder/Util/barSchema.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="ISO-8859-1" standalone="no"?>
+<database name="default" schema="bar">
+    <table name="table2">
+        <column name="id" primaryKey="true" type="INTEGER" autoIncrement="true"/>
+        <column name="table1_id" type="INTEGER"/>
+        <foreign-key foreignTable="table1" foreignSchema="foo">
+            <reference local="table1_id" foreign="id" />
+        </foreign-key>
+    </table>
+</database>

--- a/tests/Propel/Tests/Generator/Builder/Util/fooSchema.xml
+++ b/tests/Propel/Tests/Generator/Builder/Util/fooSchema.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="ISO-8859-1" standalone="no"?>
+<database name="default" schema="foo">
+    <table name="table1">
+        <column name="id" primaryKey="true" type="INTEGER" autoIncrement="true"/>
+    </table>
+</database>


### PR DESCRIPTION
This PR fix bug when `xml schema` split into several files and contains different `database schema`. Before this patch, propel will set the same schema for all tables.