### PR TITLE
[tests] fixed bug when propel trying to execute database migration

### DIFF
--- a/tests/Fixtures/bookstore/behavior-timestampable-schema.xml
+++ b/tests/Fixtures/bookstore/behavior-timestampable-schema.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1" standalone="no"?>
 <database name="bookstore-behavior" defaultIdMethod="native" package="behavior.timestampable" namespace="Propel\Tests\Bookstore\Behavior">
 
-    <table name="table1">
+    <table name="table1_ts">
         <column name="id" required="true" primaryKey="true" autoIncrement="true" type="INTEGER" />
         <column name="title" type="VARCHAR" size="100" primaryString="true" />
         <column name="created_on" type="TIMESTAMP" />
@@ -12,7 +12,7 @@
       </behavior>
     </table>
 
-    <table name="table2">
+    <table name="table2_ts">
         <column name="id" required="true" primaryKey="true" autoIncrement="true" type="INTEGER" />
         <column name="title" type="VARCHAR" size="100" primaryString="true" />
         <behavior name="timestampable" />

--- a/tests/Propel/Tests/Generator/Behavior/Timestampable/TimestampableBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Timestampable/TimestampableBehaviorTest.php
@@ -13,11 +13,11 @@ namespace Propel\Tests\Generator\Behavior\Timestampable;
 use Propel\Generator\Util\QuickBuilder;
 use Propel\Tests\Helpers\Bookstore\BookstoreTestBase;
 
-use Propel\Tests\Bookstore\Behavior\Table1;
-use Propel\Tests\Bookstore\Behavior\Map\Table1TableMap;
-use Propel\Tests\Bookstore\Behavior\Table2;
-use Propel\Tests\Bookstore\Behavior\Map\Table2TableMap;
-use Propel\Tests\Bookstore\Behavior\Table2Query;
+use Propel\Tests\Bookstore\Behavior\Table1Ts as Table1;
+use Propel\Tests\Bookstore\Behavior\Map\Table1TsTableMap as Table1TableMap;
+use Propel\Tests\Bookstore\Behavior\Table2Ts as Table2;
+use Propel\Tests\Bookstore\Behavior\Map\Table2TsTableMap as Table2TableMap;
+use Propel\Tests\Bookstore\Behavior\Table2TsQuery as Table2Query;
 
 use Propel\Runtime\Collection\ObjectCollection;
 

--- a/tests/Propel/Tests/Generator/Behavior/Timestampable/TimestampableBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Timestampable/TimestampableBehaviorTest.php
@@ -13,11 +13,11 @@ namespace Propel\Tests\Generator\Behavior\Timestampable;
 use Propel\Generator\Util\QuickBuilder;
 use Propel\Tests\Helpers\Bookstore\BookstoreTestBase;
 
-use Propel\Tests\Bookstore\Behavior\Table1Ts as Table1;
-use Propel\Tests\Bookstore\Behavior\Map\Table1TsTableMap as Table1TableMap;
-use Propel\Tests\Bookstore\Behavior\Table2Ts as Table2;
-use Propel\Tests\Bookstore\Behavior\Map\Table2TsTableMap as Table2TableMap;
-use Propel\Tests\Bookstore\Behavior\Table2TsQuery as Table2Query;
+use Propel\Tests\Bookstore\Behavior\Table1Ts;
+use Propel\Tests\Bookstore\Behavior\Map\Table1TsTableMap;
+use Propel\Tests\Bookstore\Behavior\Table2Ts;
+use Propel\Tests\Bookstore\Behavior\Map\Table2TsTableMap;
+use Propel\Tests\Bookstore\Behavior\Table2TsQuery;
 
 use Propel\Runtime\Collection\ObjectCollection;
 
@@ -51,19 +51,19 @@ class TimestampableBehaviorTest extends BookstoreTestBase
 
     public function testParameters()
     {
-        $table2 = Table2TableMap::getTableMap();
+        $table2 = Table2TsTableMap::getTableMap();
         $this->assertEquals(count($table2->getColumns()), 4, 'Timestampable adds two columns by default');
-        $this->assertTrue(method_exists('\Propel\Tests\Bookstore\Behavior\Table2', 'getCreatedAt'), 'Timestampable adds a created_at column by default');
-        $this->assertTrue(method_exists('\Propel\Tests\Bookstore\Behavior\Table2', 'getUpdatedAt'), 'Timestampable adds an updated_at column by default');
-        $table1 = Table1TableMap::getTableMap();
+        $this->assertTrue(method_exists('\Propel\Tests\Bookstore\Behavior\Table2Ts', 'getCreatedAt'), 'Timestampable adds a created_at column by default');
+        $this->assertTrue(method_exists('\Propel\Tests\Bookstore\Behavior\Table2Ts', 'getUpdatedAt'), 'Timestampable adds an updated_at column by default');
+        $table1 = Table1TsTableMap::getTableMap();
         $this->assertEquals(count($table1->getColumns()), 4, 'Timestampable does not add two columns when they already exist');
-        $this->assertTrue(method_exists('\Propel\Tests\Bookstore\Behavior\Table1', 'getCreatedOn'), 'Timestampable allows customization of create_column name');
-        $this->assertTrue(method_exists('\Propel\Tests\Bookstore\Behavior\Table1', 'getUpdatedOn'), 'Timestampable allows customization of update_column name');
+        $this->assertTrue(method_exists('\Propel\Tests\Bookstore\Behavior\Table1Ts', 'getCreatedOn'), 'Timestampable allows customization of create_column name');
+        $this->assertTrue(method_exists('\Propel\Tests\Bookstore\Behavior\Table1Ts', 'getUpdatedOn'), 'Timestampable allows customization of update_column name');
     }
 
     public function testPreSave()
     {
-        $t1 = new Table2();
+        $t1 = new Table2Ts();
         $this->assertNull($t1->getUpdatedAt());
         $tsave = time();
         $t1->save();
@@ -77,7 +77,7 @@ class TimestampableBehaviorTest extends BookstoreTestBase
 
     public function testPreSaveNoChange()
     {
-        $t1 = new Table2();
+        $t1 = new Table2Ts();
         $this->assertNull($t1->getUpdatedAt());
         $tsave = time();
         $t1->save();
@@ -90,7 +90,7 @@ class TimestampableBehaviorTest extends BookstoreTestBase
 
     public function testPreSaveManuallyUpdated()
     {
-        $t1 = new Table2();
+        $t1 = new Table2Ts();
         $t1->setUpdatedAt(time() - 10);
         $tsave = time();
         $t1->save();
@@ -106,7 +106,7 @@ class TimestampableBehaviorTest extends BookstoreTestBase
 
     public function testPreInsert()
     {
-        $t1 = new Table2();
+        $t1 = new Table2Ts();
         $this->assertNull($t1->getCreatedAt());
         $tsave = time();
         $t1->save();
@@ -120,7 +120,7 @@ class TimestampableBehaviorTest extends BookstoreTestBase
 
     public function testPreInsertManuallyUpdated()
     {
-        $t1 = new Table2();
+        $t1 = new Table2Ts();
         $t1->setCreatedAt(time() - 10);
         $tsave = time();
         $t1->save();
@@ -129,7 +129,7 @@ class TimestampableBehaviorTest extends BookstoreTestBase
 
     public function testObjectKeepUpdateDateUnchanged()
     {
-        $t1 = new Table2();
+        $t1 = new Table2Ts();
         $t1->setUpdatedAt(time() - 10);
         $tsave = time();
         $t1->save();
@@ -141,7 +141,7 @@ class TimestampableBehaviorTest extends BookstoreTestBase
         $this->assertTimeEquals($tsave, $t1->getUpdatedAt('U'));
 
         // now let's do this a second time
-        $t1 = new Table2();
+        $t1 = new Table2Ts();
         $t1->setUpdatedAt(time() - 10);
         $tsave = time();
         $t1->save();
@@ -157,11 +157,11 @@ class TimestampableBehaviorTest extends BookstoreTestBase
 
     protected function populateUpdatedAt()
     {
-        Table2Query::create()->deleteAll();
+        Table2TsQuery::create()->deleteAll();
         $ts = new ObjectCollection();
-        $ts->setModel('\Propel\Tests\Bookstore\Behavior\Table2');
+        $ts->setModel('\Propel\Tests\Bookstore\Behavior\Table2Ts');
         for ($i=0; $i < 10; $i++) {
-            $t = new Table2();
+            $t = new Table2Ts();
             $t->setTitle('UpdatedAt' . $i);
             /* additional -30 in case the check is done in the same second (which we can't guarantee, so no assert(8 ...) below).*/
             $t->setUpdatedAt(time() - $i * 24 * 60 * 60 - 30);
@@ -172,11 +172,11 @@ class TimestampableBehaviorTest extends BookstoreTestBase
 
     protected function populateCreatedAt()
     {
-        Table2Query::create()->deleteAll();
+        Table2TsQuery::create()->deleteAll();
         $ts = new ObjectCollection();
-        $ts->setModel('\Propel\Tests\Bookstore\Behavior\Table2');
+        $ts->setModel('\Propel\Tests\Bookstore\Behavior\Table2Ts');
         for ($i=0; $i < 10; $i++) {
-            $t = new Table2();
+            $t = new Table2Ts();
             $t->setTitle('CreatedAt' . $i);
             $t->setCreatedAt(time() - $i * 24 * 60 * 60 - 30);
             $ts[]= $t;
@@ -186,59 +186,59 @@ class TimestampableBehaviorTest extends BookstoreTestBase
 
     public function testQueryRecentlyUpdated()
     {
-        $q = Table2Query::create()->recentlyUpdated();
-        $this->assertTrue($q instanceof Table2Query, 'recentlyUpdated() returns the current Query object');
+        $q = Table2TsQuery::create()->recentlyUpdated();
+        $this->assertTrue($q instanceof Table2TsQuery, 'recentlyUpdated() returns the current Query object');
         $this->populateUpdatedAt();
-        $ts = Table2Query::create()->recentlyUpdated()->count();
+        $ts = Table2TsQuery::create()->recentlyUpdated()->count();
         $this->assertEquals(7, $ts, 'recentlyUpdated() returns the elements updated in the last 7 days by default');
-        $ts = Table2Query::create()->recentlyUpdated(5)->count();
+        $ts = Table2TsQuery::create()->recentlyUpdated(5)->count();
         $this->assertEquals(5, $ts, 'recentlyUpdated() accepts a number of days as parameter');
     }
 
     public function testQueryRecentlyCreated()
     {
-        $q = Table2Query::create()->recentlyCreated();
-        $this->assertTrue($q instanceof Table2Query, 'recentlyCreated() returns the current Query object');
+        $q = Table2TsQuery::create()->recentlyCreated();
+        $this->assertTrue($q instanceof Table2TsQuery, 'recentlyCreated() returns the current Query object');
         $this->populateCreatedAt();
-        $ts = Table2Query::create()->recentlyCreated()->count();
+        $ts = Table2TsQuery::create()->recentlyCreated()->count();
         $this->assertEquals(7, $ts, 'recentlyCreated() returns the elements created in the last 7 days by default');
-        $ts = Table2Query::create()->recentlyCreated(5)->count();
+        $ts = Table2TsQuery::create()->recentlyCreated(5)->count();
         $this->assertEquals(5, $ts, 'recentlyCreated() accepts a number of days as parameter');
     }
 
     public function testQueryLastUpdatedFirst()
     {
-        $q = Table2Query::create()->lastUpdatedFirst();
-        $this->assertTrue($q instanceof Table2Query, 'lastUpdatedFirst() returns the current Query object');
+        $q = Table2TsQuery::create()->lastUpdatedFirst();
+        $this->assertTrue($q instanceof Table2TsQuery, 'lastUpdatedFirst() returns the current Query object');
         $this->populateUpdatedAt();
-        $t = Table2Query::create()->lastUpdatedFirst()->findOne();
+        $t = Table2TsQuery::create()->lastUpdatedFirst()->findOne();
         $this->assertEquals('UpdatedAt0', $t->getTitle(), 'lastUpdatedFirst() returns element with most recent update date first');
     }
 
     public function testQueryFirstUpdatedFirst()
     {
-        $q = Table2Query::create()->firstUpdatedFirst();
-        $this->assertTrue($q instanceof Table2Query, 'firstUpdatedFirst() returns the current Query object');
+        $q = Table2TsQuery::create()->firstUpdatedFirst();
+        $this->assertTrue($q instanceof Table2TsQuery, 'firstUpdatedFirst() returns the current Query object');
         $this->populateUpdatedAt();
-        $t = Table2Query::create()->firstUpdatedFirst()->findOne();
+        $t = Table2TsQuery::create()->firstUpdatedFirst()->findOne();
         $this->assertEquals('UpdatedAt9', $t->getTitle(), 'firstUpdatedFirst() returns the element with oldest updated date first');
     }
 
     public function testQueryLastCreatedFirst()
     {
-        $q = Table2Query::create()->lastCreatedFirst();
-        $this->assertTrue($q instanceof Table2Query, 'lastCreatedFirst() returns the current Query object');
+        $q = Table2TsQuery::create()->lastCreatedFirst();
+        $this->assertTrue($q instanceof Table2TsQuery, 'lastCreatedFirst() returns the current Query object');
         $this->populateCreatedAt();
-        $t = Table2Query::create()->lastCreatedFirst()->findOne();
+        $t = Table2TsQuery::create()->lastCreatedFirst()->findOne();
         $this->assertEquals('CreatedAt0', $t->getTitle(), 'lastCreatedFirst() returns element with most recent create date first');
     }
 
     public function testQueryFirstCreatedFirst()
     {
-        $q = Table2Query::create()->firstCreatedFirst();
-        $this->assertTrue($q instanceof Table2Query, 'firstCreatedFirst() returns the current Query object');
+        $q = Table2TsQuery::create()->firstCreatedFirst();
+        $this->assertTrue($q instanceof Table2TsQuery, 'firstCreatedFirst() returns the current Query object');
         $this->populateCreatedAt();
-        $t = Table2Query::create()->firstCreatedFirst()->findOne();
+        $t = Table2TsQuery::create()->firstCreatedFirst()->findOne();
         $this->assertEquals('CreatedAt9', $t->getTitle(), 'firstCreatedFirst() returns the element with oldest create date first');
     }
 

--- a/tests/Propel/Tests/Generator/Builder/Om/QueryBuilderTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/QueryBuilderTest.php
@@ -101,7 +101,7 @@ class QueryBuilderTest extends BookstoreTestBase
 
     public function testBasePreSelect()
     {
-        $method = new ReflectionMethod('\Propel\Tests\Bookstore\Behavior\Table2Query', 'basePreSelect');
+        $method = new ReflectionMethod('\Propel\Tests\Bookstore\Behavior\Table2TsQuery', 'basePreSelect');
         $this->assertEquals('Propel\Runtime\ActiveQuery\ModelCriteria', $method->getDeclaringClass()->getName(), 'BaseQuery does not override basePreSelect() by default');
 
         $method = new ReflectionMethod('\Propel\Tests\Bookstore\Behavior\Table3Query', 'basePreSelect');
@@ -110,7 +110,7 @@ class QueryBuilderTest extends BookstoreTestBase
 
     public function testBasePreDelete()
     {
-        $method = new ReflectionMethod('\Propel\Tests\Bookstore\Behavior\Table2Query', 'basePreDelete');
+        $method = new ReflectionMethod('\Propel\Tests\Bookstore\Behavior\Table2TsQuery', 'basePreDelete');
         $this->assertEquals('Propel\Runtime\ActiveQuery\ModelCriteria', $method->getDeclaringClass()->getName(), 'BaseQuery does not override basePreDelete() by default');
 
         $method = new ReflectionMethod('\Propel\Tests\Bookstore\Behavior\Table3Query', 'basePreDelete');
@@ -119,7 +119,7 @@ class QueryBuilderTest extends BookstoreTestBase
 
     public function testBasePostDelete()
     {
-        $method = new ReflectionMethod('\Propel\Tests\Bookstore\Behavior\Table2Query', 'basePostDelete');
+        $method = new ReflectionMethod('\Propel\Tests\Bookstore\Behavior\Table2TsQuery', 'basePostDelete');
         $this->assertEquals('Propel\Runtime\ActiveQuery\ModelCriteria', $method->getDeclaringClass()->getName(), 'BaseQuery does not override basePostDelete() by default');
 
         $method = new ReflectionMethod('\Propel\Tests\Bookstore\Behavior\Table3Query', 'basePostDelete');
@@ -128,7 +128,7 @@ class QueryBuilderTest extends BookstoreTestBase
 
     public function testBasePreUpdate()
     {
-        $method = new ReflectionMethod('\Propel\Tests\Bookstore\Behavior\Table2Query', 'basePreUpdate');
+        $method = new ReflectionMethod('\Propel\Tests\Bookstore\Behavior\Table2TsQuery', 'basePreUpdate');
         $this->assertEquals('Propel\Runtime\ActiveQuery\ModelCriteria', $method->getDeclaringClass()->getName(), 'BaseQuery does not override basePreUpdate() by default');
 
         $method = new ReflectionMethod('\Propel\Tests\Bookstore\Behavior\Table3Query', 'basePreUpdate');
@@ -137,7 +137,7 @@ class QueryBuilderTest extends BookstoreTestBase
 
     public function testBasePostUpdate()
     {
-        $method = new ReflectionMethod('\Propel\Tests\Bookstore\Behavior\Table2Query', 'basePostUpdate');
+        $method = new ReflectionMethod('\Propel\Tests\Bookstore\Behavior\Table2TsQuery', 'basePostUpdate');
         $this->assertEquals('Propel\Runtime\ActiveQuery\ModelCriteria', $method->getDeclaringClass()->getName(), 'BaseQuery does not override basePostUpdate() by default');
 
         $method = new ReflectionMethod('\Propel\Tests\Bookstore\Behavior\Table3Query', 'basePostUpdate');

--- a/tests/Propel/Tests/Generator/Builder/Om/TableMapBuilderTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/TableMapBuilderTest.php
@@ -13,7 +13,7 @@ namespace Propel\Tests\Generator\Builder\Om;
 use Propel\Runtime\Propel;
 use Propel\Runtime\Map\RelationMap;
 use Propel\Tests\Helpers\Bookstore\BookstoreTestBase;
-use Propel\Tests\Bookstore\Behavior\Map\Table1TableMap;
+use Propel\Tests\Bookstore\Behavior\Map\Table1TsTableMap;
 
 /**
  * Test class for TableMapBuilder.
@@ -252,13 +252,13 @@ class TableMapBuilderTest extends BookstoreTestBase
             'getBehaviors() returns an empty array when no behaviors are registered'
         );
 
-        //this init tableMap for class 'Propel\Tests\Bookstore\Behavior\Table1'
-        Propel::getServiceContainer()->getDatabaseMap(Table1TableMap::DATABASE_NAME)->getTableByPhpName(
-            'Propel\Tests\Bookstore\Behavior\Table1'
+        //this init tableMap for class 'Propel\Tests\Bookstore\Behavior\Table1Ts'
+        Propel::getServiceContainer()->getDatabaseMap(Table1TsTableMap::DATABASE_NAME)->getTableByPhpName(
+            'Propel\Tests\Bookstore\Behavior\Table1Ts'
         );
 
-        $tmap = Propel::getServiceContainer()->getDatabaseMap(Table1TableMap::DATABASE_NAME)->getTable(
-            Table1TableMap::TABLE_NAME
+        $tmap = Propel::getServiceContainer()->getDatabaseMap(Table1TsTableMap::DATABASE_NAME)->getTable(
+            Table1TsTableMap::TABLE_NAME
         );
         $expectedBehaviorParams = [
             'timestampable' => [


### PR DESCRIPTION
Rename `table1` and `table2` into `table1_ts` and `table2_ts` respectively, as `table1` already defined in another schema (`tests/Fixtures/migration-command/schema.xml`).

```
Executing statement "CREATE TABLE "table1"
(
    "id" serial NOT NULL,
    "title" VARCHAR NOT NULL,
    "table2_id" INTEGER,
    PRIMARY KEY ("id")
)"
                                                
  [Propel\Runtime\Exception\RuntimeException]   
  Failed to execute SQL "CREATE TABLE "table1"  
  (                                             
      "id" serial NOT NULL,                     
      "title" VARCHAR NOT NULL,                 
      "table2_id" INTEGER,                      
      PRIMARY KEY ("id")                        
  )". Aborting migration.

```
PS: This happen only when i'm running tests using postgres