### PR TITLE
Initial custom type concept support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 vendor/
 composer.phar
 /composer.lock

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -2136,9 +2136,9 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
             \$this->$clo = \$col;
             \$this->$cloUnserialized = null;";
                 } elseif($col->isCustomType()) {
-                    $hydrateType = $this->declareClass($col->getCustomType());
+                    $customTypeInterface = $this->declareClass($col->getCustomType());
                     $script .= "
-            \$this->$clo = (null !== \$col) ? new $hydrateType(\$col) : null;";
+            \$this->$clo = (null !== \$col) ? $customTypeInterface::__deserializeFromDatabase(\$col) : null;";
                 } elseif ($col->isPhpObjectType()) {
                     $script .= "
             \$this->$clo = (null !== \$col) ? new ".$col->getPhpType()."(\$col) : null;";
@@ -5697,7 +5697,7 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
             $bindValue = '$this->' . $column->getLowercasedName();
             if ($column->isCustomType()) {
                 $bindValue = sprintf(
-                    '%s::__toDatabase(%s)',
+                    '%s::__serializeToDatabase(%s)',
                     $this->declareClass($column->getCustomType()),
                     $bindValue
                 );

--- a/src/Propel/Generator/Builder/Om/QueryBuilder.php
+++ b/src/Propel/Generator/Builder/Om/QueryBuilder.php
@@ -1013,6 +1013,10 @@ abstract class ".$this->getUnqualifiedClassName()." extends " . $parentClass . "
         if (is_object(\$$variableName)) {
             \$$variableName = serialize(\$$variableName);
         }";
+        } elseif ($col->isCustomType()) {
+            $dataType = $this->declareClass($col->getCustomType());
+            $script .= "
+        \$$variableName = $dataType::__serializeFilterBy(\$$variableName);";
         } elseif ($col->getType() == PropelTypes::PHP_ARRAY) {
             $script .= "
         \$key = \$this->getAliasedColName($qualifiedName);

--- a/src/Propel/Generator/Model/Column.php
+++ b/src/Propel/Generator/Model/Column.php
@@ -58,6 +58,13 @@ class Column extends MappingModel
     private $phpType;
 
     /**
+     * Allows you to define serialization and deserialization directly for
+     * a propel type, so it's retrieved as a specific data type and stored
+     * in the database in a specific way.
+     */
+    private $customType;
+
+    /**
      * @var Domain
      */
     private $domain;
@@ -188,6 +195,11 @@ class Column extends MappingModel
             $this->typeHint = $this->getAttribute('typeHint');
             $this->tableMapName = $this->getAttribute('tableMapName');
             $this->description = $this->getAttribute('description');
+            $this->customType = $this->getAttribute('customType', null);
+            if ($this->customType) {
+                $this->phpType = $this->customType;
+                $this->typeHint = $this->customType;
+            }
 
             /*
                 Retrieves the method for converting from specified name
@@ -434,8 +446,8 @@ class Column extends MappingModel
     }
 
     /**
-     * Returns the singular form of the name to use in PHP sources. 
-     * It will set & return a self-generated phpName from its name 
+     * Returns the singular form of the name to use in PHP sources.
+     * It will set & return a self-generated phpName from its name
      * if its not already set.
      *
      * @return string
@@ -467,7 +479,7 @@ class Column extends MappingModel
     }
 
     /**
-     * Sets the singular forn of the name to use in PHP 
+     * Sets the singular forn of the name to use in PHP
      * sources.
      *
      * It will generate a phpName from its name if no
@@ -612,6 +624,18 @@ class Column extends MappingModel
     public function getPhpType()
     {
         return $this->phpType ? $this->phpType : $this->getPhpNative();
+    }
+
+    /**
+     * Returns the custom type to use in PHP sources.
+     *
+     * If no types has been specified, then return null
+     *
+     * @return string
+     */
+    public function getCustomType()
+    {
+        return $this->customType;
     }
 
     /**
@@ -1082,6 +1106,10 @@ class Column extends MappingModel
      */
     public function getPDOType()
     {
+        if ($this->isCustomType()) {
+            $customType = $this->getCustomType();
+            return $customType::__getPDOType();
+        }
         return PropelTypes::getPDOType($this->getType());
     }
 
@@ -1413,6 +1441,16 @@ class Column extends MappingModel
     public function isPhpPrimitiveNumericType()
     {
         return PropelTypes::isPhpPrimitiveNumericType($this->getPhpType());
+    }
+
+    /**
+     * Returns whether or not the column is a custom php type
+     *
+     * @return boolean
+     */
+    public function isCustomType()
+    {
+        return $this->getCustomType() !== null;
     }
 
     /**

--- a/src/Propel/Generator/Model/PropelTypes.php
+++ b/src/Propel/Generator/Model/PropelTypes.php
@@ -242,6 +242,16 @@ class PropelTypes
     }
 
     /**
+     * Returns the PDO type ('PDO::PARAM_*' constant) name.
+     *
+     * @return string
+     */
+    public static function getPdoTypeStringFromPdoType($pdoType)
+    {
+        return self::$pdoTypeNames[$pdoType];
+    }
+
+    /**
      * Returns an array of mapping types.
      *
      * @return array

--- a/src/Propel/Generator/Platform/DefaultPlatform.php
+++ b/src/Propel/Generator/Platform/DefaultPlatform.php
@@ -1320,7 +1320,7 @@ if (is_resource($columnValueAccessor)) {
 \$stmt->bindValue(%s, %s, %s);",
             $identifier,
             $columnValueAccessor,
-            PropelTypes::getPdoTypeString($column->getType())
+            PropelTypes::getPdoTypeStringFromPdoType($column->getPDOType())
         );
 
         return preg_replace('/^(.+)/m', $tab . '$1', $script);

--- a/src/Propel/Runtime/CustomDatatypeInterface.php
+++ b/src/Propel/Runtime/CustomDatatypeInterface.php
@@ -16,13 +16,13 @@ namespace Propel\Runtime;
 interface CustomDataTypeInterface {
     /**
      * @param $instance - An instance of your custom type
-     * @return mixed
+     * @return mixed - Data to pass to PDO
      */
     public static function __serializeToDatabase($instance);
 
     /**
      * @param $data - The database representation of your objet
-     * @return mixed
+     * @return object - instance of your custom database type
      */
     public static function __deserializeFromDatabase($data);
 
@@ -33,5 +33,11 @@ interface CustomDataTypeInterface {
      */
     public static function __getPdoType();
 
+    /**
+     * Determine how filterBy<DataType> generates the data in a Where clause
+     * @param null $data - First argument to filterBy<DataType>
+     * @param null $comparison - SQL comparator (e.g. =, >)
+     * @return mixed - Way to represent data in the WHERE clause
+     */
     public static function __serializeFilterBy($data = null, $comparison = null);
 }

--- a/src/Propel/Runtime/CustomDatatypeInterface.php
+++ b/src/Propel/Runtime/CustomDatatypeInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Propel\Runtime;
+
+/**
+ * Interface CustomDataTypeInterface
+ * @package Propel\Runtime
+ *
+ * A custom data type allows you to define custom serialization and deserialization
+ * in Propel, allowing you to have fine grained control over exactly what is
+ * going into your setters, how they get to the database, and how data flows from
+ * the database to column getters.
+ * Custom data types give you a simple strategy to extend propel to support
+ * data types such as Postgres json, hstore throughout your stack.
+ */
+interface CustomDataTypeInterface {
+    /**
+     * @param $instance - An instance of your custom type
+     * @return mixed
+     */
+    public static function __toDatabase($instance);
+
+    /**
+     * @param $data - The database representation of your objet
+     * @return mixed
+     */
+    public static function __fromDatabase($data);
+
+    /**
+     * The PDO type to bind your __toDatabase value as
+     * http://php.net/manual/en/pdo.constants.php
+     * @return integer - a PDO::PARAM_* constant
+     */
+    public static function __getPdoType();
+}

--- a/src/Propel/Runtime/CustomDatatypeInterface.php
+++ b/src/Propel/Runtime/CustomDatatypeInterface.php
@@ -18,18 +18,20 @@ interface CustomDataTypeInterface {
      * @param $instance - An instance of your custom type
      * @return mixed
      */
-    public static function __toDatabase($instance);
+    public static function __serializeToDatabase($instance);
 
     /**
      * @param $data - The database representation of your objet
      * @return mixed
      */
-    public static function __fromDatabase($data);
+    public static function __deserializeFromDatabase($data);
 
     /**
-     * The PDO type to bind your __toDatabase value as
+     * The PDO type to bind your __serializeToDatabase value as
      * http://php.net/manual/en/pdo.constants.php
      * @return integer - a PDO::PARAM_* constant
      */
     public static function __getPdoType();
+
+    public static function __serializeFilterBy($data = null, $comparison = null);
 }

--- a/tests/Fixtures/bookstore/schema.xml
+++ b/tests/Fixtures/bookstore/schema.xml
@@ -400,4 +400,9 @@
         </foreign-key>
     </table>
 
+    <!-- Test custom phpType which is an object type -->
+    <table name="bookstore_custom_test">
+        <column name="id" primaryKey="true" autoIncrement="true" type="INTEGER"/>
+        <column name="test_datatype" type="VARCHAR" required="true" customType="Propel\Tests\Helpers\CustomDatabaseType"/>
+    </table>
 </database>

--- a/tests/Fixtures/bookstore/schema.xml
+++ b/tests/Fixtures/bookstore/schema.xml
@@ -401,8 +401,8 @@
     </table>
 
     <!-- Test custom phpType which is an object type -->
-    <table name="bookstore_custom_test">
+    <table name="table_with_custom_type">
         <column name="id" primaryKey="true" autoIncrement="true" type="INTEGER"/>
-        <column name="test_datatype" type="VARCHAR" required="true" customType="Propel\Tests\Helpers\CustomDatabaseType"/>
+        <column name="column_with_custom_type" type="VARCHAR" required="true" customType="Propel\Tests\Helpers\CustomDatabaseType"/>
     </table>
 </database>

--- a/tests/Propel/Tests/Helpers/Bookstore/BookstoreDataPopulator.php
+++ b/tests/Propel/Tests/Helpers/Bookstore/BookstoreDataPopulator.php
@@ -29,9 +29,10 @@ use Propel\Tests\Bookstore\Media;
 use Propel\Tests\Bookstore\Publisher;
 use Propel\Tests\Bookstore\ReaderFavorite;
 use Propel\Tests\Bookstore\Review;
-
 use Propel\Tests\Bookstore\RecordLabel;
 use Propel\Tests\Bookstore\ReleasePool;
+use Propel\Tests\Bookstore\TableWithCustomType;
+use Propel\Tests\Helpers\CustomDatabaseType;
 
 define('_LOB_SAMPLE_FILE_PATH', __DIR__ . '/../../../../Fixtures/etc/lob');
 
@@ -252,6 +253,10 @@ class BookstoreDataPopulator
         $pool->setRecordLabel($fade);
         $pool->save();
 
+        $bookstoreCustomTest = new TableWithCustomType();
+        $bookstoreCustomTest->setColumnWithCustomType(new CustomDatabaseType("FooBar"));
+        $bookstoreCustomTest->save($con);
+
         $con->commit();
     }
 
@@ -302,6 +307,7 @@ class BookstoreDataPopulator
             'Propel\Tests\Bookstore\Map\BookSummaryTableMap',
             'Propel\Tests\Bookstore\Map\RecordLabelTableMap',
             'Propel\Tests\Bookstore\Map\ReleasePoolTableMap',
+            'Propel\Tests\Bookstore\Map\TableWithCustomTypeTableMap'
         ];
         // free the memory from existing objects
         foreach ($tableMapClasses as $tableMapClass) {

--- a/tests/Propel/Tests/Helpers/CustomDatabaseType.php
+++ b/tests/Propel/Tests/Helpers/CustomDatabaseType.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Propel\Tests\Helpers;
+
+class CustomDatabaseType implements \Propel\Runtime\CustomDataTypeInterface {
+
+    public function __construct($data) {
+        $this->data = $data;
+    }
+
+    public static function __toDatabase($instance) {
+        // How the data will be bound as a PDO param
+        return $instance->data;
+    }
+
+    public static function __fromDatabase($data) {
+        return self::__construct($data);
+    }
+
+    public static function __getPdoType() {
+        return \PDO::PARAM_STR;
+    }
+}

--- a/tests/Propel/Tests/Helpers/CustomDatabaseType.php
+++ b/tests/Propel/Tests/Helpers/CustomDatabaseType.php
@@ -8,16 +8,20 @@ class CustomDatabaseType implements \Propel\Runtime\CustomDataTypeInterface {
         $this->data = $data;
     }
 
-    public static function __toDatabase($instance) {
+    public static function __serializeToDatabase($instance) {
         // How the data will be bound as a PDO param
         return $instance->data;
     }
 
-    public static function __fromDatabase($data) {
-        return self::__construct($data);
+    public static function __deserializeFromDatabase($data) {
+        return new CustomDatabaseType($data);
     }
 
     public static function __getPdoType() {
         return \PDO::PARAM_STR;
+    }
+
+    public static function __serializeFilterBy($data = null, $comparison = null) {
+        return CustomDatabaseType::__serializeToDatabase($data);
     }
 }

--- a/tests/Propel/Tests/Runtime/ActiveQuery/PropelQueryTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/PropelQueryTest.php
@@ -14,8 +14,10 @@ use Propel\Runtime\Exception\ClassNotFoundException;
 use Propel\Runtime\ActiveQuery\PropelQuery;
 use Propel\Tests\Helpers\Bookstore\BookstoreTestBase;
 use Propel\Tests\Helpers\Bookstore\BookstoreDataPopulator;
+use Propel\Tests\Helpers\CustomDatabaseType;
 use Propel\Tests\Bookstore\Book;
 use Propel\Tests\Bookstore\BookQuery;
+use Propel\Tests\Bookstore\BookstoreCustomTest;
 use Propel\Tests\Bookstore\Behavior\Table6;
 use Propel\Tests\Bookstore\Behavior\Table6Query;
 use Propel\Tests\Bookstore\Behavior\Map\Table6TableMap;
@@ -70,7 +72,21 @@ class PropelQueryTest extends BookstoreTestBase
             ->findOne();
         $this->assertTrue($book instanceof Book);
         $this->assertEquals('Don Juan', $book->getTitle());
+    }
 
+    public function testFilterByCustomDataType() {
+        $bookstoreCustomTest = new BookstoreCustomTest();
+        $bookstoreCustomTest->setTestDatatype(new CustomDatabaseType("FooBar"));
+        $bookstoreCustomTest->save($this->con);
+
+        $expected = new CustomDatabaseType("FooBar");
+        $bookstoreCustomResult = PropelQuery::from('Propel\Tests\Bookstore\BookstoreCustomTest')
+            ->filterByTestDatatype(new CustomDatabaseType("FooBar"))->findOne();
+
+        $this->assertTrue($bookstoreCustomResult instanceof BookstoreCustomTest);
+        $this->assertEquals($bookstoreCustomResult->getTestDatatype(), new CustomDatabaseType("FooBar"));
+
+        $bookstoreCustomResult->delete();
     }
 
     /**

--- a/tests/Propel/Tests/Runtime/ActiveQuery/PropelQueryTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/PropelQueryTest.php
@@ -17,7 +17,7 @@ use Propel\Tests\Helpers\Bookstore\BookstoreDataPopulator;
 use Propel\Tests\Helpers\CustomDatabaseType;
 use Propel\Tests\Bookstore\Book;
 use Propel\Tests\Bookstore\BookQuery;
-use Propel\Tests\Bookstore\BookstoreCustomTest;
+use Propel\Tests\Bookstore\TableWithCustomType;
 use Propel\Tests\Bookstore\Behavior\Table6;
 use Propel\Tests\Bookstore\Behavior\Table6Query;
 use Propel\Tests\Bookstore\Behavior\Map\Table6TableMap;
@@ -75,18 +75,15 @@ class PropelQueryTest extends BookstoreTestBase
     }
 
     public function testFilterByCustomDataType() {
-        $bookstoreCustomTest = new BookstoreCustomTest();
-        $bookstoreCustomTest->setTestDatatype(new CustomDatabaseType("FooBar"));
-        $bookstoreCustomTest->save($this->con);
-
         $expected = new CustomDatabaseType("FooBar");
-        $bookstoreCustomResult = PropelQuery::from('Propel\Tests\Bookstore\BookstoreCustomTest')
-            ->filterByTestDatatype(new CustomDatabaseType("FooBar"))->findOne();
+        $bookstoreCustomResult = PropelQuery::from('Propel\Tests\Bookstore\TableWithCustomType')
+            ->filterByColumnWithCustomType(new CustomDatabaseType("FooBar"))->findOne();
 
-        $this->assertTrue($bookstoreCustomResult instanceof BookstoreCustomTest);
-        $this->assertEquals($bookstoreCustomResult->getTestDatatype(), new CustomDatabaseType("FooBar"));
-
-        $bookstoreCustomResult->delete();
+        $this->assertTrue($bookstoreCustomResult instanceof TableWithCustomType);
+        $this->assertEquals(
+            $bookstoreCustomResult->getColumnWithCustomType(),
+            new CustomDatabaseType("FooBar")
+        );
     }
 
     /**

--- a/tests/Propel/Tests/Runtime/Collection/ArrayCollectionTest.php
+++ b/tests/Propel/Tests/Runtime/Collection/ArrayCollectionTest.php
@@ -12,10 +12,12 @@ namespace Propel\Tests\Runtime\Collection;
 
 use Propel\Tests\Bookstore\Author;
 use Propel\Tests\Bookstore\Book;
+use Propel\Tests\Bookstore\BookstoreCustomTest;
 use Propel\Tests\Bookstore\Map\BookTableMap;
 use Propel\Tests\Bookstore\Country;
 use Propel\Tests\Helpers\Bookstore\BookstoreEmptyTestBase;
 use Propel\Tests\Helpers\Bookstore\BookstoreDataPopulator;
+use Propel\Tests\Helpers\CustomDatabaseType;
 use Propel\Runtime\Collection\ObjectCollection;
 use Propel\Runtime\Collection\ArrayCollection;
 use Propel\Runtime\Exception\PropelException;
@@ -173,6 +175,21 @@ class ArrayCollectionTest extends BookstoreEmptyTestBase
             'Book_The Tin Drum'
         ];
         $this->assertEquals($keys, array_keys($booksArray));
+    }
+
+    public function testToArrayCustomDatatype() {
+        $customDataTypeTest = new BookstoreCustomTest();
+        $customDataTypeTest->setTestDatatype(new CustomDatabaseType("FooBar"));
+        $customDataTypeTest->save($this->con);
+        $bookstoreCustom = PropelQuery::from('Propel\Tests\Bookstore\BookstoreCustomTest')
+            ->setFormatter(ModelCriteria::FORMAT_ARRAY)->find();
+
+        $asArray = $bookstoreCustom->toArray();
+
+        $this->assertEquals(count($asArray), 1);
+        $this->assertTrue($asArray[0]['TestDatatype'] instanceof CustomDatabaseType);
+        $this->assertEquals($asArray[0]['TestDatatype']->data, 'FooBar');
+        $bookstoreCustom->delete();
     }
 
     public function testToArrayDeep()

--- a/tests/Propel/Tests/Runtime/Collection/ArrayCollectionTest.php
+++ b/tests/Propel/Tests/Runtime/Collection/ArrayCollectionTest.php
@@ -12,7 +12,7 @@ namespace Propel\Tests\Runtime\Collection;
 
 use Propel\Tests\Bookstore\Author;
 use Propel\Tests\Bookstore\Book;
-use Propel\Tests\Bookstore\BookstoreCustomTest;
+use Propel\Tests\Bookstore\TableWithCustomType;
 use Propel\Tests\Bookstore\Map\BookTableMap;
 use Propel\Tests\Bookstore\Country;
 use Propel\Tests\Helpers\Bookstore\BookstoreEmptyTestBase;
@@ -178,19 +178,14 @@ class ArrayCollectionTest extends BookstoreEmptyTestBase
     }
 
     public function testToArrayCustomDatatype() {
-        $bookstoreCustomTest = new BookstoreCustomTest();
-        $bookstoreCustomTest->setTestDatatype(new CustomDatabaseType("FooBar"));
-        $bookstoreCustomTest->save($this->con);
-
-        $bookstoreCustom = PropelQuery::from('Propel\Tests\Bookstore\BookstoreCustomTest')
+        $bookstoreCustom = PropelQuery::from('Propel\Tests\Bookstore\TableWithCustomType')
             ->setFormatter(ModelCriteria::FORMAT_ARRAY)->find();
 
         $asArray = $bookstoreCustom->toArray();
 
         $this->assertEquals(count($asArray), 1);
-        $this->assertTrue($asArray[0]['TestDatatype'] instanceof CustomDatabaseType);
-        $this->assertEquals($asArray[0]['TestDatatype']->data, 'FooBar');
-        $bookstoreCustom->delete();
+        $this->assertTrue($asArray[0]['ColumnWithCustomType'] instanceof CustomDatabaseType);
+        $this->assertEquals($asArray[0]['ColumnWithCustomType']->data, 'FooBar');
     }
 
     public function testToArrayDeep()

--- a/tests/Propel/Tests/Runtime/Collection/ArrayCollectionTest.php
+++ b/tests/Propel/Tests/Runtime/Collection/ArrayCollectionTest.php
@@ -178,9 +178,10 @@ class ArrayCollectionTest extends BookstoreEmptyTestBase
     }
 
     public function testToArrayCustomDatatype() {
-        $customDataTypeTest = new BookstoreCustomTest();
-        $customDataTypeTest->setTestDatatype(new CustomDatabaseType("FooBar"));
-        $customDataTypeTest->save($this->con);
+        $bookstoreCustomTest = new BookstoreCustomTest();
+        $bookstoreCustomTest->setTestDatatype(new CustomDatabaseType("FooBar"));
+        $bookstoreCustomTest->save($this->con);
+
         $bookstoreCustom = PropelQuery::from('Propel\Tests\Bookstore\BookstoreCustomTest')
             ->setFormatter(ModelCriteria::FORMAT_ARRAY)->find();
 


### PR DESCRIPTION
This conceptualizes support for customized data types in propel. This allows people to easily implement customized types that either directly or indirectly map to database values, e.g. it's suitable for utilizing Postgresql Hstore or Json, but also a Currency type which may be built on a varchar. It can also replace #1043 entirely.
Behaviors are not well-suited to this, and in fact are kind of sluggish as a general concept, because they have some tendency to conflict with eachother it seems.

This conceptualizes a more true custom type, which basically only requires one set of concepts:
1. Serializing something TO the database
2. Deserializing something FROM the database

In theory, we could just use the Serialize interface, but it's pretty hacked onto php and shows up just everywhere. Not to mention, I expect to have to extend this a bit for querying.

With those concepts in place we can guarantee that we have full control over the object the user of the propel database gets back and sends in. phpType does NOT currently suit this need: Items returned that don't go through object hydration are never the appropriate type. I actually can't figure out how the heck phpType is really supposed to be used in general (it seems to be a pretty left-on-the-side thing), and in theory a nicer 2.0.0 release might not even have it, though I realize that wouldn't be pleasant on the back-compat side of things.

We could potentially encapsulate all types in a similar manner, but that would be a massive (and probably not backwards-compatible) refactor. That said, it would be pretty darn cool to have that level of consistency.

This is not necessarily (by any means) a final revision, but an attempt to bring up a feature that's missed as of now.

We could also make this interface extend e.g. serializable, JsonSerializable if we so chose, which are probably necessary to make all propel functionality work as intended with a custom data type.

One thing I'm not certain of is exactly how these might act in terms of querying. Certainly there's a path to it (even supporting custom operators, which is one thing that's a bit awkward with implementing Hstores in a similar manner to this right now), I'm just not familiar enough with the internals of propel querying yet.

(Pretty sure tests pass as intended, travis/circleci just have some weird caching for composer autoload stuffs.)

For some context: I'm planning on using this for hstores, json, some other stuff internally. (I have a very high performance hstore implementation that I haven't opensourced for lack of a structured way to use it)