### PR TITLE
Update README.md, composer.json and circle.yml for PHP-5.5.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Propel2 #
 
-Propel2 is an open-source Object-Relational Mapping (ORM) for PHP 5.4.
+Propel2 is an open-source Object-Relational Mapping (ORM) for PHP 5.5 and up.
 
 [![Build Status](https://travis-ci.org/propelorm/Propel2.svg?branch=master)](https://travis-ci.org/propelorm/Propel2)
 [![Code Climate](https://codeclimate.com/github/propelorm/Propel2/badges/gpa.svg)](https://codeclimate.com/github/propelorm/Propel2)
@@ -20,7 +20,7 @@ Propel2 uses the following Symfony2 Components:
 Propel2 also relies on [**Composer**](https://github.com/composer/composer) to manage dependencies but you
 also can use [ClassLoader](https://github.com/symfony/ClassLoader) (see the `autoload.php.dist` file for instance).
 
-Propel2 is only supported on PHP 5.4 and up.
+Propel2 is only supported on PHP 5.5 and up.
 
 
 ## Installation ##

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ machine:
     DB_USER: ubuntu
     DB_NAME: circle_test
   php:
-    version: 5.4.9
+    version: 5.5.9
 dependencies:
   pre:
     - sed -i 's/^;//' ~/.phpenv/versions/$(phpenv global)/etc/conf.d/xdebug.ini

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "propel/propel",
     "type": "library",
-    "description": "Propel2 is an open-source Object-Relational Mapping (ORM) for PHP 5.4",
+    "description": "Propel2 is an open-source Object-Relational Mapping (ORM) for PHP 5.5 and up.",
     "keywords": [
         "ORM",
         "persistence",
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
+        "php": ">=5.5",
         "symfony/yaml": "~2.3||~3.0",
         "symfony/console": "~2.3||~3.0",
         "symfony/finder": "~2.3||~3.0",


### PR DESCRIPTION
Since Propel2 is not tested against PHP-5.4 anymore (which is EOL), I updated the README and requirements. See 13a42b95c9175dcd90b27ee030106ac94eb919f9