### PR TITLE
Use complex field in select with join if identifierQuoting="true"

### DIFF
--- a/src/Propel/Runtime/Map/ColumnMap.php
+++ b/src/Propel/Runtime/Map/ColumnMap.php
@@ -512,6 +512,7 @@ class ColumnMap
     {
         if (false !== ($pos = strrpos($name, '.'))) {
             $name = substr($name, $pos + 1);
+	     $name = trim($name," \t\n\r\0\x0B`'()\"[]~!-{}%^&.");
         }
 
         return strtoupper($name);


### PR DESCRIPTION
I work on propel with identifierQuoting="true" and I try to make a propel query with join field = A.b : 
$query->withColumn($field) or sorting by join field or where condition with join field

I have an issue on find() method because in Criteria::createSelectSql propel try to fetch columnName and tableName and try to link to TableMap column definition, in this case ColumnMap::normalizeName() for explode and fetch column name however with identifierQuoting true the field is convert to `A`.`b` so TableMap::getColumn() fail on hasColumn `b` because the column name is b (without quote)

My workaround is to remove all kind of escaping quote ` for mysql, ' for mssql with trim function (we shouldn't have space too) in normalize function, this can be more elegant with an "unquote" adapter method or change TableMap::getColumn() code but this can less performant and more harder..