### PR TITLE
Make MySQL table modifications always use one statement to fix total table-corruption bug #1115

### DIFF
--- a/src/Propel/Generator/Platform/MysqlPlatform.php
+++ b/src/Propel/Generator/Platform/MysqlPlatform.php
@@ -22,6 +22,7 @@ use Propel\Generator\Model\Table;
 use Propel\Generator\Model\Unique;
 use Propel\Generator\Model\Diff\ColumnDiff;
 use Propel\Generator\Model\Diff\DatabaseDiff;
+use Propel\Generator\Model\Diff\TableDiff;
 
 /**
  * MySql PlatformInterface implementation.
@@ -451,13 +452,13 @@ ALTER TABLE %s DROP PRIMARY KEY;
     public function getAddIndexDDL(Index $index)
     {
         $pattern = "
-CREATE %sINDEX %s ON %s (%s);
+ALTER TABLE %s ADD %sINDEX %s (%s);
 ";
 
         return sprintf($pattern,
+            $this->quoteIdentifier($index->getTable()->getName()),
             $this->getIndexType($index),
             $this->quoteIdentifier($index->getName()),
-            $this->quoteIdentifier($index->getTable()->getName()),
             $this->getIndexColumnListDDL($index)
         );
     }
@@ -471,12 +472,12 @@ CREATE %sINDEX %s ON %s (%s);
     public function getDropIndexDDL(Index $index)
     {
         $pattern = "
-DROP INDEX %s ON %s;
+ALTER TABLE %s DROP INDEX %s;
 ";
 
         return sprintf($pattern,
-            $this->quoteIdentifier($index->getName()),
-            $this->quoteIdentifier($index->getTable()->getName())
+            $this->quoteIdentifier($index->getTable()->getName()),
+            $this->quoteIdentifier($index->getName())
         );
     }
 
@@ -717,10 +718,96 @@ ALTER TABLE %s ADD %s %s;
         );
     }
 
+    public function getModifyTableDDL(TableDiff $tableDiff)
+    {
+        $alterTableStatements = '';
+
+        $toTable = $tableDiff->getToTable();
+
+        // drop indices, foreign keys
+        foreach ($tableDiff->getRemovedFks() as $fk) {
+            $alterTableStatements .= $this->getDropForeignKeyDDL($fk);
+        }
+        foreach ($tableDiff->getModifiedFks() as $fkModification) {
+            list($fromFk) = $fkModification;
+            $alterTableStatements .= $this->getDropForeignKeyDDL($fromFk);
+        }
+        foreach ($tableDiff->getRemovedIndices() as $index) {
+            $alterTableStatements .= $this->getDropIndexDDL($index);
+        }
+        foreach ($tableDiff->getModifiedIndices() as $indexModification) {
+            list($fromIndex) = $indexModification;
+            $alterTableStatements .= $this->getDropIndexDDL($fromIndex);
+        }
+
+        // alter table structure
+        if ($tableDiff->hasModifiedPk()) {
+            $alterTableStatements .= $this->getDropPrimaryKeyDDL($tableDiff->getFromTable());
+        }
+        foreach ($tableDiff->getRenamedColumns() as $columnRenaming) {
+            $alterTableStatements .= $this->getRenameColumnDDL($columnRenaming[0], $columnRenaming[1]);
+        }
+        if ($modifiedColumns = $tableDiff->getModifiedColumns()) {
+            $alterTableStatements .= $this->getModifyColumnsDDL($modifiedColumns);
+        }
+        if ($addedColumns = $tableDiff->getAddedColumns()) {
+            $alterTableStatements .= $this->getAddColumnsDDL($addedColumns);
+        }
+        foreach ($tableDiff->getRemovedColumns() as $column) {
+            $alterTableStatements .= $this->getRemoveColumnDDL($column);
+        }
+
+        // add new indices and foreign keys
+        if ($tableDiff->hasModifiedPk()) {
+            $alterTableStatements .= $this->getAddPrimaryKeyDDL($tableDiff->getToTable());
+        }
+
+        // create indices, foreign keys
+        foreach ($tableDiff->getModifiedIndices() as $indexModification) {
+            list($oldIndex, $toIndex) = $indexModification;
+            $alterTableStatements .= $this->getAddIndexDDL($toIndex);
+        }
+        foreach ($tableDiff->getAddedIndices() as $index) {
+            $alterTableStatements .= $this->getAddIndexDDL($index);
+        }
+        foreach ($tableDiff->getModifiedFks() as $fkModification) {
+            list(, $toFk) = $fkModification;
+            $alterTableStatements .= $this->getAddForeignKeyDDL($toFk);
+        }
+        foreach ($tableDiff->getAddedFks() as $fk) {
+            $alterTableStatements .= $this->getAddForeignKeyDDL($fk);
+        }
+
+        $ret = '';
+        if (trim($alterTableStatements)) {
+            //merge all changes into one command. This prevents https://github.com/propelorm/Propel2/issues/1115
+
+            $changes = explode(';', $alterTableStatements);
+            $changeFragments = [];
+            foreach ($changes as $change) {
+                if (trim($change)) {
+                    $changeFragments[] = preg_replace(
+                        sprintf('/ALTER TABLE %s /', $this->quoteIdentifier($toTable->getName())),
+                        "\n\n  ",
+                        trim($change)
+                    );
+                }
+            }
+
+            $ret .= sprintf("
+ALTER TABLE %s%s;
+",
+                $this->quoteIdentifier($toTable->getName()), implode(',', $changeFragments)
+            );
+        }
+
+        return $ret;
+    }
+
     /**
      * Builds the DDL SQL to add a list of columns
      *
-     * @param  Column[] $columns
+     * @param Column[] $columns
      *
      * @return string
      */

--- a/tests/Propel/Tests/Generator/Platform/MysqlPlatformMigrationMyISAMTest.php
+++ b/tests/Propel/Tests/Generator/Platform/MysqlPlatformMigrationMyISAMTest.php
@@ -118,23 +118,23 @@ RENAME TABLE `foo1` TO `foo2`;
     public function testGetModifyTableDDL($tableDiff)
     {
         $expected = "
-DROP INDEX `bar_baz_fk` ON `foo`;
-
-DROP INDEX `foo1_fi_2` ON `foo`;
-
-DROP INDEX `bar_fk` ON `foo`;
-
 ALTER TABLE `foo`
+
+  DROP INDEX `bar_baz_fk`,
+
+  DROP INDEX `foo1_fi_2`,
+
+  DROP INDEX `bar_fk`,
 
   CHANGE `bar` `bar1` INTEGER,
 
   CHANGE `baz` `baz` VARCHAR(12),
 
-  ADD `baz3` TEXT AFTER `baz`;
+  ADD `baz3` TEXT AFTER `baz`,
 
-CREATE INDEX `bar_fk` ON `foo` (`bar1`);
+  ADD INDEX `bar_fk` (`bar1`),
 
-CREATE INDEX `baz_fk` ON `foo` (`baz3`);
+  ADD INDEX `baz_fk` (`baz3`);
 ";
         $this->assertEquals($expected, $this->getPlatform()->getModifyTableDDL($tableDiff));
     }
@@ -173,13 +173,13 @@ ALTER TABLE `foo` ADD PRIMARY KEY (`id`,`bar`);
     public function testGetModifyTableIndicesDDL($tableDiff)
     {
         $expected = "
-DROP INDEX `bar_fk` ON `foo`;
+ALTER TABLE `foo` DROP INDEX `bar_fk`;
 
-CREATE INDEX `baz_fk` ON `foo` (`baz`);
+ALTER TABLE `foo` ADD INDEX `baz_fk` (`baz`);
 
-DROP INDEX `bar_baz_fk` ON `foo`;
+ALTER TABLE `foo` DROP INDEX `bar_baz_fk`;
 
-CREATE INDEX `bar_baz_fk` ON `foo` (`id`, `bar`, `baz`);
+ALTER TABLE `foo` ADD INDEX `bar_baz_fk` (`id`, `bar`, `baz`);
 ";
         $this->assertEquals($expected, $this->getPlatform()->getModifyTableIndicesDDL($tableDiff));
     }

--- a/tests/Propel/Tests/Generator/Platform/MysqlPlatformMigrationTest.php
+++ b/tests/Propel/Tests/Generator/Platform/MysqlPlatformMigrationTest.php
@@ -119,29 +119,29 @@ RENAME TABLE `foo1` TO `foo2`;
     public function testGetModifyTableDDL($tableDiff)
     {
         $expected = "
-ALTER TABLE `foo` DROP FOREIGN KEY `foo1_fk_2`;
-
-ALTER TABLE `foo` DROP FOREIGN KEY `foo1_fk_1`;
-
-DROP INDEX `bar_baz_fk` ON `foo`;
-
-DROP INDEX `foo1_fi_2` ON `foo`;
-
-DROP INDEX `bar_fk` ON `foo`;
-
 ALTER TABLE `foo`
+
+  DROP FOREIGN KEY `foo1_fk_2`,
+
+  DROP FOREIGN KEY `foo1_fk_1`,
+
+  DROP INDEX `bar_baz_fk`,
+
+  DROP INDEX `foo1_fi_2`,
+
+  DROP INDEX `bar_fk`,
 
   CHANGE `bar` `bar1` INTEGER,
 
   CHANGE `baz` `baz` VARCHAR(12),
 
-  ADD `baz3` TEXT AFTER `baz`;
+  ADD `baz3` TEXT AFTER `baz`,
 
-CREATE INDEX `bar_fk` ON `foo` (`bar1`);
+  ADD INDEX `bar_fk` (`bar1`),
 
-CREATE INDEX `baz_fk` ON `foo` (`baz3`);
+  ADD INDEX `baz_fk` (`baz3`),
 
-ALTER TABLE `foo` ADD CONSTRAINT `foo1_fk_1`
+  ADD CONSTRAINT `foo1_fk_1`
     FOREIGN KEY (`bar1`)
     REFERENCES `foo2` (`bar`);
 ";
@@ -182,13 +182,13 @@ ALTER TABLE `foo` ADD PRIMARY KEY (`id`,`bar`);
     public function testGetModifyTableIndicesDDL($tableDiff)
     {
         $expected = "
-DROP INDEX `bar_fk` ON `foo`;
+ALTER TABLE `foo` DROP INDEX `bar_fk`;
 
-CREATE INDEX `baz_fk` ON `foo` (`baz`);
+ALTER TABLE `foo` ADD INDEX `baz_fk` (`baz`);
 
-DROP INDEX `bar_baz_fk` ON `foo`;
+ALTER TABLE `foo` DROP INDEX `bar_baz_fk`;
 
-CREATE INDEX `bar_baz_fk` ON `foo` (`id`, `bar`, `baz`);
+ALTER TABLE `foo` ADD INDEX `bar_baz_fk` (`id`, `bar`, `baz`);
 ";
         $this->assertEquals($expected, $this->getPlatform()->getModifyTableIndicesDDL($tableDiff));
     }

--- a/tests/Propel/Tests/Generator/Platform/MysqlPlatformMyISAMTest.php
+++ b/tests/Propel/Tests/Generator/Platform/MysqlPlatformMyISAMTest.php
@@ -546,9 +546,9 @@ ALTER TABLE `foo` ADD PRIMARY KEY (`bar`);
     public function testAddIndicesDDL($table)
     {
         $expected = "
-CREATE INDEX `babar` ON `foo` (`bar1`, `bar2`);
+ALTER TABLE `foo` ADD INDEX `babar` (`bar1`, `bar2`);
 
-CREATE INDEX `foo_index` ON `foo` (`bar1`);
+ALTER TABLE `foo` ADD INDEX `foo_index` (`bar1`);
 ";
         $this->assertEquals($expected, $this->getPlatform()->getAddIndicesDDL($table));
     }
@@ -559,7 +559,7 @@ CREATE INDEX `foo_index` ON `foo` (`bar1`);
     public function testAddIndexDDL($index)
     {
         $expected = "
-CREATE INDEX `babar` ON `foo` (`bar1`, `bar2`);
+ALTER TABLE `foo` ADD INDEX `babar` (`bar1`, `bar2`);
 ";
         $this->assertEquals($expected, $this->getPlatform()->getAddIndexDDL($index));
     }
@@ -570,7 +570,7 @@ CREATE INDEX `babar` ON `foo` (`bar1`, `bar2`);
     public function testDropIndexDDL($index)
     {
         $expected = "
-DROP INDEX `babar` ON `foo`;
+ALTER TABLE `foo` DROP INDEX `babar`;
 ";
         $this->assertEquals($expected, $this->getPlatform()->getDropIndexDDL($index));
     }

--- a/tests/Propel/Tests/Generator/Platform/MysqlPlatformTest.php
+++ b/tests/Propel/Tests/Generator/Platform/MysqlPlatformTest.php
@@ -558,9 +558,9 @@ ALTER TABLE `foo` ADD PRIMARY KEY (`bar`);
     public function testAddIndicesDDL($table)
     {
         $expected = "
-CREATE INDEX `babar` ON `foo` (`bar1`, `bar2`);
+ALTER TABLE `foo` ADD INDEX `babar` (`bar1`, `bar2`);
 
-CREATE INDEX `foo_index` ON `foo` (`bar1`);
+ALTER TABLE `foo` ADD INDEX `foo_index` (`bar1`);
 ";
         $this->assertEquals($expected, $this->getPlatform()->getAddIndicesDDL($table));
     }
@@ -571,7 +571,7 @@ CREATE INDEX `foo_index` ON `foo` (`bar1`);
     public function testAddIndexDDL($index)
     {
         $expected = "
-CREATE INDEX `babar` ON `foo` (`bar1`, `bar2`);
+ALTER TABLE `foo` ADD INDEX `babar` (`bar1`, `bar2`);
 ";
         $this->assertEquals($expected, $this->getPlatform()->getAddIndexDDL($index));
     }
@@ -582,7 +582,7 @@ CREATE INDEX `babar` ON `foo` (`bar1`, `bar2`);
     public function testDropIndexDDL($index)
     {
         $expected = "
-DROP INDEX `babar` ON `foo`;
+ALTER TABLE `foo` DROP INDEX `babar`;
 ";
         $this->assertEquals($expected, $this->getPlatform()->getDropIndexDDL($index));
     }

--- a/tests/Propel/Tests/Issues/Issue1115Test.php
+++ b/tests/Propel/Tests/Issues/Issue1115Test.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Propel\Tests\Issues;
+
+use Propel\Tests\Generator\Migration\MigrationTestCase;
+
+/**
+ * This test proves the bug described in https://github.com/propelorm/Propel2/issues/1115.
+ *
+ * @group mysql
+ * @group database
+ */
+class Issue1115Test extends MigrationTestCase
+{
+
+    /**
+     * Test if an error is caused by attempting to add an index that includes a
+     * foreign-keyed column while also making another change to the same table.
+     */
+    public function testChange() {
+        $originXml = '
+<database>
+    <table name="foo">
+        <column name="bar_id" type="integer"/>
+        <column name="other_column" type="integer"/>
+        <foreign-key foreignTable="bar">
+            <reference local="bar_id" foreign="id"/>
+        </foreign-key>
+    </table>
+    <table name="bar">
+        <column name="id" type="integer" primaryKey="true"/>
+    </table>
+</database>
+';
+
+        $targetXml = '
+<database>
+    <table name="foo">
+        <column name="bar_id" type="integer"/>
+        <column name="other_column" type="integer"/>
+        <column name="new_column" type="integer"/>
+        <foreign-key foreignTable="bar">
+            <reference local="bar_id" foreign="id"/>
+        </foreign-key>
+        <index>
+            <index-column name="bar_id"/>
+            <index-column name="other_column"/>
+        </index>
+    </table>
+    <table name="bar">
+        <column name="id" type="integer" primaryKey="true"/>
+    </table>
+</database>
+';
+        $this->migrateAndTest($originXml, $targetXml);
+    }
+
+}

--- a/tests/Propel/Tests/Issues/Issue617Test.php
+++ b/tests/Propel/Tests/Issues/Issue617Test.php
@@ -153,11 +153,11 @@ CREATE TABLE `issue617_group`
         $sql = $this->database->getPlatform()->getModifyDatabaseDDL($diff);
 
         $expected = '
-ALTER TABLE `issue617_user` DROP FOREIGN KEY `issue617_user_fk_5936b3`;
-
-DROP INDEX `issue617_user_fi_5936b3` ON `issue617_user`;
-
 ALTER TABLE `issue617_user`
+
+  DROP FOREIGN KEY `issue617_user_fk_5936b3`,
+
+  DROP INDEX `issue617_user_fi_5936b3`,
 
   DROP `group_id`;
 ';


### PR DESCRIPTION
There are three commits in here. The first adds a test that proves https://github.com/propelorm/Propel2/issues/1115. The second fixes it by changing the way that Propel generates DDL statements for MySQL to always modify a table with a single big statement instead of many. This breaks lots of tests that were simply asserting on the exact DDL output. The third commit changes all those tests so that they pass again.