### PR TITLE
Replace DateTime for DateTimeInterface

### DIFF
--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -469,10 +469,7 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
     protected function addColumnAttributeComment(&$script, Column $column)
     {
         if ($column->isTemporalType()) {
-            $cptype = $this->getBuildProperty('dateTimeClass');
-            if (!$cptype) {
-                $cptype = '\DateTime';
-            }
+            $cptype = $this->getDateTimeClass($column);
         } else {
             $cptype = $column->getPhpType();
         }
@@ -745,10 +742,7 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
             $clo = $column->getLowercasedName();
             $defaultValue = $this->getDefaultValueString($column);
             if ($column->isTemporalType()) {
-                $dateTimeClass = $this->getBuildProperty('generator.dateTime.dateTimeClass');
-                if (!$dateTimeClass) {
-                    $dateTimeClass = '\DateTime';
-                }
+                $dateTimeClass = $this->getDateTimeClass($column);
                 $script .= "
         \$this->".$clo." = PropelDateTime::newInstance($defaultValue, null, '$dateTimeClass');";
             } else {
@@ -794,10 +788,7 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
     {
         $clo = $column->getLowercasedName();
 
-        $dateTimeClass = $this->getBuildProperty('generator.dateTime.dateTimeClass');
-        if (!$dateTimeClass) {
-            $dateTimeClass = '\DateTime';
-        }
+        $dateTimeClass = $this->getDateTimeClass($column);
 
         $handleMysqlDate = false;
         if ($this->getPlatform() instanceof MysqlPlatform) {
@@ -896,10 +887,8 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
     {
         $clo = $column->getLowercasedName();
 
-        $dateTimeClass = $this->getBuildProperty('generator.dateTime.dateTimeClass');
-        if (!$dateTimeClass) {
-            $dateTimeClass = '\DateTime';
-        }
+        $dateTimeClass = $this->getDateTimeClass($column);
+
         $this->declareClasses($dateTimeClass);
         $defaultfmt = null;
 
@@ -1690,10 +1679,8 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
     {
         $clo = $col->getLowercasedName();
 
-        $dateTimeClass = $this->getBuildProperty('generator.dateTime.dateTimeClass');
-        if (!$dateTimeClass) {
-            $dateTimeClass = '\DateTime';
-        }
+        $dateTimeClass = $this->getDateTimeClass($col);
+
         $this->declareClasses($dateTimeClass, '\Propel\Runtime\Util\PropelDateTime');
 
         $this->addTemporalMutatorComment($script, $col);
@@ -2252,10 +2239,7 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
                 \$this->$clo = null;
             }";
                 } elseif ($col->isTemporalType()) {
-                    $dateTimeClass = $this->getBuildProperty('generator.dateTime.dateTimeClass');
-                    if (!$dateTimeClass) {
-                        $dateTimeClass = '\DateTime';
-                    }
+                    $dateTimeClass = $this->getDateTimeClass($col);
                     $handleMysqlDate = false;
                     if ($this->getPlatform() instanceof MysqlPlatform) {
                         if ($col->getType() === PropelTypes::TIMESTAMP) {
@@ -6507,5 +6491,19 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
         $script .= $this->renderTemplate('baseObjectMethodMagicCall', [
                 'behaviorCallScript' => $behaviorCallScript
                 ]);
+    }
+
+    protected function getDateTimeClass(Column $column)
+    {
+        if (PropelTypes::isPhpObjectType($column->getPhpType())) {
+            return $column->getPhpType();
+        }
+
+        $dateTimeClass = $this->getBuildProperty('generator.dateTime.dateTimeClass');
+        if (!$dateTimeClass) {
+            $dateTimeClass = '\DateTime';
+        }
+
+        return $dateTimeClass;
     }
 }

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -924,7 +924,7 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
         if (\$format === null) {
             return \$this->$clo;
         } else {
-            return \$this->$clo instanceof \DateTime ? \$this->{$clo}->format(\$format) : null;
+            return \$this->$clo instanceof \DateTimeInterface ? \$this->{$clo}->format(\$format) : null;
         }";
     }
 
@@ -1744,7 +1744,7 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
     /**
      * Sets the value of [$clo] column to a normalized version of the date/time value specified.
      * ".$col->getDescription()."
-     * @param  mixed \$v string, integer (timestamp), or \DateTime value.
+     * @param  mixed \$v string, integer (timestamp), or \DateTimeInterface value.
      *               Empty strings are treated as NULL.
      * @return \$this|".$this->getObjectClassName(true)." The current object (for fluent API support)
      */";

--- a/src/Propel/Runtime/Parser/XmlParser.php
+++ b/src/Propel/Runtime/Parser/XmlParser.php
@@ -120,7 +120,7 @@ class XmlParser extends AbstractParser
                 $value = htmlspecialchars($value, ENT_COMPAT, 'UTF-8');
                 $child = $element->ownerDocument->createCDATASection($value);
                 $element->appendChild($child);
-            } elseif ($value instanceof \DateTime) {
+            } elseif ($value instanceof \DateTimeInterface) {
                 $element->setAttribute('type', 'xsd:dateTime');
                 $child = $element->ownerDocument->createTextNode($value->format(\DateTime::ISO8601));
                 $element->appendChild($child);

--- a/src/Propel/Runtime/Util/PropelDateTime.php
+++ b/src/Propel/Runtime/Util/PropelDateTime.php
@@ -70,7 +70,7 @@ class PropelDateTime extends \DateTime
      */
     public static function newInstance($value, DateTimeZone $timeZone = null, $dateTimeClass = 'DateTime')
     {
-        if ($value instanceof \DateTime) {
+        if ($value instanceof \DateTimeInterface) {
             return $value;
         }
         if (empty($value)) {

--- a/tests/Propel/Tests/Runtime/Util/PropelDateTimeTest.php
+++ b/tests/Propel/Tests/Runtime/Util/PropelDateTimeTest.php
@@ -193,7 +193,8 @@ class PropelDateTimeTest extends \PHPUnit_Framework_TestCase
             'Y-m-d H:is'		  => ['2011-08-10 10:22:15', '2011-08-10 10:22:15'],
             'Ymd'		         => ['20110810', '2011-08-10 00:00:00'],
             'Ymd'		         => ['20110720', '2011-07-20 00:00:00'],
-            'datetime_object' => [new DateTime('2011-08-10 10:23:10'), '2011-08-10 10:23:10']
+            'datetime_object' => [new DateTime('2011-08-10 10:23:10'), '2011-08-10 10:23:10'],
+            'datetimeimmutable_object' => [new \DateTimeImmutable('2011-08-10 10:23:10'), '2011-08-10 10:23:10'],
         ];
     }
 


### PR DESCRIPTION
In php5.5 added new interface for working with dates and a new class DateTimeImmutable, and now we can change DateTime class in the config on DateTimeImmutable