### PR TITLE
Log function in model deprecated now

### DIFF
--- a/src/Propel/Generator/Builder/Om/templates/baseObjectMethods.php
+++ b/src/Propel/Generator/Builder/Om/templates/baseObjectMethods.php
@@ -171,6 +171,8 @@
      * @param  string  $msg
      * @param  int     $priority One of the Propel::LOG_* logging levels
      * @return boolean
+     *
+     * @deprecated
      */
     protected function log($msg, $priority = Propel::LOG_INFO)
     {


### PR DESCRIPTION
We should not loging anything in the model, and I think we need declared this function as deprecated, and will remove later.