### PR TITLE
Problem with ObjectCollection::removeObject

### DIFF
--- a/src/Propel/Runtime/Collection/ObjectCollection.php
+++ b/src/Propel/Runtime/Collection/ObjectCollection.php
@@ -431,10 +431,12 @@ class ObjectCollection extends Collection
             return;
         }
 
-        $pos = count($this->data);
+        $this->data[] = $value;
+        end($this->data);
+        $pos = key($this->data);
+
         $this->index[$value->hashCode()] = $pos;
         $this->indexSplHash[spl_object_hash($value)] = $value->hashCode();
-        $this->data[] = $value;
     }
 
     /**
@@ -451,9 +453,12 @@ class ObjectCollection extends Collection
         $hashCode = $value->hashCode();
 
         if (is_null($offset)) {
-            $this->index[$hashCode] = count($this->data);
-            $this->indexSplHash[spl_object_hash($value)] = $hashCode;
             $this->data[] = $value;
+            end($this->data);
+            $pos = key($this->data);
+
+            $this->index[$hashCode] = $pos;
+            $this->indexSplHash[spl_object_hash($value)] = $hashCode;
         } else {
             if (isset($this->data[$offset])) {
                 unset($this->indexSplHash[spl_object_hash($this->data[$offset])]);

--- a/tests/Propel/Tests/Issues/Issue1133Test.php
+++ b/tests/Propel/Tests/Issues/Issue1133Test.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Propel\Tests\Issues;
+
+use Propel\Tests\TestCase;
+use Propel\Runtime\Collection\ObjectCollection;
+
+class DummyObject
+{
+    private $id;
+
+    public function __construct($id)
+    {
+        $this->id = $id;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function hashCode()
+    {
+        return (string)$this->id;
+    }
+}
+
+/**
+ * This test proves the bug described in https://github.com/propelorm/Propel2/issues/1133.
+ *
+ * @group database
+ */
+class Issue1133Test extends TestCase
+{
+
+    public function testIssue1133Append()
+    {
+        $testCollection = new ObjectCollection;
+        $testCollection->setModel(DummyObject::class);
+
+        for ($i = 0; $i < 3; $i++)
+        {
+            $testCollection->append(new DummyObject($i));
+        }
+
+        $firstToRemove = $testCollection[0];
+        $objectThatShouldNotBeRemoved = $testCollection[2];
+
+        // breaks index numbering
+        $testCollection->removeObject($firstToRemove);
+        $objectThatWillBeRemoved = new DummyObject(3);
+        $testCollection->append($objectThatWillBeRemoved);
+        $testCollection->removeObject($objectThatWillBeRemoved);
+
+        $this->assertContains($objectThatShouldNotBeRemoved, $testCollection, 'ObjectCollection does not contain item that should be in collection.');
+        $this->assertNotContains($objectThatWillBeRemoved, $testCollection, 'ObjectCollection contains item that should be removed.');
+    }
+
+    public function testIssue1133OffsetSet()
+    {
+        $testCollection = new ObjectCollection;
+        $testCollection->setModel(DummyObject::class);
+
+        for ($i = 0; $i < 3; $i++)
+        {
+            $testCollection->append(new DummyObject($i));
+        }
+
+        $firstToRemove = $testCollection[0];
+        $objectThatShouldNotBeRemoved = $testCollection[2];
+
+        // breaks index numbering
+        $testCollection->removeObject($firstToRemove);
+
+        $objectThatWillBeRemoved = new DummyObject(3);
+        // calls offsetSet
+        $testCollection[] = $objectThatWillBeRemoved;
+        $testCollection->removeObject($objectThatWillBeRemoved);
+
+        $this->assertContains($objectThatShouldNotBeRemoved, $testCollection, 'ObjectCollection does not contain item that should be in collection.');
+        $this->assertNotContains($objectThatWillBeRemoved, $testCollection, 'ObjectCollection contains item that should be removed.');
+
+    }
+}


### PR DESCRIPTION
Hello. I ran into a problem while using ObjectCollection. Subsequential use of `ObjectCollection::removeObject` and `ObjectCollection::append` results with wrong index mapping, which causes that improper items are removed and left in the collection.

I have provided simple test case to reproduce this issue.

It seems it is caused by optimistic assumption in `ObjectCollection::append` that `$pos = count($this->data);`