### PR TITLE
BaseModel::save(): call $this->preSave() before fetching $this->isNew()

### DIFF
--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -6024,13 +6024,13 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
             \$con = Propel::getServiceContainer()->getWriteConnection(".$this->getTableMapClass()."::DATABASE_NAME);
         }
 
-        return \$con->transaction(function () use (\$con".($reloadOnUpdate || $reloadOnInsert ? ", \$skipReload" : "").") {
-            \$isInsert = \$this->isNew();";
+        return \$con->transaction(function () use (\$con".($reloadOnUpdate || $reloadOnInsert ? ", \$skipReload" : "").") {";
 
         if ($this->getBuildProperty('generator.objectModel.addHooks')) {
             // save with runtime hooks
             $script .= "
-            \$ret = \$this->preSave(\$con);";
+            \$ret = \$this->preSave(\$con);
+            \$isInsert = \$this->isNew();";
             $this->applyBehaviorModifier('preSave', $script, "            ");
             $script .= "
             if (\$isInsert) {
@@ -6064,6 +6064,8 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
             return \$affectedRows;";
         } else {
             // save without runtime hooks
+            $script .= "
+            \$isInsert = \$this->isNew();";
             $this->applyBehaviorModifier('preSave', $script, "            ");
             if ($this->hasBehaviorModifier('preUpdate')) {
                 $script .= "


### PR DESCRIPTION
references issue #1137 


$ php -d 'memory_limit=4G' vendor/bin/phpunit --verbose
Tests started in temp /tmp.
PHPUnit 5.2.10 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.0.3 with Xdebug 2.4.0RC4
Configuration: /home/damien/Propel2/phpunit.xml

....SS.......................................................   61 / 3358 (  1%)
.............................................................  122 / 3358 (  3%)
.............................................................  183 / 3358 (  5%)
.............................................................  244 / 3358 (  7%)
.............................................................  305 / 3358 (  9%)
.............................................................  366 / 3358 ( 10%)
.............................................................  427 / 3358 ( 12%)
..........S..................................................  488 / 3358 ( 14%)
.............................................................  549 / 3358 ( 16%)
.............................................................  610 / 3358 ( 18%)
.............S...............................................  671 / 3358 ( 19%)
.............................................................  732 / 3358 ( 21%)
.............................................................  793 / 3358 ( 23%)
.............................................................  854 / 3358 ( 25%)
.............................................................  915 / 3358 ( 27%)
.............................................................  976 / 3358 ( 29%)
............................................................. 1037 / 3358 ( 30%)
............................................................. 1098 / 3358 ( 32%)
....................................................SSSSSSSS. 1159 / 3358 ( 34%)
............................................................. 1220 / 3358 ( 36%)
............................................................. 1281 / 3358 ( 38%)
............................................................. 1342 / 3358 ( 39%)
............................................................. 1403 / 3358 ( 41%)
............................................................. 1464 / 3358 ( 43%)
............................................................. 1525 / 3358 ( 45%)
............................................................. 1586 / 3358 ( 47%)
............................................................. 1647 / 3358 ( 49%)
............................................................. 1708 / 3358 ( 50%)
............................................................. 1769 / 3358 ( 52%)
............................................................. 1830 / 3358 ( 54%)
............................................................. 1891 / 3358 ( 56%)
............................................................. 1952 / 3358 ( 58%)
............................................................. 2013 / 3358 ( 59%)
............................................................. 2074 / 3358 ( 61%)
............................................................. 2135 / 3358 ( 63%)
.....................S....................................... 2196 / 3358 ( 65%)
............................................................. 2257 / 3358 ( 67%)
............................................................. 2318 / 3358 ( 69%)
............................................................. 2379 / 3358 ( 70%)
............................................................. 2440 / 3358 ( 72%)
............................................................. 2501 / 3358 ( 74%)
............................................................. 2562 / 3358 ( 76%)
............................................................. 2623 / 3358 ( 78%)
............................................................. 2684 / 3358 ( 79%)
............................................................. 2745 / 3358 ( 81%)
............................................................. 2806 / 3358 ( 83%)
............................................................. 2867 / 3358 ( 85%)
...............S..................................S.......... 2928 / 3358 ( 87%)
.................S........................................III 2989 / 3358 ( 89%)
I............................................................ 3050 / 3358 ( 90%)
............................................................. 3111 / 3358 ( 92%)
............................................................. 3172 / 3358 ( 94%)
............................................................. 3233 / 3358 ( 96%)
............................................................. 3294 / 3358 ( 98%)
....................................S...SSSSS................ 3355 / 3358 ( 99%)
.SS                                                           3358 / 3358 (100%)

Time: 57.14 seconds, Memory: 162.00Mb

There were 4 incomplete tests:

1) Propel\Tests\Runtime\Map\RelatedMapSymmetricalWithSchemasTest::testOneToMany
The two following tests don't pass

/home/damien/Propel2/tests/Propel/Tests/Runtime/Map/RelatedMapSymmetricalWithSchemasTest.php:41

2) Propel\Tests\Runtime\Map\RelatedMapSymmetricalWithSchemasTest::testOneToOne
The two following tests don't pass

/home/damien/Propel2/tests/Propel/Tests/Runtime/Map/RelatedMapSymmetricalWithSchemasTest.php:53

3) Propel\Tests\Runtime\Map\RelatedMapSymmetricalWithSchemasTest::testSeveralRelationsOnSameTable
The two following tests don't pass

/home/damien/Propel2/tests/Propel/Tests/Runtime/Map/RelatedMapSymmetricalWithSchemasTest.php:65

4) Propel\Tests\Runtime\Map\RelatedMapSymmetricalWithSchemasTest::testCompositeForeignKey
The two following tests don't pass

/home/damien/Propel2/tests/Propel/Tests/Runtime/Map/RelatedMapSymmetricalWithSchemasTest.php:77

--

There were 24 skipped tests:

1) Propel\Tests\CharacterEncodingTest::testUtf8
Skipped because of weird behavior on some platforms

/home/damien/Propel2/tests/Propel/Tests/CharacterEncodingTest.php:60

2) Propel\Tests\CharacterEncodingTest::testInvalidCharset
Skipped because of weird behavior on some platforms

/home/damien/Propel2/tests/Propel/Tests/CharacterEncodingTest.php:91

3) Propel\Tests\Generator\Behavior\I18n\I18nBehaviorQueryBuilderModifierTest::testJoinWithI18nDoesNotExecuteAdditionalQueryWhenNoTranslationIsFound

/home/damien/Propel2/tests/Propel/Tests/Generator/Behavior/I18n/I18nBehaviorQueryBuilderModifierTest.php:261

4) Propel\Tests\Generator\Behavior\Sluggable\SluggableBehaviorTest::testUniqueViolationWithoutScope
Skipping...

/home/damien/Propel2/tests/Propel/Tests/Generator/Behavior/Sluggable/SluggableBehaviorTest.php:283

5) Propel\Tests\Generator\Builder\Om\GeneratedQueryDoSelectTest::testDoSelect
not used anymore look if all tests are present in Query

/home/damien/Propel2/tests/Propel/Tests/Generator/Builder/Om/GeneratedQueryDoSelectTest.php:65

6) Propel\Tests\Generator\Builder\Om\GeneratedQueryDoSelectTest::testDoSelect_Limit
not used anymore look if all tests are present in Query

/home/damien/Propel2/tests/Propel/Tests/Generator/Builder/Om/GeneratedQueryDoSelectTest.php:65

7) Propel\Tests\Generator\Builder\Om\GeneratedQueryDoSelectTest::testDoSelectJoin
not used anymore look if all tests are present in Query

/home/damien/Propel2/tests/Propel/Tests/Generator/Builder/Om/GeneratedQueryDoSelectTest.php:65

8) Propel\Tests\Generator\Builder\Om\GeneratedQueryDoSelectTest::testObjectInstances
not used anymore look if all tests are present in Query

/home/damien/Propel2/tests/Propel/Tests/Generator/Builder/Om/GeneratedQueryDoSelectTest.php:65

9) Propel\Tests\Generator\Builder\Om\GeneratedQueryDoSelectTest::testInheritance
not used anymore look if all tests are present in Query

/home/damien/Propel2/tests/Propel/Tests/Generator/Builder/Om/GeneratedQueryDoSelectTest.php:65

10) Propel\Tests\Generator\Builder\Om\GeneratedQueryDoSelectTest::testHydrationJoinLazyLoad
not used anymore look if all tests are present in Query

/home/damien/Propel2/tests/Propel/Tests/Generator/Builder/Om/GeneratedQueryDoSelectTest.php:65

11) Propel\Tests\Generator\Builder\Om\GeneratedQueryDoSelectTest::testMultiColFk
not used anymore look if all tests are present in Query

/home/damien/Propel2/tests/Propel/Tests/Generator/Builder/Om/GeneratedQueryDoSelectTest.php:65

12) Propel\Tests\Generator\Builder\Om\GeneratedQueryDoSelectTest::testMultiColJoin
not used anymore look if all tests are present in Query

/home/damien/Propel2/tests/Propel/Tests/Generator/Builder/Om/GeneratedQueryDoSelectTest.php:65

13) Propel\Tests\Generator\Reverse\MysqlSchemaParserTest::testParse
Skipped as we now use one database for the whole test suite

/home/damien/Propel2/tests/Propel/Tests/Generator/Reverse/MysqlSchemaParserTest.php:33

14) Propel\Tests\Runtime\Formatter\ArrayFormatterWithTest::testFindWithLeftJoinWithManyToOneAndNullObject
This test is designed for SQLite as it saves an empty object.

/home/damien/Propel2/tests/Propel/Tests/Runtime/Formatter/ArrayFormatterWithTest.php:396

15) Propel\Tests\Runtime\Formatter\ObjectFormatterWithTest::testFindWithLeftJoinWithManyToOneAndNullObject
This test is designed for SQLite as it saves an empty object.

/home/damien/Propel2/tests/Propel/Tests/Runtime/Formatter/ObjectFormatterWithTest.php:443

16) Propel\Tests\Runtime\Formatter\OnDemandFormatterWithTest::testFindWithLeftJoinWithManyToOneAndNullObject
This test is designed for SQLite as it saves an empty object.

/home/damien/Propel2/tests/Propel/Tests/Runtime/Formatter/OnDemandFormatterWithTest.php:270

17) Propel\Tests\Runtime\Util\TableMapTest::testMultipleFunctionInCriteria
Configured database vendor is not PostgreSQL

/home/damien/Propel2/tests/Propel/Tests/Runtime/Util/TableMapTest.php:48

18) Propel\Tests\Runtime\Util\TableMapTest::testMixedJoinOrder
Famous cross join problem, to be solved one day

/home/damien/Propel2/tests/Propel/Tests/Runtime/Util/TableMapTest.php:125

19) Propel\Tests\Runtime\Util\TableMapTest::testMssqlApplyLimitNoOffset
Configured database vendor is not MsSQL

/home/damien/Propel2/tests/Propel/Tests/Runtime/Util/TableMapTest.php:144

20) Propel\Tests\Runtime\Util\TableMapTest::testMssqlApplyLimitWithOffset
Configured database vendor is not MsSQL

/home/damien/Propel2/tests/Propel/Tests/Runtime/Util/TableMapTest.php:169

21) Propel\Tests\Runtime\Util\TableMapTest::testMssqlApplyLimitWithOffsetOrderByAggregate
Configured database vendor is not MsSQL

/home/damien/Propel2/tests/Propel/Tests/Runtime/Util/TableMapTest.php:192

22) Propel\Tests\Runtime\Util\TableMapTest::testMssqlApplyLimitWithOffsetMultipleOrderBy
Configured database vendor is not MsSQL

/home/damien/Propel2/tests/Propel/Tests/Runtime/Util/TableMapTest.php:216

23) Propel\Tests\Ticket520Test::testDeletedBookDisappears

/home/damien/Propel2/tests/Propel/Tests/Ticket520Test.php:193

24) Propel\Tests\Ticket520Test::testNewObjectsGetLostOnJoin

/home/damien/Propel2/tests/Propel/Tests/Ticket520Test.php:231

OK, but incomplete, skipped, or risky tests!
Tests: 3358, Assertions: 8358, Skipped: 24, Incomplete: 4.