### PR TITLE
Added user and password options to the slaves configuration

### DIFF
--- a/src/Propel/Common/Config/PropelConfiguration.php
+++ b/src/Propel/Common/Config/PropelConfiguration.php
@@ -139,6 +139,8 @@ class PropelConfiguration implements ConfigurationInterface
                                         ->prototype('array')
                                             ->children()
                                                 ->scalarNode('dsn')->end()
+                                                ->scalarNode('user')->end()
+                                                ->scalarNode('password')->end()
                                             ->end()
                                         ->end()
                                     ->end()


### PR DESCRIPTION
This fixes a problem in which propel always tried to connect with empty username/password for all read queries