### PR TITLE
Prevented function redeclaration error by skipping reserved methods

### DIFF
--- a/src/Propel/Generator/Builder/Om/ClassTools.php
+++ b/src/Propel/Generator/Builder/Om/ClassTools.php
@@ -121,4 +121,11 @@ class ClassTools
             'throw', 'this', 'namespace'
         ];
     }
+
+    public static function getPropelReservedMethods()
+    {
+        return [
+            'isModified', 'isColumnModified', 'isNew', 'isDeleted',
+        ];
+    }
 }

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -1015,6 +1015,10 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
      */
     protected function addBooleanAccessor(&$script, Column $column)
     {
+        $name = $column->getCamelCaseName();
+        if (in_array($name, ClassTools::getPropelReservedMethods())) {
+            return; // Skip boolean accessors for reserved names
+        }
         $this->addDefaultAccessorComment($script, $column);
         $this->addBooleanAccessorOpen($script, $column);
         $this->addBooleanAccessorBody($script, $column);

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -1017,6 +1017,7 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
     {
         $name = self::getBooleanAccessorName($column);
         if (in_array($name, ClassTools::getPropelReservedMethods())) {
+            //TODO: Issue a warning telling the user to use default accessors
             return; // Skip boolean accessors for reserved names
         }
         $this->addDefaultAccessorComment($script, $column);

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -1015,7 +1015,7 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
      */
     protected function addBooleanAccessor(&$script, Column $column)
     {
-        $name = $column->getCamelCaseName();
+        $name = self::getBooleanAccessorName($column);
         if (in_array($name, ClassTools::getPropelReservedMethods())) {
             return; // Skip boolean accessors for reserved names
         }
@@ -1026,6 +1026,21 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
     }
 
     /**
+     * Returns the name to be used as boolean accessor name
+     *
+     * @param Column $column
+     * @return string
+     */
+    protected static function getBooleanAccessorName(Column $column)
+    {
+        $name = $column->getCamelCaseName();
+        if (!preg_match('/^(?:is|has)(?=[A-Z])/', $name)) {
+            $name = 'is' . ucfirst($name);
+        }
+        return $name;
+    }
+
+    /**
      * Adds the function declaration for a boolean accessor.
      *
      * @param string &$script
@@ -1033,10 +1048,7 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
      */
     public function addBooleanAccessorOpen(&$script, Column $column)
     {
-        $name = $column->getCamelCaseName();
-        if (!preg_match('/^(?:is|has)(?=[A-Z])/', $name)) {
-            $name = 'is' . ucfirst($name);
-        }
+        $name = self::getBooleanAccessorName($column);
         $visibility = $column->getAccessorVisibility();
 
         $script .= "


### PR DESCRIPTION
This fix prevents propel to generate duplicated methods such as isDeleted() or isNew()
The getters will still be available via getIsDeleted() etc.
