### PR TITLE
fixed SchemaTest

### DIFF
--- a/tests/Propel/Tests/Generator/Model/SchemaTest.php
+++ b/tests/Propel/Tests/Generator/Model/SchemaTest.php
@@ -70,11 +70,6 @@ class SchemaTest extends ModelTestCase
     public function testJoinMultipleSchemasWithSameDatabase()
     {
         $behavior = $this->getBehaviorMock('sluggable');
-        $behavior
-            ->expects($this->any())
-            ->method('hasBehavior')
-            ->will($this->returnValue(false))
-        ;
 
         $tables[] = $this->getTableMock('books');
         $tables[] = $this->getTableMock('authors');


### PR DESCRIPTION
The Behavior class does not have a method called `hasBehavior`.