### PR TITLE
Fix versionable behavior

### DIFF
--- a/src/Propel/Generator/Behavior/Versionable/VersionableBehavior.php
+++ b/src/Propel/Generator/Behavior/Versionable/VersionableBehavior.php
@@ -107,7 +107,7 @@ class VersionableBehavior extends Behavior
     {
         $table = $this->getTable();
         $database = $table->getDatabase();
-        $versionTableName = $this->getParameter('version_table') ? $this->getParameter('version_table') : ($table->getName() . '_version');
+        $versionTableName = $this->getParameter('version_table') ? $this->getParameter('version_table') : ($table->getOriginCommonName() . '_version');
         if (!$database->hasTable($versionTableName)) {
             // create the version table
             $versionTable = $database->addTable([


### PR DESCRIPTION
As mentioned in issue #824  versionble behavior was generating the version table with duplicate prefix.

Table was changed the call method Table::getName() and replaced by Table::getOriginCommonName()

And finally been implemented tests for database with tablePrefix.