### PR TITLE
Allow PROPEL_ATTR_CACHE_PREPARES to be set via config

### DIFF
--- a/src/Propel/Common/Config/PropelConfiguration.php
+++ b/src/Propel/Common/Config/PropelConfiguration.php
@@ -124,6 +124,8 @@ class PropelConfiguration implements ConfigurationInterface
                                     ->end()
                                     ->arrayNode('attributes')
                                         ->children()
+                                            ->booleanNode('PROPEL_ATTR_CACHE_PREPARES')->defaultFalse()->end()
+                                            ->booleanNode('PropelPDO::PROPEL_ATTR_CACHE_PREPARES')->defaultFalse()->end()
                                             ->booleanNode('ATTR_EMULATE_PREPARES')->defaultFalse()->end()
                                             ->integerNode('ATTR_TIMEOUT')->min(1)->defaultValue(30)->end()
                                         ->end()


### PR DESCRIPTION
It's documented as being settable in the config: http://propelorm.org/documentation/reference/configuration-file.html#attributes but it fails validation.
