### PR TITLE
Fix archivable behavior

### DIFF
--- a/src/Propel/Generator/Behavior/Archivable/ArchivableBehavior.php
+++ b/src/Propel/Generator/Behavior/Archivable/ArchivableBehavior.php
@@ -69,7 +69,7 @@ class ArchivableBehavior extends Behavior
     {
         $table = $this->getTable();
         $database = $table->getDatabase();
-        $archiveTableName = $this->getParameter('archive_table') ? $this->getParameter('archive_table') : ($this->getTable()->getName() . '_archive');
+        $archiveTableName = $this->getParameter('archive_table') ? $this->getParameter('archive_table') : ($this->getTable()->getOriginCommonName() . '_archive');
         if (!$database->hasTable($archiveTableName)) {
             // create the version table
             $archiveTable = $database->addTable([


### PR DESCRIPTION
Fix similar problem like https://github.com/propelorm/Propel2/pull/1171 (Fix versionable behavior)

The archivable behavior duplicate the table prefix.

The generated class name has a table prefix name, for example:

- tablePrefix: `foo_`
- table name: `bar`
- generated class: `FooBarArchive` and `FooBarArchiveQuery`

I think the generated class name should be `BarArchive` and `BarArchiveQuery`