### PR TITLE
Fixing `PropelConfiguration` for syslog'ing.

### DIFF
--- a/src/Propel/Common/Config/PropelConfiguration.php
+++ b/src/Propel/Common/Config/PropelConfiguration.php
@@ -243,6 +243,7 @@ class PropelConfiguration implements ConfigurationInterface
                             ->prototype('array')
                                 ->children()
                                     ->scalarNode('type')->end()
+                                    ->scalarNode('facility')->end()
                                     ->scalarNode('path')->end()
                                     ->enumNode('level')->values([100, 200, 250, 300, 400, 500, 550, 600])->end()
                                 ->end()

--- a/src/Propel/Common/Config/PropelConfiguration.php
+++ b/src/Propel/Common/Config/PropelConfiguration.php
@@ -244,6 +244,7 @@ class PropelConfiguration implements ConfigurationInterface
                                 ->children()
                                     ->scalarNode('type')->end()
                                     ->scalarNode('facility')->end()
+                                    ->scalarNode('ident')->end()
                                     ->scalarNode('path')->end()
                                     ->enumNode('level')->values([100, 200, 250, 300, 400, 500, 550, 600])->end()
                                 ->end()


### PR DESCRIPTION
Without this, it throws:
```
  [Symfony\Component\Config\Definition\Exception\InvalidConfigurationException]  
  Unrecognized option "facility" under "propel.runtime.log.defaultLogger"   
```

At runtime, without this configuration option, it throws:
```
PHP Fatal error:  Uncaught exception 'UnexpectedValueException' with message 'Unknown facility value "" given' in /vendor/monolog/monolog/src/Monolog/Handler/AbstractSyslogHandler.php:88
```

... when using "syslog" configuration.