### PR TITLE
force input size type to int when using `replaceSize`

### DIFF
--- a/src/Propel/Generator/Model/Domain.php
+++ b/src/Propel/Generator/Model/Domain.php
@@ -216,7 +216,7 @@ class Domain extends MappingModel
     public function replaceSize($size)
     {
         if (null !== $size) {
-            $this->size = $size;
+            $this->size = (int) $size;
         }
     }
 


### PR DESCRIPTION
The input `$size` argument should convert to int, otherwise the `diff` command will check incorrectly.

When `Propel/Generator/Model/Diff/ColumnComparator` checking the column size propery, the `$fromDomain->getSize()` is a `int` type, and the `$toDomain->getSize()` is a `string`type.

https://github.com/propelorm/Propel2/blob/b511db089c7ff4f3353e75db49fb6870b3a656b1/src/Propel/Generator/Model/Diff/ColumnComparator.php#L58-L60

```php
if ($fromDomain->getSize() !== $toDomain->getSize()) {
    $changedProperties['size'] = [ $fromDomain->getSize(), $toDomain->getSize() ];
}
```