### PR TITLE
Pass specific driver options to PDO constructor

### DIFF
--- a/src/Propel/Generator/Config/GeneratorConfig.php
+++ b/src/Propel/Generator/Config/GeneratorConfig.php
@@ -240,7 +240,10 @@ class GeneratorConfig extends ConfigurationManager implements GeneratorConfigInt
         $username = isset($buildConnection['user']) && $buildConnection['user'] ? $buildConnection['user'] : null;
         $password = isset($buildConnection['password']) && $buildConnection['password'] ? $buildConnection['password'] : null;
 
-        $con = ConnectionFactory::create(['dsn' => $dsn, 'user' => $username, 'password' => $password], AdapterFactory::create($buildConnection['adapter']));
+        // Get options from and config and default to null
+        $options = isset($buildConnection['options']) && is_array($buildConnection['options']) ? $buildConnection['options'] : null;
+
+        $con = ConnectionFactory::create(['dsn' => $dsn, 'user' => $username, 'password' => $password, 'options' => $options], AdapterFactory::create($buildConnection['adapter']));
 
         return $con;
     }

--- a/src/Propel/Runtime/Connection/PdoConnection.php
+++ b/src/Propel/Runtime/Connection/PdoConnection.php
@@ -46,7 +46,16 @@ class PdoConnection extends \PDO implements ConnectionInterface
      */
     public function __construct($dsn, $user = null, $password = null, array $options = null)
     {
-        parent::__construct($dsn, $user, $password, $options);
+
+        // Convert option keys from a string to a \PDO:: constant
+        $pdoOptions = [];
+        if (is_array($options)) {
+            foreach ($options as $key => $option) {
+                $pdoOptions[constant('self::' . $key)] = $option;
+            }
+        }
+
+        parent::__construct($dsn, $user, $password, $pdoOptions);
 
         $this->setAttribute(\PDO::ATTR_STATEMENT_CLASS, ['\Propel\Runtime\Adapter\Pdo\PdoStatement', []]);
         $this->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);


### PR DESCRIPTION
Pull request related to issue https://github.com/propelorm/Propel2/issues/1185

This allows to pass specific PDO options such as MYSQL_ATTR_SSL_KEY