### PR TITLE
Update VersionableBehaviorObjectBuilderModifier.php

### DIFF
--- a/src/Propel/Generator/Behavior/Versionable/VersionableBehaviorObjectBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/Versionable/VersionableBehaviorObjectBuilderModifier.php
@@ -110,7 +110,7 @@ class VersionableBehaviorObjectBuilderModifier
     public function postDelete($builder)
     {
         $this->builder = $builder;
-        if (!$builder->getPlatform()->supportsNativeDeleteTrigger() && !$builder->get()['generator']['objectModel']['emulateForeignKeyConstraints']) {
+        if (!$builder->getPlatform()->supportsNativeDeleteTrigger() && !$builder->getBuildProperty('generator.objectModel.emulateForeignKeyConstraints')) {
             $script = "// emulate delete cascade
 {$this->getVersionQueryClassName()}::create()
     ->filterBy{$this->table->getPhpName()}(\$this)


### PR DESCRIPTION
Fix an issue with an outdated method being called.  The error only shows up when NativeDeleteTrigger is not supported.