### PR TITLE
Add ability to use specified namespace in propel init command

### DIFF
--- a/src/Propel/Generator/Command/DatabaseReverseCommand.php
+++ b/src/Propel/Generator/Command/DatabaseReverseCommand.php
@@ -37,6 +37,7 @@ class DatabaseReverseCommand extends AbstractCommand
             ->addOption('output-dir',    null, InputOption::VALUE_REQUIRED, 'The output directory', self::DEFAULT_OUTPUT_DIRECTORY)
             ->addOption('database-name', null, InputOption::VALUE_REQUIRED, 'The database name used in the created schema.xml. If not defined we use `connection`.')
             ->addOption('schema-name',   null, InputOption::VALUE_REQUIRED, 'The schema name to generate', self::DEFAULT_SCHEMA_NAME)
+            ->addOption('namespace',     null, InputOption::VALUE_OPTIONAL, 'The PHP namespace to use for generated models')
             ->addArgument(
                 'connection',
                 InputArgument::OPTIONAL,
@@ -89,6 +90,12 @@ class DatabaseReverseCommand extends AbstractCommand
         $manager->setWorkingDirectory($input->getOption('output-dir'));
         $manager->setDatabaseName($input->getOption('database-name'));
         $manager->setSchemaName($input->getOption('schema-name'));
+
+        $namespace = $input->getOption('namespace');
+        
+        if ($namespace) {
+            $manager->setNamespace($namespace);
+        }
 
         if (true === $manager->reverse()) {
             $output->writeln('<info>Schema reverse engineering finished.</info>');

--- a/src/Propel/Generator/Manager/ReverseManager.php
+++ b/src/Propel/Generator/Manager/ReverseManager.php
@@ -25,6 +25,12 @@ class ReverseManager extends AbstractManager
      * @var string|null
      */
     private $schemaName;
+
+    /**
+     * @var string|null
+     */
+    private $namespace;
+
     /**
      * DOM document produced.
      *
@@ -95,6 +101,26 @@ class ReverseManager extends AbstractManager
     public function setSchemaName($schemaName)
     {
         $this->schemaName = $schemaName;
+    }
+
+    /**
+     * Gets the (optional) php namespace to use.
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Sets the php namespace to use (optional).
+     *
+     * @param string $namespace
+     */
+    public function setNamespace($namespace)
+    {
+        $this->namespace = $namespace;
     }
 
     /**
@@ -187,6 +213,8 @@ class ReverseManager extends AbstractManager
         $database = new Database($this->getDatabaseName());
         $database->setPlatform($config->getConfiguredPlatform($connection), $databaseName);
         $database->setDefaultIdMethod(IdMethod::NATIVE);
+
+        $this->getNamespace() && $database->setNamespace($this->getNamespace());
 
         $buildConnection = $config->getBuildConnection($databaseName);
         $this->log(sprintf('Reading database structure of database `%s` using dsn `%s`', $this->getDatabaseName(), $buildConnection['dsn']));

--- a/src/Propel/Generator/Model/ScopedMappingModel.php
+++ b/src/Propel/Generator/Model/ScopedMappingModel.php
@@ -154,7 +154,7 @@ abstract class ScopedMappingModel extends MappingModel
             $this->packageOverridden = true;
         }
 
-        if ($schema && !$this->namespace && $this->getBuildProperty('schemaAutoNamespace')) {
+        if ($schema && !$this->namespace && $this->getBuildProperty('generator.schema.autoNamespace')) {
             $this->namespace = $schema;
         }
     }

--- a/tests/Propel/Tests/Generator/Command/DatabaseReverseTest.php
+++ b/tests/Propel/Tests/Generator/Command/DatabaseReverseTest.php
@@ -12,23 +12,23 @@ use Symfony\Component\Console\Application;
  */
 class DatabaseReverseTest extends TestCaseFixturesDatabase
 {
-    public function testCommand()
+    public function testCommandWithoutNamespace()
     {
         $app = new Application('Propel', Propel::VERSION);
         $command = new DatabaseReverseCommand();
         $app->add($command);
 
-	$currentDir = getcwd();
-        $outputDir = __DIR__.'/../../../../reversecommand';
+        $currentDir = getcwd();
+        $outputDir = __DIR__ . '/../../../../reversecommand';
 
-	chdir(__DIR__.'/../../../../Fixtures/bookstore');
+        chdir(__DIR__ . '/../../../../Fixtures/bookstore');
 
         $input = new \Symfony\Component\Console\Input\ArrayInput([
             'command' => 'database:reverse',
             '--database-name' => 'reverse-test',
             '--output-dir' => $outputDir,
             '--verbose' => true,
-            '--platform' => ucfirst($this->getDriver()).'Platform',
+            '--platform' => ucfirst($this->getDriver()) . 'Platform',
             'connection' => $this->getConnectionDsn('bookstore-schemas', true)
         ]);
 
@@ -36,7 +36,7 @@ class DatabaseReverseTest extends TestCaseFixturesDatabase
         $app->setAutoExit(false);
         $result = $app->run($input, $output);
 
-	chdir($currentDir);
+        chdir($currentDir);
 
         if (0 !== $result) {
             rewind($output->getStream());
@@ -44,7 +44,7 @@ class DatabaseReverseTest extends TestCaseFixturesDatabase
         }
         $this->assertEquals(0, $result, 'database:reverse tests exited successfully');
 
-        $databaseXml = simplexml_load_file($outputDir.'/schema.xml');
+        $databaseXml = simplexml_load_file($outputDir . '/schema.xml');
         $this->assertEquals('reverse-test', $databaseXml['name']);
 
         $this->assertGreaterThan(20, $databaseXml->xpath("table"));
@@ -55,7 +55,44 @@ class DatabaseReverseTest extends TestCaseFixturesDatabase
         $this->assertEquals('acct_access_role', $table['name']);
         $this->assertEquals('AcctAccessRole', $table['phpName']);
         $this->assertCount(2, $table->xpath('column'));
+    }
 
+    public function testCommandWithNamespace()
+    {
+        $app = new Application('Propel', Propel::VERSION);
+        $command = new DatabaseReverseCommand();
+        $app->add($command);
+
+        $currentDir = getcwd();
+        $outputDir = __DIR__ . '/../../../../reversecommand';
+        $testNamespace = '\ReverseVendor\ReversePackage';
+
+        chdir(__DIR__ . '/../../../../Fixtures/bookstore');
+
+        $input = new \Symfony\Component\Console\Input\ArrayInput([
+            'command' => 'database:reverse',
+            '--database-name' => 'reverse-test',
+            '--output-dir' => $outputDir,
+            '--verbose' => true,
+            '--platform' => ucfirst($this->getDriver()) . 'Platform',
+            '--namespace' => $testNamespace,
+            'connection' => $this->getConnectionDsn('bookstore-schemas', true)
+        ]);
+
+        $output = new \Symfony\Component\Console\Output\StreamOutput(fopen("php://temp", 'r+'));
+        $app->setAutoExit(false);
+        $result = $app->run($input, $output);
+
+        chdir($currentDir);
+
+        if (0 !== $result) {
+            rewind($output->getStream());
+            echo stream_get_contents($output->getStream());
+        }
+        $this->assertEquals(0, $result, 'database:reverse tests exited successfully');
+
+        $databaseXml = simplexml_load_file($outputDir . '/schema.xml');
+        $this->assertEquals($testNamespace, $databaseXml['namespace']);
     }
 
 }


### PR DESCRIPTION
Fixes #1201 by placing the namespace (given by the user) into schema.xml when reverse engineering an existing database.  Also replaces the unused `schemaAutoNamespace` configuration option with the currently used `generator.schema.autoNamespace` propel configuration option.