### PR TITLE
Added possibility to decorate generated migration files with a custom suffix

### DIFF
--- a/src/Propel/Generator/Command/MigrationCreateCommand.php
+++ b/src/Propel/Generator/Command/MigrationCreateCommand.php
@@ -37,6 +37,7 @@ class MigrationCreateCommand extends AbstractCommand
             ->addOption('connection',         null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Connection to use. Example: \'bookstore=mysql:host=127.0.0.1;dbname=test;user=root;password=foobar\' where "bookstore" is your propel database name (used in your schema.xml)', [])
             ->addOption('editor',             null, InputOption::VALUE_OPTIONAL,  'The text editor to use to open diff files', null)
             ->addOption('comment',            "m",  InputOption::VALUE_OPTIONAL,  'A comment for the migration', '')
+            ->addOption('suffix',             null, InputOption::VALUE_OPTIONAL,  'A suffix for the migration class', '')
             ->setName('migration:create')
             ->setDescription('Create an empty migration class')
             ;
@@ -80,8 +81,8 @@ class MigrationCreateCommand extends AbstractCommand
         }
 
         $timestamp = time();
-        $migrationFileName  = $manager->getMigrationFileName($timestamp);
-        $migrationClassBody = $manager->getMigrationClassBody($migrationsUp, $migrationsDown, $timestamp, $input->getOption('comment'));
+        $migrationFileName  = $manager->getMigrationFileName($timestamp, $input->getOption('suffix'));
+        $migrationClassBody = $manager->getMigrationClassBody($migrationsUp, $migrationsDown, $timestamp, $input->getOption('comment'), $input->getOption('suffix'));
 
         $file = $generatorConfig->getSection('paths')['migrationDir'] . DIRECTORY_SEPARATOR . $migrationFileName;
         file_put_contents($file, $migrationClassBody);

--- a/src/Propel/Generator/Command/MigrationDiffCommand.php
+++ b/src/Propel/Generator/Command/MigrationDiffCommand.php
@@ -45,6 +45,7 @@ class MigrationDiffCommand extends AbstractCommand
             ->addOption('skip-tables',        null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_OPTIONAL, 'List of excluded tables', [])
             ->addOption('disable-identifier-quoting', null, InputOption::VALUE_NONE, 'Disable identifier quoting in SQL queries for reversed database tables.')
             ->addOption('comment',            "m",  InputOption::VALUE_OPTIONAL,  'A comment for the migration', '')
+            ->addOption('suffix',             null, InputOption::VALUE_OPTIONAL,  'A suffix for the migration class', '')
             ->setName('migration:diff')
             ->setAliases(['diff'])
             ->setDescription('Generate diff classes')
@@ -215,8 +216,8 @@ class MigrationDiffCommand extends AbstractCommand
         }
 
         $timestamp = time();
-        $migrationFileName  = $manager->getMigrationFileName($timestamp);
-        $migrationClassBody = $manager->getMigrationClassBody($migrationsUp, $migrationsDown, $timestamp, $input->getOption('comment'));
+        $migrationFileName  = $manager->getMigrationFileName($timestamp, $input->getOption('suffix'));
+        $migrationClassBody = $manager->getMigrationClassBody($migrationsUp, $migrationsDown, $timestamp, $input->getOption('comment'), $input->getOption('suffix'));
 
         $file = $generatorConfig->getSection('paths')['migrationDir'] . DIRECTORY_SEPARATOR . $migrationFileName;
         file_put_contents($file, $migrationClassBody);

--- a/src/Propel/Generator/Manager/MigrationManager.php
+++ b/src/Propel/Generator/Manager/MigrationManager.php
@@ -230,7 +230,7 @@ class MigrationManager extends AbstractManager
         if (is_dir($path)) {
             $files = scandir($path);
             foreach ($files as $file) {
-                if (preg_match('/^PropelMigration_(\d+)\.php$/', $file, $matches)) {
+                if (preg_match('/^PropelMigration_(\d+).*\.php$/', $file, $matches)) {
                     $migrationTimestamps[] = (integer) $matches[1];
                 }
             }
@@ -272,9 +272,30 @@ class MigrationManager extends AbstractManager
         return $this->getOldestDatabaseVersion();
     }
 
-    public static function getMigrationClassName($timestamp)
+    public function getMigrationClassName($timestamp, $suffix = "")
     {
-        return sprintf('PropelMigration_%d', $timestamp);
+        $className = sprintf('PropelMigration_%d', $timestamp);
+        if ($suffix === "") {
+            $suffix = $this->findMigrationClassNameSuffix($timestamp);
+        }
+        if ($suffix !== "") {
+            $className .= '_' . $suffix;
+        }
+        return $className;
+    }
+
+    public function findMigrationClassNameSuffix($timestamp) {
+        $suffix = "";
+        $path = $this->getWorkingDirectory();
+        if (is_dir($path)) {
+            $files = scandir($path);
+            foreach ($files as $file) {
+                if (preg_match('/^PropelMigration_'.$timestamp.'(_)?(.*)\.php$/', $file, $matches)) {
+                    $suffix = (string) $matches[2];
+                }
+            }
+        }
+        return $suffix;
     }
 
     public function getMigrationObject($timestamp)
@@ -288,11 +309,11 @@ class MigrationManager extends AbstractManager
         return new $className();
     }
 
-    public function getMigrationClassBody($migrationsUp, $migrationsDown, $timestamp, $comment = "")
+    public function getMigrationClassBody($migrationsUp, $migrationsDown, $timestamp, $comment = "", $suffix = "")
     {
         $timeInWords = date('Y-m-d H:i:s', $timestamp);
         $migrationAuthor = ($author = $this->getUser()) ? 'by ' . $author : '';
-        $migrationClassName = $this->getMigrationClassName($timestamp);
+        $migrationClassName = $this->getMigrationClassName($timestamp, $suffix);
         $migrationUpString = var_export($migrationsUp, true);
         $migrationDownString = var_export($migrationsDown, true);
         $commentString = var_export($comment, true);
@@ -358,9 +379,9 @@ EOP;
         return $migrationClassBody;
     }
 
-    public static function getMigrationFileName($timestamp)
+    public function getMigrationFileName($timestamp, $suffix = "")
     {
-        return sprintf('%s.php', self::getMigrationClassName($timestamp));
+        return sprintf('%s.php', $this->getMigrationClassName($timestamp, $suffix));
     }
 
     public static function getUser()

--- a/tests/Propel/Tests/Generator/Command/MigrationTest.php
+++ b/tests/Propel/Tests/Generator/Command/MigrationTest.php
@@ -74,6 +74,48 @@ class MigrationTest extends TestCaseFixturesDatabase
         $this->assertContains('CREATE TABLE ', $content);
     }
 
+    public function testDiffCommandUsingSuffix()
+    {
+        $app = new Application('Propel', Propel::VERSION);
+        $command = new MigrationDiffCommand();
+        $app->add($command);
+
+        $files = glob($this->outputDir . '/PropelMigration_*.php');
+        foreach ($files as $file) {
+            unlink($file);
+        }
+
+        $input = new \Symfony\Component\Console\Input\ArrayInput([
+            'command' => 'migration:diff',
+            '--schema-dir' => $this->schemaDir,
+            '--config-dir' => $this->configDir,
+            '--output-dir' => $this->outputDir,
+            '--platform' => ucfirst($this->getDriver()) . 'Platform',
+            '--connection' => $this->connectionOption,
+            '--suffix' => 'an_explanatory_filename_suffix',
+            '--verbose' => true
+        ]);
+
+        $output = new \Symfony\Component\Console\Output\StreamOutput(fopen("php://temp", 'r+'));
+        $app->setAutoExit(false);
+        $result = $app->run($input, $output);
+
+        if (0 !== $result) {
+            rewind($output->getStream());
+            echo stream_get_contents($output->getStream());
+        }
+
+        $this->assertEquals(0, $result, 'migration:diff tests exited successfully');
+
+        $files = glob($this->outputDir . '/PropelMigration_*_an_explanatory_filename_suffix.php');
+        $this->assertGreaterThanOrEqual(1, count($files));
+        $file = $files[0];
+
+        $content = file_get_contents($file);
+        $this->assertGreaterThanOrEqual(2, substr_count($content, "CREATE TABLE "));
+        $this->assertContains('CREATE TABLE ', $content);
+    }
+
     public function testUpCommand()
     {
         $app = new Application('Propel', Propel::VERSION);
@@ -197,6 +239,47 @@ class MigrationTest extends TestCaseFixturesDatabase
         $this->assertEquals(0, $result, 'migration:create tests exited successfully');
 
         $files = glob($this->outputDir . '/PropelMigration_*.php');
+        $this->assertGreaterThanOrEqual(1, count($files));
+        $file = $files[0];
+
+        $content = file_get_contents($file);
+        $this->assertNotContains('CREATE TABLE ', $content);
+    }
+
+    public function testCreateCommandUsingSuffix()
+    {
+        $app = new Application('Propel', Propel::VERSION);
+        $command = new MigrationCreateCommand();
+        $app->add($command);
+
+        $files = glob($this->outputDir . '/PropelMigration_*.php');
+        foreach ($files as $file) {
+            unlink($file);
+        }
+
+        $input = new \Symfony\Component\Console\Input\ArrayInput([
+            'command' => 'migration:create',
+            '--schema-dir' => $this->schemaDir,
+            '--config-dir' => $this->configDir,
+            '--output-dir' => $this->outputDir,
+            '--platform' => ucfirst($this->getDriver()) . 'Platform',
+            '--connection' => $this->connectionOption,
+            '--suffix' => 'an_explanatory_filename_suffix',
+            '--verbose' => true
+        ]);
+
+        $output = new \Symfony\Component\Console\Output\StreamOutput(fopen("php://temp", 'r+'));
+        $app->setAutoExit(false);
+        $result = $app->run($input, $output);
+
+        if (0 !== $result) {
+            rewind($output->getStream());
+            echo stream_get_contents($output->getStream());
+        }
+
+        $this->assertEquals(0, $result, 'migration:create tests exited successfully');
+
+        $files = glob($this->outputDir . '/PropelMigration_*_an_explanatory_filename_suffix.php');
         $this->assertGreaterThanOrEqual(1, count($files));
         $file = $files[0];
 


### PR DESCRIPTION
It is rather hard to find a certain migration with the current filenames:

```
PropelMigration_1456744599.php
PropelMigration_1457186710.php
PropelMigration_1457212222.php
PropelMigration_1458157955.php
PropelMigration_1461870141.php
PropelMigration_1462121943.php
PropelMigration_1462860381.php
PropelMigration_1462946617.php
PropelMigration_1463383579.php
PropelMigration_1464338765.php
```

This PR allows an optional suffix to be specified when creating migrations, so that the filenames directly hint at what the migrations contain:

```
PropelMigration_1456744599_import_process_data_model_enhancements.php
PropelMigration_1457186710_user_entry_rows_cascade_delete.php
PropelMigration_1457212222_data_model_correction.php
PropelMigration_1458157955_transaction_row_additional_booleans.php
PropelMigration_1461870141_additional_fields.php
PropelMigration_1462121943_input_results_created.php
PropelMigration_1462860381_import_improvements.php
PropelMigration_1462946617_core_mapping_indices.php
PropelMigration_1463383579_correct_utf8_encoding_for_foo_table.php
PropelMigration_1464338765_user_table_definition_correction.php
```

