### PR TITLE
Inconsistent behavior between join and joinWith leading to malformed on clause

### DIFF
--- a/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
@@ -1861,7 +1861,7 @@ class ModelCriteria extends BaseModelCriteria
 
             if (false !== strpos($key, '.')) {
                 list($tableName, $columnName) = explode('.', $key);
-                $realColumnName = array_pop(explode('.', $realFullColumnName));
+                $realColumnName = substr($realFullColumnName, strrpos($realFullColumnName, '.') + 1);
                 if (isset($this->aliases[$tableName])) {
                     //don't replace a alias with their real table name
                     return $this->quoteIdentifier($tableName.'.'.$realColumnName);

--- a/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
@@ -1861,7 +1861,7 @@ class ModelCriteria extends BaseModelCriteria
 
             if (false !== strpos($key, '.')) {
                 list($tableName, $columnName) = explode('.', $key);
-                list($realTableName, $realColumnName) = explode('.', $realFullColumnName);
+                $realColumnName = array_pop(explode('.', $realFullColumnName));
                 if (isset($this->aliases[$tableName])) {
                     //don't replace a alias with their real table name
                     return $this->quoteIdentifier($tableName.'.'.$realColumnName);


### PR DESCRIPTION
$realFullColumnName may be either table.field or schema.table.field so the correct $realColumnName is always the last field of the exploded array and not the second.
