### PR TITLE
Fix Versionable behavior with FK and Custom Version Column

### DIFF
--- a/src/Propel/Generator/Behavior/Versionable/VersionableBehaviorObjectBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/Versionable/VersionableBehaviorObjectBuilderModifier.php
@@ -393,7 +393,7 @@ public function populateFromVersion(\$version, \$con = null, &\$loadedObjects = 
             \$related = new {$relatedClassName}();
             \$relatedVersion = {$relatedVersionQueryClassName}::create()
                 ->filterBy{$fk->getForeignColumn()->getPhpName()}(\$fkValue)
-                ->filterByVersion(\$version->get{$fkVersionColumnPhpName}())
+                ->filterBy{$col->getPhpName()}(\$version->get{$fkVersionColumnPhpName}())
                 ->findOne(\$con);
             \$related->populateFromVersion(\$relatedVersion, \$con, \$loadedObjects);
             \$related->setNew(false);

--- a/tests/Propel/Tests/Generator/Behavior/Versionable/VersionableBehaviorObjectBuilderModifierTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Versionable/VersionableBehaviorObjectBuilderModifierTest.php
@@ -376,7 +376,6 @@ EOF;
     {
         \VersionableBehaviorTestCustomFieldQuery::create()->deleteAll();
         \VersionableBehaviorTestCustomFieldVersionQuery::create()->deleteAll();
-
         \VersionableBehaviorTestCustomFieldKeyQuery::create()->deleteAll();
         \VersionableBehaviorTestCustomFieldKeyVersionQuery::create()->deleteAll();
 
@@ -411,13 +410,11 @@ EOF;
         $this->assertNotNull($versions[0]->getBar());
         $this->assertEquals($o->getId(), $versions[1]->getId());
         $this->assertEquals(123, $versions[1]->getBar());
-
         $this->assertEquals(2, $o->getVersion());
 
         $o->toVersion(1);
 
         $this->assertEquals(1, $o->getVersion());
-
         $this->assertEquals($o->getId(), $versions[0]->getId());
     }
 


### PR DESCRIPTION
Fix versionable behavior when exists 2 tables with versionable behavior and custom version_column parameter.

Changed filterByVersion to filterBy[PHPNameOfField]

Issue #774 