### PR TITLE
Performance improvement for getTableByPhpName

### DIFF
--- a/src/Propel/Runtime/Adapter/Pdo/PdoAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/PdoAdapter.php
@@ -54,7 +54,7 @@ abstract class PdoAdapter
         $driver_options = array();
         if (isset($conparams['options']) && is_array($conparams['options'])) {
             foreach ($conparams['options'] as $option => $optiondata) {
-                $value = $optiondata['value'];
+                $value = $optiondata;
                 if (is_string($value) && false !== strpos($value, '::')) {
                     if (!defined($value)) {
                         throw new InvalidArgumentException(sprintf('Error processing driver options for dsn "%s"', $dsn));

--- a/src/Propel/Runtime/Map/DatabaseMap.php
+++ b/src/Propel/Runtime/Map/DatabaseMap.php
@@ -182,12 +182,6 @@ class DatabaseMap
             return $this->tablesByPhpName[$phpName];
         }
 
-        if (class_exists($tmClass = $phpName . 'TableMap')) {
-            $this->addTableFromMapClass($tmClass);
-
-            return $this->tablesByPhpName[$phpName];
-        }
-
         if (class_exists($tmClass = substr_replace($phpName, '\\Map\\', strrpos($phpName, '\\'), 1) . 'TableMap')
             || class_exists($tmClass = '\\Map\\' .$phpName . 'TableMap')) {
             $this->addTableFromMapClass($tmClass);
@@ -199,6 +193,12 @@ class DatabaseMap
             if (isset($this->tablesByPhpName[$phpName])) {
                 return $this->tablesByPhpName[$phpName];
             }
+        }
+
+        if (class_exists($tmClass = $phpName . 'TableMap')) {
+            $this->addTableFromMapClass($tmClass);
+
+            return $this->tablesByPhpName[$phpName];
         }
 
         throw new TableNotFoundException(sprintf('Cannot fetch TableMap for undefined table phpName: %s.', $phpName));


### PR DESCRIPTION
First try to look from \Map\ folder instead in model base folder which is most
of the time the correct case. Optimized composer autoloader now finds the
classes correctly from class map. Later on this should be configurable most
likely.

This relates to issue #642 
