### PR TITLE
Alternate fix for double-namespace on db:reverse

### DIFF
--- a/src/Propel/Generator/Manager/ReverseManager.php
+++ b/src/Propel/Generator/Manager/ReverseManager.php
@@ -241,6 +241,8 @@ class ReverseManager extends AbstractManager
                 }
             }
 
+            $table->setNamespace(null);
+
             $skip && $database->removeTable($table);
         }
 

--- a/tests/Propel/Tests/Generator/Command/DatabaseReverseTest.php
+++ b/tests/Propel/Tests/Generator/Command/DatabaseReverseTest.php
@@ -93,6 +93,10 @@ class DatabaseReverseTest extends TestCaseFixturesDatabase
 
         $databaseXml = simplexml_load_file($outputDir . '/schema.xml');
         $this->assertEquals($testNamespace, $databaseXml['namespace']);
+
+        foreach ($databaseXml->children() as $tableXml) {
+            $this->assertNotTrue(isset($tableXml['namespace']));
+        }
     }
 
 }


### PR DESCRIPTION
Fix for #1233 
Provides alternative PR to #1235 per request.

Basically here's how this bug occurs:
In `ReverseManager::buildModel()`
Line 217 sets the namespace of the database.
https://github.com/propelorm/Propel2/blob/master/src/Propel/Generator/Manager/ReverseManager.php#L217
Line 222 gets the schema parser (eg. MysqlSchemaParser)
https://github.com/propelorm/Propel2/blob/master/src/Propel/Generator/Manager/ReverseManager.php#L222
Line 224 parses the database
https://github.com/propelorm/Propel2/blob/master/src/Propel/Generator/Manager/ReverseManager.php#L224

`MysqlSchemaParser::parse()`
calls `MysqlSchemaParser::parseTables()`
which calls `Propel\Generator\Model\Database::addTable()`
which calls `Propel\Generator\Model\Database::computeTableNamespace()`
which is where the table namespace is generated from the rules specified in http://propelorm.org/documentation/cookbook/namespaces.html

If the database namespace is an absolute namespace, things work fine.
However, when the database namespace is relative (without a leading ), this is where the bug is introduced.

This fix feels hacky.  I would prefer #1235 over this fix, since that fix also fixes lots of other tests where the namespace of the schema.xml in those tests do not follow the same rules as specified in the documentation.  However, this fix does limit the affected code to only the bug specified in #1233, which could be better in some regard.
