### PR TITLE
Locale-independent functionality of PropelDateTime::createHighPrecision

### DIFF
--- a/src/Propel/Runtime/Util/PropelDateTime.php
+++ b/src/Propel/Runtime/Util/PropelDateTime.php
@@ -68,7 +68,20 @@ class PropelDateTime extends \DateTime
      */
     public static function createHighPrecision($time = null)
     {
-        return \DateTime::createFromFormat('U.u', $time ?: microtime(true));
+        return \DateTime::createFromFormat('U.u', $time ?: self::getMicrotime());
+    }
+
+    /**
+     * Get the current microtime with milliseconds. Making sure that the decimal point separator is always ".", ignoring
+     * what is set with the current locale. Otherwise self::createHighPrecision would return false.
+     *
+     * @return string
+     */
+    public static function getMicrotime()
+    {
+        $mtime = microtime(true);
+
+        return str_replace(',', '.', $mtime);
     }
 
     /**

--- a/tests/Propel/Tests/Runtime/Util/PropelDateTimeTest.php
+++ b/tests/Propel/Tests/Runtime/Util/PropelDateTimeTest.php
@@ -216,6 +216,16 @@ class PropelDateTimeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(true, TestPropelDateTime::isTimestamp(1319580000));
         $this->assertEquals(false, TestPropelDateTime::isTimestamp('2011-07-20 00:00:00'));
     }
+
+    public function testCreateHighPrecision()
+    {
+        $createHP = PropelDateTime::createHighPrecision();
+        $this->assertInstanceOf(DateTime::class, $createHP);
+
+        setlocale(LC_ALL, 'de_DE.UTF-8');
+        $createHP = PropelDateTime::createHighPrecision();
+        $this->assertInstanceOf(DateTime::class, $createHP);
+    }
 }
 
 class TestPropelDateTime extends PropelDateTime


### PR DESCRIPTION
It came to my attention that PropelDateTime::createHighPrecision can return "false" when the numeric format for floats is changed by setting specific locales. For example in the locale "de_DE" floats will be formatted with a "," (comma) as decimal pointer. This will result in a "false" from DateTime::createFromFormat.

I submitted a patch, just replacing a "," with a "." in the value of "microtime(true)".
