### PR TITLE
specify timezone in PropelDateTime::createHighPrecision

### DIFF
--- a/src/Propel/Runtime/Util/PropelDateTime.php
+++ b/src/Propel/Runtime/Util/PropelDateTime.php
@@ -68,7 +68,11 @@ class PropelDateTime extends \DateTime
      */
     public static function createHighPrecision($time = null)
     {
-        return \DateTime::createFromFormat('U.u', $time ?: self::getMicrotime());
+        $dateTime = \DateTime::createFromFormat('U.u', $time ?: self::getMicrotime());
+        
+        $dateTime->setTimeZone(new \DateTimeZone(date_default_timezone_get()));
+        
+        return $dateTime;
     }
 
     /**


### PR DESCRIPTION
just like in the newInstance
timezone must be explicitly specified and then changed
because of a DateTime bug: http://bugs.php.net/bug.php?id=43003