### PR TITLE
Fix schemaname for PostgreSQL 9.5

### DIFF
--- a/src/Propel/Generator/Reverse/PgsqlSchemaParser.php
+++ b/src/Propel/Generator/Reverse/PgsqlSchemaParser.php
@@ -229,7 +229,7 @@ class PgsqlSchemaParser extends AbstractSchemaParser
             $searchPath = explode(',', $searchPathString);
 
             foreach ($searchPath as &$path) {
-                $params[] = $path;
+                $params[] = trim($path);
                 $path = '?';
             }
             $searchPath = implode(', ', $searchPath);


### PR DESCRIPTION
I discovered it was the migration, but in fact the problem is PgsqlSchemaParser. For up to version 9.4 the command  **show search_path** returns:

```SQL
# show search_path;
|    search_path |
|----------------|
| "$user",public |
```

From the postgreSQL version 9.5 we have the result.
```SQL
# show search_path;
|    search_path  |
|-----------------|
| "$user", public |
```
Just only one space and everything explodes.

So I removed the spaces at the time of reading the schemas :smiley: 


The **TravisCI** is not ready for **PostgreSQL9.5** why not add it in .travis.yml(travis-ci/travis-ci#4264). Not ready without sudo.
