### PR TITLE
Update to use TIME & DATE types

### DIFF
--- a/src/Propel/Generator/Platform/MssqlPlatform.php
+++ b/src/Propel/Generator/Platform/MssqlPlatform.php
@@ -40,9 +40,9 @@ class MssqlPlatform extends DefaultPlatform
         $this->setSchemaDomainMapping(new Domain(PropelTypes::DOUBLE, "FLOAT"));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::LONGVARCHAR, "VARCHAR(MAX)"));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::CLOB, "VARCHAR(MAX)"));
-        $this->setSchemaDomainMapping(new Domain(PropelTypes::DATE, "DATETIME"));
-        $this->setSchemaDomainMapping(new Domain(PropelTypes::BU_DATE, "DATETIME"));
-        $this->setSchemaDomainMapping(new Domain(PropelTypes::TIME, "DATETIME"));
+        $this->setSchemaDomainMapping(new Domain(PropelTypes::DATE, "DATE"));
+        $this->setSchemaDomainMapping(new Domain(PropelTypes::BU_DATE, "DATE"));
+        $this->setSchemaDomainMapping(new Domain(PropelTypes::TIME, "TIME"));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::TIMESTAMP, "DATETIME"));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::BU_TIMESTAMP, "DATETIME"));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::BINARY, "BINARY(7132)"));


### PR DESCRIPTION
Previously these used DATETIME, but then propel tried to insert just a date or time into the database, resulting in a error "[S0001][241] Conversion failed when converting date and/or time from character string."