### PR TITLE
Ensuring that PropelDateTime::getMicrotime() includes the fractional part

### DIFF
--- a/src/Propel/Runtime/Util/PropelDateTime.php
+++ b/src/Propel/Runtime/Util/PropelDateTime.php
@@ -76,8 +76,8 @@ class PropelDateTime extends \DateTime
     }
 
     /**
-     * Get the current microtime with milliseconds. Making sure that the decimal point separator is always ".", ignoring
-     * what is set with the current locale. Otherwise self::createHighPrecision would return false.
+     * Get the current microtime with milliseconds. Making sure that the decimal point separator is always "."
+     * and always including the fractional part. Otherwise self::createHighPrecision would return false.
      *
      * @return string
      */
@@ -85,7 +85,7 @@ class PropelDateTime extends \DateTime
     {
         $mtime = microtime(true);
 
-        return str_replace(',', '.', $mtime);
+        return number_format($mtime, 6, '.', '');
     }
 
     /**


### PR DESCRIPTION
... to match the expected 'U.u' format in createHighPrecision(). (#1257)