### PR TITLE
Check incomplete foreign-keys #675

### DIFF
--- a/src/Propel/Generator/Model/Table.php
+++ b/src/Propel/Generator/Model/Table.php
@@ -784,6 +784,25 @@ class Table extends ScopedMappingModel implements IdMethod
                 }
             }
 
+            // check for incomplete foreign key references when foreign table
+            // has a composite primary key
+            if ($foreignTable->hasCompositePrimaryKey()) {
+                // get composite foreign key's keys
+                $foreignPrimaryKeys = $foreignTable->getPrimaryKey();
+                // check all keys are referenced in foreign key
+                foreach ($foreignPrimaryKeys as $foreignPrimaryKey) {
+                    if (!$foreignPrimaryKey->hasReferrer($foreignKey) && $throwErrors) {
+                        // foreign primary key is not being referenced in foreign key
+                        throw new BuildException(sprintf(
+                            'Table "%s" contains a foreign key to table "%s" but does not have a reference to foreign primary key "%s"',
+                            $this->getName(),
+                            $foreignTable->getName(),
+                            $foreignPrimaryKey->getName()
+                        ));
+                    }
+                }
+            }
+
             if ($this->getPlatform() instanceof MysqlPlatform) {
                 $this->addExtraIndices();
             }

--- a/src/Propel/Runtime/Util/PropelDateTime.php
+++ b/src/Propel/Runtime/Util/PropelDateTime.php
@@ -76,8 +76,8 @@ class PropelDateTime extends \DateTime
     }
 
     /**
-     * Get the current microtime with milliseconds. Making sure that the decimal point separator is always "."
-     * and always including the fractional part. Otherwise self::createHighPrecision would return false.
+     * Get the current microtime with milliseconds. Making sure that the decimal point separator is always ".", ignoring
+     * what is set with the current locale. Otherwise self::createHighPrecision would return false.
      *
      * @return string
      */
@@ -85,7 +85,7 @@ class PropelDateTime extends \DateTime
     {
         $mtime = microtime(true);
 
-        return number_format($mtime, 6, '.', '');
+        return str_replace(',', '.', $mtime);
     }
 
     /**

--- a/tests/Fixtures/bookstore/schema.xml
+++ b/tests/Fixtures/bookstore/schema.xml
@@ -378,9 +378,11 @@
     <table name="release_pool">
         <column name="id" type="INTEGER" primaryKey="true" autoIncrement="true" />
         <column name="record_label_id" type="INTEGER" required="true"/>
+        <column name="record_label_abbr" type="VARCHAR" size="5" required="true"/>
         <column name="name" type="VARCHAR" />
         <foreign-key foreignTable="record_label" onDelete="cascade">
             <reference local="record_label_id" foreign="id" />
+            <reference local="record_label_abbr" foreign="abbr" />
         </foreign-key>
     </table>
 

--- a/tests/Propel/Tests/Generator/Builder/Om/QueryBuilderTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/QueryBuilderTest.php
@@ -727,8 +727,7 @@ class QueryBuilderTest extends BookstoreTestBase
         BookstoreDataPopulator::populate();
 
         $testLabel = RecordLabelQuery::create()
-            ->limit(2)
-            ->find($this->con);
+            ->findOne($this->con);
 
         $testRelease = ReleasePoolQuery::create()
             ->addJoin(ReleasePoolTableMap::COL_RECORD_LABEL_ID, RecordLabelTableMap::COL_ID)
@@ -738,12 +737,34 @@ class QueryBuilderTest extends BookstoreTestBase
 
         $releasePool = ReleasePoolQuery::create()
             ->addJoin(ReleasePoolTableMap::COL_RECORD_LABEL_ID, RecordLabelTableMap::COL_ID)
-            ->add(ReleasePoolTableMap::COL_RECORD_LABEL_ID, $testLabel->toKeyValue('Id', 'Id'), Criteria::IN)
+            ->add(ReleasePoolTableMap::COL_RECORD_LABEL_ID, $testLabel->getId(), Criteria::EQUAL)
+            ->add(ReleasePoolTableMap::COL_RECORD_LABEL_ABBR, $testLabel->getAbbr(), Criteria::EQUAL)
             ->find($this->con);
         $q2 = $this->con->getLastExecutedQuery();
 
-        $this->assertEquals($q2, $q1, 'filterBy{RelationName}() only accepts arguments of type {RelationName} or PropelCollection');
+        $this->assertEquals($q2, $q1, 'Generated query handles filterByRefFk() methods correctly for composite fkeys');
         $this->assertEquals($releasePool, $testRelease);
+    }
+
+    /**
+     * @throws \Propel\Runtime\Exception\PropelException
+     * @expectedException \Propel\Runtime\Exception\PropelException
+     */
+    public function testFilterUsingCollectionByRelationNameCompositePk()
+    {
+        BookstoreDataPopulator::depopulate();
+        BookstoreDataPopulator::populate();
+
+        $testLabel = RecordLabelQuery::create()
+            ->limit(2)
+            ->find($this->con);
+
+        ReleasePoolQuery::create()
+            ->addJoin(ReleasePoolTableMap::COL_RECORD_LABEL_ID, RecordLabelTableMap::COL_ID)
+            ->filterByRecordLabel($testLabel)
+            ->find($this->con);
+
+        $this->fail('Expected PropelException : filterBy{RelationName}() only accepts arguments of type {RelationName}');
     }
 
     public function testFilterByRefFkCompositeKey()

--- a/tests/Propel/Tests/Issues/Issue675Test.php
+++ b/tests/Propel/Tests/Issues/Issue675Test.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT License
+ */
+namespace Propel\Tests\Issues;
+
+use Propel\Generator\Util\QuickBuilder;
+use Propel\Tests\TestCaseFixtures;
+
+/**
+ * Test : Propel should not allow incomplete foreign key references when foreign table has a composite primary key
+ * Issue described in https://github.com/propelorm/Propel2/issues/675.
+ * Originally described in http://stackoverflow.com/questions/7947085/are-incomplete-key-references-in-propel-useful
+ * @group model
+ */
+class Issue675Test extends TestCaseFixtures
+{
+    /**
+     * Test incomplete foreign key references
+     * @expectedException \Propel\Generator\Exception\BuildException
+     */
+    public function testIncompleteForeignReference()
+    {
+        $schema = <<<EOF
+<?xml version="1.0" encoding="utf-8"?>
+<database name="test" defaultIdMethod="native">
+    <table name="event">
+        <column name="id" type="integer" required="true" primaryKey="true" autoIncrement="true" />
+        <column name="name" type="varchar" size="50" required="true" />
+        <column name="organiser_id" type="integer" required="true" />
+        <!-- This FK is incomplete -->
+        <foreign-key foreignTable="organiser">
+            <reference local="organiser_id" foreign="id" />
+        </foreign-key>
+    </table>
+
+    <table name="organiser">
+        <!-- Has composite PK -->
+        <column name="id" type="integer" required="true" primaryKey="true" autoIncrement="true" />
+        <column name="secondary" type="integer" required="true" primaryKey="true" />
+        <column name="name" type="varchar" size="50" required="true" />
+    </table>
+</database>
+EOF;
+
+        $builder = new QuickBuilder();
+        $builder->setSchema($schema);
+        $builder->buildClasses(null, true);
+
+        // Propel should disallow incomplete foreign reference
+        $this->expectException('\Propel\Generator\Exception\BuildException');
+
+        // Explanation
+        $this->fail('Expected to throw a BuildException due to incomplete foreign key reference.');
+    }
+}


### PR DESCRIPTION
Propel should not allow incomplete foreign key references when foreign
table has a composite primary key.

https://github.com/propelorm/Propel2/issues/675
