### PR TITLE
Allows the use of TimestampableBehavior with INTEGER columns

### DIFF
--- a/src/Propel/Generator/Behavior/Timestampable/TimestampableBehavior.php
+++ b/src/Propel/Generator/Behavior/Timestampable/TimestampableBehavior.php
@@ -83,8 +83,12 @@ class TimestampableBehavior extends Behavior
     public function preUpdate($builder)
     {
         if ($this->withUpdatedAt()) {
+            $valueSource = strtoupper($this->getTable()->getColumn($this->getParameter('update_column'))->getType()) === 'INTEGER'
+                ? 'time()'
+                : '\\Propel\\Runtime\\Util\\PropelDateTime::createHighPrecision()'
+            ;
             return "if (\$this->isModified() && !\$this->isColumnModified(" . $this->getColumnConstant('update_column', $builder) . ")) {
-    \$this->" . $this->getColumnSetter('update_column') . "(\\Propel\\Runtime\\Util\\PropelDateTime::createHighPrecision());
+    \$this->" . $this->getColumnSetter('update_column') . "(${valueSource});
 }";
         }
 
@@ -101,16 +105,24 @@ class TimestampableBehavior extends Behavior
         $script = '';
 
         if ($this->withCreatedAt()) {
+            $valueSource = strtoupper($this->getTable()->getColumn($this->getParameter('create_column'))->getType()) === 'INTEGER'
+                ? 'time()'
+                : '\\Propel\\Runtime\\Util\\PropelDateTime::createHighPrecision()'
+            ;
             $script .= "
 if (!\$this->isColumnModified(" . $this->getColumnConstant('create_column', $builder) . ")) {
-    \$this->" . $this->getColumnSetter('create_column') . "(\\Propel\\Runtime\\Util\\PropelDateTime::createHighPrecision());
+    \$this->" . $this->getColumnSetter('create_column') . "(${valueSource});
 }";
         }
 
         if ($this->withUpdatedAt()) {
+            $valueSource = strtoupper($this->getTable()->getColumn($this->getParameter('update_column'))->getType()) === 'INTEGER'
+                ? 'time()'
+                : '\\Propel\\Runtime\\Util\\PropelDateTime::createHighPrecision()'
+            ;
             $script .= "
 if (!\$this->isColumnModified(" . $this->getColumnConstant('update_column', $builder) . ")) {
-    \$this->" . $this->getColumnSetter('update_column') . "(\\Propel\\Runtime\\Util\\PropelDateTime::createHighPrecision());
+    \$this->" . $this->getColumnSetter('update_column') . "(${valueSource});
 }";
         }
 


### PR DESCRIPTION
This restores the possibility of using Timestampable behavior with INTEGER column to store an unix timestamp, which has been broken recently.