### PR TITLE
Support more complex counts

### DIFF
--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -2498,16 +2498,8 @@ class Criteria
             $con = Propel::getServiceContainer()->getReadConnection($this->getDbName());
         }
 
-        $needsComplexCount = $this->getGroupByColumns()
-            || $this->getOffset()
-            || $this->getLimit() >= 0
-            || $this->getHaving()
-            || in_array(Criteria::DISTINCT, $this->getSelectModifiers())
-            || count($this->selectQueries) > 0
-        ;
-
         $params = [];
-        if ($needsComplexCount) {
+        if ($this->needsComplexCount()) {
             if ($this->needsSelectAliases()) {
                 if ($this->getHaving()) {
                     throw new LogicException('Propel cannot create a COUNT query when using HAVING and  duplicate column names in the SELECT part');
@@ -2531,6 +2523,16 @@ class Criteria
         }
 
         return $con->getDataFetcher($stmt);
+    }
+
+    public function needsComplexCount()
+    {
+        return $this->getGroupByColumns()
+            || $this->getOffset()
+            || $this->getLimit() >= 0
+            || $this->getHaving()
+            || in_array(Criteria::DISTINCT, $this->getSelectModifiers())
+            || count($this->selectQueries) > 0;
     }
 
     /**

--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -2489,16 +2489,9 @@ class Criteria
         return $params;
     }
 
-    public function doCount(ConnectionInterface $con = null)
+    public function createCountSql(&$params)
     {
-        $dbMap = Propel::getServiceContainer()->getDatabaseMap($this->getDbName());
         $db = Propel::getServiceContainer()->getAdapter($this->getDbName());
-
-        if (null === $con) {
-            $con = Propel::getServiceContainer()->getReadConnection($this->getDbName());
-        }
-
-        $params = [];
         if ($this->needsComplexCount()) {
             if ($this->needsSelectAliases()) {
                 if ($this->getHaving()) {
@@ -2515,6 +2508,21 @@ class Criteria
             $this->clearSelectColumns()->addSelectColumn('COUNT(*)');
             $sql = $this->createSelectSql($params);
         }
+        return $sql;
+    }
+
+    public function doCount(ConnectionInterface $con = null)
+    {
+        $dbMap = Propel::getServiceContainer()->getDatabaseMap($this->getDbName());
+        $db = Propel::getServiceContainer()->getAdapter($this->getDbName());
+
+        if (null === $con) {
+            $con = Propel::getServiceContainer()->getReadConnection($this->getDbName());
+        }
+
+        $params = [];
+        $sql = $this->createCountSql($params);
+
         try {
             $stmt = $con->prepare($sql);
             $db->bindValues($stmt, $params, $dbMap);

--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -2502,7 +2502,9 @@ class Criteria
         if ($this->needsComplexCount()) {
             if ($this->needsSelectAliases()) {
                 if ($this->getHaving()) {
-                    throw new LogicException('Propel cannot create a COUNT query when using HAVING and  duplicate column names in the SELECT part');
+                    $selectColumns = $this->getSelectColumns();
+                    $firstSelectColumn = array_shift($selectColumns);
+                    $this->clearSelectColumns()->addSelectColumn($firstSelectColumn);
                 }
                 $db->turnSelectColumnsToAliases($this);
             }

--- a/tests/Propel/Tests/Runtime/ActiveQuery/ComplexCountTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/ComplexCountTest.php
@@ -10,10 +10,12 @@
 
 namespace Propel\Tests\Runtime\ActiveQuery;
 
-use Propel\Tests\Bookstore\AuthorQuery;
 use Propel\Tests\Helpers\Bookstore\BookstoreTestBase;
+use Propel\Tests\Bookstore\AuthorQuery;
+use Propel\Tests\Bookstore\Map\BookTableMap;
 
 use Propel\Runtime\Propel;
+use Propel\Runtime\ActiveQuery\Criteria;
 
 /**
  * Test class for ComplexCountTest.
@@ -24,9 +26,6 @@ use Propel\Runtime\Propel;
  */
 class ComplexCountTest extends BookstoreTestBase
 {
-    /**
-     * @expectedException \Propel\Runtime\Exception\LogicException
-     */
     public function testCountQueryWhenUsingHavingAndDuplicateColumnNamesInTheSelectPart()
     {
         $c = new AuthorQuery();
@@ -40,5 +39,7 @@ class ComplexCountTest extends BookstoreTestBase
         $this->assertTrue((bool) $c->getHaving(), 'query has a having clause');
 
         $nbAuthorsWithAtLeastOneBook = $c->count();
+
+        $this->assertEquals(0, $nbAuthorsWithAtLeastOneBook, 'query returns expected count in an empty database');
     }
 }

--- a/tests/Propel/Tests/Runtime/ActiveQuery/ComplexCountTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/ComplexCountTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT License
+ */
+
+namespace Propel\Tests\Runtime\ActiveQuery;
+
+use Propel\Tests\Bookstore\AuthorQuery;
+use Propel\Tests\Helpers\Bookstore\BookstoreTestBase;
+
+use Propel\Runtime\Propel;
+
+/**
+ * Test class for ComplexCountTest.
+ *
+ * @author Fredrik Wollsén
+ *
+ * @group database
+ */
+class ComplexCountTest extends BookstoreTestBase
+{
+    /**
+     * @expectedException \Propel\Runtime\Exception\LogicException
+     */
+    public function testCountQueryWhenUsingHavingAndDuplicateColumnNamesInTheSelectPart()
+    {
+        $c = new AuthorQuery();
+        $c->leftJoinWithBook();
+        $c->addHaving('COUNT(Book.id) > 1');
+
+        $this->assertTrue($c->needsSelectAliases(), 'query needs select aliases');
+
+        $this->assertTrue((bool) $c->getHaving(), 'query has a having clause');
+
+        $nbAuthorsWithAtLeastOneBook = $c->count();
+    }
+}

--- a/tests/Propel/Tests/Runtime/ActiveQuery/ComplexCountTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/ComplexCountTest.php
@@ -33,6 +33,8 @@ class ComplexCountTest extends BookstoreTestBase
         $c->leftJoinWithBook();
         $c->addHaving('COUNT(Book.id) > 1');
 
+        $this->assertTrue($c->needsComplexCount(), 'query needs complex count');
+
         $this->assertTrue($c->needsSelectAliases(), 'query needs select aliases');
 
         $this->assertTrue((bool) $c->getHaving(), 'query has a having clause');

--- a/tests/Propel/Tests/Runtime/ActiveQuery/SubQueryTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/SubQueryTest.php
@@ -261,8 +261,10 @@ class SubQueryTest extends BookstoreTestBase
         $c = new BookQuery();
         $c->addSelectQuery($subCriteria, 'subCriteriaAlias');
         $c->filterByPrice(20, Criteria::LESS_THAN);
-        $nbBooks = $c->count();
 
+        $this->assertTrue($c->needsComplexCount(), 'addSelectQuery() doCount implies a need for complex count');
+
+        $nbBooks = $c->count();
         $query = Propel::getConnection()->getLastExecutedQuery();
 
         $sql = $this->getSql("SELECT COUNT(*) FROM (SELECT subCriteriaAlias.id, subCriteriaAlias.title, subCriteriaAlias.isbn, subCriteriaAlias.price, subCriteriaAlias.publisher_id, subCriteriaAlias.author_id FROM (SELECT book.id, book.title, book.isbn, book.price, book.publisher_id, book.author_id FROM book) AS subCriteriaAlias WHERE subCriteriaAlias.price<20) propelmatch4cnt");


### PR DESCRIPTION
Full backwards compatibility. The LogicException with message "Propel cannot create a COUNT query when using HAVING and  duplicate column names in the SELECT part" has been removed.
