### PR TITLE
Fixed versionable behavior

### DIFF
--- a/src/Propel/Generator/Behavior/Versionable/VersionableBehaviorObjectBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/Versionable/VersionableBehaviorObjectBuilderModifier.php
@@ -457,7 +457,7 @@ public function populateFromVersion(\$version, \$con = null, &\$loadedObjects = 
             $relatedVersionQueryClassName = $this->builder->getClassNameFromBuilder($this->builder->getNewStubQueryBuilder($foreignVersionTable));
             $relatedVersionTableMapClassName = $this->builder->getClassNameFromBuilder($this->builder->getNewTableMapBuilder($foreignVersionTable));
             $relatedClassName = $this->builder->getClassNameFromBuilder($this->builder->getNewStubObjectBuilder($foreignTable));
-            $fkColumn = $fk->getLocalColumn();
+            $fkColumn = $foreignTable->getFirstPrimaryKeyColumn();
             $fkVersionColumn = $foreignVersionTable->getColumn($this->behavior->getParameter('version_column'));
 
             $script .= "

--- a/src/Propel/Generator/Behavior/Versionable/VersionableBehaviorObjectBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/Versionable/VersionableBehaviorObjectBuilderModifier.php
@@ -343,7 +343,7 @@ public function addVersion(ConnectionInterface \$con = null)
             if (!$fk->isLocalPrimaryKey()) {
                 $script .= "
 
-    if (\$object && \$relateds = \$object->toKeyValue('{$fk->getForeignColumn()->getPhpName()}', 'Version')) {
+    if (\$object && \$relateds = \$object->toKeyValue('{$fk->getTable()->getFirstPrimaryKeyColumn()->getPhpName()}', 'Version')) {
         \$version->set{$idsColumn->getPhpName()}(array_keys(\$relateds));
         \$version->set{$versionsColumn->getPhpName()}(array_values(\$relateds));
     }
@@ -457,7 +457,7 @@ public function populateFromVersion(\$version, \$con = null, &\$loadedObjects = 
             $relatedVersionQueryClassName = $this->builder->getClassNameFromBuilder($this->builder->getNewStubQueryBuilder($foreignVersionTable));
             $relatedVersionTableMapClassName = $this->builder->getClassNameFromBuilder($this->builder->getNewTableMapBuilder($foreignVersionTable));
             $relatedClassName = $this->builder->getClassNameFromBuilder($this->builder->getNewStubObjectBuilder($foreignTable));
-            $fkColumn = $fk->getForeignColumn();
+            $fkColumn = $fk->getLocalColumn();
             $fkVersionColumn = $foreignVersionTable->getColumn($this->behavior->getParameter('version_column'));
 
             $script .= "

--- a/tests/Propel/Tests/Generator/Behavior/Versionable/VersionableBehaviorObjectBuilderModifierTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Versionable/VersionableBehaviorObjectBuilderModifierTest.php
@@ -583,6 +583,10 @@ EOF;
         $bs = $a->getVersionableBehaviorTest5s();
         $this->assertEquals(1, $bs[0]->getVersion());
         $this->assertEquals(1, $bs[1]->getVersion());
+
+        $bs[0]->toVersion(2);
+        $a = $bs[0]->getVersionableBehaviorTest4();
+        $this->assertEquals(2, $a->getVersion());
     }
 
     public function testGetLastVersionNumber()


### PR DESCRIPTION
Versioning from N:1 side of the relation was not working properly due to the generator adding the foreign column instead of the primary key. This was effecting "addVersion"  and "populateFromVersion" calls. Exchanged the $fk usage with the use of "$fk->getTable()->getFirstPrimaryKey()". This means that the N side of the relation should use the primary key instead of using the foreign key. 
