### PR TITLE
Phpunit boot scripts accepts command line arguments

### DIFF
--- a/tests/bin/phpunit.agnostic.sh
+++ b/tests/bin/phpunit.agnostic.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-./vendor/bin/phpunit -c tests/agnostic.phpunit.xml
+./vendor/bin/phpunit -c tests/agnostic.phpunit.xml $@

--- a/tests/bin/phpunit.mysql.sh
+++ b/tests/bin/phpunit.mysql.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-./vendor/bin/phpunit -c tests/mysql.phpunit.xml
+./vendor/bin/phpunit -c tests/mysql.phpunit.xml $@

--- a/tests/bin/phpunit.pgsql.sh
+++ b/tests/bin/phpunit.pgsql.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-./vendor/bin/phpunit -c tests/pgsql.phpunit.xml
+./vendor/bin/phpunit -c tests/pgsql.phpunit.xml $@

--- a/tests/bin/phpunit.sqlite.sh
+++ b/tests/bin/phpunit.sqlite.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-./vendor/bin/phpunit -c tests/sqlite.phpunit.xml
+./vendor/bin/phpunit -c tests/sqlite.phpunit.xml $@


### PR DESCRIPTION
Allows to use [the command-line arguments when running phpunit tests](https://phpunit.de/manual/current/en/textui.html)