### PR TITLE
removing leading space within the sqlite dsn

### DIFF
--- a/src/Propel/Generator/Command/InitCommand.php
+++ b/src/Propel/Generator/Command/InitCommand.php
@@ -177,7 +177,7 @@ class InitCommand extends AbstractCommand
     {
         $path = $consoleHelper->askQuestion('Where should the sqlite database be stored?', getcwd() . '/my.app.sq3');
 
-        return sprintf('sqlite: %s', $path);
+        return sprintf('sqlite:%s', $path);
     }
 
     private function initPgsql(ConsoleHelperInterface $consoleHelper)


### PR DESCRIPTION
the extra space was causing the below error when using an absolute path like /home/my.app.sq3
Unable to connect to the specific sql server: SQLSTATE[HY000] [14] unable to open database file