### PR TITLE
Use DATETIME2 to allow high precision timestamps

### DIFF
--- a/src/Propel/Generator/Platform/MssqlPlatform.php
+++ b/src/Propel/Generator/Platform/MssqlPlatform.php
@@ -43,8 +43,8 @@ class MssqlPlatform extends DefaultPlatform
         $this->setSchemaDomainMapping(new Domain(PropelTypes::DATE, "DATE"));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::BU_DATE, "DATE"));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::TIME, "TIME"));
-        $this->setSchemaDomainMapping(new Domain(PropelTypes::TIMESTAMP, "DATETIME"));
-        $this->setSchemaDomainMapping(new Domain(PropelTypes::BU_TIMESTAMP, "DATETIME"));
+        $this->setSchemaDomainMapping(new Domain(PropelTypes::TIMESTAMP, "DATETIME2"));
+        $this->setSchemaDomainMapping(new Domain(PropelTypes::BU_TIMESTAMP, "DATETIME2"));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::BINARY, "BINARY(7132)"));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::VARBINARY, "VARBINARY(MAX)"));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::LONGVARBINARY, "VARBINARY(MAX)"));


### PR DESCRIPTION
DATETIME timestamps are limited to 3 digit precision, where DATETTIME2 allows 7 digits. The timestampable behavior needs this precision. 

Example of types: 
datetime	2007-05-08 12:35:29.123
datetime2	2007-05-08 12:35:29. 1234567