### PR TITLE
Check for null key in InstancePoolTrait

### DIFF
--- a/src/Propel/Runtime/ActiveQuery/InstancePoolTrait.php
+++ b/src/Propel/Runtime/ActiveQuery/InstancePoolTrait.php
@@ -23,7 +23,7 @@ trait InstancePoolTrait
                 $key = static::getInstanceKey($object);
             }
 
-            if (null !== $key) {
+            if (false !== empty($key)) {
                 self::$instances[$key] = $object;
             }
         }

--- a/src/Propel/Runtime/ActiveQuery/InstancePoolTrait.php
+++ b/src/Propel/Runtime/ActiveQuery/InstancePoolTrait.php
@@ -23,7 +23,9 @@ trait InstancePoolTrait
                 $key = static::getInstanceKey($object);
             }
 
-            self::$instances[$key] = $object;
+            if (null !== $key) {
+                self::$instances[$key] = $object;
+            }
         }
     }
 


### PR DESCRIPTION
Sometimes getInstanceKey returns null and it messes the instance pool. I think it has something to do with the joinWith populating the related objects.