### PR TITLE
array columns getter: return correct value for `[0]`

### DIFF
--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -1002,7 +1002,7 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
         }
         if (!\$this->$cloUnserialized && null !== \$this->$clo) {
             \$$cloUnserialized = substr(\$this->$clo, 2, -2);
-            \$this->$cloUnserialized = \$$cloUnserialized ? explode(' | ', \$$cloUnserialized) : array();
+            \$this->$cloUnserialized = '' !== \$$cloUnserialized ? explode(' | ', \$$cloUnserialized) : array();
         }
 
         return \$this->$cloUnserialized;";

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectArrayColumnTypeTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectArrayColumnTypeTest.php
@@ -126,6 +126,14 @@ EOF;
         $this->assertEquals($value, $e->getTags(), 'array columns can store arrays');
     }
 
+    public function testGetterForArrayWithOnlyOneZeroValue()
+    {
+        $e = new ComplexColumnTypeEntity2();
+        $value = [0];
+        $e->setTags($value);
+        $this->assertEquals($value, $e->getTags());
+    }
+
     public function testSetterResetValue()
     {
         $e = new ComplexColumnTypeEntity2();


### PR DESCRIPTION
For arrays containing only `0`, the getter currently returns an empty array.