### PR TITLE
Added polymorphic many-to-many relationships.

### DIFF
--- a/src/Propel/Common/Util/CartesianProduct.php
+++ b/src/Propel/Common/Util/CartesianProduct.php
@@ -1,0 +1,43 @@
+<?php namespace Propel\Common\Util;
+
+class CartesianProduct
+{
+    public static function get($input) {
+        $result = array();
+
+        while (list($key, $values) = each($input)) {
+            if (empty($values)) {
+                continue;
+            }
+
+            if (empty($result)) {
+                if (!is_array($values)) {
+                    $values = [$values];
+                }
+                foreach($values as $value) {
+                    $result[] = array($key => $value);
+                }
+            }
+            else {
+                $append = array();
+
+                foreach($result as &$product) {
+                    $product[$key] = array_shift($values);
+
+                    $copy = $product;
+
+                    foreach($values as $item) {
+                        $copy[$key] = $item;
+                        $append[] = $copy;
+                    }
+
+                    array_unshift($values, $product[$key]);
+                }
+
+                $result = array_merge($result, $append);
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -4458,10 +4458,16 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
             foreach ($crossFKs->getIncomingForeignKey()->getColumnObjectsMapping() as $reference) {
                 $local   = $reference['local'];
                 $foreign = $reference['foreign'];
+                $value   = $reference['value'];
 
                 $idx = array_search($local, $crossPks, true);
-                $script .= "
+                if ($value) {
+                    $script .= "
+                        \$entryPk[$idx] = '$value';";
+                } else {
+                    $script .= "
                         \$entryPk[$idx] = \$this->get{$foreign->getPhpName()}();";
+                }
             }
 
             $combinationIdx = 0;
@@ -4469,10 +4475,16 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
                 foreach ($crossFK->getColumnObjectsMapping() as $reference) {
                     $local   = $reference['local'];
                     $foreign = $reference['foreign'];
+                    $value   = $reference['value'];
 
                     $idx = array_search($local, $crossPks, true);
-                    $script .= "
+                    if ($value) {
+                        $script .= "
+                        \$entryPk[$idx] = '$value';";
+                    } else {
+                        $script .= "
                         \$entryPk[$idx] = \$combination[$combinationIdx]->get{$foreign->getPhpName()}();";
+                    }
                 }
                 $combinationIdx++;
             }
@@ -4506,20 +4518,32 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
             foreach ($crossFKs->getIncomingForeignKey()->getColumnObjectsMapping() as $reference) {
                 $local   = $reference['local'];
                 $foreign = $reference['foreign'];
+                $value   = $reference['value'];
 
                 $idx = array_search($local, $crossPks, true);
-                $script .= "
+                if ($value) {
+                    $script .= "
+                        \$entryPk[$idx] = '$value';";
+                } else {
+                    $script .= "
                         \$entryPk[$idx] = \$this->get{$foreign->getPhpName()}();";
+                }
             }
 
             $crossFK = $crossFKs->getCrossForeignKeys()[0];
             foreach ($crossFK->getColumnObjectsMapping() as $reference) {
                 $local   = $reference['local'];
                 $foreign = $reference['foreign'];
+                $value   = $reference['value'];
 
                 $idx = array_search($local, $crossPks, true);
-                $script .= "
+                if ($value) {
+                    $script .= "
+                        \$entryPk[$idx] = '$value';";
+                } else {
+                    $script .= "
                         \$entryPk[$idx] = \$entry->get{$foreign->getPhpName()}();";
+                }
             }
 
             $script .= "

--- a/src/Propel/Generator/Model/CrossForeignKeys.php
+++ b/src/Propel/Generator/Model/CrossForeignKeys.php
@@ -136,7 +136,7 @@ class CrossForeignKeys
         foreach ($primaryKeys as $primaryKey) {
             $covered = false;
             foreach ($this->getCrossForeignKeys() as $crossFK) {
-                if ($crossFK->hasLocalColumn($primaryKey)) {
+                if ($crossFK->hasLocalColumn($primaryKey) && $crossFK->getLocalValues() == $fk->getLocalValues()) {
                     $covered = true;
                     break;
                 }
@@ -148,6 +148,17 @@ class CrossForeignKeys
         }
 
         return false;
+    }
+
+    public function isNotContainingColumnSignature(ForeignKey $fk)
+    {
+        foreach ($this->getCrossForeignKeys() as $crossFK) {
+            if ($crossFK->isTheSameColumnSignature($fk)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/src/Propel/Generator/Model/ForeignKey.php
+++ b/src/Propel/Generator/Model/ForeignKey.php
@@ -1019,4 +1019,30 @@ class ForeignKey extends MappingModel
 
         return 0 !== count($cols);
     }
+
+    public function isTheSamePolymorphicSignature(ForeignKey $fk)
+    {
+        return $this->getPolymorphicSignature() == $fk->getPolymorphicSignature();
+    }
+
+    public function isAPolymorphicSiblingRelationship(ForeignKey $fk)
+    {
+        if (!($this->isPolymorphic() && $fk->isPolymorphic())) {
+            return false;
+        }
+
+        return $this->isTheSamePolymorphicSignature($fk);
+    }
+
+    public function getPolymorphicSignature()
+    {
+        if (!$this->isPolymorphic()) {
+            return false;
+        }
+
+        $sortedCols = $this->getLocalColumns();
+        sort($sortedCols);
+
+        return sha1(implode('|||', $sortedCols));
+    }
 }

--- a/src/Propel/Generator/Model/Table.php
+++ b/src/Propel/Generator/Model/Table.php
@@ -10,6 +10,7 @@
 
 namespace Propel\Generator\Model;
 
+use Propel\Common\Util\CartesianProduct;
 use Propel\Generator\Config\GeneratorConfig;
 use Propel\Generator\Exception\BuildException;
 use Propel\Generator\Exception\EngineException;
@@ -819,15 +820,39 @@ class Table extends ScopedMappingModel implements IdMethod
         $crossFks = [];
         foreach ($this->referrers as $refFK) {
             if ($refFK->getTable()->isCrossRef()) {
-                $crossFK = new CrossForeignKeys($refFK, $this);
-                foreach ($refFK->getOtherFks() as $fk) {
-                    if ($fk->isAtLeastOneLocalPrimaryKeyIsRequired() &&
-                        $crossFK->isAtLeastOneLocalPrimaryKeyNotCovered($fk)) {
-                        $crossFK->addCrossForeignKey($fk);
+                // group all polymorphic fks
+                $refFKOtherFKs = $refFK->getOtherFks();
+                $havePMFKs = false;
+                foreach ($refFKOtherFKs as $k => $refFKOtherFk) {
+                    if ($refFKOtherFk->isPolymorphic()) {
+                        $havePMFKs = true;
+                        $refFKOtherFKs[$refFKOtherFk->getPolymorphicSignature()][] = $refFKOtherFk;
+                        unset($refFKOtherFKs[$k]);
                     }
                 }
-                if ($crossFK->hasCrossForeignKeys()) {
-                    $crossFks[] = $crossFK;
+
+                if (!$havePMFKs) {
+                    $combinations = [$refFKOtherFKs];
+                } else {
+                    // Calculate cartesian product
+                    $combinations = CartesianProduct::get(array_values($refFKOtherFKs));
+                }
+
+                foreach ($combinations as $combination) {
+                    $crossFK = new CrossForeignKeys($refFK, $this);
+                    foreach ($combination as $fk) {
+                        /** @var ForeignKey $fk */
+                        if ($fk->isAtLeastOneLocalPrimaryKeyIsRequired() &&
+                            $crossFK->isAtLeastOneLocalPrimaryKeyNotCovered($fk) &&
+                            !$crossFK->getIncomingForeignKey()->isAPolymorphicSiblingRelationship($fk)
+                        ) {
+                            $crossFK->addCrossForeignKey($fk);
+                        }
+                    }
+
+                    if ($crossFK->hasCrossForeignKeys()) {
+                        $crossFks[] = $crossFK;
+                    }
                 }
             }
         }

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectM2MRelationPolymorphic.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectM2MRelationPolymorphic.php
@@ -1,0 +1,234 @@
+<?php namespace Propel\Tests\Generator\Builder\Om;
+
+use Propel\Generator\Platform\MysqlPlatform;
+use Propel\Generator\Util\QuickBuilder;
+use Propel\Runtime\Collection\ObjectCollection;
+use Propel\Runtime\Collection\ObjectCombinationCollection;
+use Propel\Tests\Helpers\PlatformDatabaseBuildTimeBase;
+
+
+class GeneratedObjectM2MRelationPolymorphic extends PlatformDatabaseBuildTimeBase
+{
+    /**
+     * Tests for a M2M relation with three pks where each is a FK.
+     *
+     * @group database
+     */
+    protected $databaseName = 'migration';
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        if (!class_exists('\RelationPMUserQuery')) {
+            $schema = '
+    <database name="migration" schema="migration">
+        <table name="relationpm_user_child" isCrossRef="true">
+            <column name="user_id" type="integer" primaryKey="true"/>
+            <column name="child_type" primaryKey="true"/>
+            <column name="child_id" type="integer" primaryKey="true"/>       
+
+            <foreign-key foreignTable="relationpm_user" phpName="User" onDelete="cascade">
+                <reference local="user_id" foreign="id"/>
+            </foreign-key>            
+
+            <foreign-key foreignTable="relationpm_position" phpName="Position" onDelete="cascade">
+                <reference local="child_id" foreign="id"/>
+                <reference local="child_type" value="position"/>
+            </foreign-key>                        
+            
+            <foreign-key foreignTable="relationpm_group" phpName="Group" onDelete="cascade">
+                <reference local="child_id" foreign="id"/>
+                <reference local="child_type" value="group"/>
+            </foreign-key>
+        </table>
+
+        <table name="relationpm_user">
+            <column name="id" type="integer" primaryKey="true" autoIncrement="true"/>
+            <column name="name" />
+        </table>
+
+        <table name="relationpm_group">
+            <column name="id" type="integer" primaryKey="true" autoIncrement="true"/>
+            <column name="name" />
+        </table>        
+
+        <table name="relationpm_position">
+            <column name="id" type="integer" primaryKey="true" autoIncrement="true"/>
+            <column name="name" />
+        </table>                
+    </database>
+        ';
+
+            $this->buildAndMigrate($schema);
+        }
+    }
+
+    /**
+     *
+     *           add     |    remove     |    set     |    get
+     *        +---------------------------------------------------
+     * add    |    1             2             3            4
+     * remove |    5             6             7            8
+     * set    |    9            10            11           12
+     *
+     */
+
+
+
+    /*
+     * ####################################
+     * 1. add, add
+     */
+    public function test1()
+    {
+        \RelationpmUserQuery::create()->deleteAll();
+        \RelationpmGroupQuery::create()->deleteAll();
+        \RelationpmUserChildQuery::create()->deleteAll();
+        \RelationpmPositionQuery::create()->deleteAll();
+
+        $hans = new \RelationpmUser();
+        $hans->setName('hans');
+
+        $admins = new \RelationpmGroup();
+        $admins->setName('Admins');
+
+        $position = new \RelationpmPosition();
+        $position->setName('Trainee');
+
+        $hans->addGroup($admins);
+        $hans->addPosition($position);
+        $this->assertCount(1, $hans->getGroups());
+        $this->assertCount(1, $hans->getPositions());
+        $this->assertCount(1, $admins->getUsers());
+        $this->assertCount(1, $position->getUsers());
+        $hans->save();
+
+        $this->assertEquals(2, \RelationpmUserChildQuery::create()->count(), 'We have two connections.');
+        $this->assertEquals(1, \RelationpmUserQuery::create()->count(), 'We have one user.');
+        $this->assertEquals(1, \RelationpmGroupQuery::create()->count(), 'We have one group.');
+        $this->assertEquals(1, \RelationpmPositionQuery::create()->count(), 'We have one position.');
+
+        $positionLead = new \RelationpmPosition();
+        $positionLead->setName('Lead');
+        $hans->addPosition($positionLead);
+        $this->assertCount(1, $hans->getGroups());
+        $this->assertCount(2, $hans->getPositions());
+        $this->assertCount(1, $admins->getUsers());
+        $this->assertCount(1, $positionLead->getUsers());
+        $hans->save();
+
+        $this->assertEquals(3, \RelationpmUserChildQuery::create()->count(), 'We have three connections.');
+        $this->assertEquals(1, \RelationpmUserQuery::create()->count(), 'We have one user.');
+        $this->assertEquals(1, \RelationpmGroupQuery::create()->count(), 'We have one group.');
+        $this->assertEquals(2, \RelationpmPositionQuery::create()->count(), 'We have two positions.');
+
+        //try to add the same combination on a new instance
+        \Map\RelationpmUserTableMap::clearInstancePool();
+        /** @var $newHansObject \RelationpmUser */
+        $newHansObject = \RelationpmUserQuery::create()->findOneByName('hans');
+
+        $newHansObject->addGroup($admins);
+        $newHansObject->addPosition($position);
+        $this->assertCount(1, $newHansObject->getGroups());
+        $this->assertCount(2, $newHansObject->getPositions());
+        $this->assertCount(1, $admins->getUsers());
+        $this->assertCount(1, $position->getUsers());
+        $newHansObject->save();
+
+        $this->assertEquals(3, \RelationpmUserChildQuery::create()->count(), 'We have three connections.');
+        $this->assertEquals(1, \RelationpmUserQuery::create()->count(), 'We have one user.');
+        $this->assertEquals(1, \RelationpmGroupQuery::create()->count(), 'We have one group.');
+        $this->assertEquals(2, \RelationpmPositionQuery::create()->count(), 'We have two positions.');
+    }
+
+
+    /*
+     * ####################################
+     * 2. add, remove
+     */
+    public function test2()
+    {
+        \RelationpmUserQuery::create()->deleteAll();
+        \RelationpmGroupQuery::create()->deleteAll();
+        \RelationpmUserChildQuery::create()->deleteAll();
+        \RelationpmPositionQuery::create()->deleteAll();
+
+        $hans = new \RelationpmUser();
+        $hans->setName('hans');
+
+        $admins = new \RelationpmGroup();
+        $admins->setName('Admins');
+
+        $position = new \RelationpmPosition();
+        $position->setName('Trainee');
+
+        $hans->addGroup($admins);
+        $hans->addPosition($position);
+        $this->assertCount(1, $hans->getGroups());
+        $this->assertCount(1, $hans->getPositions());
+        $hans->save();
+
+        $this->assertEquals(2, \RelationpmUserChildQuery::create()->count(), 'We have two connections.');
+        $this->assertEquals(1, \RelationpmUserQuery::create()->count(), 'We have one user.');
+        $this->assertEquals(1, \RelationpmGroupQuery::create()->count(), 'We have one group.');
+        $this->assertEquals(1, \RelationpmPositionQuery::create()->count(), 'We have one position.');
+
+        $hans->removeGroup($admins);
+        $hans->removePosition($position);
+        $this->assertCount(0, $hans->getGroups());
+        $this->assertCount(0, $hans->getPositions());
+        $hans->save();
+
+        $this->assertEquals(0, \RelationpmUserChildQuery::create()->count(), 'We have zero connections.');
+        $this->assertEquals(1, \RelationpmUserQuery::create()->count(), 'We have one user.');
+        $this->assertEquals(1, \RelationpmGroupQuery::create()->count(), 'We have one group.');
+        $this->assertEquals(1, \RelationpmPositionQuery::create()->count(), 'We have one position.');
+
+    }
+
+    /*
+     * ####################################
+     * 3. add, set
+     */
+    public function test3()
+    {
+        \RelationpmUserQuery::create()->deleteAll();
+        \RelationpmGroupQuery::create()->deleteAll();
+        \RelationpmUserChildQuery::create()->deleteAll();
+        \RelationpmPositionQuery::create()->deleteAll();
+
+        $hans = new \RelationpmUser();
+        $hans->setName('hans');
+
+        $admins = new \RelationpmGroup();
+        $admins->setName('Admins');
+
+        $position = new \RelationpmPosition();
+        $position->setName('Trainee');
+
+        $hans->addGroup($admins);
+        $hans->addPosition($position);
+        $this->assertCount(1, $hans->getGroups());
+        $this->assertCount(1, $hans->getPositions());
+        $hans->save();
+
+        $this->assertEquals(2, \RelationpmUserChildQuery::create()->count(), 'We have two connections.');
+        $this->assertEquals(1, \RelationpmUserQuery::create()->count(), 'We have one user.');
+        $this->assertEquals(1, \RelationpmGroupQuery::create()->count(), 'We have one group.');
+        $this->assertEquals(1, \RelationpmPositionQuery::create()->count(), 'We have one position.');
+
+        $emptyColl = new ObjectCombinationCollection();
+        $hans->setGroups($emptyColl);
+        $hans->setPositions($emptyColl);
+        $this->assertCount(0, $hans->getGroups());
+        $this->assertCount(0, $hans->getPositions());
+        $hans->save();
+
+        $this->assertEquals(0, \RelationpmUserChildQuery::create()->count(), 'We have zero connections.');
+        $this->assertEquals(1, \RelationpmUserQuery::create()->count(), 'We have one user.');
+        $this->assertEquals(1, \RelationpmGroupQuery::create()->count(), 'We have one group.');
+        $this->assertEquals(1, \RelationpmPositionQuery::create()->count(), 'We have one position.');
+    }
+
+}

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectM2MRelationPolymorphicWithSelfReference.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectM2MRelationPolymorphicWithSelfReference.php
@@ -1,0 +1,133 @@
+<?php namespace Propel\Tests\Generator\Builder\Om;
+
+use Propel\Generator\Platform\MysqlPlatform;
+use Propel\Generator\Util\QuickBuilder;
+use Propel\Runtime\Collection\ObjectCollection;
+use Propel\Runtime\Collection\ObjectCombinationCollection;
+use Propel\Tests\Helpers\PlatformDatabaseBuildTimeBase;
+
+
+class GeneratedObjectM2MRelationPolymorphic extends PlatformDatabaseBuildTimeBase
+{
+    /**
+     * Tests for a M2M relation with three pks where each is a FK.
+     *
+     * @group database
+     */
+    protected $databaseName = 'migration';
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        if (!class_exists('\RelationpmsrUserQuery')) {
+            $schema = '
+    <database name="migration" schema="migration">
+        <table name="relationpmsr_user_child" isCrossRef="true">
+            <column name="user_id" type="integer" primaryKey="true"/>
+            <column name="child_type" primaryKey="true"/>
+            <column name="child_id" type="integer" primaryKey="true"/>       
+
+            <foreign-key foreignTable="relationpmsr_user" phpName="User" onDelete="cascade">
+                <reference local="user_id" foreign="id"/>
+            </foreign-key>            
+
+            <foreign-key foreignTable="relationpmsr_position" phpName="Position" onDelete="cascade">
+                <reference local="child_id" foreign="id"/>
+                <reference local="child_type" value="position"/>
+            </foreign-key>                        
+            
+            <foreign-key foreignTable="relationpmsr_user" phpName="ChildUser" onDelete="cascade">
+                <reference local="child_id" foreign="id"/>
+                <reference local="child_type" value="user"/>
+            </foreign-key>
+        </table>
+
+        <table name="relationpmsr_user">
+            <column name="id" type="integer" primaryKey="true" autoIncrement="true"/>
+            <column name="name" />
+        </table>
+
+        <table name="relationpmsr_position">
+            <column name="id" type="integer" primaryKey="true" autoIncrement="true"/>
+            <column name="name" />
+        </table>                
+    </database>
+        ';
+
+            $this->buildAndMigrate($schema);
+        }
+    }
+
+    /**
+     *
+     *           add     |    remove     |    set     |    get
+     *        +---------------------------------------------------
+     * add    |    1             2             3            4
+     * remove |    5             6             7            8
+     * set    |    9            10            11           12
+     *
+     */
+
+
+
+    /*
+     * ####################################
+     * 1. add, add
+     */
+    public function test1()
+    {
+        \RelationpmsrUserQuery::create()->deleteAll();
+        \RelationpmsrUserChildQuery::create()->deleteAll();
+        \RelationpmsrPositionQuery::create()->deleteAll();
+
+        $hans = new \RelationpmsrUser();
+        $hans->setName('hans');
+
+        $frank = new \RelationpmsrUser();
+        $frank->setName('frank');
+
+        $position = new \RelationpmsrPosition();
+        $position->setName('Trainee');
+
+        $hans->addChildUser($frank);
+        $hans->addPosition($position);
+        $this->assertCount(1, $hans->getChildUsers());
+        $this->assertCount(1, $hans->getPositions());
+        $this->assertCount(1, $position->getUsers());
+        $hans->save();
+
+        $this->assertEquals(2, \RelationpmsrUserChildQuery::create()->count(), 'We have two connections.');
+        $this->assertEquals(2, \RelationpmsrUserQuery::create()->count(), 'We have two users.');
+        $this->assertEquals(1, \RelationpmsrPositionQuery::create()->count(), 'We have one position.');
+
+        $positionLead = new \RelationpmsrPosition();
+        $positionLead->setName('Lead');
+        $hans->addPosition($positionLead);
+        $this->assertCount(1, $hans->getChildUsers());
+        $this->assertCount(2, $hans->getPositions());
+        $this->assertCount(1, $positionLead->getUsers());
+        $hans->save();
+
+        $this->assertEquals(3, \RelationpmsrUserChildQuery::create()->count(), 'We have three connections.');
+        $this->assertEquals(2, \RelationpmsrUserQuery::create()->count(), 'We have two users.');
+        $this->assertEquals(2, \RelationpmsrPositionQuery::create()->count(), 'We have two positions.');
+
+        //try to add the same combination on a new instance
+        \Map\RelationpmsrUserTableMap::clearInstancePool();
+        /** @var $newHansObject \RelationpmsrUser */
+        $newHansObject = \RelationpmsrUserQuery::create()->findOneByName('hans');
+
+        $newHansObject->addChildUser($frank);
+        $newHansObject->addPosition($position);
+        $this->assertCount(1, $newHansObject->getChildUsers());
+        $this->assertCount(2, $newHansObject->getPositions());
+        $this->assertCount(1, $frank->getUsers());
+        $this->assertCount(1, $position->getUsers());
+        $newHansObject->save();
+
+        $this->assertEquals(3, \RelationpmsrUserChildQuery::create()->count(), 'We have three connections.');
+        $this->assertEquals(2, \RelationpmsrUserQuery::create()->count(), 'We have two users.');
+        $this->assertEquals(2, \RelationpmsrPositionQuery::create()->count(), 'We have two positions.');
+    }
+}

--- a/tests/Propel/Tests/Generator/Model/ForeignKeyTest.php
+++ b/tests/Propel/Tests/Generator/Model/ForeignKeyTest.php
@@ -443,6 +443,35 @@ class ForeignKeyTest extends ModelTestCase
         $this->assertSame($normalized, $fk->normalizeFKey($behavior));
     }
 
+    public function testPolymorphicSiblings()
+    {
+        $fk1 = new ForeignKey();
+        $fk2 = new ForeignKey();
+
+        $fk1->addReference([
+            'local' => 'col1',
+            'value' => '123'
+        ]);
+        $fk1->addReference([
+            'local' => 'col2',
+            'foreign' => 'id'
+        ]);
+
+        $fk2->addReference([
+            'local' => 'col2',
+            'foreign' => 'id'
+        ]);
+        $fk2->addReference([
+            'local' => 'col1',
+            'value' => '321'
+        ]);
+
+        $this->assertEquals(sha1('col1|||col2'), $fk1->getPolymorphicSignature());
+        $this->assertEquals(sha1('col1|||col2'), $fk2->getPolymorphicSignature());
+        $this->assertTrue($fk1->isAPolymorphicSiblingRelationship($fk2));
+        $this->assertTrue($fk2->isAPolymorphicSiblingRelationship($fk1));
+    }
+
     public function provideOnActionBehaviors()
     {
         return [


### PR DESCRIPTION
Allows for polymorphic many-to-many relationships. Unfortunately at this time does not allow additional static FKs. The builder almost supports it, but since each polymorphic sibling requires a unique relation, the builder tries to also create a new relation for the other static FKs. Example: I have a table that has two static FK relationships A and B and two polymorphic siblings, C1 and C2. When creating object A the builder has to create properties and methods for the unique C1 and C2 relationships, but then also creates two B relationships, creating duplicate properties and methods. Not sure exactly how to implement that properly. But if that caveat is fixed, this would support any combination of static FKs and Polymorphic FKs.