### PR TITLE
Support XML Inclusions in configuration, adds #1321

### DIFF
--- a/src/Propel/Common/Config/XmlToArrayConverter.php
+++ b/src/Propel/Common/Config/XmlToArrayConverter.php
@@ -12,6 +12,7 @@ namespace Propel\Common\Config;
 
 use Propel\Common\Config\Exception\InvalidArgumentException;
 use Propel\Common\Config\Exception\XmlParseException;
+use SimpleXMLElement;
 
 /**
  * Class to convert an xml string to array
@@ -21,9 +22,9 @@ class XmlToArrayConverter
     /**
      * Create a PHP array from the XML file
      *
-     * @param String $xmlFile The XML file or a string containing xml to parse
+     * @param String $xmlToParse The XML file or a string containing xml to parse
      *
-     * @return Array
+     * @return array
      *
      * @throws \Propel\Common\Config\Exception\XmlParseException if parse errors occur
      */
@@ -33,28 +34,38 @@ class XmlToArrayConverter
             throw new InvalidArgumentException("XmlToArrayConverter::convert method expects an xml file to parse, or a string containing valid xml");
         }
 
-        if (file_exists($xmlToParse)) {
-            $xmlToParse = file_get_contents($xmlToParse);
-        }
+        $isFile = file_exists($xmlToParse);
 
         //Empty xml file returns empty array
-        if ('' === $xmlToParse) {
+        if (
+            ($isFile && 0 === filesize($xmlToParse))
+            or (!$isFile && '' === $xmlToParse)
+        ) {
             return [];
         }
 
-        if ($xmlToParse[0] !== '<') {
+        if (
+            ($isFile && file_get_contents($xmlToParse, false, null, 0, 1) !== '<')
+            or (!$isFile && $xmlToParse[0] !== '<')
+        ) {
             throw new InvalidArgumentException('Invalid xml content');
         }
 
-        $currentEntityLoader = libxml_disable_entity_loader(true);
         $currentInternalErrors = libxml_use_internal_errors(true);
 
-        $xml = simplexml_load_string($xmlToParse);
+        if ($isFile) {
+            $xml = simplexml_load_file($xmlToParse);
+            if ($xml instanceof SimpleXMLElement) {
+                dom_import_simplexml($xml)->ownerDocument->xinclude();
+            }
+        } else {
+            $xml = simplexml_load_string($xmlToParse);
+        }
+
         $errors = libxml_get_errors();
 
         libxml_clear_errors();
         libxml_use_internal_errors($currentInternalErrors);
-        libxml_disable_entity_loader($currentEntityLoader);
 
         if (count($errors) > 0) {
             throw new XmlParseException($errors);

--- a/tests/Propel/Tests/Common/Config/DataProviderTrait.php
+++ b/tests/Propel/Tests/Common/Config/DataProviderTrait.php
@@ -312,4 +312,30 @@ EOF
             ]
         ];
     }
+
+    public function providerForXmlToArrayConverterXmlInclusions() {
+        return [
+            [
+                <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<database name="named" defaultIdMethod="native">
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+                href="testconvert_include.xml"
+                xpointer="xpointer( /database/* )"
+                />
+</database>
+XML
+                , <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<database name="mixin" defaultIdMethod="native">
+    <table name="book" phpName="Book"/>
+</database>
+XML
+            , ['table' => [
+                'name' => 'book',
+                'phpName' => 'Book',
+            ]]
+            ],
+        ];
+    }
 }

--- a/tests/Propel/Tests/Common/Config/XmlToArrayConverterTest.php
+++ b/tests/Propel/Tests/Common/Config/XmlToArrayConverterTest.php
@@ -38,6 +38,17 @@ class XmlToArrayConverterTest extends ConfigTestCase
     }
 
     /**
+     * @dataProvider providerForXmlToArrayConverterXmlInclusions
+     */
+    public function testConvertFromFileWithXmlInclusion($xmlLoad, $xmlInclude, $expected)
+    {
+        $this->dumpTempFile('testconvert.xml', $xmlLoad);
+        $this->dumpTempFile('testconvert_include.xml', $xmlInclude);
+        $actual = XmlToArrayConverter::convert(sys_get_temp_dir() . '/testconvert.xml');
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
      * @expectedException \Propel\Common\Config\Exception\InvalidArgumentException
      * @expectedExceptionMessage XmlToArrayConverter::convert method expects an xml file to parse, or a string containing valid xml
      */


### PR DESCRIPTION
Implemented via the existing functionality in PHP's DOMDocument object.

Additionally libxml_disable_entity_loader(true) is not necessary any
longer (it prevented opening XML files from disc earlier) since Oct 2012
with the release of libxml2 version 2.9.0.

The old code looked influenced by the (earlier to that date) hotfix in
the Symfony project however the XXE attack Symfony was prone to, did not
apply to the XmlToArrayConverter (no validate on parse).

Refs:

- #1321

- https://www.w3.org/TR/xinclude/

- https://mail.gnome.org/archives/xml/2012-October/msg00045.html