### PR TITLE
set foreignSchema when schema is public

### DIFF
--- a/src/Propel/Generator/Reverse/PgsqlSchemaParser.php
+++ b/src/Propel/Generator/Reverse/PgsqlSchemaParser.php
@@ -417,9 +417,9 @@ class PgsqlSchemaParser extends AbstractSchemaParser
                 $fk = new ForeignKey($name);
                 $fk->setForeignTableCommonName($foreignTable->getCommonName());
                 if ($table->guessSchemaName() != $foreignTable->guessSchemaName()) {
-                     if($foreignTable->getSchema())
+                        if($foreignTable->getSchema())
                             $fk->setForeignSchemaName($foreignTable->getSchema());
-                     elseif($foreignTable->getSchema() == 'public')
+                        else
                             $fk->setForeignSchemaName("public");
                 }
                 $fk->setOnDelete($ondelete);

--- a/src/Propel/Generator/Reverse/PgsqlSchemaParser.php
+++ b/src/Propel/Generator/Reverse/PgsqlSchemaParser.php
@@ -417,7 +417,10 @@ class PgsqlSchemaParser extends AbstractSchemaParser
                 $fk = new ForeignKey($name);
                 $fk->setForeignTableCommonName($foreignTable->getCommonName());
                 if ($table->guessSchemaName() != $foreignTable->guessSchemaName()) {
-                    $fk->setForeignSchemaName($foreignTable->getSchema());
+                     if($foreignTable->getSchema())
+                            $fk->setForeignSchemaName($foreignTable->getSchema());
+                     elseif($foreignTable->getSchema() == 'public')
+                            $fk->setForeignSchemaName("public");
                 }
                 $fk->setOnDelete($ondelete);
                 $fk->setOnUpdate($onupdate);


### PR DESCRIPTION
Since Propel ignore the public schema of Postgres, there is a problem when in the schema.xml there is a foreign-key with reference to a foreignTable that is located in the public schema. 

In this example the table `approvals` is in `schema1` while the foreignTable `orders` is located in `public`, this generates a problem because the reverse-engineer will look for the foreignTable in `schema1`:
```
<table name="approvals" schema="schema1" idMethod="native" >
    <column name="orderid" phpName="Orderid" required="true"/>
    <foreign-key foreignTable="orders" name="approvals_orderid_fk">
      ..........
    </foreign-key>
```


With this fix it is possible to reference a foreignTable when it is in the public schema:
```
<table name="approvals" schema="schema1" idMethod="native" >
    <column name="orderid" phpName="Orderid" required="true"/>
    <foreign-key foreignTable="orders" foreignSchema="public" name="approvals_orderid_fk">
      ..........
    </foreign-key>
