### PR TITLE
Fix regression in ObjectCollection of Collections.

### DIFF
--- a/src/Propel/Runtime/Collection/Collection.php
+++ b/src/Propel/Runtime/Collection/Collection.php
@@ -164,10 +164,10 @@ class Collection implements \ArrayAccess, \IteratorAggregate, \Countable, \Seria
     {
         return new CollectionIterator($this);
     }
-    
+
     /**
      * Count elements in the collection
-     * 
+     *
      * @return int
      */
     public function count()
@@ -602,5 +602,10 @@ class Collection implements \ArrayAccess, \IteratorAggregate, \Countable, \Seria
     protected function getPluralModelName()
     {
         return $this->getPluralizer()->getPluralForm($this->getModel());
+    }
+
+    public function hashCode()
+    {
+        return spl_object_hash($this);
     }
 }

--- a/tests/Propel/Tests/Runtime/Collection/ObjectCollectionTest.php
+++ b/tests/Propel/Tests/Runtime/Collection/ObjectCollectionTest.php
@@ -266,6 +266,20 @@ class ObjectCollectionTest extends BookstoreTestBase
         $this->assertFalse(0 === $col->search($b2));
     }
 
+    public function testObjectCollectionOfObjectCollections()
+    {
+        $col1 = new ObjectCollection();
+        $b1  = new Book();
+        $b1->setTitle('Bar');
+        $b1->setISBN('012345');
+        $col2  = clone $b1;
+
+        $col = new ObjectCollection([$col1]);
+
+        $this->assertTrue($col->contains($col1));
+        $this->assertFalse($col->contains($col2));
+    }
+
     /**
      * @afterClass
      */


### PR DESCRIPTION
The test I add was failing with:
```
Propel\Runtime\Exception\BadMethodCallException: Call to undefined method: hashCode

/home/peter/dev/Propel2/src/Propel/Runtime/Collection/Collection.php:558
/home/peter/dev/Propel2/src/Propel/Runtime/Collection/ObjectCollection.php:496
/home/peter/dev/Propel2/src/Propel/Runtime/Collection/ObjectCollection.php:496
/home/peter/dev/Propel2/src/Propel/Runtime/Collection/ObjectCollection.php:485
/home/peter/dev/Propel2/tests/Propel/Tests/Runtime/Collection/ObjectCollectionTest.php:277
```
because `ObjectCollection.php:496` calls `hashCode()` on itself with:
```
        if (is_object($object) && is_callable([$object, 'hashCode'])) {
            return $object->hashCode();
        }
```
The test returns `true` because `Collection.php` has a `__call()` method. It then fails because that method does not handle `hashCode`.

So I added a `hashCode` method in `Collection.php`.

Collections of collections worked in Propel1 (with class `PropelCollection`). They happen when you create Symfony forms with `'multiple' => true` when the subform returns a Collection.