### PR TITLE
fix TableMapTrait.php

### DIFF
--- a/src/Propel/Runtime/Map/TableMapTrait.php
+++ b/src/Propel/Runtime/Map/TableMapTrait.php
@@ -58,8 +58,8 @@ trait TableMapTrait
         $toNames = static::getFieldNames($toType);
         $newRow = [];
         foreach ($row as $name => $field) {
-            if ($key = static::$fieldKeys[$fromType][$name]) {
-                $newRow[$toNames[$key]] = $field;
+            if (isset(static::$fieldKeys[$fromType][$name])) {
+                $newRow[$toNames[static::$fieldKeys[$fromType][$name]]] = $field;
             } else {
                 $newRow[$name] = $field;
             }


### PR DESCRIPTION
Fix translateFieldNames method in Propel/Runtime/Map/TableMapTrait.php.
Bug: if key == 0(id in my case) field name does not translated.