### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "symfony/yaml": "~2.3||~3.0",
         "symfony/console": "~2.3||~3.0",
         "symfony/finder": "~2.3||~3.0",
-        "symfony/validator": "~2.3||~3.0 !=3.2.2",
+        "symfony/validator": "~2.3||~3.0 !=3.2.2 !=3.2.3",
         "symfony/filesystem": "~2.3||~3.0",
         "symfony/config": "~2.3||~3.0",
         "psr/log": "~1.0"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "symfony/yaml": "~2.3||~3.0",
         "symfony/console": "~2.3||~3.0",
         "symfony/finder": "~2.3||~3.0",
-        "symfony/validator": "~2.3||~3.0 <=3.2.1",
+        "symfony/validator": "~2.3||~3.0 !=3.2.2",
         "symfony/filesystem": "~2.3||~3.0",
         "symfony/config": "~2.3||~3.0",
         "psr/log": "~1.0"


### PR DESCRIPTION
skip symfony/validator 3.2.2, because changes that breaks test in propel was reverted in https://github.com/symfony/symfony/pull/21592