### PR TITLE
Allows the use of Unsigned="true|false" as a MySQL vendor column parameter

### DIFF
--- a/src/Propel/Generator/Platform/MysqlPlatform.php
+++ b/src/Propel/Generator/Platform/MysqlPlatform.php
@@ -366,6 +366,17 @@ DROP TABLE IF EXISTS " . $this->quoteIdentifier($table->getName()) . ";
             $ddl[] = $sqlType;
         }
         $colinfo = $col->getVendorInfoForType($this->getDatabaseType());
+        if ($colinfo->hasParameter('Unsigned')) {
+            $unsigned = $colinfo->getParameter('Unsigned');
+            switch (strtoupper($unsigned)) {
+                case 'FALSE': break;
+                case 'TRUE':
+                    $ddl[] = 'UNSIGNED';
+                    break;
+                default:
+                    throw new EngineException('Unexpected value "'.$unsigned.'" for MySQL vendor column parameter "Unsigned", expecting "true" or "false".');
+            }
+        }
         if ($colinfo->hasParameter('Charset')) {
             $ddl[] = 'CHARACTER SET '. $this->quote($colinfo->getParameter('Charset'));
         }


### PR DESCRIPTION
(stupid) example:
```xml
        <column name="metricIdStart"      phpName="MetricIdStart" type="integer"            required="true" expose="true">
            <vendor type="mysql">
                <parameter name="Unsigned" value="true"/>
            </vendor>
        </column>
        <column name="metricIdEnd"        phpName="MetricIdEnd"   type="integer"            required="true" expose="true">
            <vendor type="mysql">
                <parameter name="Unsigned" value="false"/>
            </vendor>
        </column>
```

Will yield the following SQL

```mysql
    `metricIdStart` INTEGER UNSIGNED NOT NULL,
    `metricIdEnd` INTEGER NOT NULL,
```

I did no check upon column type when processing Unsigned attribute to keep the code simple, I wonder if I should test it and raise an exception if not applicable to current column type?