### PR TITLE
Set timestamp size to 6 to account for high precision timestamps

### DIFF
--- a/src/Propel/Generator/Platform/MysqlPlatform.php
+++ b/src/Propel/Generator/Platform/MysqlPlatform.php
@@ -47,7 +47,7 @@ class MysqlPlatform extends DefaultPlatform
         $this->setSchemaDomainMapping(new Domain(PropelTypes::VARBINARY, 'MEDIUMBLOB'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::LONGVARBINARY, 'LONGBLOB'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::CLOB, 'LONGTEXT'));
-        $this->setSchemaDomainMapping(new Domain(PropelTypes::TIMESTAMP, 'DATETIME'));
+        $this->setSchemaDomainMapping(new Domain(PropelTypes::TIMESTAMP, 'DATETIME', 6));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::OBJECT, 'MEDIUMBLOB'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::PHP_ARRAY, 'TEXT'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::ENUM, 'TINYINT'));

--- a/tests/Propel/Tests/Resources/blog-schema.xml
+++ b/tests/Propel/Tests/Resources/blog-schema.xml
@@ -13,8 +13,8 @@
       <column name="body" phpName="Body" type="clob"/>
       <column name="average_rating" phpName="AverageRating" type="float" size="2" scale="2" description="The post rating in percentage"/>
       <column name="price_without_decimal_places" phpName="PriceWithoutDecimalPlaces" type="DECIMAL" size="10" scale="0" description="The Price without decimal places"/>
-      <column name="created_at" phpName="CreatedAt" type="TIMESTAMP"/>
-      <column name="updated_at" phpName="UpdatedAt" type="TIMESTAMP"/>
+      <column name="created_at" phpName="CreatedAt" type="TIMESTAMP" size="6"/>
+      <column name="updated_at" phpName="UpdatedAt" type="TIMESTAMP" size="6"/>
       <column name="slug" phpName="Slug" type="VARCHAR" size="255"/>
       <foreign-key foreignTable="blog_author" name="fk_post_has_author" phpName="Author" refPhpName="Posts" defaultJoin="Criteria::LEFT_JOIN" onDelete="CASCADE">
         <reference local="author_id" foreign="id"/>


### PR DESCRIPTION
The Propel timestampable behavior was recently updated to allow high precision timestamps. In theory, this is good, but unfortunately, MySQL discards the extra precision when saving, causing some problems when you want to compare two objects (one that was "saved" but not "reloaded from database" vs. one that is read from the database). For tests with fixtures, this is quite inconvenient, so I added a size for the timestamp field to make MySQL store the extra precision. 

From https://dev.mysql.com/doc/refman/5.6/en/fractional-seconds.html:

```TIMESTAMP(N) was permitted in old MySQL versions, but N was a display width rather than fractional seconds precision. Support for this behavior was removed in MySQL 5.5.3, so applications that are reasonably up to date should not be subject to this issue. Otherwise, code must be rewritten.```

This means that there might be some side effects here before the mentioned version. Which minimal version does Propel require?