### PR TITLE
Prevent generating table namespaces in case they are exact duplicates of the database's namespace

### DIFF
--- a/src/Propel/Generator/Model/Database.php
+++ b/src/Propel/Generator/Model/Database.php
@@ -655,7 +655,9 @@ class Database extends ScopedMappingModel
                 $namespace .= '\\'.$table->getNamespace();
             }
 
-            $table->setNamespace($namespace);
+            if ($this->getNamespace() !== $namespace) {
+                $table->setNamespace($namespace);
+            }
         }
 
         return $namespace;


### PR DESCRIPTION
This is a suggested fix for issue #1260.