### PR TITLE
Allowing file loader to accept empty env vars (e.g. DB_PW)

### DIFF
--- a/src/Propel/Common/Config/Loader/FileLoader.php
+++ b/src/Propel/Common/Config/Loader/FileLoader.php
@@ -320,7 +320,7 @@ abstract class FileLoader extends BaseFileLoader
         $env = explode('.', $value);
         if ('env' === $env[0]) {
             $envParam = getenv($env[1]);
-            if (!$envParam) {
+            if (false === $envParam) {
                 throw new InvalidArgumentException("Environment variable '$env[1]' is not defined.");
             }
 

--- a/tests/Propel/Tests/Common/Config/Loader/FileLoaderTest.php
+++ b/tests/Propel/Tests/Common/Config/Loader/FileLoaderTest.php
@@ -254,6 +254,24 @@ class FileLoaderTest extends TestCase
         putenv('integer');
     }
 
+    public function testResolveEmptyEnvironmentVariable()
+    {
+        putenv('home=');
+
+        $config = [
+            'home' => '%env.home%'
+        ];
+
+        $expected = [
+            'home' => ''
+        ];
+
+        $this->assertEquals($expected, $this->loader->resolveParams($config));
+
+        //cleanup environment
+        putenv('home');
+    }
+
     public function testResourceNameIsNotStringReturnsFalse()
     {
         $this->assertFalse($this->loader->checkSupports('ini', null));


### PR DESCRIPTION
getenv() returns a string response, which may be an empty string.
This is a valid response and may represent, for example, and empty db password variable (DB_PW).
The patch is to check if getenv() returned false in order to determine if an error occurred or not.
* The same check is used in [TestCaseFixtures.php (line 101)](https://github.com/propelorm/Propel2/blob/618c192272b5bc9636412659bf32bd572910b819/tests/Propel/Tests/TestCaseFixtures.php#L101)