### PR TITLE
MSSQL `applyLimit` Greedy Regex Fix

### DIFF
--- a/src/Propel/Runtime/Adapter/Pdo/MssqlAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/MssqlAdapter.php
@@ -144,7 +144,7 @@ class MssqlAdapter extends PdoAdapter implements SqlAdapterInterface
 
         $selectText = 'SELECT ';
 
-        preg_match('/\Aselect(.*)from(.*)/si', $sql, $selectSegment);
+        preg_match('/\Aselect (.+?) from (.*)/si', $sql, $selectSegment);
         if (3 === count($selectSegment)) {
             $selectStatement = trim($selectSegment[1]);
             $fromStatement = trim($selectSegment[2]);


### PR DESCRIPTION
Fixes an issue with the `applyLimit` in the MssqlAdapter incorrectly splitting the query string when inner select statements are included. 

Example use case:
```php
$projects = ProjectQuery::create()
    ->where('Project.ProjectID IN (
      SELECT InstanceID FROM RBAC.dbo.InstanceTemp
    )')
    ->offset(10)
    ->limit(10)
    ->find();
```