### PR TITLE
Data Dictionary Markdown Generator

### DIFF
--- a/src/Propel/Generator/Command/DataDictionaryGenerateCommand.php
+++ b/src/Propel/Generator/Command/DataDictionaryGenerateCommand.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
+namespace Propel\Generator\Command;
+
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Propel\Generator\Manager\DataDictionaryManager;
+
+/**
+ * @author Charles Crossan <crossan007@gmail.com>
+ */
+class DataDictionaryGenerateCommand extends AbstractCommand
+{
+    const DEFAULT_OUTPUT_DIRECTORY  = 'generated-datadictionary';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        parent::configure();
+
+        $this
+            ->addOption('output-dir',   null, InputOption::VALUE_REQUIRED,  'The output directory', self::DEFAULT_OUTPUT_DIRECTORY)
+            ->addOption('schema-dir',   null, InputOption::VALUE_REQUIRED,  'The directory where the schema files are placed')
+            ->setName('datadictionary:generate')
+            ->setAliases(['datadictionary'])
+            ->setDescription('Generate Data Dictionary files (.md)')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $configOptions = [];
+        if ($this->hasInputOption('schema-dir', $input)){
+            $configOptions['propel']['paths']['schemaDir'] = $input->getOption('schema-dir');
+        }
+        $generatorConfig = $this->getGeneratorConfig($configOptions, $input);
+
+        $this->createDirectory($input->getOption('output-dir'));
+
+        $manager = new DataDictionaryManager();
+        $manager->setGeneratorConfig($generatorConfig);
+        $manager->setSchemas($this->getSchemas($generatorConfig->getSection('paths')['schemaDir'], $generatorConfig->getSection('generator')['recursive']));
+        $manager->setLoggerClosure(function ($message) use ($input, $output) {
+            if ($input->getOption('verbose')) {
+                $output->writeln($message);
+            }
+        });
+        $manager->setWorkingDirectory($input->getOption('output-dir'));
+
+        $manager->build();
+    }
+}

--- a/src/Propel/Generator/Manager/DataDictionaryManager.php
+++ b/src/Propel/Generator/Manager/DataDictionaryManager.php
@@ -70,10 +70,11 @@ class DataDictionaryManager extends AbstractManager
                     $columnRow[0] = $col->getName();
                     $columnRow[1] = $col->getPhpName();
                     if (count($col->getForeignKeys()) > 0) {
-                       foreach ($col->getForeignKeys() as $fk)
-                       {
-                         $columnRow[2] .= '[FK] [' . $fk->getForeignTableName() .'](#'.$this->getAnchorName($fk->getForeignTableName()).')';
-                       }
+                      $columnRow[2] = '';
+                      foreach ($col->getForeignKeys() as $fk)
+                      {
+                        $columnRow[2] .= '[FK] [' . $fk->getForeignTableName() .'](#'.$this->getAnchorName($fk->getForeignTableName()).')';
+                      }
                       
                     } elseif ($col->isPrimaryKey()) {
                        $columnRow[2] =  ' [PK]';

--- a/src/Propel/Generator/Manager/DataDictionaryManager.php
+++ b/src/Propel/Generator/Manager/DataDictionaryManager.php
@@ -89,49 +89,6 @@ class DataDictionaryManager extends AbstractManager
                     
                     $MdSyntax .= "|".join("|",$columnRow)."|\n";
                 }
-                
-                /*
-                    if (count($col->getForeignKeys()) > 0) {
-                        $dotSyntax .= ' [FK]';
-                    } elseif ($col->isPrimaryKey()) {
-                        $dotSyntax .= ' [PK]';
-                    }
-                    $dotSyntax .= '\l';
-                }
-                $dotSyntax .= '}", shape=record];';
-                $dotSyntax .= "\n";
-
-     
-            }
-
-            // print the relations
-            $count = 0;
-            $dotSyntax .= "\n";
-            foreach ($database->getTables() as $tbl) {
-                foreach ($tbl->getForeignKeys() as $fk) {
-                    $dotSyntax .= 'node'.$tbl->getName();
-                    $dotSyntax .= ':cols -> node'.$fk->getForeignTableName();
-                    $label = [];
-                    foreach ($fk->getMapping() as $map) {
-                        list ($localColumn, $foreignValueOrColumn) = $map;
-                        $labelString = $localColumn->getName().'=';
-                        if ($foreignValueOrColumn instanceof Column) {
-                            $labelString .= $foreignValueOrColumn->getName();
-                        } else {
-                            $labelString .= var_export($foreignValueOrColumn, true);
-                        }
-
-                        $label[] = $labelString;
-                    }
-                    $dotSyntax .= ':table [label="' . implode('\l', $label) . ' ", color=gray];';
-                    $dotSyntax .= "\n";
-                }
-
-                $count++;
-            }
-
-            $dotSyntax .= "}\n";*/
-                
             }
 
             $this->writeMd($MdSyntax, $database->getName());

--- a/src/Propel/Generator/Manager/DataDictionaryManager.php
+++ b/src/Propel/Generator/Manager/DataDictionaryManager.php
@@ -1,0 +1,131 @@
+<?php
+
+/**
+ * This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT License
+ */
+
+namespace Propel\Generator\Manager;
+
+use Propel\Generator\Model\Column;
+
+/**
+ * Manager for Markdown Data Dictionary
+ *
+ * @author Charles Crossan <crossan007@gmail.com>
+ */
+class DataDictionaryManager extends AbstractManager
+{
+    private $dictionaryColumns = ["Column Name","PHP Name", "Primary Key","Format","Length","Description"];
+  
+    public function build()
+    {
+        $count = 0;
+
+        foreach ($this->getDatabases() as $database) {
+            $MdSyntax = "# Data Dictionary for " .  $database->getName() ."\n";
+            $this->log("db: " . $database->getName());
+            $MdSyntax = "# Table of Contents <a name=\"TOC\"></a>\n";
+            
+            $tableCount=1;
+            
+            $tables = $database->getTables();
+            usort($tables, function($a, $b)
+            {
+              return strcmp($a->getName(), $b->getName());
+            });
+            
+            foreach ($tables as $tbl) {
+                $MdSyntax .= $tableCount.". [" . $tbl->getName() . "](#". preg_replace('/[^A-Z|a-z]/','-',$tbl->getName()) .")\n";
+                $tableCount ++;
+            }
+
+            // print the tables
+            foreach ($tables as $tbl) {
+                $this->log("\t+ " . $tbl->getName());
+                
+                $MdSyntax .= "## Table: " . $tbl->getName() . "<a name=\"".preg_replace('/[^A-Z|a-z]/','-',$tbl->getName())."\"></a>\n";
+                $MdSyntax .= "[Table of Contents](#TOC)\n\n";
+                
+                if ($tbl->getDescription())
+                {
+                  $MdSyntax .= "### Description:\n";
+                  $MdSyntax .= $tbl->getDescription()."\n";
+                }
+                
+               $MdSyntax .= "### Columns:\n";
+                $MdSyntax .= "|".join("|",$this->dictionaryColumns)."|\n";
+                $MdSyntax .= "|".join("|",array_fill(0,count($this->dictionaryColumns),"---"))."|\n";
+
+                foreach ($tbl->getColumns() as $col) {
+                    $columnRow = [];
+                    $columnRow[0] = $col->getName();
+                    $columnRow[1] = $col->getPhpName();
+                    $columnRow[2] = ($col->isPrimaryKey() ? "YES":"NO");
+                    $columnRow[3] = $col->getType();
+                    $columnRow[4] = $col->getSize();
+                    $columnRow[5] = $col->getDescription();
+                    
+                    $MdSyntax .= "|".join("|",$columnRow)."|\n";
+                }
+                
+                /*
+                    if (count($col->getForeignKeys()) > 0) {
+                        $dotSyntax .= ' [FK]';
+                    } elseif ($col->isPrimaryKey()) {
+                        $dotSyntax .= ' [PK]';
+                    }
+                    $dotSyntax .= '\l';
+                }
+                $dotSyntax .= '}", shape=record];';
+                $dotSyntax .= "\n";
+
+     
+            }
+
+            // print the relations
+            $count = 0;
+            $dotSyntax .= "\n";
+            foreach ($database->getTables() as $tbl) {
+                foreach ($tbl->getForeignKeys() as $fk) {
+                    $dotSyntax .= 'node'.$tbl->getName();
+                    $dotSyntax .= ':cols -> node'.$fk->getForeignTableName();
+                    $label = [];
+                    foreach ($fk->getMapping() as $map) {
+                        list ($localColumn, $foreignValueOrColumn) = $map;
+                        $labelString = $localColumn->getName().'=';
+                        if ($foreignValueOrColumn instanceof Column) {
+                            $labelString .= $foreignValueOrColumn->getName();
+                        } else {
+                            $labelString .= var_export($foreignValueOrColumn, true);
+                        }
+
+                        $label[] = $labelString;
+                    }
+                    $dotSyntax .= ':table [label="' . implode('\l', $label) . ' ", color=gray];';
+                    $dotSyntax .= "\n";
+                }
+
+                $count++;
+            }
+
+            $dotSyntax .= "}\n";*/
+                
+            }
+
+            $this->writeMd($MdSyntax, $database->getName());
+        }
+    }
+
+    protected function writeMd($MdSyntax, $baseFilename)
+    {
+        $file = $this->getWorkingDirectory() . DIRECTORY_SEPARATOR . $baseFilename . '.schema.md';
+
+        $this->log("Writing md file to " . $file);
+
+        file_put_contents($file, $MdSyntax);
+    }
+}

--- a/src/Propel/Generator/Manager/DataDictionaryManager.php
+++ b/src/Propel/Generator/Manager/DataDictionaryManager.php
@@ -33,7 +33,7 @@ class DataDictionaryManager extends AbstractManager
         foreach ($this->getDatabases() as $database) {
             $MdSyntax = "# Data Dictionary for " .  $database->getName() ."\n";
             $this->log("db: " . $database->getName());
-            $MdSyntax = "# Table of Contents <a name=\"TOC\"></a>\n";
+            $MdSyntax = "<a name=\"TOC\"></a>\n# Table of Contents\n";
             
             $tableCount=1;
             
@@ -52,7 +52,7 @@ class DataDictionaryManager extends AbstractManager
             foreach ($tables as $tbl) {
                 $this->log("\t+ " . $tbl->getName());
                 
-                $MdSyntax .= "## Table: " . $tbl->getName() . "<a name=\"".$this->getAnchorName($tbl->getName())."\"></a>\n";
+                $MdSyntax .= "<a name=\"".$this->getAnchorName($tbl->getName())."\"></a>\n## Table: " . $tbl->getName() . "\n";
                 $MdSyntax .= "[Table of Contents](#TOC)\n\n";
                 
                 if ($tbl->getDescription())


### PR DESCRIPTION
Adds a generator for creating markdown data dictionaries.

usage: ```propel --config-dir=propel datadictionary:generate```

Proof of concept usage here: https://github.com/ChurchCRM/CRM/blob/5be16c7f1016ac117556dab623e5c9efdf7d2065/generated-datadictionary/default.schema.md