### PR TITLE
Fix issue #1345: Corrupt data returned: many-to-many without primary key

### DIFF
--- a/src/Propel/Generator/Model/Table.php
+++ b/src/Propel/Generator/Model/Table.php
@@ -791,7 +791,7 @@ class Table extends ScopedMappingModel implements IdMethod
                 $foreignPrimaryKeys = $foreignTable->getPrimaryKey();
                 // check all keys are referenced in foreign key
                 foreach ($foreignPrimaryKeys as $foreignPrimaryKey) {
-                    if (!$foreignPrimaryKey->hasReferrer($foreignKey) && $throwErrors) {
+                    if (!$foreignPrimaryKey->hasReferrer($foreignKey) && !$foreignKey->isSkipSql() && $throwErrors) {
                         // foreign primary key is not being referenced in foreign key
                         throw new BuildException(sprintf(
                             'Table "%s" contains a foreign key to table "%s" but does not have a reference to foreign primary key "%s"',

--- a/src/Propel/Runtime/ActiveQuery/InstancePoolTrait.php
+++ b/src/Propel/Runtime/ActiveQuery/InstancePoolTrait.php
@@ -23,7 +23,9 @@ trait InstancePoolTrait
                 $key = static::getInstanceKey($object);
             }
 
-            self::$instances[$key] = $object;
+            if (!empty($key)) {
+                self::$instances[$key] = $object;
+            }
         }
     }
 

--- a/src/Propel/Runtime/Util/PropelDateTime.php
+++ b/src/Propel/Runtime/Util/PropelDateTime.php
@@ -85,7 +85,7 @@ class PropelDateTime extends \DateTime
     {
         $mtime = microtime(true);
 
-        return str_replace(',', '.', $mtime);
+        return number_format($mtime, 6, '.', '');
     }
 
     /**

--- a/tests/Propel/Tests/Issues/Issue1345Test.php
+++ b/tests/Propel/Tests/Issues/Issue1345Test.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT License
+ */
+namespace Propel\Tests\Issues;
+
+use Propel\Tests\Bookstore\Map\BookTableMap;
+use Propel\Tests\TestCase;
+
+/**
+ * This test proves the bug described in https://github.com/propelorm/Propel2/issues/1345.
+ * When trying to add an instance without primary key, it should NOT be stored.
+ * Otherwise for any instance without primary key the latest added one will be returned by its empty key.
+ */
+class Issue1345Test extends TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        BookTableMap::clearInstancePool();
+    }
+
+    public function testAddingToInstancePoolWithoutPrimaryKey()
+    {
+        BookTableMap::addInstanceToPool(new \stdClass(), '');
+
+        $this->assertNull(BookTableMap::getInstanceFromPool(''));
+    }
+}

--- a/tests/Propel/Tests/Issues/Issue1388Test.php
+++ b/tests/Propel/Tests/Issues/Issue1388Test.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT License
+ */
+namespace Propel\Tests\Issues;
+
+use Propel\Generator\Util\QuickBuilder;
+use Propel\Tests\TestCaseFixtures;
+
+/**
+ * Test : Propel should allow marked to be skipped foreign key references on table with composite primary key
+ * @group model
+ */
+class Issue1388Test extends TestCaseFixtures
+{
+    public function testSkippedIncompleteForeignReference()
+    {
+        $schema = <<<EOF
+<?xml version="1.0" encoding="utf-8"?>
+<database name="test" defaultIdMethod="native">
+    <table name="event">
+        <column name="id" type="integer" required="true" primaryKey="true" autoIncrement="true" />
+        <column name="name" type="varchar" size="50" required="true" />
+        <column name="organiser_type_id" type="integer" required="true" />
+        <!-- This FK is incomplete -->
+        <foreign-key foreignTable="organiser" skipSql="true">
+            <reference local="organiser_type_id" foreign="type_id" />
+        </foreign-key>
+    </table>
+
+    <table name="organiser">
+        <!-- Has composite PK -->
+        <column name="id" type="integer" required="true" primaryKey="true" autoIncrement="true" />
+        <column name="secondary" type="integer" required="true" primaryKey="true" />
+        <column name="type_id" type="integer" required="true" />
+        <column name="name" type="varchar" size="50" required="true" />
+    </table>
+</database>
+EOF;
+
+        $builder = new QuickBuilder();
+        $builder->setSchema($schema);
+        
+        try {
+            $builder->buildClasses(null, true);
+            $noExceptionThrown = true;
+        } catch (\Exception $e) {
+            $noExceptionThrown = false;
+        }
+
+        $this->assertTrue($noExceptionThrown);
+
+    }
+}


### PR DESCRIPTION
InstancePoolTrait::addInstanceToPool didn't check if the primary key of instance was empty string. And since addInstanceToPool assigned each of instances without primary constraint to empty string key, InstancePoolTrait::getInstanceFromPool could return only the last written one.