### PR TITLE
Fix MssqlAdapter::applyLimit from generating malformed queries when `from` is included as a non-keyword

### DIFF
--- a/src/Propel/Runtime/Adapter/Pdo/MssqlAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/MssqlAdapter.php
@@ -155,11 +155,11 @@ class MssqlAdapter extends PdoAdapter implements SqlAdapterInterface
                 $parenthesisMatch++;
             } else if (')' === $sql[$i]) {
                 $parenthesisMatch--;
-            } else if (0 === $parenthesisMatch && $i === stripos($sql, 'from', $i)) {
+            } else if (0 === $parenthesisMatch && $i === stripos($sql, ' from ', $i)) {
                 // If we hit a 'from' clause outside of matching parenthesis, split the
                 // query string into `SELECT $selectStatement FROM $fromStatement`
                 $selectStatement = trim(substr($sql, $selectTextLen, $i - $selectTextLen));
-                $fromStatement = trim(substr($sql, $i + 4));
+                $fromStatement = trim(substr($sql, $i + 6));
                 break;
             }
         }

--- a/tests/Propel/Tests/Runtime/Adapter/Pdo/MssqlAdapterTest.php
+++ b/tests/Propel/Tests/Runtime/Adapter/Pdo/MssqlAdapterTest.php
@@ -204,4 +204,30 @@ class MssqlAdapterTest extends TestCase
 
         $this->assertEquals($expected, $result);
     }
+
+    /**
+     * Regression: Ensure correct parsing when `from` is used as a non-keyword
+     * e.g. as a column name
+     */
+    public function testApplyLimitWithFromNonKeyword()
+    {
+        $c = new Criteria();
+        BookTableMap::addSelectColumns($c);
+
+        $c->addAsColumn(
+            'date_from',
+            '(SELECT GETDATE())'
+        );
+
+        $c->setOffset(0);
+        $c->setLimit(10);
+
+        $params = [];
+        $sql = $c->createSelectSql($params);
+
+        // Expect a well-formed query where the `date_from` column remains untouched
+        $expected = 'SELECT TOP 10 book.id, book.title, book.isbn, book.price, book.publisher_id, book.author_id, (SELECT GETDATE()) AS date_from FROM book';
+
+        $this->assertEquals($expected, $sql);
+    }
 }


### PR DESCRIPTION
Fixes regression issue found after PR #1382 was merged in. Now correctly identifies `FROM` as a keyword versus `FROM` as part of a column name.