### PR TITLE
Fix json equality check

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,8 +43,7 @@
     ],
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0-dev",
-            "dev-fix-json-equality": "2.0-dev"
+            "dev-master": "2.0-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
     ],
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0-dev"
+            "dev-master": "2.0-dev",
+            "dev-fix-json-equality": "2.0-dev"
         }
     }
 }

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -1887,7 +1887,7 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
         if (is_array(\$v)) {
             \$v = json_decode(json_encode(\$v));
         }
-        if (is_string(\$v)) {
+        elseif (is_string(\$v)) {
             \$v = json_decode(\$v);
         }
         if (\$v != json_decode(\$this->$clo)) {

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -1013,7 +1013,7 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
         $visibility = $column->getAccessorVisibility();
 
         $script .= "
-    ".$visibility." function get$cfc(\$asArray = false";
+    ".$visibility." function get$cfc(\$asArray = true";
         if ($column->isLazyLoad()) {
             $script .= ", ConnectionInterface \$con = null";
         }
@@ -1887,7 +1887,7 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
         if (is_array(\$v)) {
             \$v = json_decode(json_encode(\$v));
         }
-        elseif (is_string(\$v)) {
+        if (is_string(\$v)) {
             \$v = json_decode(\$v);
         }
         if (\$v != json_decode(\$this->$clo)) {

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -971,7 +971,7 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
     protected function addJsonAccessor(&$script, Column $column)
     {
         $this->addJsonAccessorComment($script, $column);
-        $this->addDefaultAccessorOpen($script, $column);
+        $this->addJsonAccessorOpen($script, $column);
         $this->addJsonAccessorBody($script, $column);
         $this->addDefaultAccessorClose($script);
     }
@@ -989,7 +989,9 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
         $script .= "
     /**
      * Get the [$clo] column value.
-     * ".$column->getDescription();
+     * ".$column->getDescription() ."
+     * @param bool \$asArray Returns the JSON data as array instead of object
+     ";
         if ($column->isLazyLoad()) {
             $script .= "
      * @param      ConnectionInterface \$con An optional ConnectionInterface connection to use for fetching this lazy-loaded column.";
@@ -999,11 +1001,32 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
      */";
     }
 
+    /**
+     * Adds the function declaration for a JSON accessor.
+     *
+     * @param string &$script
+     * @param Column $column
+     */
+    public function addJsonAccessorOpen(&$script, Column $column)
+    {
+        $cfc = $column->getPhpName();
+        $visibility = $column->getAccessorVisibility();
+
+        $script .= "
+    ".$visibility." function get$cfc(\$asArray = false";
+        if ($column->isLazyLoad()) {
+            $script .= ", ConnectionInterface \$con = null";
+        }
+
+        $script .= ")
+    {";
+    }
+
     protected function addJsonAccessorBody(&$script, Column $column)
     {
         $clo = $column->getLowercasedName();
         $script .= "
-        return json_decode(\$this->$clo);";
+        return json_decode(\$this->$clo, \$asArray);";
     }
 
     /**

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -1884,14 +1884,13 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
         $this->addJsonMutatorOpen($script, $col);
 
         $script .= "
-        if (is_array(\$v)) {
-            \$v = json_decode(json_encode(\$v));
-        }
         if (is_string(\$v)) {
+            // JSON as string needs to be decoded/encoded to get a reliable comparison (spaces, ...)
             \$v = json_decode(\$v);
         }
-        if (\$v != json_decode(\$this->$clo)) {
-            \$this->$clo = json_encode(\$v);
+        \$encodedValue = json_encode(\$v);
+        if (\$encodedValue !== \$this->$clo) {
+            \$this->$clo = \$encodedValue;
             \$this->modifiedColumns[".$this->getColumnConstant($col)."] = true;
         }
 ";

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -980,7 +980,7 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
     {
         $clo = $column->getLowercasedName();
         $script .= "
-        return json_decode(\$this->$clo);";
+        return json_decode(\$this->$clo, true);";
     }
 
     /**

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -1807,8 +1807,13 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
         $this->addMutatorOpen($script, $col);
 
         $script .= "
-        \$this->$clo = json_encode(\$v);
-        \$this->modifiedColumns[".$this->getColumnConstant($col)."] = true;
+        if (is_string(\$v)) {
+            \$v = json_decode(\$v, true);
+        }
+        if (\$v != json_decode(\$this->$clo, true)) {
+            \$this->$clo = json_encode(\$v);
+            \$this->modifiedColumns[".$this->getColumnConstant($col)."] = true;
+        }
 ";
         $this->addMutatorClose($script, $col);
     }

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -1512,6 +1512,37 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
     }
 
     /**
+     * Adds the open of the mutator (setter) method for a JSON column.
+     *
+     * @param string &$script
+     * @param Column $column
+     */
+    protected function addJsonMutatorOpen(&$script, Column $column)
+    {
+        $this->addJsonMutatorComment($script, $column);
+        $this->addMutatorOpenOpen($script, $column);
+        $this->addMutatorOpenBody($script, $column);
+    }
+
+    /**
+     * Adds the comment for a mutator.
+     *
+     * @param string &$script
+     * @param Column $column
+     */
+    public function addJsonMutatorComment(&$script, Column $column)
+    {
+        $clo = $column->getLowercasedName();
+        $script .= "
+    /**
+     * Set the value of [$clo] column.
+     * ".$column->getDescription()."
+     * @param string|array \$v new value
+     * @return \$this|".$this->getObjectClassName(true)." The current object (for fluent API support)
+     */";
+    }
+
+    /**
      * Adds the comment for a mutator.
      *
      * @param string &$script
@@ -1804,7 +1835,7 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
     {
         $clo = $col->getLowercasedName();
 
-        $this->addMutatorOpen($script, $col);
+        $this->addJsonMutatorOpen($script, $col);
 
         $script .= "
         if (is_string(\$v)) {

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectJsonColumnTypeTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectJsonColumnTypeTest.php
@@ -49,12 +49,12 @@ EOF;
     {
         $this->assertTrue(method_exists('ComplexColumnTypeJsonEntity', 'getBar'));
         $e = new \ComplexColumnTypeJsonEntity();
-        $this->assertInstanceOf('stdClass', $e->getBar());
+        $this->assertInstanceOf('stdClass', $e->getBar(false));
         $e = new \PublicComplexColumnTypeJsonEntity();
         $e->bar = '{"key":"value"}';
-        $this->assertTrue($e->getBar() instanceof \stdClass);
-        $this->assertEquals('value', $e->getBar()->key);
-        $this->assertEquals('value', $e->getBar(true)['key']);
+        $this->assertInstanceOf('stdClass', $e->getBar(false));
+        $this->assertEquals('value', $e->getBar(false)->key);
+        $this->assertEquals('value', $e->getBar()['key']);
     }
 
     public function testSetter()
@@ -110,7 +110,8 @@ EOF;
         $e->save();
         \Map\ComplexColumnTypeJsonEntityTableMap::clearInstancePool();
         $e = \ComplexColumnTypeJsonEntityQuery::create()->findOne();
-        $this->assertEquals('value', $e->getBar()->key);
+        $this->assertEquals('value', $e->getBar(false)->key);
+        $this->assertEquals('value', $e->getBar()['key']);
     }
 
     public function testValueIsCopied()
@@ -121,6 +122,7 @@ EOF;
         ));
         $e2 = new \ComplexColumnTypeJsonEntity();
         $e1->copyInto($e2);
-        $this->assertEquals('value', $e2->getBar()->key);
+        $this->assertEquals('value', $e2->getBar()['key']);
+        $this->assertEquals('value', $e2->getBar(false)->key);
     }
 }

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectJsonColumnTypeTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectJsonColumnTypeTest.php
@@ -29,7 +29,7 @@ class GeneratedObjectJsonColumnTypeTest extends TestCase
 <database name="generated_object_complex_type_test_json">
     <table name="complex_column_type_json_entity">
         <column name="id" primaryKey="true" type="INTEGER" autoIncrement="true" />
-        <column name="bar" type="JSON" sqlType="json" />
+        <column name="bar" type="JSON" sqlType="json" default='{"defaultKey":"defaultValue"}'/>
     </table>
 </database>
 EOF;
@@ -49,11 +49,12 @@ EOF;
     {
         $this->assertTrue(method_exists('ComplexColumnTypeJsonEntity', 'getBar'));
         $e = new \ComplexColumnTypeJsonEntity();
-        $this->assertNull($e->getBar());
+        $this->assertInstanceOf('stdClass', $e->getBar());
         $e = new \PublicComplexColumnTypeJsonEntity();
         $e->bar = '{"key":"value"}';
         $this->assertTrue($e->getBar() instanceof \stdClass);
         $this->assertEquals('value', $e->getBar()->key);
+        $this->assertEquals('value', $e->getBar(true)['key']);
     }
 
     public function testSetter()
@@ -66,6 +67,38 @@ EOF;
         $this->assertEquals('{"key":"value"}', $e->bar);
         $e->setBar(null);
         $this->assertNull($e->getBar());
+    }
+    
+    public function testIsModified()
+    {
+      $this->assertTrue(method_exists('ComplexColumnTypeJsonEntity', 'setBar'));
+      $e = new \PublicComplexColumnTypeJsonEntity();
+      $e->setBar(array(
+          'key' => 'value'
+      ));
+      $this->assertTrue($e->isModified());
+      
+      $e = new \PublicComplexColumnTypeJsonEntity();
+      $e->setBar(array(
+          'defaultKey' => 'defaultValue'
+      ));
+      $this->assertFalse($e->isModified());
+      
+      $e->setBar('{"defaultKey":"defaultValue"}');
+      $this->assertFalse($e->isModified());
+      
+      $e->setBar('{"defaultKey"  :  "defaultValue"}');
+      $this->assertFalse($e->isModified());
+      
+      $e->setBar((object)array(
+          'defaultKey' => 'defaultValue'
+      ));
+      $this->assertFalse($e->isModified());
+      
+      $e->setBar((object)array(
+          'key' => 'value'
+      ));
+      $this->assertTrue($e->isModified());
     }
 
     public function testValueIsPersisted()


### PR DESCRIPTION
Previously, when using JSON Type for a column, every setXXX() on this column would result in a modified column.
This PR adds a check between old JSON and new value, as objects.