### PR TITLE
Fix getPrimaryKeyFromRow for custom php types

### DIFF
--- a/src/Propel/Generator/Builder/Om/TableMapBuilder.php
+++ b/src/Propel/Generator/Builder/Om/TableMapBuilder.php
@@ -847,11 +847,11 @@ class ".$this->getUnqualifiedClassName()." extends TableMap
                 if (!$col->isLazyLoad()) {
                     if ($col->isPrimaryKey()) {
                         $script .= '
-        $pks[] = (' . $col->getPhpType() . ') ' . "\$row[
+        $pks[] = ' . ($col->isPhpObjectType() ? 'new ' . $col->getPhpType() . '(' : '(' . $col->getPhpType() . ') ') . "\$row[
             \$indexType == TableMap::TYPE_NUM
                 ? $n + \$offset
                 : self::translateFieldName('{$col->getPhpName()}', TableMap::TYPE_PHPNAME, \$indexType)
-        ];";
+        ]" . ($col->isPhpObjectType() ? ')' : '') . ';';
                     }
                     $n++;
                 }
@@ -866,11 +866,11 @@ class ".$this->getUnqualifiedClassName()." extends TableMap
             foreach ($table->getColumns() as $col) {
                 if (!$col->isLazyLoad()) {
                     if ($col->isPrimaryKey()) {
-                        $pk = '(' . $col->getPhpType() . ') ' . "\$row[
+                        $pk = ($col->isPhpObjectType() ? 'new ' . $col->getPhpType() . '(' : '(' . $col->getPhpType() . ') ') . "\$row[
             \$indexType == TableMap::TYPE_NUM
                 ? $n + \$offset
                 : self::translateFieldName('{$col->getPhpName()}', TableMap::TYPE_PHPNAME, \$indexType)
-        ]";
+        ]" . ($col->isPhpObjectType() ? ')' : '');
                     }
                     $n++;
                 }


### PR DESCRIPTION
In the generated TableMap, the `getPrimaryKeyFromRow` method gave an error when using a custom `phpType`. This is fixed by only casting to the php type if its not an custom object type. In that case, use the contstructor. Fixes #926 