### PR TITLE
Remove tailing hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Propel2 #
+# Propel2
 
 Propel2 is an open-source Object-Relational Mapping (ORM) for PHP 5.5 and up.
 
@@ -7,7 +7,7 @@ Propel2 is an open-source Object-Relational Mapping (ORM) for PHP 5.5 and up.
 <a href="https://codeclimate.com/github/propelorm/Propel2"><img src="https://codeclimate.com/github/propelorm/Propel2/badges/coverage.svg" /></a>
 [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/propelorm/Propel)
 
-## Requirements ##
+## Requirements
 
 Propel2 uses the following Symfony2 Components:
 
@@ -23,18 +23,18 @@ also can use [ClassLoader](https://github.com/symfony/ClassLoader) (see the `aut
 Propel2 is only supported on PHP 5.5 and up.
 
 
-## Installation ##
+## Installation
 
 Read the [Propel documentation](http://propelorm.org/documentation/01-installation.html).
 
 
-## Contribute ##
+## Contribute
 
 Everybody can contribute to Propel2. Just fork it, and send Pull Requests.
 You have to follow [Propel2 Coding Standards](https://github.com/propelorm/Propel2/wiki/Coding-Standards) and provides unit tests as much as possible. Also [check out the roadmap](https://github.com/propelorm/Propel2/wiki) to get an overview of what we are working on!
 
 Please see our [contribution guideline](http://propelorm.org/contribute.html). Thank you!
 
-## License ##
+## License
 
 See the `LICENSE` file.


### PR DESCRIPTION
It is recommended to write hashes only on the left side, not wrapping the title up.

And this also fixes the trailing single hash behind title.