### PR TITLE
Fix issue #1406 : diff issue with CURRENT_TIMESTAMP on maria 10.2

### DIFF
--- a/src/Propel/Generator/Reverse/MysqlSchemaParser.php
+++ b/src/Propel/Generator/Reverse/MysqlSchemaParser.php
@@ -251,7 +251,8 @@ class MysqlSchemaParser extends AbstractSchemaParser
                     $default = 'false';
                 }
             }
-            if (in_array($default, ['CURRENT_TIMESTAMP'])) {
+            if (in_array($default, ['CURRENT_TIMESTAMP', 'current_timestamp()'])) {
+                $default = 'CURRENT_TIMESTAMP';
                 $type = ColumnDefaultValue::TYPE_EXPR;
             } else {
                 $type = ColumnDefaultValue::TYPE_VALUE;


### PR DESCRIPTION
In mariadb 10.2 `CURRENT_TIMESTAMP` is replaced by`current_timestamp()` in `SHOW COLUMNS FROM my_table`