### PR TITLE
Fixes invalid hydration when using mergeWith of criteria with "with" models

### DIFF
--- a/src/Propel/Generator/Builder/Om/TableMapBuilder.php
+++ b/src/Propel/Generator/Builder/Om/TableMapBuilder.php
@@ -190,6 +190,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
     protected function addSelectMethods(&$script)
     {
         $this->addAddSelectColumns($script);
+        $this->addRemoveSelectColumns($script);
     }
 
     /**
@@ -1270,6 +1271,53 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
     }
 
  // addAddSelectColumns()
+
+    /**
+     * Adds the removeSelectColumns() method.
+     *
+     * @param string &$script The script will be modified in this method.
+     *
+     * @return void
+     */
+    protected function addRemoveSelectColumns(&$script)
+    {
+        $script .= "
+    /**
+     * Remove all the columns needed to create a new object.
+     *
+     * Note: any columns that were marked with lazyLoad=\"true\" in the
+     * XML schema will not be removed as they are only loaded on demand.
+     *
+     * @param Criteria \$criteria object containing the columns to remove.
+     * @param string   \$alias    optional table alias
+     * @throws PropelException Any exceptions caught during processing will be
+     *                         rethrown wrapped into a PropelException.
+     */
+    public static function removeSelectColumns(Criteria \$criteria, \$alias = null)
+    {
+        if (null === \$alias) {";
+        foreach ($this->getTable()->getColumns() as $col) {
+            if (!$col->isLazyLoad()) {
+                $script .= "
+            \$criteria->removeSelectColumn({$col->getFQConstantName()});";
+            } // if !col->isLazyLoad
+        } // foreach
+        $script .= "
+        } else {";
+        foreach ($this->getTable()->getColumns() as $col) {
+            if (!$col->isLazyLoad()) {
+                $script .= "
+            \$criteria->removeSelectColumn(\$alias . '." . $col->getName() . "');";
+            } // if !col->isLazyLoad
+        } // foreach
+        $script .= "
+        }";
+        $script .= "
+    }
+";
+    }
+
+ // addRemoveSelectColumns()
 
     /**
      * Adds the getTableMap() method which is a convenience method for apps to get DB metadata.

--- a/src/Propel/Generator/Builder/Om/TableMapBuilder.php
+++ b/src/Propel/Generator/Builder/Om/TableMapBuilder.php
@@ -1275,7 +1275,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
     /**
      * Adds the removeSelectColumns() method.
      *
-     * @param string &$script The script will be modified in this method.
+     * @param string $script The script will be modified in this method.
      *
      * @return void
      */

--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -1364,6 +1364,22 @@ class Criteria
     }
 
     /**
+     * Remove select column.
+     *
+     * @param string $name Name of the select column.
+     *
+     * @return $this Modified Criteria object (for fluent API)
+     */
+    public function removeSelectColumn($name)
+    {
+        while (false !== ($key = array_search($name, $this->selectColumns, true))) {
+            unset($this->selectColumns[$key]);
+        }
+
+        return $this;
+    }
+
+    /**
      * Set the query comment, that appears after the first verb in the SQL query
      *
      * @param string|null $comment The comment to add to the query, without comment sign

--- a/tests/Propel/Tests/Issues/Issue1420Test.php
+++ b/tests/Propel/Tests/Issues/Issue1420Test.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT License
+ */
+
+namespace Propel\Tests\Issues;
+
+use Propel\Generator\Util\QuickBuilder;
+use Propel\Tests\TestCase;
+
+/**
+ * Regression test for https://github.com/propelorm/Propel2/issues/1420
+ *
+ * @group database
+ */
+class Issue1420Test extends TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        if (!class_exists('\Table1420A')) {
+            $schema = <<<XML
+            <!DOCTYPE database SYSTEM "../../../../resources/dtd/database.dtd">
+            <database name="issue_1420" defaultIdMethod="native">
+                <table name="table_1420_a">
+                    <column name="id" primaryKey="true" type="INTEGER" />
+                    <column name="a_field" type="VARCHAR" size="10" />
+                </table>
+                <table name="table_1420_b">
+                    <column name="id" primaryKey="true" type="INTEGER" />
+                    <column name="table_1420_a_id" type="INTEGER" />
+                    <column name="b_field" type="VARCHAR" size="10" />
+                    
+                    <foreign-key foreignTable="table_1420_a" name="table_1420_b_fk1">
+                        <reference local="table_1420_a_id" foreign="id"/>
+                    </foreign-key>
+                </table>
+                <table name="table_1420_c">
+                    <column name="id" primaryKey="true" type="INTEGER" />
+                    <column name="table_1420_a_id" type="INTEGER" />
+                    <column name="c_field" type="VARCHAR" size="10" />
+                    
+                    <foreign-key foreignTable="table_1420_a" name="table_1420_c_fk1">
+                        <reference local="table_1420_a_id" foreign="id"/>
+                    </foreign-key>
+                </table>
+            </database>
+XML;
+            QuickBuilder::buildSchema($schema);
+        }
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+        \Table1420CQuery::create()->deleteAll();
+        \Table1420BQuery::create()->deleteAll();
+        \Table1420AQuery::create()->deleteAll();
+    }
+
+    /*
+     * Test whether hydration works properly for all the models
+     */
+    public function testValidHydration()
+    {
+        // Set up 3 models in relations A hasMany B, A hasMany C
+        // A: id=1, a_field=a_value
+        // B: id=2, b_field=b_value (referenced to A:1)
+        // C: id=3, c_field=c_value (referenced to A:1)
+        (new \Table1420A)->setId(1)->setAField('a_value')->save();
+        (new \Table1420B)->setId(2)->setTable1420AId(1)->setBField('b_value')->save();
+        (new \Table1420C)->setId(3)->setTable1420AId(1)->setCField('c_value')->save();
+
+        // querying for A models together with B models hydrated
+        $aQuery = (new \Table1420AQuery)->leftJoinWith('Table1420B');
+
+        // merged criteria has with model and adds self columns (because it's primary criteria)
+        $mergeWith = (new \Table1420AQuery)->leftJoinWith('Table1420C');
+
+        // merging queries together results produces these columns in SELECT part:
+        // A columns, B columns (base criteria), A columns again, C columns
+        // "A columns again" causes the further models be hydrated with wrong data
+        // (here C is hydrated partially from A columns)
+        $aQuery->mergeWith($mergeWith);
+
+        $a = $aQuery->find()->getFirst();
+
+        $this->assertSame(1, $a->getId());
+        $this->assertSame('a_value', $a->getAField());
+
+        $b = $a->getTable1420Bs()->getFirst();
+        $this->assertSame(2, $b->getId());
+        $this->assertSame(1, $b->getTable1420AId());
+        $this->assertSame('b_value', $b->getBField());
+
+        $c = $a->getTable1420Cs()->getFirst();
+        $this->assertSame(3, $c->getId());
+        $this->assertSame(1, $c->getTable1420AId());
+        $this->assertSame('c_value', $c->getCField());
+    }
+}

--- a/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaTest.php
@@ -2990,6 +2990,7 @@ class ModelCriteriaTest extends BookstoreTestBase
         $c1->leftJoinWith('b.Author a');
         $c2 = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Author');
         $c1->mergeWith($c2);
+        $this->assertCount(1, array_filter($c1->getSelectColumns(), function($v) { return BookTableMap::COL_ID == $v; }), '$c1 criteria has selected Book columns twice');
         $with = $c1->getWith();
         $this->assertEquals(1, count($with), 'mergeWith() does not remove an existing join');
         $this->assertEquals('modelName: Propel\Tests\Bookstore\Author, relationName: Author, relationMethod: setAuthor, leftPhpName: , rightPhpName: a', $with['a']->__toString(), 'mergeWith() does not remove an existing join');
@@ -2998,6 +2999,7 @@ class ModelCriteriaTest extends BookstoreTestBase
         $c1->leftJoinWith('b.Author a');
         $c2 = new ModelCriteria('bookstore', '\Propel\Tests\Bookstore\Author');
         $c1->mergeWith($c2);
+        $this->assertCount(1, array_filter($c1->getSelectColumns(), function($v) { return BookTableMap::COL_ID == $v; }), '$c1 criteria has selected Book columns twice');
         $with = $c1->getWith();
         $this->assertEquals(1, count($with), 'mergeWith() does not remove an existing join');
         $this->assertEquals('modelName: Propel\Tests\Bookstore\Author, relationName: Author, relationMethod: setAuthor, leftPhpName: , rightPhpName: a', $with['a']->__toString(), 'mergeWith() does not remove an existing join');
@@ -3006,6 +3008,7 @@ class ModelCriteriaTest extends BookstoreTestBase
         $c2 = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book', 'b');
         $c2->leftJoinWith('b.Author a');
         $c1->mergeWith($c2);
+        $this->assertCount(1, array_filter($c1->getSelectColumns(), function($v) { return BookTableMap::COL_ID == $v; }), '$c1 criteria has selected Book columns twice');
         $with = $c1->getWith();
         $this->assertEquals(1, count($with), 'mergeWith() merge joins to an empty join');
         $this->assertEquals('modelName: Propel\Tests\Bookstore\Author, relationName: Author, relationMethod: setAuthor, leftPhpName: , rightPhpName: a', $with['a']->__toString(), 'mergeWith() merge joins to an empty join');
@@ -3015,6 +3018,7 @@ class ModelCriteriaTest extends BookstoreTestBase
         $c2 = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book', 'b');
         $c2->innerJoinWith('b.Publisher p');
         $c1->mergeWith($c2);
+        $this->assertCount(1, array_filter($c1->getSelectColumns(), function($v) { return BookTableMap::COL_ID == $v; }), '$c1 criteria has selected Book columns twice');
         $with = $c1->getWith();
         $this->assertEquals(2, count($with), 'mergeWith() merge joins to an existing join');
         $this->assertEquals('modelName: Propel\Tests\Bookstore\Author, relationName: Author, relationMethod: setAuthor, leftPhpName: , rightPhpName: a', $with['a']->__toString(), 'mergeWith() merge joins to an empty join');


### PR DESCRIPTION
fixes #1420

---

## Background
- 3 models defined in DB: A, B, C
- A hasOne/hasMany B
- A hasOne/hasMany C

## Scenario
Making a query for A models with B models hydrated and merging criteria for the same base model having "with" models (here: C model)

```php
$aModels = (new AQuery)
    ->leftJoinWith('B');
    ->mergeWith((new AQuery)->leftJoinWith('C'))
    ->find();
```

## Produced SQL:
```sql
SELECT
    a.id, a.a_field, -- A fields
    b.id, b.a_id, b.b_field, -- B fields
    a.id, a.a_field, -- A fields again
    c.id, c.a_id, c.c_field -- C fields
FROM a
    LEFT JOIN b ON (a.id = b.a_id)
    LEFT JOIN c ON (a.id = c.a_id)
```

## Results
- model A hydrated properly
- model B hydrated properly
- model C hydrated improperly

## Reason
`PDODataFetcher::getIndexType` is `TableMap::TYPE_NUM` so object hydration relies on the order of the columns in `SELECT` part.

At the beginning the `offset` of hydration is 0 meaning the A model is hydrated from columns indexed `0` and `1`. Then `offset` is incremented to point to next column for next model hydration.
Then B model is hydrated from `offset=2` to `offset=4` (3 columns).
Then C model is hydrated from `offset=5` to `offset=7`

__Due to fact that A columns are selected twice the C model is hydrated partly from A columns being selected between B model columns and C model columns.__

| SELECT column | mapping   | notes                        |
|:--------------|:----------|:-----------------------------|
| a.id          | A->id     | valid                        |
| a.a_field     | A->aField | valid                        |
| b.id          | B->id     | valid                        |
| b.a_id        | B->aId    | valid                        |
| b.b_field     | B->bField | valid                        |
| a.id          | C->id     | __(inconsistency!)__         |
| a.a_field     | C->aId    | __(inconsistency!)__         |
| c.id          | C->bField | __(inconsistency!)__         |
| c.a_id        |           | *(ignored during hydration)* |
