### PR TITLE
PropelModelPager.php fix

### DIFF
--- a/src/Propel/Runtime/Util/PropelModelPager.php
+++ b/src/Propel/Runtime/Util/PropelModelPager.php
@@ -145,8 +145,10 @@ class PropelModelPager implements \IteratorAggregate, \Countable
                 $newQueryKey = sprintf('%s offset %s limit %s', $queryKey, $this->getQuery()->getOffset(), $this->getQuery()->getLimit());
                 $this->getQuery()->setQueryKey($newQueryKey);
             }
-            
+                        
             $this->results = $this->getQuery()
+                ->offset($this->getPage() * $this->getMaxPerPage())
+                ->limit($this->getMaxPerPage())
                 ->find($this->con)
             ;
         }


### PR DESCRIPTION
It happens that getResults of PropelModelPager does not return paged results but the whole dataset (i.e. like with LIMIT = -1). 
The change does fix the problem for me.