### PR TITLE
Compobility with php 7.2 and strict type

### DIFF
--- a/src/Propel/Runtime/ActiveQuery/InstancePoolTrait.php
+++ b/src/Propel/Runtime/ActiveQuery/InstancePoolTrait.php
@@ -30,7 +30,8 @@ trait InstancePoolTrait
     public static function getInstanceKey($value)
     {
         if (!($value instanceof Criteria) && is_object($value)) {
-            if (count($pk = $value->getPrimaryKey()) > 1 || is_object($value->getPrimaryKey())) {
+            $pk = $value->getPrimaryKey();
+            if ((is_array($pk) && count($pk) > 1) || is_object($pk)) {
                 $pk = serialize($pk);
             }
 


### PR DESCRIPTION
>Warning: count(): Parameter must be an array or an object that implements Countable
```
if (count($pk = $value->getPrimaryKey()) > 1 || is_object($value->getPrimaryKey())) {
```
If $value->getPrimaryKey() return int