### PR TITLE
Added referenceOnly attribute to external-schema

### DIFF
--- a/resources/xsd/database.xsd
+++ b/resources/xsd/database.xsd
@@ -542,6 +542,13 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="referenceOnly" type="xs:boolean" default="true" use="optional">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    If set to true, instructs Propel to take the tables from the external schema into account in SQL.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="table">


### PR DESCRIPTION
I use this xsd file in my IDE and it always complains, that the referenceOnly-attribute 'is not allowed here', even though it is [0]. Thats why I would like this to be merged :)

[0]: http://propelorm.org/documentation/reference/schema.html#external-schema-element