### PR TITLE
Allow Database Reverse command to receive only a --config-dir parameter

### DIFF
--- a/src/Propel/Common/Config/PropelConfiguration.php
+++ b/src/Propel/Common/Config/PropelConfiguration.php
@@ -212,6 +212,7 @@ class PropelConfiguration implements ConfigurationInterface
                 ->arrayNode('reverse')
                     ->children()
                         ->scalarNode('connection')->end()
+                        ->scalarNode('namespace')->defaultNull()->end()
                         ->scalarNode('parserClass')->end()
                     ->end()
                 ->end() //reverse

--- a/tests/Fixtures/bookstore/propel.yaml.dist
+++ b/tests/Fixtures/bookstore/propel.yaml.dist
@@ -3,6 +3,9 @@ propel:
   general:
     project: bookstore
 
+  paths:
+    schemaDir: ../../reversecommand
+
   database:
     connections:
       bookstore:
@@ -44,6 +47,10 @@ propel:
         #Propel specific settings
         settings:
           charset: utf8
+
+  reverse:
+    connection: bookstore
+    namespace: \ReverseVendor\ReversePackageWithConfDir
 
   generator:
     defaultConnection: bookstore


### PR DESCRIPTION
Allow Database Reverse command to receive only a --config-dir parameter and read all the needed parameters from those configuration files. Making all command parameters optional.

You can still replace configuration file settings by passing their related command parameters.
You may need to change the documentation reflect this changes.