### PR TITLE
Make offsetGet compatible with the parent's offsetGet method

### DIFF
--- a/src/Propel/Runtime/Collection/OnDemandCollection.php
+++ b/src/Propel/Runtime/Collection/OnDemandCollection.php
@@ -128,7 +128,7 @@ class OnDemandCollection extends Collection
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function &offsetGet($offset)
     {
         throw new PropelException('The On Demand Collection does not allow access by offset');
     }


### PR DESCRIPTION
This fixes fatal errors with PHP 7.2.