### PR TITLE
Address failed tests after applying fix for issue #1425

### DIFF
--- a/src/Propel/Runtime/ActiveQuery/InstancePoolTrait.php
+++ b/src/Propel/Runtime/ActiveQuery/InstancePoolTrait.php
@@ -31,9 +31,11 @@ trait InstancePoolTrait
     {
         if (!($value instanceof Criteria) && is_object($value)) {
             $pk = $value->getPrimaryKey();
-            if(is_object($pk) || (is_numeric($pk) && $pk > 1) || (is_array($pk) && count($pk) > 1)) {
+            if (((is_array($pk) || $pk instanceof \Countable) && count($pk) > 1)
+                || is_object($pk)) {
                 $pk = serialize($pk);
             }
+
             return (string) $pk;
         }
 


### PR DESCRIPTION
Address failed tests after applying fix for issue #1425 which is ralated to the countable issue in php 7.2.

I think the issue is related to the fact that the fix added the condition: is_numeric($pk) && $pk > 1 to the if, which is not present in the previous releases, which then caused some tests to start failing.