### PR TITLE
 #1447. On preInsert object in TimestampableBehavior we get different…

### DIFF
--- a/src/Propel/Generator/Behavior/Timestampable/TimestampableBehavior.php
+++ b/src/Propel/Generator/Behavior/Timestampable/TimestampableBehavior.php
@@ -102,12 +102,13 @@ class TimestampableBehavior extends Behavior
      */
     public function preInsert($builder)
     {
-        $script = '';
+        $script = '$time = time();
+$highPrecision = \\Propel\\Runtime\\Util\\PropelDateTime::createHighPrecision();';
 
         if ($this->withCreatedAt()) {
             $valueSource = strtoupper($this->getTable()->getColumn($this->getParameter('create_column'))->getType()) === 'INTEGER'
-                ? 'time()'
-                : '\\Propel\\Runtime\\Util\\PropelDateTime::createHighPrecision()'
+                ? '$time'
+                : '$highPrecision'
             ;
             $script .= "
 if (!\$this->isColumnModified(" . $this->getColumnConstant('create_column', $builder) . ")) {
@@ -117,8 +118,8 @@ if (!\$this->isColumnModified(" . $this->getColumnConstant('create_column', $bui
 
         if ($this->withUpdatedAt()) {
             $valueSource = strtoupper($this->getTable()->getColumn($this->getParameter('update_column'))->getType()) === 'INTEGER'
-                ? 'time()'
-                : '\\Propel\\Runtime\\Util\\PropelDateTime::createHighPrecision()'
+                ? '$time'
+                : '$highPrecision'
             ;
             $script .= "
 if (!\$this->isColumnModified(" . $this->getColumnConstant('update_column', $builder) . ")) {

--- a/tests/Propel/Tests/Generator/Behavior/Timestampable/TimestampableBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Timestampable/TimestampableBehaviorTest.php
@@ -65,9 +65,12 @@ class TimestampableBehaviorTest extends BookstoreTestBase
     {
         $t1 = new Table2();
         $this->assertNull($t1->getUpdatedAt());
-        $tsave = time();
         $t1->save();
-        $this->assertTimeEquals($tsave, $t1->getUpdatedAt('U'), 'Timestampable sets updated_column to time() on creation');
+        $this->assertEquals(
+            $t1->getUpdatedAt(),
+            $t1->getCreatedAt(),
+            'Timestampable sets updated_column same created_column on creation'
+        );
         sleep(1);
         $t1->setTitle('foo');
         $tupdate = time();


### PR DESCRIPTION
… dataTime.

For solve this situation we need available set same time on create and update field.