### PR TITLE
Allow option MYSQL_ATTR_SSL_VERIFY_SERVER_CERT to be set

### DIFF
--- a/src/Propel/Common/Config/PropelConfiguration.php
+++ b/src/Propel/Common/Config/PropelConfiguration.php
@@ -130,6 +130,7 @@ class PropelConfiguration implements ConfigurationInterface
                                             ->scalarNode('MYSQL_ATTR_SSL_CA')->end()
                                             ->scalarNode('MYSQL_ATTR_SSL_CERT')->end()
                                             ->scalarNode('MYSQL_ATTR_SSL_KEY')->end()
+                                            ->booleanNode('MYSQL_ATTR_SSL_VERIFY_SERVER_CERT')->end()
                                             ->scalarNode('MYSQL_ATTR_MAX_BUFFER_SIZE')->end()
                                         ->end()
                                     ->end()


### PR DESCRIPTION
This was implemented in early 2017 (see https://github.com/php/php-src/commit/247ce052cd0fc7d0d8ea1a0e7ea2075e9601766a), and is very useful for self-signed certificates.