### PR TITLE
Archivable behavior with FK customization.

### DIFF
--- a/src/Propel/Generator/Behavior/Archivable/ArchivableBehavior.php
+++ b/src/Propel/Generator/Behavior/Archivable/ArchivableBehavior.php
@@ -28,6 +28,8 @@ class ArchivableBehavior extends Behavior
         'archive_table'       => '',
         'archive_phpname'     => null,
         'archive_class'       => '',
+        'archive_foreign_keys' => 'false',
+        'archive_foreign_keys_skip_sql' => 'true',
         'log_archived_at'     => 'true',
         'archived_at_column'  => 'archived_at',
         'archive_on_insert'   => 'false',
@@ -99,7 +101,15 @@ class ArchivableBehavior extends Behavior
                     'type' => 'TIMESTAMP'
                 ]);
             }
-            // do not copy foreign keys
+            // copy foreign keys if enabled in parameters
+            if ($this->getParameter('archive_foreign_keys')) {
+                foreach ($table->getForeignKeys() as $foreignKey) {
+                    $copiedForeignKey = clone $foreignKey;
+                    // database foreing keys are not required
+                    $copiedForeignKey->setSkipSql($this->getParameter('archive_foreign_keys_skip_sql'));
+                    $archiveTable->addForeignKey($copiedForeignKey);
+                }
+            }
             // copy the indices
             foreach ($table->getIndices() as $index) {
                 $copiedIndex = clone $index;

--- a/src/Propel/Generator/Behavior/Archivable/ArchivableBehavior.php
+++ b/src/Propel/Generator/Behavior/Archivable/ArchivableBehavior.php
@@ -102,11 +102,11 @@ class ArchivableBehavior extends Behavior
                 ]);
             }
             // copy foreign keys if enabled in parameters
-            if ($this->getParameter('archive_foreign_keys')) {
+            if ($this->getParameter('archive_foreign_keys') == 'true') {
                 foreach ($table->getForeignKeys() as $foreignKey) {
                     $copiedForeignKey = clone $foreignKey;
                     // database foreing keys are not required
-                    $copiedForeignKey->setSkipSql($this->getParameter('archive_foreign_keys_skip_sql'));
+                    $copiedForeignKey->setSkipSql($this->getParameter('archive_foreign_keys_skip_sql') == 'true');
                     $archiveTable->addForeignKey($copiedForeignKey);
                 }
             }


### PR DESCRIPTION
Added two boolan parameters:
* **archive_foreign_keys** (default: false) - on true FK will be copied to Archive table class, so API for archive and non-archive class is the same.
* **archive_foreign_keys_skip_sql** (default: true) - same API is enought so database FK will be skiped by default.