### PR TITLE
Do not try to fetch related objects of new object

### DIFF
--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -4172,10 +4172,19 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
     public function get$relCol(Criteria \$criteria = null, ConnectionInterface \$con = null)
     {
         \$partial = \$this->{$collName}Partial && !\$this->isNew();
-        if (null === \$this->$collName || null !== \$criteria  || \$partial) {
-            if (\$this->isNew() && null === \$this->$collName) {
+        if (null === \$this->$collName || null !== \$criteria || \$partial) {
+            if (\$this->isNew()) {
                 // return empty collection
-                \$this->init" . $this->getRefFKPhpNameAffix($refFK, $plural = true) . "();
+                if (null === \$this->$collName) {
+                    \$this->init" . $this->getRefFKPhpNameAffix($refFK, $plural = true) . "();
+                } else {
+                    \$collectionClassName = ".$this->getClassNameFromBuilder($this->getNewTableMapBuilder($refFK->getTable()))."::getTableMap()->getCollectionClassName();
+
+                    \$$collName = new \$collectionClassName;
+                    \${$collName}->setModel('" . $this->getClassNameFromBuilder($this->getNewStubObjectBuilder($refFK->getTable()), true) . "');
+
+                    return \$$collName;
+                }
             } else {
                 \$$collName = $fkQueryClassName::create(null, \$criteria)
                     ->filterBy" . $this->getFKPhpNameAffix($refFK) . "(\$this)

--- a/tests/Propel/Tests/BookstoreTest.php
+++ b/tests/Propel/Tests/BookstoreTest.php
@@ -12,6 +12,7 @@ namespace Propel\Tests;
 
 use Propel\Runtime\ActiveQuery\Criteria;
 
+use Propel\Runtime\Collection\Collection;
 use Propel\Tests\Bookstore\Author;
 use Propel\Tests\Bookstore\AuthorQuery;
 use Propel\Tests\Bookstore\Book;
@@ -712,5 +713,33 @@ class BookstoreTest extends BookstoreEmptyTestBase
         $this->assertCount(0, MediaQuery::create()->find(), 'no records in [media] table');
         $this->assertCount(0, BookClubListQuery::create()->find(), 'no records in [book_club_list] table');
         $this->assertCount(0, BookListRelQuery::create()->find(), 'no records in [book_x_list] table');
+    }
+
+    public function testIssue1493()
+    {
+        $review = new Review();
+        $review->setReviewedBy("Reviewer");
+        $review->setRecommended(true);
+        $review->setReviewDate(time());
+        $review->save();
+
+        $review = new Review();
+        $review->setReviewedBy("Reviewer");
+        $review->setRecommended(true);
+        $review->setReviewDate(time());
+        $review->save();
+
+        $this->assertCount(2, ReviewQuery::create()->find(), 'reviews were saved to database');
+
+        $book = new Book();
+        $book->setISBN("0140422161");
+        $book->setTitle("Don Juan");
+
+        $book->getReviews();
+        $book->setReviews(new Collection());
+
+        $book->save();
+
+        $this->assertCount(2, ReviewQuery::create()->find(), 'reviews are still there');
     }
 }


### PR DESCRIPTION
Example database:

```xml
    <table name="book" description="Book Table">
        <column name="id" required="true" primaryKey="true" autoIncrement="true" type="INTEGER" description="Book Id" />
        <column name="title" type="VARCHAR" required="true" description="Book Title" primaryString="true" />
        <column name="author_id" required="false" type="INTEGER" description="Foreign Key Author" />
        <foreign-key foreignTable="author" onDelete="setnull" onUpdate="cascade">
            <reference local="author_id" foreign="id" />
        </foreign-key>
    </table>

    <table name="author" description="Author Table">
        <column name="id" required="true" primaryKey="true" autoIncrement="true" type="INTEGER" description="Author Id" />
        <column name="first_name" required="true" type="VARCHAR" size="128" description="First Name" />
        <column name="last_name" required="true" type="VARCHAR" size="128" description="Last Name" />
    </table>
```

Example code:

```php
$author = new Author();
// ...
$author->getBooks(); // $author->collBooks is initialized
// ...
$author->setBooks(new Collection());
$author->save();
```

In `setBooks` there is this line:
https://github.com/propelorm/Propel2/blob/6c4996fc130c7555d82d9dca04396c6f3eeef306/src/Propel/Generator/Builder/Om/ObjectBuilder.php#L4231
(the previous books are scheduled for deletion)
But while fetching the previous books the [`else` part](https://github.com/propelorm/Propel2/blob/6c4996fc130c7555d82d9dca04396c6f3eeef306/src/Propel/Generator/Builder/Om/ObjectBuilder.php#L4165-L4168) is used, because `$this->collBooks` is not null any more. So `BookQuery::create()->filterByAuthor($this)->find()` is used. This will result in a query with `WHERE author_id IS NULL`, because `$this->getId()` is null.
So all books without an author will be scheduled for deletion!

So for a new object (id is null), the query for fetching the related objects should be never used.