### PR TITLE
Fixed relative template path assumption

### DIFF
--- a/src/Propel/Generator/Builder/Om/AbstractOMBuilder.php
+++ b/src/Propel/Generator/Builder/Om/AbstractOMBuilder.php
@@ -992,12 +992,17 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @param  string $filename
      * @param  array  $vars
-     * @param  string $templateDir
+     * @param  string|null $templateDir
      * @return string
      */
-    public function renderTemplate($filename, $vars = [], $templateDir = '/templates/')
+    public function renderTemplate($filename, $vars = [], $templateDir = null)
     {
-        $filePath = __DIR__ . $templateDir . $filename;
+        if (!$templateDir) {
+            $filePath = __DIR__ . '/templates/' . $filename;
+        } else {
+            $filePath = $templateDir . $filename;
+        }
+        
         if (!file_exists($filePath)) {
             // try with '.php' at the end
             $filePath = $filePath . '.php';


### PR DESCRIPTION
As this is currently written, it's difficult to write behaviors and specify a template dir since it's using the __DIR__ constant, effectively making it relative.  The change keeps the same defaults, but expects a full absolute path, as it should be.