### PR TITLE
Update to PHP74 travis and simplify matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,12 @@ language: php
 
 php:
   - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
-  - nightly
+  - 7.3
+  - 7.4snapshot
+
+services:
+  - postgresql
+  - mysql
 
 env:
   - DB=agnostic #only database agnostic tests
@@ -18,11 +19,10 @@ install:
   - composer install
 
 before_script:
-  - if [[ $DB != 'agnostic' && $DB != 'sqlite' ]]; then ./tests/bin/setup.$DB.sh; fi
+  - if [[ $DB != 'agnostic' && $DB != 'sqlite' ]]; then tests/bin/setup.$DB.sh; fi
 
 script:
-  - ./vendor/bin/phpunit -v -c tests/$DB.phpunit.xml;
-
+  - vendor/bin/phpunit -v -c tests/$DB.phpunit.xml;
 
 matrix:
   include:
@@ -62,7 +62,7 @@ matrix:
     - php: 7.1
       env: DB=mysql MARIADB=10.0
       addons:
-        mariadb: 10.0    
+        mariadb: 10.0
     - php: 7.2
       env: DB=mysql MARIADB=10.0
       addons:
@@ -100,7 +100,7 @@ matrix:
     - php: 7.2
       env: DB=pgsql POSTGRES=9.2
       addons:
-        postgresql: 9.2    
+        postgresql: 9.2
 
     - php: 5.5
       env: DB=pgsql POSTGRES=9.3
@@ -143,64 +143,55 @@ matrix:
       env: DB=pgsql POSTGRES=9.4
       addons:
         postgresql: 9.4
-    
-    - php: 5.5
-      env: DB=pgsql POSTGRES=9.5
-      addons:
-        postgresql: 9.5
-    - php: 5.6
-      env: DB=pgsql POSTGRES=9.5
-      addons:
-        postgresql: 9.5
-    - php: 7.0
-      env: DB=pgsql POSTGRES=9.5
-      addons:
-        postgresql: 9.5
-    - php: 7.1
-      env: DB=pgsql POSTGRES=9.5
-      addons:
-        postgresql: 9.5
-    - php: 7.2
-      env: DB=pgsql POSTGRES=9.5
-      addons:
-        postgresql: 9.5
-    
-    - php: 5.5
-      env: DB=pgsql POSTGRES=9.6
-      addons:
-        postgresql: 9.6
-    - php: 5.6
-      env: DB=pgsql POSTGRES=9.6
-      addons:
-        postgresql: 9.6
-    - php: 7.0
-      env: DB=pgsql POSTGRES=9.6
-      addons:
-        postgresql: 9.6
-    - php: 7.1
-      env: DB=pgsql POSTGRES=9.6
-      addons:
-        postgresql: 9.6
-    - php: 7.2
-      env: DB=pgsql POSTGRES=9.6
-      addons:
-        postgresql: 9.6
-    
 
-  allow_failures:
-    - php: nightly
+    - php: 5.5
+      env: DB=pgsql POSTGRES=9.5
+      addons:
+        postgresql: 9.5
+    - php: 5.6
+      env: DB=pgsql POSTGRES=9.5
+      addons:
+        postgresql: 9.5
+    - php: 7.0
+      env: DB=pgsql POSTGRES=9.5
+      addons:
+        postgresql: 9.5
+    - php: 7.1
+      env: DB=pgsql POSTGRES=9.5
+      addons:
+        postgresql: 9.5
+    - php: 7.2
+      env: DB=pgsql POSTGRES=9.5
+      addons:
+        postgresql: 9.5
+
+    - php: 5.5
+      env: DB=pgsql POSTGRES=9.6
+      addons:
+        postgresql: 9.6
+    - php: 5.6
+      env: DB=pgsql POSTGRES=9.6
+      addons:
+        postgresql: 9.6
+    - php: 7.0
+      env: DB=pgsql POSTGRES=9.6
+      addons:
+        postgresql: 9.6
+    - php: 7.1
+      env: DB=pgsql POSTGRES=9.6
+      addons:
+        postgresql: 9.6
+    - php: 7.2
+      env: DB=pgsql POSTGRES=9.6
+      addons:
+        postgresql: 9.6
 
   fast_finish: true
 
-# cache vendors
 cache:
   directories:
     - vendor
     - $HOME/.composer/cache
-
-# This triggers builds to run on the new TravisCI infrastructure.
-# See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
-sudo: false
 
 notifications:
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 php:
-  - 5.5
+  - 5.6
   - 7.3
   - 7.4snapshot
 
@@ -26,10 +26,6 @@ script:
 
 matrix:
   include:
-    - php: 5.5
-      env: DB=mysql MARIADB=5.5
-      addons:
-        mariadb: 5.5
     - php: 5.6
       env: DB=mysql MARIADB=5.5
       addons:
@@ -47,10 +43,6 @@ matrix:
       addons:
         mariadb: 5.5
 
-    - php: 5.5
-      env: DB=mysql MARIADB=10.0
-      addons:
-        mariadb: 10.0
     - php: 5.6
       env: DB=mysql MARIADB=10.0
       addons:
@@ -68,10 +60,6 @@ matrix:
       addons:
         mariadb: 10.0
 
-#    - php: 5.5
-#      env: DB=mysql MARIADB=10.1
-#      addons:
-#        mariadb: 10.1
 #    - php: 5.6
 #      env: DB=mysql MARIADB=10.1
 #      addons:
@@ -81,10 +69,6 @@ matrix:
 #      addons:
 #        mariadb: 10.1
 
-    - php: 5.5
-      env: DB=pgsql POSTGRES=9.2
-      addons:
-        postgresql: 9.2
     - php: 5.6
       env: DB=pgsql POSTGRES=9.2
       addons:
@@ -102,10 +86,6 @@ matrix:
       addons:
         postgresql: 9.2
 
-    - php: 5.5
-      env: DB=pgsql POSTGRES=9.3
-      addons:
-        postgresql: 9.3
     - php: 5.6
       env: DB=pgsql POSTGRES=9.3
       addons:
@@ -123,10 +103,6 @@ matrix:
       addons:
         postgresql: 9.3
 
-    - php: 5.5
-      env: DB=pgsql POSTGRES=9.4
-      addons:
-        postgresql: 9.4
     - php: 5.6
       env: DB=pgsql POSTGRES=9.4
       addons:
@@ -144,10 +120,6 @@ matrix:
       addons:
         postgresql: 9.4
 
-    - php: 5.5
-      env: DB=pgsql POSTGRES=9.5
-      addons:
-        postgresql: 9.5
     - php: 5.6
       env: DB=pgsql POSTGRES=9.5
       addons:
@@ -165,10 +137,6 @@ matrix:
       addons:
         postgresql: 9.5
 
-    - php: 5.5
-      env: DB=pgsql POSTGRES=9.6
-      addons:
-        postgresql: 9.6
     - php: 5.6
       env: DB=pgsql POSTGRES=9.6
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language: php
 
 php:
   - 5.6
-  - 7.3
-  - 7.4snapshot
+  - 7.4
 
 services:
   - postgresql
@@ -158,7 +157,6 @@ matrix:
 
 cache:
   directories:
-    - vendor
     - $HOME/.composer/cache
 
 notifications:


### PR DESCRIPTION
Refs https://github.com/propelorm/Propel2/issues/1521
package should be bumped to 5.6+ in composer and docs as well, no point maintaining 5.5 anymore here.

Lots of fails though still in Travis that require fixing.

There seem to now surface more severe issues, as well:

> Class 'Symfony\Component\Translation\IdentityTranslator' not found

Follow up tasks
- [ ] Enable commented out travis checks
- [ ] Get travis matrix green
