### PR TITLE
Rearrange implode() arguments where necessary to conform to php7.4

### DIFF
--- a/src/Propel/Generator/Model/MappingModel.php
+++ b/src/Propel/Generator/Model/MappingModel.php
@@ -127,7 +127,7 @@ abstract class MappingModel implements MappingModelInterface
             $values[] = trim($v);
         }
 
-        $value = implode($values, ' | ');
+        $value = implode(' | ', $values);
         if (empty($value) || ' | ' === $value) {
             return null;
         }

--- a/src/Propel/Generator/Platform/DefaultPlatform.php
+++ b/src/Propel/Generator/Platform/DefaultPlatform.php
@@ -1269,7 +1269,7 @@ ALTER TABLE %s ADD
             $values[] = trim($v);
         }
 
-        $value = implode($values, ' | ');
+        $value = implode(' | ', $values);
         if (empty($value) || ' | ' === $value) {
             return null;
         }

--- a/src/Propel/Runtime/ActiveQuery/Join.php
+++ b/src/Propel/Runtime/ActiveQuery/Join.php
@@ -666,7 +666,7 @@ class Join
                     $conditions[] = $this->getLeftColumn($i) . $this->getOperator($i) . $this->getRightColumn($i);
                 }
             }
-            $joinCondition = sprintf('(%s)', implode($conditions, ' AND '));
+            $joinCondition = sprintf('(%s)', implode(' AND ', $conditions));
         } else {
             $joinCondition = '';
             $this->getJoinCondition()->appendPsTo($joinCondition, $params);


### PR DESCRIPTION
implode() should be called with `glue` first to support php 7.4  
[see here](https://wiki.php.net/rfc/deprecations_php_7_4#implode_parameter_order_mix)