### PR TITLE
Use PSR-4 now.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,8 +33,8 @@
         "monolog/monolog": "The recommended logging library to use with Propel."
     },
     "autoload": {
-        "psr-0": {
-            "Propel": "src/"
+        "psr-4": {
+            "Propel\\": "src/Propel/"
         }
     },
     "bin": [


### PR DESCRIPTION
Refs https://github.com/propelorm/Propel2/issues/575

We should get all to psr-4 including tests (which currently are not yet in autoloader at all)

This would probably be for the 2.0 stable release.