### PR TITLE
Required changes in generator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
-  - nightly
+  - 7.4
+
+services:
+  - postgresql
+  - mysql
 
 env:
   - DB=agnostic #only database agnostic tests
@@ -18,18 +18,13 @@ install:
   - composer install
 
 before_script:
-  - if [[ $DB != 'agnostic' && $DB != 'sqlite' ]]; then ./tests/bin/setup.$DB.sh; fi
+  - if [[ $DB != 'agnostic' && $DB != 'sqlite' ]]; then tests/bin/setup.$DB.sh; fi
 
 script:
-  - ./vendor/bin/phpunit -v -c tests/$DB.phpunit.xml;
-
+  - vendor/bin/phpunit -v -c tests/$DB.phpunit.xml;
 
 matrix:
   include:
-    - php: 5.5
-      env: DB=mysql MARIADB=5.5
-      addons:
-        mariadb: 5.5
     - php: 5.6
       env: DB=mysql MARIADB=5.5
       addons:
@@ -47,10 +42,6 @@ matrix:
       addons:
         mariadb: 5.5
 
-    - php: 5.5
-      env: DB=mysql MARIADB=10.0
-      addons:
-        mariadb: 10.0
     - php: 5.6
       env: DB=mysql MARIADB=10.0
       addons:
@@ -62,16 +53,12 @@ matrix:
     - php: 7.1
       env: DB=mysql MARIADB=10.0
       addons:
-        mariadb: 10.0    
+        mariadb: 10.0
     - php: 7.2
       env: DB=mysql MARIADB=10.0
       addons:
         mariadb: 10.0
 
-#    - php: 5.5
-#      env: DB=mysql MARIADB=10.1
-#      addons:
-#        mariadb: 10.1
 #    - php: 5.6
 #      env: DB=mysql MARIADB=10.1
 #      addons:
@@ -81,10 +68,6 @@ matrix:
 #      addons:
 #        mariadb: 10.1
 
-    - php: 5.5
-      env: DB=pgsql POSTGRES=9.2
-      addons:
-        postgresql: 9.2
     - php: 5.6
       env: DB=pgsql POSTGRES=9.2
       addons:
@@ -100,12 +83,8 @@ matrix:
     - php: 7.2
       env: DB=pgsql POSTGRES=9.2
       addons:
-        postgresql: 9.2    
+        postgresql: 9.2
 
-    - php: 5.5
-      env: DB=pgsql POSTGRES=9.3
-      addons:
-        postgresql: 9.3
     - php: 5.6
       env: DB=pgsql POSTGRES=9.3
       addons:
@@ -123,10 +102,6 @@ matrix:
       addons:
         postgresql: 9.3
 
-    - php: 5.5
-      env: DB=pgsql POSTGRES=9.4
-      addons:
-        postgresql: 9.4
     - php: 5.6
       env: DB=pgsql POSTGRES=9.4
       addons:
@@ -143,64 +118,46 @@ matrix:
       env: DB=pgsql POSTGRES=9.4
       addons:
         postgresql: 9.4
-    
-    - php: 5.5
-      env: DB=pgsql POSTGRES=9.5
-      addons:
-        postgresql: 9.5
-    - php: 5.6
-      env: DB=pgsql POSTGRES=9.5
-      addons:
-        postgresql: 9.5
-    - php: 7.0
-      env: DB=pgsql POSTGRES=9.5
-      addons:
-        postgresql: 9.5
-    - php: 7.1
-      env: DB=pgsql POSTGRES=9.5
-      addons:
-        postgresql: 9.5
-    - php: 7.2
-      env: DB=pgsql POSTGRES=9.5
-      addons:
-        postgresql: 9.5
-    
-    - php: 5.5
-      env: DB=pgsql POSTGRES=9.6
-      addons:
-        postgresql: 9.6
-    - php: 5.6
-      env: DB=pgsql POSTGRES=9.6
-      addons:
-        postgresql: 9.6
-    - php: 7.0
-      env: DB=pgsql POSTGRES=9.6
-      addons:
-        postgresql: 9.6
-    - php: 7.1
-      env: DB=pgsql POSTGRES=9.6
-      addons:
-        postgresql: 9.6
-    - php: 7.2
-      env: DB=pgsql POSTGRES=9.6
-      addons:
-        postgresql: 9.6
-    
 
-  allow_failures:
-    - php: nightly
+    - php: 5.6
+      env: DB=pgsql POSTGRES=9.5
+      addons:
+        postgresql: 9.5
+    - php: 7.0
+      env: DB=pgsql POSTGRES=9.5
+      addons:
+        postgresql: 9.5
+    - php: 7.1
+      env: DB=pgsql POSTGRES=9.5
+      addons:
+        postgresql: 9.5
+    - php: 7.2
+      env: DB=pgsql POSTGRES=9.5
+      addons:
+        postgresql: 9.5
+
+    - php: 5.6
+      env: DB=pgsql POSTGRES=9.6
+      addons:
+        postgresql: 9.6
+    - php: 7.0
+      env: DB=pgsql POSTGRES=9.6
+      addons:
+        postgresql: 9.6
+    - php: 7.1
+      env: DB=pgsql POSTGRES=9.6
+      addons:
+        postgresql: 9.6
+    - php: 7.2
+      env: DB=pgsql POSTGRES=9.6
+      addons:
+        postgresql: 9.6
 
   fast_finish: true
 
-# cache vendors
 cache:
   directories:
-    - vendor
     - $HOME/.composer/cache
-
-# This triggers builds to run on the new TravisCI infrastructure.
-# See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
-sudo: false
 
 notifications:
   webhooks:

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
     ],
     "require": {
         "php": ">=5.5",
-        "symfony/yaml": "~2.3||~3.0||~4.0",
-        "symfony/console": "~2.3||~3.0||~4.0",
-        "symfony/finder": "~2.3||~3.0||~4.0",
-        "symfony/validator": "~2.3||~3.0.0||~3.1.0||^3.2.4||~4.0",
-        "symfony/filesystem": "~2.3||~3.0||~4.0",
-        "symfony/config": "~2.3||~3.0||~4.0",
+        "symfony/yaml": "~2.3||~3.0||~4.0||~5.0",
+        "symfony/console": "~2.3||~3.0||~4.0||~5.0",
+        "symfony/finder": "~2.3||~3.0||~4.0||~5.0",
+        "symfony/validator": "~2.3||~3.0.0||~3.1.0||^3.2.4||~4.0||~5.0",
+        "symfony/filesystem": "~2.3||~3.0||~4.0||~5.0",
+        "symfony/config": "~2.3||~3.0||~4.0||~5.0",
         "psr/log": "~1.0"
     },
     "require-dev": {

--- a/src/Propel/Common/Config/PropelConfiguration.php
+++ b/src/Propel/Common/Config/PropelConfiguration.php
@@ -29,8 +29,8 @@ class PropelConfiguration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('propel');
+        $treeBuilder = new TreeBuilder('propel');
+        $rootNode = $treeBuilder->getRootNode();
 
         $this->addGeneralSection($rootNode);
         $this->addExcludeTablesSection($rootNode);

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -675,6 +675,14 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
                 $hooks[$hook.$action] = false === strpos($script, "function $hook.$action(");
             }
         }
+
+        if (null !== $this->getBehaviorContent('parentClass') ||
+            null !== ClassTools::classname($this->getBaseClass())) {
+	    $hooks['hasBaseClass'] = true;
+        } else {
+	    $hooks['hasBaseClass'] = false;
+	}
+
         $script .= $this->renderTemplate('baseObjectMethodHook', $hooks);
     }
 

--- a/src/Propel/Generator/Builder/Om/QueryBuilder.php
+++ b/src/Propel/Generator/Builder/Om/QueryBuilder.php
@@ -533,10 +533,10 @@ abstract class ".$this->getUnqualifiedClassName()." extends " . $parentClass . "
             foreach ($pks as $col) {
                 $colNames[]= '$' . $col->getName();
             }
-            $pkType = 'array['. join($colNames, ', ') . ']';
+            $pkType = 'array['. join(', ', $colNames) . ']';
             $script .= "
      * <code>
-     * \$obj = \$c->findPk(array(" . join($examplePk, ', ') . "), \$con);";
+     * \$obj = \$c->findPk(array(" . join(', ', $examplePk) . "), \$con);";
         } else {
             $pkType = 'mixed';
             $script .= "

--- a/src/Propel/Generator/Builder/Om/templates/baseObjectMethodHook.php
+++ b/src/Propel/Generator/Builder/Om/templates/baseObjectMethodHook.php
@@ -7,9 +7,11 @@
      */
     public function preSave(ConnectionInterface $con = null)
     {
+        <?php if ($hasBaseClass): ?>
         if (is_callable('parent::preSave')) {
 	        return parent::preSave($con);
         }
+        <?php endif?>
         return true;
     }
 
@@ -21,9 +23,11 @@
      */
     public function postSave(ConnectionInterface $con = null)
     {
+        <?php if ($hasBaseClass): ?>
         if (is_callable('parent::postSave')) {
 	        parent::postSave($con);
         }
+        <?php endif?>
     }
 
 <?php endif?>
@@ -35,9 +39,11 @@
      */
     public function preInsert(ConnectionInterface $con = null)
     {
+        <?php if ($hasBaseClass): ?>
         if (is_callable('parent::preInsert')) {
 	        return parent::preInsert($con);
         }
+        <?php endif?>
         return true;
     }
 
@@ -49,9 +55,11 @@
      */
     public function postInsert(ConnectionInterface $con = null)
     {
+        <?php if ($hasBaseClass): ?>
         if (is_callable('parent::postInsert')) {
 	        parent::postInsert($con);
         }
+        <?php endif?>
     }
 
 <?php endif?>
@@ -63,9 +71,11 @@
      */
     public function preUpdate(ConnectionInterface $con = null)
     {
+        <?php if ($hasBaseClass): ?>
         if (is_callable('parent::preUpdate')) {
 	        return parent::preUpdate($con);
         }
+        <?php endif?>
         return true;
     }
 
@@ -77,9 +87,11 @@
      */
     public function postUpdate(ConnectionInterface $con = null)
     {
+        <?php if ($hasBaseClass): ?>
         if (is_callable('parent::postUpdate')) {
 	        parent::postUpdate($con);
         }
+        <?php endif?>
     }
 
 <?php endif?>
@@ -91,9 +103,11 @@
      */
     public function preDelete(ConnectionInterface $con = null)
     {
+        <?php if ($hasBaseClass): ?>
         if (is_callable('parent::preDelete')) {
 	        return parent::preDelete($con);
         }
+        <?php endif?>
         return true;
     }
 
@@ -105,9 +119,11 @@
      */
     public function postDelete(ConnectionInterface $con = null)
     {
+        <?php if ($hasBaseClass): ?>
         if (is_callable('parent::postDelete')) {
 	        parent::postDelete($con);
         }
+        <?php endif?>
     }
 
 <?php endif?>

--- a/src/Propel/Generator/Builder/Util/SchemaReader.php
+++ b/src/Propel/Generator/Builder/Util/SchemaReader.php
@@ -187,7 +187,7 @@ class SchemaReader
                         $this->isForReferenceOnly = (null !== $isForRefOnly ? ('true' === strtolower($isForRefOnly)) : true); // defaults to TRUE
                     }
 
-                    if ('/' !== $xmlFile{0}) {
+                    if ('/' !== $xmlFile[0]) {
                         $xmlFile = realpath(dirname($this->currentXmlFile) . DIRECTORY_SEPARATOR . $xmlFile);
                         if (!file_exists($xmlFile)) {
                             throw new SchemaException(sprintf('Unknown include external "%s"', $xmlFile));
@@ -202,12 +202,12 @@ class SchemaReader
                     break;
 
                 case 'table':
-                    if (!isset($attributes['schema']) 
+                    if (!isset($attributes['schema'])
                         && $this->currDB->getSchema() && $this->currDB->getPlatform()->supportsSchemas()
                         && false === strpos($attributes['name'], $this->currDB->getPlatform()->getSchemaDelimiter())) {
                         $attributes['schema'] = $this->currDB->getSchema();
                     }
-                    
+
                     $this->currTable = $this->currDB->addTable($attributes);
                     if ($this->isExternalSchema()) {
                         $this->currTable->setForReferenceOnly($this->isForReferenceOnly);

--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -2408,10 +2408,10 @@ class Criteria
                                 $rawcvt = '';
                                 // parse the $params['raw'] for ? chars
                                 for ($r = 0, $len = strlen($raw); $r < $len; $r++) {
-                                    if ($raw{$r} == '?') {
+                                    if ($raw[$r] == '?') {
                                         $rawcvt .= ':p'.$p++;
                                     } else {
-                                        $rawcvt .= $raw{$r};
+                                        $rawcvt .= $raw[$r];
                                     }
                                 }
                                 $sql .= $rawcvt . ', ';


### PR DESCRIPTION
Required root name for symfony/config 5.X versions

In the version 4.4 the vendor config show this warning message:

-- > https://github.com/symfony/config/blob/4.4/Definition/Builder/TreeBuilder.php (30)

in the version 5.X is mandatory to set  the root name in the constructor in order to user the Propel generator.