### PR TITLE
Use term primary/replica instead, deprecate in BC way.

### DIFF
--- a/src/Propel/Runtime/Connection/ConnectionManagerMasterSlave.php
+++ b/src/Propel/Runtime/Connection/ConnectionManagerMasterSlave.php
@@ -10,180 +10,32 @@
 
 namespace Propel\Runtime\Connection;
 
-use Propel\Runtime\Adapter\AdapterInterface;
-
 /**
  * Manager for master/slave connection to a datasource.
+ *
+ * @deprecated Use ConnectionManagerPrimaryReplica instead.
  */
-class ConnectionManagerMasterSlave implements ConnectionManagerInterface
+class ConnectionManagerMasterSlave extends ConnectionManagerPrimaryReplica
 {
-    /**
-     * @var string The datasource name associated to this connection
-     */
-    protected $name;
-
-    /**
-     * @var array
-     */
-    protected $writeConfiguration = [];
-
-    /**
-     * @var \Propel\Runtime\Connection\ConnectionInterface
-     */
-    protected $writeConnection;
-
-    /**
-     * @var array
-     */
-    protected $readConfiguration;
-
-    /**
-     * @var \Propel\Runtime\Connection\ConnectionInterface
-     */
-    protected $readConnection;
-
-    /**
-     * @var boolean Whether a call to getReadConnection() always returns a write connection.
-     */
-    protected $isForceMasterConnection = false;
-
-    /**
-     * @param string $name The datasource name associated to this connection
-     */
-    public function setName($name)
-    {
-        $this->name = $name;
-    }
-
-    /**
-     * @return string The datasource name associated to this connection
-     */
-    public function getName()
-    {
-        return $this->name;
-    }
-
     /**
      * For replication, whether to always force the use of a master connection.
      *
      * @return boolean
+     * @deprecated Use isForcePrimaryConnection() instead.
      */
     public function isForceMasterConnection()
     {
-        return $this->isForceMasterConnection;
+        return $this->isForcePrimaryConnection();
     }
 
     /**
      * For replication, set whether to always force the use of a master connection.
      *
      * @param boolean $isForceMasterConnection
+     * @deprecated Use setForcePrimaryConnection() instead.
      */
     public function setForceMasterConnection($isForceMasterConnection)
     {
-        $this->isForceMasterConnection = (bool) $isForceMasterConnection;
-    }
-
-    /**
-     * Set the configuration for the master (write) connection.
-     *
-     * <code>
-     * $manager->setWriteConfiguration(array(
-     *   'dsn'      => 'mysql:dbname=test_master',
-     *   'user'     => 'mywriteuser',
-     *   'password' => 'S3cr3t'
-     * ));
-     * </code>
-     *
-     * @param array $configuration
-     */
-    public function setWriteConfiguration($configuration)
-    {
-        $this->writeConfiguration = $configuration;
-        $this->closeConnections();
-    }
-
-    /**
-     * Set the configuration for the slave (read) connections.
-     *
-     * <code>
-     * $manager->setReadConfiguration(array(
-     *   array(
-     *     'dsn'      => 'mysql:dbname=test_slave1',
-     *     'user'     => 'myreaduser',
-     *     'password' => 'F00baR'
-     *   ),
-     *   array(
-     *     'dsn'      => 'mysql:dbname=test_slave2',
-     *     'user'     => 'myreaduser',
-     *     'password' => 'F00baR'
-     *   )
-     * ));
-     * </code>
-     *
-     * @param array $configuration
-     */
-    public function setReadConfiguration($configuration)
-    {
-        $this->readConfiguration = $configuration;
-        $this->closeConnections();
-    }
-
-    /**
-     * Get a master connection.
-     *
-     * If no master connection exist yet, open it using the write configuration.
-     *
-     * @param \Propel\Runtime\Adapter\AdapterInterface $adapter
-     *
-     * @return \Propel\Runtime\Connection\ConnectionInterface
-     */
-    public function getWriteConnection(AdapterInterface $adapter = null)
-    {
-        if (null === $this->writeConnection) {
-            $this->writeConnection = ConnectionFactory::create($this->writeConfiguration, $adapter);
-            $this->writeConnection->setName($this->getName());
-        }
-
-        return $this->writeConnection;
-    }
-
-    /**
-     * Get a slave connection.
-     *
-     * If no slave connection exist yet, choose one configuration randomly in the
-     * read configuration to open it.
-     *
-     * @param \Propel\Runtime\Adapter\AdapterInterface $adapter
-     *
-     * @return \Propel\Runtime\Connection\ConnectionInterface
-     */
-    public function getReadConnection(AdapterInterface $adapter = null)
-    {
-        if ($this->writeConnection && $this->writeConnection->inTransaction()) {
-            return $this->writeConnection;
-        }
-
-        if ($this->isForceMasterConnection()) {
-            return $this->getWriteConnection($adapter);
-        }
-        if (null === $this->readConnection) {
-            if (null === $this->readConfiguration) {
-                $this->readConnection = $this->getWriteConnection($adapter);
-            } else {
-                $keys = array_keys($this->readConfiguration);
-                $key = $keys[mt_rand(0, count($keys) - 1)];
-                $configuration = $this->readConfiguration[$key];
-                $this->readConnection = ConnectionFactory::create($configuration, $adapter);
-                $this->readConnection->setName($this->getName());
-            }
-        }
-
-        return $this->readConnection;
-    }
-
-    public function closeConnections()
-    {
-        $this->writeConnection = null;
-        $this->readConnection = null;
+        $this->setForcePrimaryConnection($isForceMasterConnection);
     }
 }

--- a/src/Propel/Runtime/Connection/ConnectionManagerPrimaryReplica.php
+++ b/src/Propel/Runtime/Connection/ConnectionManagerPrimaryReplica.php
@@ -1,0 +1,189 @@
+<?php
+
+/**
+ * This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT License
+ */
+
+namespace Propel\Runtime\Connection;
+
+use Propel\Runtime\Adapter\AdapterInterface;
+
+/**
+ * Manager for primary/replica connection to a datasource.
+ */
+class ConnectionManagerPrimaryReplica implements ConnectionManagerInterface
+{
+    /**
+     * @var string The datasource name associated to this connection
+     */
+    protected $name;
+
+    /**
+     * @var array
+     */
+    protected $writeConfiguration = [];
+
+    /**
+     * @var \Propel\Runtime\Connection\ConnectionInterface
+     */
+    protected $writeConnection;
+
+    /**
+     * @var array
+     */
+    protected $readConfiguration;
+
+    /**
+     * @var \Propel\Runtime\Connection\ConnectionInterface
+     */
+    protected $readConnection;
+
+    /**
+     * @var boolean Whether a call to getReadConnection() always returns a write connection.
+     */
+    protected $isForcePrimaryConnection = false;
+
+    /**
+     * @param string $name The datasource name associated to this connection
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return string The datasource name associated to this connection
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * For replication, whether to always force the use of a primary connection.
+     *
+     * @return boolean
+     */
+    public function isForcePrimaryConnection()
+    {
+        return $this->isForcePrimaryConnection;
+    }
+
+    /**
+     * For replication, set whether to always force the use of a primary connection.
+     *
+     * @param boolean $isForceMasterConnection
+     */
+    public function setForcePrimaryConnection($isForceMasterConnection)
+    {
+        $this->isForcePrimaryConnection = (bool) $isForceMasterConnection;
+    }
+
+    /**
+     * Set the configuration for the master (write) connection.
+     *
+     * <code>
+     * $manager->setWriteConfiguration(array(
+     *   'dsn'      => 'mysql:dbname=test_master',
+     *   'user'     => 'mywriteuser',
+     *   'password' => 'S3cr3t'
+     * ));
+     * </code>
+     *
+     * @param array $configuration
+     */
+    public function setWriteConfiguration($configuration)
+    {
+        $this->writeConfiguration = $configuration;
+        $this->closeConnections();
+    }
+
+    /**
+     * Set the configuration for the replica (read) connections.
+     *
+     * <code>
+     * $manager->setReadConfiguration(array(
+     *   array(
+     *     'dsn'      => 'mysql:dbname=test_replica1',
+     *     'user'     => 'myreaduser',
+     *     'password' => 'F00baR'
+     *   ),
+     *   array(
+     *     'dsn'      => 'mysql:dbname=test_replica2',
+     *     'user'     => 'myreaduser',
+     *     'password' => 'F00baR'
+     *   )
+     * ));
+     * </code>
+     *
+     * @param array $configuration
+     */
+    public function setReadConfiguration($configuration)
+    {
+        $this->readConfiguration = $configuration;
+        $this->closeConnections();
+    }
+
+    /**
+     * Get a master connection.
+     *
+     * If no master connection exist yet, open it using the write configuration.
+     *
+     * @param \Propel\Runtime\Adapter\AdapterInterface $adapter
+     *
+     * @return \Propel\Runtime\Connection\ConnectionInterface
+     */
+    public function getWriteConnection(AdapterInterface $adapter = null)
+    {
+        if (null === $this->writeConnection) {
+            $this->writeConnection = ConnectionFactory::create($this->writeConfiguration, $adapter);
+            $this->writeConnection->setName($this->getName());
+        }
+
+        return $this->writeConnection;
+    }
+
+    /**
+     * Get a replica connection.
+     *
+     * If no replica connection exist yet, choose one configuration randomly in the
+     * read configuration to open it.
+     *
+     * @param \Propel\Runtime\Adapter\AdapterInterface $adapter
+     *
+     * @return \Propel\Runtime\Connection\ConnectionInterface
+     */
+    public function getReadConnection(AdapterInterface $adapter = null)
+    {
+        if ($this->writeConnection && $this->writeConnection->inTransaction()) {
+            return $this->writeConnection;
+        }
+
+        if ($this->isForcePrimaryConnection()) {
+            return $this->getWriteConnection($adapter);
+        }
+        if (null === $this->readConnection) {
+            if (null === $this->readConfiguration) {
+                $this->readConnection = $this->getWriteConnection($adapter);
+            } else {
+                $keys = array_keys($this->readConfiguration);
+                $key = $keys[mt_rand(0, count($keys) - 1)];
+                $configuration = $this->readConfiguration[$key];
+                $this->readConnection = ConnectionFactory::create($configuration, $adapter);
+                $this->readConnection->setName($this->getName());
+            }
+        }
+
+        return $this->readConnection;
+    }
+
+    public function closeConnections()
+    {
+        $this->writeConnection = null;
+        $this->readConnection = null;
+    }
+}

--- a/tests/Propel/Tests/Common/Config/ConfigurationManagerTest.php
+++ b/tests/Propel/Tests/Common/Config/ConfigurationManagerTest.php
@@ -345,7 +345,7 @@ buildtime:
 EOF;
         $this->getFilesystem()->dumpFile('propel.yaml', $yamlConf);
 
-        $manager = new ConfigurationManager();
+        new ConfigurationManager();
     }
 
     public function testNotDefineRuntimeAndGeneratorSectionUsesDefaultConnections()
@@ -392,7 +392,7 @@ propel:
 EOF;
         $this->getFilesystem()->dumpFile('propel.yaml', $yamlConf);
 
-        $manager = new ConfigurationManager();
+        new ConfigurationManager();
     }
 
     /**
@@ -423,7 +423,7 @@ propel:
 EOF;
         $this->getFilesystem()->dumpFile('propel.yaml', $yamlConf);
 
-        $manager = new ConfigurationManager();
+        new ConfigurationManager();
     }
 
     /**
@@ -435,7 +435,7 @@ EOF;
             "`wrongsource` isn't a valid configured connection (Section: propel.$section.connections).");
 
         $this->getFilesystem()->dumpFile('propel.yaml', $yamlConf);
-        $manager = new ConfigurationManager();
+        new ConfigurationManager();
     }
 
     /**
@@ -447,7 +447,7 @@ EOF;
             "`wrongsource` isn't a valid configured connection (Section: propel.$section.defaultConnection).");
 
         $this->getFilesystem()->dumpFile('propel.yaml', $yamlConf);
-        $manager = new ConfigurationManager();
+        new ConfigurationManager();
     }
 
     public function testLoadValidConfigurationFile()
@@ -610,7 +610,7 @@ EOF;
         $this->getFilesystem()->dumpFile('propel.yaml', $yamlConf);
 
         $manager = new ConfigurationManager();
-        $value = $manager->getConfigProperty(10);
+        $manager->getConfigProperty(10);
     }
 
     public function testGetConfigPropertyBadName()

--- a/tests/Propel/Tests/Runtime/Connection/ConnectionManagerMasterSlaveTest.php
+++ b/tests/Propel/Tests/Runtime/Connection/ConnectionManagerMasterSlaveTest.php
@@ -1,0 +1,177 @@
+<?php
+
+/**
+ * This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT License
+ */
+
+namespace Propel\Tests\Runtime\Connection;
+
+use Propel\Tests\Helpers\BaseTestCase;
+
+use Propel\Runtime\Connection\ConnectionManagerMasterSlave;
+use Propel\Runtime\Adapter\Pdo\SqliteAdapter;
+
+use \PDO;
+
+/**
+ * @deprecated Will be removed with the deprecated class.
+ */
+class ConnectionManagerMasterSlaveTest extends BaseTestCase
+{
+    public function testGetNameReturnsNullByDefault()
+    {
+        $manager = new ConnectionManagerMasterSlave();
+        $this->assertNull($manager->getName());
+    }
+
+    public function testGetNameReturnsNameSetUsingSetName()
+    {
+        $manager = new ConnectionManagerMasterSlave();
+        $manager->setName('foo');
+        $this->assertEquals('foo', $manager->getName());
+    }
+
+    /**
+     * @expectedException \Propel\Runtime\Exception\InvalidArgumentException
+     */
+    public function testGetWriteConnectionFailsIfManagerIsNotConfigured()
+    {
+        $manager = new ConnectionManagerMasterSlave();
+        $con = $manager->getWriteConnection(new SqliteAdapter());
+    }
+
+    public function testGetWriteConnectionBuildsConnectionBasedOnWriteConfiguration()
+    {
+        $manager = new ConnectionManagerMasterSlave();
+        $manager->setWriteConfiguration(['dsn' => 'sqlite::memory:']);
+        $con = $manager->getWriteConnection(new SqliteAdapter());
+        $this->assertInstanceOf('Propel\Runtime\Connection\ConnectionWrapper', $con);
+        $pdo = $con->getWrappedConnection();
+        $this->assertInstanceOf('Propel\Runtime\Connection\PdoConnection', $pdo);
+    }
+
+    public function testGetWriteConnectionBuildsConnectionNotBasedOnReadConfiguration()
+    {
+        $manager = new ConnectionManagerMasterSlave();
+        $manager->setWriteConfiguration(['dsn' => 'sqlite::memory:', 'attributes' => ['ATTR_CASE' => PDO::CASE_UPPER]]);
+        $manager->setReadConfiguration([['dsn' => 'sqlite::memory:', 'attributes' => ['ATTR_CASE' => PDO::CASE_LOWER]]]);
+        $con = $manager->getWriteConnection(new SqliteAdapter());
+        $pdo = $con->getWrappedConnection();
+        $this->assertEquals(PDO::CASE_UPPER, $pdo->getAttribute(PDO::ATTR_CASE));
+    }
+
+    public function testGetWriteConnectionReturnsAConnectionNamedAfterTheManager()
+    {
+        $manager = new ConnectionManagerMasterSlave();
+        $manager->setName('foo');
+        $manager->setWriteConfiguration(['dsn' => 'sqlite::memory:']);
+        $con = $manager->getWriteConnection(new SqliteAdapter());
+        $this->assertEquals('foo', $con->getName());
+    }
+
+    public function testGetReadConnectionBuildsConnectionBasedOnReadConfiguration()
+    {
+        $manager = new ConnectionManagerMasterSlave();
+        $manager->setReadConfiguration([['dsn' => 'sqlite::memory:']]);
+        $con = $manager->getReadConnection(new SqliteAdapter());
+        $this->assertInstanceOf('Propel\Runtime\Connection\ConnectionWrapper', $con);
+        $pdo = $con->getWrappedConnection();
+        $this->assertInstanceOf('Propel\Runtime\Connection\PdoConnection', $pdo);
+    }
+
+    public function testGetReadConnectionBuildsConnectionNotBasedOnWriteConfiguration()
+    {
+        $manager = new ConnectionManagerMasterSlave();
+        $manager->setWriteConfiguration(['dsn' => 'sqlite::memory:', 'attributes' => ['ATTR_CASE' => PDO::CASE_UPPER]]);
+        $manager->setReadConfiguration([['dsn' => 'sqlite::memory:', 'attributes' => ['ATTR_CASE' => PDO::CASE_LOWER]]]);
+        $con = $manager->getReadConnection(new SqliteAdapter());
+        $pdo = $con->getWrappedConnection();
+        $this->assertEquals(PDO::CASE_LOWER, $pdo->getAttribute(PDO::ATTR_CASE));
+    }
+
+    public function testGetReadConnectionReturnsWriteConnectionIfNoReadConnectionIsSet()
+    {
+        $manager = new ConnectionManagerMasterSlave();
+        $manager->setWriteConfiguration(['dsn' => 'sqlite::memory:']);
+        $writeCon = $manager->getWriteConnection(new SqliteAdapter());
+        $readCon  = $manager->getReadConnection(new SqliteAdapter());
+        $this->assertSame($writeCon, $readCon);
+    }
+
+    public function testGetReadConnectionBuildsConnectionBasedOnARandomReadConfiguration()
+    {
+        $manager = new ConnectionManagerMasterSlave();
+        $manager->setReadConfiguration([
+            ['dsn' => 'sqlite::memory:', 'attributes' => ['ATTR_CASE' => PDO::CASE_LOWER]],
+            ['dsn' => 'sqlite::memory:', 'attributes' => ['ATTR_CASE' => PDO::CASE_UPPER]]
+        ]);
+        $con = $manager->getReadConnection(new SqliteAdapter());
+        $pdo = $con->getWrappedConnection();
+        $expected = [PDO::CASE_LOWER, PDO::CASE_UPPER];
+        $this->assertContains($pdo->getAttribute(PDO::ATTR_CASE), $expected);
+    }
+
+    public function testGetReadConnectionReturnsAConnectionNamedAfterTheManager()
+    {
+        $manager = new ConnectionManagerMasterSlave();
+        $manager->setName('foo');
+        $manager->setReadConfiguration([['dsn' => 'sqlite::memory:']]);
+        $con = $manager->getReadConnection(new SqliteAdapter());
+        $this->assertEquals('foo', $con->getName());
+    }
+
+    public function testIsForceMasterConnectionFalseByDefault()
+    {
+        $manager = new ConnectionManagerMasterSlave();
+        $this->assertFalse($manager->isForceMasterConnection());
+    }
+
+    public function testSetForceMasterConnection()
+    {
+        $manager = new ConnectionManagerMasterSlave();
+        $manager->setForceMasterConnection(true);
+        $this->assertTrue($manager->isForceMasterConnection());
+        $manager->setForceMasterConnection(false);
+        $this->assertFalse($manager->isForceMasterConnection());
+    }
+
+    public function testForceMasterConnectionForcesMasterConnectionOnRead()
+    {
+        $manager = new ConnectionManagerMasterSlave();
+        $manager->setForceMasterConnection(true);
+        $manager->setWriteConfiguration(['dsn' => 'sqlite::memory:', 'attributes' => ['ATTR_CASE' => PDO::CASE_UPPER]]);
+        $manager->setReadConfiguration([['dsn' => 'sqlite::memory:', 'attributes' => ['ATTR_CASE' => PDO::CASE_LOWER]]]);
+        $con = $manager->getReadConnection(new SqliteAdapter());
+        $pdo = $con->getWrappedConnection();
+        $this->assertEquals(PDO::CASE_UPPER, $pdo->getAttribute(PDO::ATTR_CASE));
+    }
+
+    /**
+     * When master is in transaction then we need to return the master connection for getReadConnection,
+     * otherwise lookup queries fail
+     */
+    public function testReadConnectionWhenMasterIsInTransaction()
+    {
+        $manager = new ConnectionManagerMasterSlave();
+        $manager->setWriteConfiguration(['dsn' => 'sqlite::memory:', 'attributes' => ['ATTR_CASE' => PDO::CASE_UPPER]]);
+        $manager->setReadConfiguration([['dsn' => 'sqlite::memory:', 'attributes' => ['ATTR_CASE' => PDO::CASE_LOWER]]]);
+
+        $writeConnection = $manager->getWriteConnection(new SqliteAdapter());
+        $this->assertFalse($writeConnection->inTransaction());
+
+        $this->assertNotSame($writeConnection, $manager->getReadConnection(new SqliteAdapter()));
+        $writeConnection->beginTransaction();
+        $this->assertSame($writeConnection, $manager->getReadConnection(new SqliteAdapter()));
+        $writeConnection->rollBack();
+        $this->assertNotSame($writeConnection, $manager->getReadConnection(new SqliteAdapter()));
+
+        $writeConnection->beginTransaction();
+        $this->assertSame($writeConnection, $manager->getReadConnection(new SqliteAdapter()));
+        $writeConnection->commit();
+        $this->assertNotSame($writeConnection, $manager->getReadConnection(new SqliteAdapter()));
+    }
+}

--- a/tests/Propel/Tests/Runtime/Connection/ConnectionManagerPrimaryReplicaTest.php
+++ b/tests/Propel/Tests/Runtime/Connection/ConnectionManagerPrimaryReplicaTest.php
@@ -12,22 +12,22 @@ namespace Propel\Tests\Runtime\Connection;
 
 use Propel\Tests\Helpers\BaseTestCase;
 
-use Propel\Runtime\Connection\ConnectionManagerMasterSlave;
+use Propel\Runtime\Connection\ConnectionManagerPrimaryReplica;
 use Propel\Runtime\Adapter\Pdo\SqliteAdapter;
 
 use \PDO;
 
-class ConnectionManagerMasterSlaveTest extends BaseTestCase
+class ConnectionManagerPrimaryReplicaTest extends BaseTestCase
 {
     public function testGetNameReturnsNullByDefault()
     {
-        $manager = new ConnectionManagerMasterSlave();
+        $manager = new ConnectionManagerPrimaryReplica();
         $this->assertNull($manager->getName());
     }
 
     public function testGetNameReturnsNameSetUsingSetName()
     {
-        $manager = new ConnectionManagerMasterSlave();
+        $manager = new ConnectionManagerPrimaryReplica();
         $manager->setName('foo');
         $this->assertEquals('foo', $manager->getName());
     }
@@ -37,13 +37,13 @@ class ConnectionManagerMasterSlaveTest extends BaseTestCase
      */
     public function testGetWriteConnectionFailsIfManagerIsNotConfigured()
     {
-        $manager = new ConnectionManagerMasterSlave();
-        $con = $manager->getWriteConnection(new SqliteAdapter());
+        $manager = new ConnectionManagerPrimaryReplica();
+        $manager->getWriteConnection(new SqliteAdapter());
     }
 
     public function testGetWriteConnectionBuildsConnectionBasedOnWriteConfiguration()
     {
-        $manager = new ConnectionManagerMasterSlave();
+        $manager = new ConnectionManagerPrimaryReplica();
         $manager->setWriteConfiguration(['dsn' => 'sqlite::memory:']);
         $con = $manager->getWriteConnection(new SqliteAdapter());
         $this->assertInstanceOf('Propel\Runtime\Connection\ConnectionWrapper', $con);
@@ -53,7 +53,7 @@ class ConnectionManagerMasterSlaveTest extends BaseTestCase
 
     public function testGetWriteConnectionBuildsConnectionNotBasedOnReadConfiguration()
     {
-        $manager = new ConnectionManagerMasterSlave();
+        $manager = new ConnectionManagerPrimaryReplica();
         $manager->setWriteConfiguration(['dsn' => 'sqlite::memory:', 'attributes' => ['ATTR_CASE' => PDO::CASE_UPPER]]);
         $manager->setReadConfiguration([['dsn' => 'sqlite::memory:', 'attributes' => ['ATTR_CASE' => PDO::CASE_LOWER]]]);
         $con = $manager->getWriteConnection(new SqliteAdapter());
@@ -63,7 +63,7 @@ class ConnectionManagerMasterSlaveTest extends BaseTestCase
 
     public function testGetWriteConnectionReturnsAConnectionNamedAfterTheManager()
     {
-        $manager = new ConnectionManagerMasterSlave();
+        $manager = new ConnectionManagerPrimaryReplica();
         $manager->setName('foo');
         $manager->setWriteConfiguration(['dsn' => 'sqlite::memory:']);
         $con = $manager->getWriteConnection(new SqliteAdapter());
@@ -72,7 +72,7 @@ class ConnectionManagerMasterSlaveTest extends BaseTestCase
 
     public function testGetReadConnectionBuildsConnectionBasedOnReadConfiguration()
     {
-        $manager = new ConnectionManagerMasterSlave();
+        $manager = new ConnectionManagerPrimaryReplica();
         $manager->setReadConfiguration([['dsn' => 'sqlite::memory:']]);
         $con = $manager->getReadConnection(new SqliteAdapter());
         $this->assertInstanceOf('Propel\Runtime\Connection\ConnectionWrapper', $con);
@@ -82,7 +82,7 @@ class ConnectionManagerMasterSlaveTest extends BaseTestCase
 
     public function testGetReadConnectionBuildsConnectionNotBasedOnWriteConfiguration()
     {
-        $manager = new ConnectionManagerMasterSlave();
+        $manager = new ConnectionManagerPrimaryReplica();
         $manager->setWriteConfiguration(['dsn' => 'sqlite::memory:', 'attributes' => ['ATTR_CASE' => PDO::CASE_UPPER]]);
         $manager->setReadConfiguration([['dsn' => 'sqlite::memory:', 'attributes' => ['ATTR_CASE' => PDO::CASE_LOWER]]]);
         $con = $manager->getReadConnection(new SqliteAdapter());
@@ -92,7 +92,7 @@ class ConnectionManagerMasterSlaveTest extends BaseTestCase
 
     public function testGetReadConnectionReturnsWriteConnectionIfNoReadConnectionIsSet()
     {
-        $manager = new ConnectionManagerMasterSlave();
+        $manager = new ConnectionManagerPrimaryReplica();
         $manager->setWriteConfiguration(['dsn' => 'sqlite::memory:']);
         $writeCon = $manager->getWriteConnection(new SqliteAdapter());
         $readCon  = $manager->getReadConnection(new SqliteAdapter());
@@ -101,7 +101,7 @@ class ConnectionManagerMasterSlaveTest extends BaseTestCase
 
     public function testGetReadConnectionBuildsConnectionBasedOnARandomReadConfiguration()
     {
-        $manager = new ConnectionManagerMasterSlave();
+        $manager = new ConnectionManagerPrimaryReplica();
         $manager->setReadConfiguration([
             ['dsn' => 'sqlite::memory:', 'attributes' => ['ATTR_CASE' => PDO::CASE_LOWER]],
             ['dsn' => 'sqlite::memory:', 'attributes' => ['ATTR_CASE' => PDO::CASE_UPPER]]
@@ -114,32 +114,32 @@ class ConnectionManagerMasterSlaveTest extends BaseTestCase
 
     public function testGetReadConnectionReturnsAConnectionNamedAfterTheManager()
     {
-        $manager = new ConnectionManagerMasterSlave();
+        $manager = new ConnectionManagerPrimaryReplica();
         $manager->setName('foo');
         $manager->setReadConfiguration([['dsn' => 'sqlite::memory:']]);
         $con = $manager->getReadConnection(new SqliteAdapter());
         $this->assertEquals('foo', $con->getName());
     }
 
-    public function testIsForceMasterConnectionFalseByDefault()
+    public function testIsForcePrimaryConnectionFalseByDefault()
     {
-        $manager = new ConnectionManagerMasterSlave();
-        $this->assertFalse($manager->isForceMasterConnection());
+        $manager = new ConnectionManagerPrimaryReplica();
+        $this->assertFalse($manager->isForcePrimaryConnection());
     }
 
-    public function testSetForceMasterConnection()
+    public function testSetForcePrimaryConnection()
     {
-        $manager = new ConnectionManagerMasterSlave();
-        $manager->setForceMasterConnection(true);
-        $this->assertTrue($manager->isForceMasterConnection());
-        $manager->setForceMasterConnection(false);
-        $this->assertFalse($manager->isForceMasterConnection());
+        $manager = new ConnectionManagerPrimaryReplica();
+        $manager->setForcePrimaryConnection(true);
+        $this->assertTrue($manager->isForcePrimaryConnection());
+        $manager->setForcePrimaryConnection(false);
+        $this->assertFalse($manager->isForcePrimaryConnection());
     }
 
-    public function testForceMasterConnectionForcesMasterConnectionOnRead()
+    public function testForcePrimaryConnectionForcesMasterConnectionOnRead()
     {
-        $manager = new ConnectionManagerMasterSlave();
-        $manager->setForceMasterConnection(true);
+        $manager = new ConnectionManagerPrimaryReplica();
+        $manager->setForcePrimaryConnection(true);
         $manager->setWriteConfiguration(['dsn' => 'sqlite::memory:', 'attributes' => ['ATTR_CASE' => PDO::CASE_UPPER]]);
         $manager->setReadConfiguration([['dsn' => 'sqlite::memory:', 'attributes' => ['ATTR_CASE' => PDO::CASE_LOWER]]]);
         $con = $manager->getReadConnection(new SqliteAdapter());
@@ -153,7 +153,7 @@ class ConnectionManagerMasterSlaveTest extends BaseTestCase
      */
     public function testReadConnectionWhenMasterIsInTransaction()
     {
-        $manager = new ConnectionManagerMasterSlave();
+        $manager = new ConnectionManagerPrimaryReplica();
         $manager->setWriteConfiguration(['dsn' => 'sqlite::memory:', 'attributes' => ['ATTR_CASE' => PDO::CASE_UPPER]]);
         $manager->setReadConfiguration([['dsn' => 'sqlite::memory:', 'attributes' => ['ATTR_CASE' => PDO::CASE_LOWER]]]);
 


### PR DESCRIPTION
Spryker would like to start using primary/replica functionality of Propel.
We would like to have this change first, though. It keeps naming consistent with modern tech like aws rds https://aws.amazon.com/rds/features/read-replicas/