### PR TITLE
fix for broken alter-table statements when default column values cont…

### DIFF
--- a/src/Propel/Generator/Platform/DefaultPlatform.php
+++ b/src/Propel/Generator/Platform/DefaultPlatform.php
@@ -25,6 +25,7 @@ use Propel\Generator\Model\Diff\ColumnDiff;
 use Propel\Generator\Model\Diff\DatabaseDiff;
 use Propel\Generator\Model\Diff\TableDiff;
 use Propel\Generator\Exception\EngineException;
+use Propel\Generator\Util\SqlParser;
 use Propel\Runtime\Connection\ConnectionInterface;
 
 /**
@@ -815,7 +816,10 @@ ALTER TABLE %s RENAME TO %s;
         if ($columnChanges) {
             //merge column changes into one command. This is more compatible especially with PK constraints.
 
-            $changes = explode(';', $columnChanges);
+            $sqlParser = new SqlParser();
+            $sqlParser->setSQL($columnChanges);
+            $changes = $sqlParser->explodeIntoStatements();
+
             $columnChanges = [];
 
             foreach ($changes as $change) {


### PR DESCRIPTION
# The problem

When a column `defaultValue` contains a semicolon (`;`) the generated alter-table statement is broken.
```
<column name="attachement_allowed_extensions" phpName="AttachementAllowedExtensions" 
type="VARCHAR" size="250" required="true" defaultValue="pdf;jpg;png;doc;docx;xls;xlsx;txt"/>
```

the reason for that can be found in file `/src/Propel/Generator/Platform/DefaultPlatform.php` line `818ff`
```
if ($columnChanges) {
    //merge column changes into one command. This is more compatible especially with PK constraints.

    $changes = explode(';', $columnChanges);
```
the already generated sql string consists of multiple `alter table` statements and shall be split into single `alter table` statements to merge. If the generated statement 
```
ALTER TABLE `newsletter_sets`  CHANGE `attachement_allowed_extensions` `attachement_allowed_extensions` VARCHAR(250) DEFAULT 'pdf;jpg;png;doc;docx;xls;xlsx;txt' NOT NULL;
``` 
contains multiple semicolons so the splitting goes wrong.

# The solution

propel already contains a sql statement parser that can be used as a drop-in replacement here. 
```
$sqlParser = new SqlParser();
$sqlParser->setSQL($columnChanges);
$changes = $sqlParser->explodeIntoStatements();
```



