### PR TITLE
Required root name for symfony/config 5.X versions

### DIFF
--- a/src/Propel/Common/Config/PropelConfiguration.php
+++ b/src/Propel/Common/Config/PropelConfiguration.php
@@ -29,8 +29,14 @@ class PropelConfiguration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
+        // Create TreeBuilder with default param, before version 4.4 is not required
         $treeBuilder = new TreeBuilder('propel');
-        $rootNode = $treeBuilder->getRootNode();
+        // Check if exists root method for versions before 4.4
+        if(method_exists($treeBuilder, 'root')) {
+            $rootNode = $treeBuilder->root('propel');
+        } else { // Versions greater than 4.4 and 5.x
+            $rootNode = $treeBuilder->getRootNode();
+        }
 
         $this->addGeneralSection($rootNode);
         $this->addExcludeTablesSection($rootNode);

--- a/src/Propel/Common/Config/PropelConfiguration.php
+++ b/src/Propel/Common/Config/PropelConfiguration.php
@@ -32,7 +32,7 @@ class PropelConfiguration implements ConfigurationInterface
         // Create TreeBuilder with default param, before version 4.4 is not required
         $treeBuilder = new TreeBuilder('propel');
         // Check if exists root method for versions before 4.4
-        if(method_exists($treeBuilder, 'root')) {
+        if (method_exists($treeBuilder, 'root')) {
             $rootNode = $treeBuilder->root('propel');
         } else { // Versions greater than 4.4 and 5.x
             $rootNode = $treeBuilder->getRootNode();

--- a/src/Propel/Common/Config/PropelConfiguration.php
+++ b/src/Propel/Common/Config/PropelConfiguration.php
@@ -29,8 +29,8 @@ class PropelConfiguration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('propel');
+        $treeBuilder = new TreeBuilder('propel');
+        $rootNode = $treeBuilder->getRootNode();
 
         $this->addGeneralSection($rootNode);
         $this->addExcludeTablesSection($rootNode);


### PR DESCRIPTION
In the version 4.4 the vendor config show this warning message:

-- > https://github.com/symfony/config/blob/4.4/Definition/Builder/TreeBuilder.php (30)

in the version 5.X is mandatory to set  the root name in the constructor in order to user the Propel generator.