### PR TITLE
Remove prefer lowest from allow failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ dist: bionic
 
 php:
   - 7.1
+  - 7.2
+  - 7.3
   - 7.4
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ dist: bionic
 
 php:
   - 7.1
-  - 7.2
-  - 7.3
   - 7.4
 
 env:
@@ -36,7 +34,7 @@ before_script:
   - if [[ $DB != 'agnostic' && $DB != 'sqlite' ]]; then ./tests/bin/setup.$DB.sh; fi
 
 script:
-  - ./vendor/bin/phpunit -v -c tests/$DB.phpunit.xml
+  - vendor/bin/phpunit -v -c tests/$DB.phpunit.xml
 
 jobs:
   include:
@@ -335,7 +333,7 @@ jobs:
       script:
         - vendor/bin/validate-prefer-lowest
         - composer show
-        - ./vendor/bin/phpunit -v -c tests/$DB.phpunit.xml
+        - vendor/bin/phpunit -v -c tests/$DB.phpunit.xml
 
     - name: Minimum versions on php7.3
       php: 7.3
@@ -346,7 +344,7 @@ jobs:
       script:
         - vendor/bin/validate-prefer-lowest
         - composer show
-        - ./vendor/bin/phpunit -v -c tests/$DB.phpunit.xml
+        - vendor/bin/phpunit -v -c tests/$DB.phpunit.xml
 
     - name: Minimum versions on php7.4
       php: 7.4
@@ -357,13 +355,10 @@ jobs:
       script:
         - vendor/bin/validate-prefer-lowest
         - composer show
-        - ./vendor/bin/phpunit -v -c tests/$DB.phpunit.xml
+        - vendor/bin/phpunit -v -c tests/$DB.phpunit.xml
 
   allow_failures:
     - php: nightly
-    - name: Minimum versions on php7.2
-    - name: Minimum versions on php7.3
-    - name: Minimum versions on php7.4
 
   fast_finish: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -324,30 +324,8 @@ jobs:
         - composer install --ignore-platform-reqs
         - composer show
 
-    - name: Minimum versions on php7.2
+    - name: Minimum versions using prefer-lowest
       php: 7.2
-      env: DB=agnostic
-      install:
-        - composer update --prefer-lowest --prefer-stable --prefer-dist --no-interaction
-        - composer require --dev dereuromark/composer-prefer-lowest
-      script:
-        - vendor/bin/validate-prefer-lowest
-        - composer show
-        - vendor/bin/phpunit -v -c tests/$DB.phpunit.xml
-
-    - name: Minimum versions on php7.3
-      php: 7.3
-      env: DB=agnostic
-      install:
-        - composer update --prefer-lowest --prefer-stable --prefer-dist --no-interaction
-        - composer require --dev dereuromark/composer-prefer-lowest
-      script:
-        - vendor/bin/validate-prefer-lowest
-        - composer show
-        - vendor/bin/phpunit -v -c tests/$DB.phpunit.xml
-
-    - name: Minimum versions on php7.4
-      php: 7.4
       env: DB=agnostic
       install:
         - composer update --prefer-lowest --prefer-stable --prefer-dist --no-interaction


### PR DESCRIPTION
prefer lowest should fail the built if they fail.

~~Also removed non-minimal prefer lowest as they have no additional value~~

we now still run 42 jobs, which we could further limit down
but this is probably a fair compromise for now