### PR TITLE
Fix SQLite sprintf() error

### DIFF
--- a/src/Propel/Runtime/Adapter/Pdo/SqliteAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/SqliteAdapter.php
@@ -107,7 +107,7 @@ class SqliteAdapter extends PdoAdapter implements SqlAdapterInterface
         if ($limit >= 0) {
             $sql .= ' LIMIT ' . $limit . ($offset > 0 ? ' OFFSET ' . $offset : '');
         } elseif ($offset > 0) {
-            $sql .= sprintf(' LIMIT -1 OFFSET %i', $offset);
+            $sql .= sprintf(' LIMIT -1 OFFSET %s', $offset);
         }
     }
 


### PR DESCRIPTION
phpstan reports

>  Call to sprintf contains 0 placeholders, 1 value given.  

%i seems indeed invalid
I wonder if there were no tests for this so far.