### PR TITLE
Adds Maria 10.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,19 +41,27 @@ script:
 jobs:
   include:
     - php: 7.1
+      dist: trusty
       env: DB=mysql MARIADB=10.1
+      services:
       addons:
         mariadb: 10.1
     - php: 7.2
+      dist: trusty
       env: DB=mysql MARIADB=10.1
+      services:
       addons:
         mariadb: 10.1
     - php: 7.3
+      dist: trusty
       env: DB=mysql MARIADB=10.1
+      services:
       addons:
         mariadb: 10.1
     - php: 7.4
+      dist: trusty
       env: DB=mysql MARIADB=10.1
+      services:
       addons:
         mariadb: 10.1
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,24 +40,22 @@ script:
 
 jobs:
   include:
-# Travis-ci doesn't know how to install Maria 10.1
-#   - php: 7.1
-#     env: DB=mysql MARIADB=10.1
-#     addons:
-#       mariadb: 10.1
-#   - php: 7.2
-#     env: DB=mysql MARIADB=10.1
-#     addons:
-#       mariadb: 10.1
-#   - php: 7.3
-#     env: DB=mysql MARIADB=10.1
-#     addons:
-#       mariadb: 10.1
-#   - php: 7.4
-#     env: DB=mysql MARIADB=10.1
-#     addons:
-#       mariadb: 10.1
-#       TODO add maria 5.5, it is not EOL yet.
+    - php: 7.1
+      env: DB=mysql MARIADB=10.1
+      addons:
+        mariadb: 10.1
+    - php: 7.2
+      env: DB=mysql MARIADB=10.1
+      addons:
+        mariadb: 10.1
+    - php: 7.3
+      env: DB=mysql MARIADB=10.1
+      addons:
+        mariadb: 10.1
+    - php: 7.4
+      env: DB=mysql MARIADB=10.1
+      addons:
+        mariadb: 10.1
 
     - php: 7.1
       env: DB=mysql MARIADB=10.2


### PR DESCRIPTION
Fixes: https://github.com/propelorm/Propel2/issues/1570

Uses a deprecated unix distro because it's the only one from Travis that actually works with maria 10.1, everyone else using travis-ci fixed this with custom hacks or docker.

![Screenshot from 2020-06-26 10-16-24](https://user-images.githubusercontent.com/379322/85835919-1bf15680-b796-11ea-85a5-4a5d618eb534.png)

