### PR TITLE
Finish Symfony 5 support.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "psr/log": "^1.0"
     },
     "require-dev": {
+        "symfony/translation": "^3.4.0||^4.3.0||^5.0.0",
         "monolog/monolog": "^1.3",
         "phpstan/phpstan": "^0.12.4",
         "phpunit/phpunit": "^7.5.15"

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
         "psr/log": "^1.0"
     },
     "require-dev": {
-        "symfony/translation": "^3.4.0||^4.3.0||^5.0.0",
         "monolog/monolog": "^1.3",
         "phpstan/phpstan": "^0.12.4",
         "phpunit/phpunit": "^7.5.15"

--- a/src/Propel/Generator/Command/AbstractCommand.php
+++ b/src/Propel/Generator/Command/AbstractCommand.php
@@ -23,7 +23,10 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 abstract class AbstractCommand extends Command
 {
-    const DEFAULT_CONFIG_DIRECTORY   = '.';
+    public const DEFAULT_CONFIG_DIRECTORY   = '.';
+
+    public const CODE_SUCCESS = 0;
+    public const CODE_ERROR = 1;
 
     protected $filesystem;
 
@@ -142,7 +145,7 @@ abstract class AbstractCommand extends Command
 
     /**
      * Parse a connection string and return an array of properties to pass to GeneratorConfig constructor.
-     * The connection must be in the following format: 
+     * The connection must be in the following format:
      * `bookstore=mysql:host=127.0.0.1;dbname=test;user=root;password=foobar`
      * where "bookstore" is your propel database name (used in your schema.xml).
      *
@@ -152,18 +155,18 @@ abstract class AbstractCommand extends Command
      * @return array
      */
     protected function connectionToProperties($connection, $section = null)
-    {        
+    {
         list($name, $dsn, $infos) = $this->parseConnection($connection);
         $config['propel']['database']['connections'][$name]['classname'] = '\Propel\Runtime\Connection\ConnectionWrapper';
         $config['propel']['database']['connections'][$name]['adapter'] = strtolower($infos['adapter']);
         $config['propel']['database']['connections'][$name]['dsn'] = $dsn;
         $config['propel']['database']['connections'][$name]['user'] = isset($infos['user']) && $infos['user'] ? $infos['user'] : null;
         $config['propel']['database']['connections'][$name]['password'] = isset($infos['password']) ? $infos['password'] : null;
-        
+
         if (null === $section) {
             $section = 'generator';
         }
-        
+
         if ('reverse' === $section) {
             $config['propel']['reverse']['connection'] = $name;
         } else {
@@ -185,7 +188,7 @@ abstract class AbstractCommand extends Command
     {
         return $input->hasOption($option) && null !== $input->getOption($option);
     }
-    
+
     /**
      * Check if a given input argument exists and it isn't null.
      *

--- a/src/Propel/Generator/Command/ConfigConvertCommand.php
+++ b/src/Propel/Generator/Command/ConfigConvertCommand.php
@@ -78,6 +78,6 @@ class ConfigConvertCommand extends AbstractCommand
             $output->writeln(sprintf('Successfully wrote PHP configuration in file <info>"%s"</info>.', $outputFilePath));
         }
 
-        return 0;
+        return static::CODE_SUCCESS;
     }
 }

--- a/src/Propel/Generator/Command/DatabaseReverseCommand.php
+++ b/src/Propel/Generator/Command/DatabaseReverseCommand.php
@@ -92,7 +92,7 @@ class DatabaseReverseCommand extends AbstractCommand
         $manager->setSchemaName($input->getOption('schema-name'));
 
         $namespace = $input->getOption('namespace');
-        
+
         if ($namespace) {
             $manager->setNamespace($namespace);
         }
@@ -101,6 +101,6 @@ class DatabaseReverseCommand extends AbstractCommand
             $output->writeln('<info>Schema reverse engineering finished.</info>');
         }
 
-        return 0;
+        return static::CODE_SUCCESS;
     }
 }

--- a/src/Propel/Generator/Command/GraphvizGenerateCommand.php
+++ b/src/Propel/Generator/Command/GraphvizGenerateCommand.php
@@ -63,6 +63,6 @@ class GraphvizGenerateCommand extends AbstractCommand
 
         $manager->build();
 
-        return 0;
+        return static::CODE_SUCCESS;
     }
 }

--- a/src/Propel/Generator/Command/InitCommand.php
+++ b/src/Propel/Generator/Command/InitCommand.php
@@ -147,7 +147,7 @@ class InitCommand extends AbstractCommand
 
         if (!$correct) {
             $consoleHelper->writeln('<error>Process aborted.</error>');
-            return 1;
+            return static::CODE_ERROR;
         }
 
         $consoleHelper->writeln('');
@@ -155,7 +155,7 @@ class InitCommand extends AbstractCommand
         $this->generateProject($consoleHelper->getOutput(), $options);
         $consoleHelper->writeSection('Propel 2 is ready to be used!');
 
-        return 0;
+        return static::CODE_SUCCESS;
     }
 
     private function detectDefaultPhpDir()
@@ -305,11 +305,11 @@ class InitCommand extends AbstractCommand
             'connection' => $fullDsn,
             '--output-dir' => $outputDir
         ];
-        
+
         if (isset($options['namespace'])) {
             $arrInput['--namespace'] = $options['namespace'];
         }
-        
+
         $input = new ArrayInput($arrInput);
         $result = $this->getApplication()->run($input,$output);
 

--- a/src/Propel/Generator/Command/MigrationCreateCommand.php
+++ b/src/Propel/Generator/Command/MigrationCreateCommand.php
@@ -97,7 +97,7 @@ class MigrationCreateCommand extends AbstractCommand
             $output->writeln('Once the migration class is valid, call the "migrate" task to execute it.');
         }
 
-        return 0;
+        return static::CODE_SUCCESS;
     }
 
 }

--- a/src/Propel/Generator/Command/MigrationDiffCommand.php
+++ b/src/Propel/Generator/Command/MigrationDiffCommand.php
@@ -169,7 +169,7 @@ class MigrationDiffCommand extends AbstractCommand
         $excludedTables = $input->getOption('skip-tables');
         $configManager = new ConfigurationManager($input->getOption('config-dir'));
         $excludedTables = array_merge((array) $excludedTables, (array) $configManager->getSection('exclude_tables'));
-        
+
         foreach ($reversedSchema->getDatabases() as $database) {
             $name = $database->getName();
 
@@ -212,7 +212,7 @@ class MigrationDiffCommand extends AbstractCommand
         if (!$migrationsUp) {
             $output->writeln('Same XML and database structures for all datasource - no diff to generate');
 
-            return 0;
+            return static::CODE_SUCCESS;
         }
 
         $timestamp = time();
@@ -232,7 +232,7 @@ class MigrationDiffCommand extends AbstractCommand
             $output->writeln('Once the migration class is valid, call the "migrate" task to execute it.');
         }
 
-        return 0;
+        return static::CODE_SUCCESS;
     }
 
 }

--- a/src/Propel/Generator/Command/MigrationDownCommand.php
+++ b/src/Propel/Generator/Command/MigrationDownCommand.php
@@ -55,7 +55,7 @@ class MigrationDownCommand extends AbstractCommand
         if ($this->hasInputOption('migration-table', $input)) {
             $configOptions['propel']['migrations']['tableName'] = $input->getOption('migration-table');
         }
-        
+
         $generatorConfig = $this->getGeneratorConfig($configOptions, $input);
 
         $this->createDirectory($generatorConfig->getSection('paths')['migrationDir']);
@@ -83,7 +83,7 @@ class MigrationDownCommand extends AbstractCommand
         if (!$nextMigrationTimestamp) {
             $output->writeln('No migration were ever executed on this database - nothing to reverse.');
 
-            return 1;
+            return static::CODE_ERROR;
         }
 
         $output->writeln(sprintf(
@@ -108,7 +108,7 @@ class MigrationDownCommand extends AbstractCommand
                 } else {
                     $output->writeln('<error>preDown() returned false. Aborting migration.</error>');
 
-                    return 1;
+                    return static::CODE_ERROR;
                 }
             }
         }
@@ -182,6 +182,6 @@ class MigrationDownCommand extends AbstractCommand
             $output->writeln('Reverse migration complete. No more migration available for reverse');
         }
 
-        return 0;
+        return static::CODE_SUCCESS;
     }
 }

--- a/src/Propel/Generator/Command/MigrationMigrateCommand.php
+++ b/src/Propel/Generator/Command/MigrationMigrateCommand.php
@@ -55,7 +55,7 @@ class MigrationMigrateCommand extends AbstractCommand
         if ($this->hasInputOption('migration-table', $input)) {
             $configOptions['propel']['migrations']['tableName'] = $input->getOption('migration-table');
         }
-        
+
         $generatorConfig = $this->getGeneratorConfig($configOptions, $input);
 
         $this->createDirectory($generatorConfig->getSection('paths')['migrationDir']);
@@ -81,7 +81,7 @@ class MigrationMigrateCommand extends AbstractCommand
         if (!$manager->getFirstUpMigrationTimestamp()) {
             $output->writeln('All migrations were already executed - nothing to migrate.');
 
-            return 1;
+            return static::CODE_ERROR;
         }
 
         $timestamps = $manager->getValidMigrationTimestamps();
@@ -113,7 +113,7 @@ class MigrationMigrateCommand extends AbstractCommand
                     } else {
                         $output->writeln('<error>preUp() returned false. Aborting migration.</error>');
 
-                        return 1;
+                        return static::CODE_ERROR;
                     }
                 }
 
@@ -187,6 +187,6 @@ class MigrationMigrateCommand extends AbstractCommand
 
         $output->writeln('Migration complete. No further migration to execute.');
 
-        return 0;
+        return static::CODE_SUCCESS;
     }
 }

--- a/src/Propel/Generator/Command/MigrationStatusCommand.php
+++ b/src/Propel/Generator/Command/MigrationStatusCommand.php
@@ -47,11 +47,11 @@ class MigrationStatusCommand extends AbstractCommand
         if ($this->hasInputOption('output-dir', $input)) {
             $configOptions['propel']['paths']['migrationDir'] = $input->getOption('output-dir');
         }
-        
+
         if ($this->hasInputOption('migration-table', $input)) {
             $configOptions['propel']['migrations']['tableName'] = $input->getOption('migration-table');
         }
-        
+
         $generatorConfig = $this->getGeneratorConfig($configOptions, $input);
 
         $this->createDirectory($generatorConfig->getSection('paths')['migrationDir']);
@@ -142,7 +142,7 @@ class MigrationStatusCommand extends AbstractCommand
         } else {
             $output->writeln(sprintf('No migration file found in "%s".', $dir));
 
-            return 1;
+            return static::CODE_ERROR;
         }
 
         $migrationTimestamps = $manager->getValidMigrationTimestamps();
@@ -151,7 +151,7 @@ class MigrationStatusCommand extends AbstractCommand
         if (!$nbNotYetExecutedMigrations) {
             $output->writeln('All migration files were already executed - Nothing to migrate.');
 
-            return 1;
+            return static::CODE_ERROR;
         }
 
         $output->writeln(sprintf(
@@ -159,6 +159,6 @@ class MigrationStatusCommand extends AbstractCommand
             $countValidTimestamps == 1 ? 'it' : 'them'
         ));
 
-        return 0;
+        return static::CODE_SUCCESS;
     }
 }

--- a/src/Propel/Generator/Command/MigrationUpCommand.php
+++ b/src/Propel/Generator/Command/MigrationUpCommand.php
@@ -51,11 +51,11 @@ class MigrationUpCommand extends AbstractCommand
         if ($this->hasInputOption('output-dir', $input)) {
             $configOptions['propel']['paths']['migrationDir'] = $input->getOption('output-dir');
         }
-        
+
         if ($this->hasInputOption('migration-table', $input)) {
             $configOptions['propel']['migrations']['tableName'] = $input->getOption('migration-table');
         }
-        
+
         $generatorConfig = $this->getGeneratorConfig($configOptions, $input);
 
         $this->createDirectory($generatorConfig->getSection('paths')['migrationDir']);
@@ -82,7 +82,7 @@ class MigrationUpCommand extends AbstractCommand
         if (!$nextMigrationTimestamp) {
             $output->writeln('All migrations were already executed - nothing to migrate.');
 
-            return 1;
+            return static::CODE_ERROR;
         }
 
         if ($input->getOption('fake')) {
@@ -109,7 +109,7 @@ class MigrationUpCommand extends AbstractCommand
                     $output->writeln('<error>preUp() returned false. Continue migration.</error>');
                 } else {
                     $output->writeln('<error>preUp() returned false. Aborting migration.</error>');
-                    return 1;
+                    return static::CODE_ERROR;
                 }
             }
         }
@@ -191,6 +191,6 @@ class MigrationUpCommand extends AbstractCommand
             $output->writeln('Migration complete. No further migration to execute.');
         }
 
-        return 0;
+        return static::CODE_SUCCESS;
     }
 }

--- a/src/Propel/Generator/Command/ModelBuildCommand.php
+++ b/src/Propel/Generator/Command/ModelBuildCommand.php
@@ -132,6 +132,6 @@ class ModelBuildCommand extends AbstractCommand
 
         $manager->build();
 
-        return 0;
+        return static::CODE_SUCCESS;
     }
 }

--- a/src/Propel/Generator/Command/SqlBuildCommand.php
+++ b/src/Propel/Generator/Command/SqlBuildCommand.php
@@ -111,6 +111,6 @@ class SqlBuildCommand extends AbstractCommand
 
         $manager->buildSql();
 
-        return 0;
+        return static::CODE_SUCCESS;
     }
 }

--- a/src/Propel/Generator/Command/SqlInsertCommand.php
+++ b/src/Propel/Generator/Command/SqlInsertCommand.php
@@ -26,7 +26,7 @@ class SqlInsertCommand extends AbstractCommand
     protected function configure()
     {
         parent::configure();
-        
+
         $this
             ->addOption('sql-dir', null, InputOption::VALUE_REQUIRED, 'The SQL files directory')
             ->addOption('connection', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Connection to use. Example: \'bookstore=mysql:host=127.0.0.1;dbname=test;user=root;password=foobar\' where "bookstore" is your propel database name (used in your schema.xml)')
@@ -71,6 +71,6 @@ class SqlInsertCommand extends AbstractCommand
 
         $manager->insertSql();
 
-        return 0;
+        return static::CODE_SUCCESS;
     }
 }

--- a/src/Propel/Generator/Command/TestPrepareCommand.php
+++ b/src/Propel/Generator/Command/TestPrepareCommand.php
@@ -95,11 +95,15 @@ class TestPrepareCommand extends AbstractCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $result = static::CODE_SUCCESS;
         foreach ($this->fixtures as $fixturesDir => $connections) {
-            $this->buildFixtures(sprintf('%s/%s', self::FIXTURES_DIR, $fixturesDir), $connections, $input, $output);
+            $run = $this->buildFixtures(sprintf('%s/%s', self::FIXTURES_DIR, $fixturesDir), $connections, $input, $output);
+            if ($run !== static::CODE_SUCCESS) {
+                $result = $run;
+            }
         }
 
-        return 0;
+        return $result;
     }
 
     /**
@@ -107,13 +111,14 @@ class TestPrepareCommand extends AbstractCommand
      * @param $connections
      * @param InputInterface  $input
      * @param OutputInterface $output
+     * @return int Exit code
      */
-    protected function buildFixtures($fixturesDir, $connections, InputInterface $input, OutputInterface $output)
+    protected function buildFixtures($fixturesDir, $connections, InputInterface $input, OutputInterface $output): int
     {
         if (!file_exists($this->root . '/' . $fixturesDir)) {
             $output->writeln(sprintf('<error>Directory "%s" not found.</error>', $fixturesDir));
 
-            return 1;
+            return static::CODE_ERROR;
         }
 
         $output->writeln(sprintf('Building fixtures in <info>%-40s</info> ' . ($input->getOption('exclude-database') ? '(exclude-database)' : ''), $fixturesDir));
@@ -158,7 +163,7 @@ class TestPrepareCommand extends AbstractCommand
         }
 
         if ($input->getOption('exclude-database')) {
-            return 0;
+            return static::CODE_SUCCESS;
         }
 
         if (0 < count($this->getSchemas('.'))) {
@@ -201,5 +206,7 @@ class TestPrepareCommand extends AbstractCommand
         }
 
         chdir($this->root);
+
+        return static::CODE_SUCCESS;
     }
 }


### PR DESCRIPTION
Start to resolve 
- https://github.com/propelorm/Propel2/issues/1574
- https://github.com/propelorm/Propel2/issues/1573
- https://github.com/propelorm/Propel2/issues/1578

by
- adding Symfony5
- dropping EOL versions to simplify the very broad dependency spectrum
- using proper semver on this low level

Now only PHPUnit is outdated and needs in the future to go to 8+

This is what we should be supporting moving forward
Now we just need to start fixing the issues showing up.

EDIT: I will rebase mine on top of https://github.com/propelorm/Propel2/pull/1595 now.