### PR TITLE
Add PHPStan level 1 check with baseline until we can remove symf2.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+; This file is for unifying the coding style for different editors and IDEs.
+; More information at https://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.bat]
+end_of_line = crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,32 @@
+# Define the line ending behavior of the different file extensions
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text text=auto eol=lf
+
+# Declare files that will always have CRLF line endings on checkout.
+*.bat eol=crlf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary
+*.gif binary
+*.jpeg binary
+*.zip binary
+*.phar binary
+*.ttf binary
+*.woff binary
+*.eot binary
+*.ico binary
+*.mo binary
+*.pdf binary
+*.xcf binary
+*.eps binary
+*.psd binary
+*.doc binary
+
+# Remove files for archives generated using `git archive`
+phpstan.neon export-ignore
+phpstan-baseline.neon export-ignore linguist-generated=true
+.travis.yml export-ignore
+.editorconfig export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -747,7 +747,6 @@ jobs:
 
   allow_failures:
     - php: nightly
-    - name: "Checks"
 
   fast_finish: true
 

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     ],
     "scripts": {
         "stan": [
-            "vendor/bin/phpstan analyze -c tests/phpstan.neon"
+            "vendor/bin/phpstan analyze"
         ]
     },
     "extra": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,222 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Variable \\$paramsDoc might not be defined\\.$#"
+			count: 4
+			path: src/Propel/Generator/Behavior/Sortable/SortableBehaviorQueryBuilderModifier.php
+
+		-
+			message: "#^Variable \\$methodSignature might not be defined\\.$#"
+			count: 10
+			path: src/Propel/Generator/Behavior/Sortable/SortableBehaviorQueryBuilderModifier.php
+
+		-
+			message: "#^Variable \\$buildScope might not be defined\\.$#"
+			count: 1
+			path: src/Propel/Generator/Behavior/Sortable/SortableBehaviorQueryBuilderModifier.php
+
+		-
+			message: "#^Variable \\$col might not be defined\\.$#"
+			count: 1
+			path: src/Propel/Generator/Behavior/Versionable/VersionableBehaviorObjectBuilderModifier.php
+
+		-
+			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addTemporalAccessor\\(\\)\\.$#"
+			count: 1
+			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
+
+		-
+			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addObjectAccessor\\(\\)\\.$#"
+			count: 1
+			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
+
+		-
+			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addArrayAccessor\\(\\)\\.$#"
+			count: 1
+			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
+
+		-
+			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addHasArrayElement\\(\\)\\.$#"
+			count: 2
+			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
+
+		-
+			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addJsonAccessor\\(\\)\\.$#"
+			count: 1
+			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
+
+		-
+			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addEnumAccessor\\(\\)\\.$#"
+			count: 1
+			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
+
+		-
+			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addSetAccessor\\(\\)\\.$#"
+			count: 1
+			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
+
+		-
+			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addDefaultAccessor\\(\\)\\.$#"
+			count: 2
+			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
+
+		-
+			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addBooleanAccessor\\(\\)\\.$#"
+			count: 1
+			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
+
+		-
+			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addLazyLoader\\(\\)\\.$#"
+			count: 1
+			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
+
+		-
+			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addObjectMutator\\(\\)\\.$#"
+			count: 1
+			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
+
+		-
+			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addLobMutator\\(\\)\\.$#"
+			count: 1
+			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
+
+		-
+			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addTemporalMutator\\(\\)\\.$#"
+			count: 1
+			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
+
+		-
+			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addArrayMutator\\(\\)\\.$#"
+			count: 1
+			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
+
+		-
+			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addAddArrayElement\\(\\)\\.$#"
+			count: 2
+			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
+
+		-
+			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addRemoveArrayElement\\(\\)\\.$#"
+			count: 2
+			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
+
+		-
+			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addJsonMutator\\(\\)\\.$#"
+			count: 1
+			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
+
+		-
+			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addEnumMutator\\(\\)\\.$#"
+			count: 1
+			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
+
+		-
+			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addSetMutator\\(\\)\\.$#"
+			count: 1
+			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
+
+		-
+			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addBooleanMutator\\(\\)\\.$#"
+			count: 1
+			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
+
+		-
+			message: "#^Call to an undefined method Propel\\\\Generator\\\\Builder\\\\Om\\\\AbstractObjectBuilder\\:\\:addDefaultMutator\\(\\)\\.$#"
+			count: 1
+			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
+
+		-
+			message: "#^Variable \\$mysqlInvalidDateString might not be defined\\.$#"
+			count: 2
+			path: src/Propel/Generator/Builder/Om/ObjectBuilder.php
+
+		-
+			message: "#^Variable \\$crossFK might not be defined\\.$#"
+			count: 1
+			path: src/Propel/Generator/Builder/Om/ObjectBuilder.php
+
+		-
+			message: "#^Parameter \\$definition of method Propel\\\\Generator\\\\Command\\\\Console\\\\Input\\\\ArrayInput\\:\\:__construct\\(\\) has invalid typehint type Propel\\\\Generator\\\\Command\\\\Console\\\\Input\\\\InputDefinition\\.$#"
+			count: 1
+			path: src/Propel/Generator/Command/Console/Input/ArrayInput.php
+
+		-
+			message: "#^Variable \\$migration might not be defined\\.$#"
+			count: 1
+			path: src/Propel/Generator/Command/MigrationMigrateCommand.php
+
+		-
+			message: "#^Variable \\$countValidTimestamps might not be defined\\.$#"
+			count: 1
+			path: src/Propel/Generator/Command/MigrationStatusCommand.php
+
+		-
+			message: "#^Variable \\$defaultDatasource might not be defined\\.$#"
+			count: 1
+			path: src/Propel/Generator/Config/ArrayToPhpConverter.php
+
+		-
+			message: "#^Call to an undefined method Propel\\\\Generator\\\\Manager\\\\AbstractManager\\:\\:getLocation\\(\\)\\.$#"
+			count: 1
+			path: src/Propel/Generator/Manager/AbstractManager.php
+
+		-
+			message: "#^Call to an undefined method Propel\\\\Generator\\\\Model\\\\ForeignKey\\:\\:getLocalForeignMapping\\(\\)\\.$#"
+			count: 1
+			path: src/Propel/Generator/Model/ForeignKey.php
+
+		-
+			message: "#^Variable \\$strDefault might not be defined\\.$#"
+			count: 1
+			path: src/Propel/Generator/Reverse/PgsqlSchemaParser.php
+
+		-
+			message: "#^Variable \\$fk might not be defined\\.$#"
+			count: 1
+			path: src/Propel/Generator/Reverse/SqliteSchemaParser.php
+
+		-
+			message: "#^Access to an undefined property Propel\\\\Runtime\\\\ActiveQuery\\\\BaseModelCriteria\\:\\:\\$useAliasInSQL\\.$#"
+			count: 1
+			path: src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
+
+		-
+			message: "#^Call to an undefined static method Propel\\\\Runtime\\\\ActiveQuery\\\\BaseModelCriteria\\:\\:getShortName\\(\\)\\.$#"
+			count: 1
+			path: src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
+
+		-
+			message: "#^Call to an undefined method Propel\\\\Runtime\\\\ActiveQuery\\\\BaseModelCriteria\\:\\:find\\(\\)\\.$#"
+			count: 1
+			path: src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
+
+		-
+			message: "#^Access to an undefined property Propel\\\\Runtime\\\\ActiveQuery\\\\Criteria\\:\\:\\$currentAlias\\.$#"
+			count: 1
+			path: src/Propel/Runtime/ActiveQuery/Criteria.php
+
+		-
+			message: "#^Access to an undefined property Propel\\\\Runtime\\\\ActiveQuery\\\\Criteria\\:\\:\\$foundMatch\\.$#"
+			count: 1
+			path: src/Propel/Runtime/ActiveQuery/Criteria.php
+
+		-
+			message: "#^Variable \\$sql might not be defined\\.$#"
+			count: 3
+			path: src/Propel/Runtime/ActiveQuery/Criteria.php
+
+		-
+			message: "#^Variable \\$sql might not be defined\\.$#"
+			count: 1
+			path: src/Propel/Runtime/ActiveQuery/ModelCriteria.php
+
+		-
+			message: "#^Variable \\$dbMap might not be defined\\.$#"
+			count: 1
+			path: src/Propel/Runtime/Adapter/Pdo/PgsqlAdapter.php
+
+		-
+			message: "#^Variable \\$params might not be defined\\.$#"
+			count: 1
+			path: src/Propel/Runtime/Adapter/Pdo/PgsqlAdapter.php
+

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,5 @@
+includes:
+    - phpstan-baseline.neon
 parameters:
     level: 1
     paths:
@@ -12,5 +14,9 @@ parameters:
         - '%rootDir%/../../../src/Propel/Generator/Behavior/Delegate/templates/*'
         - '%rootDir%/../../../src/Propel/Generator/Behavior/Sortable/templates/*'
         - '%rootDir%/../../../src/Propel/Generator/Behavior/NestedSet/templates/*'
+        - '%rootDir%/../../../src/Propel/Runtime/Connection/PdoConnection.php'
+        - '%rootDir%/../../../src/Propel/Generator/Command/Helper/ConsoleHelper.php'
+        - '%rootDir%/../../../src/Propel/Generator/Command/InitCommand.php'
     ignoreErrors:
         - '#Call to an undefined method .+Collection::.+Array\(\)#'
+        - '#Class .+TreeBuilder constructor invoked with 0 parameters, 1-3 required#'

--- a/src/Propel/Generator/Behavior/Versionable/VersionableBehaviorObjectBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/Versionable/VersionableBehaviorObjectBuilderModifier.php
@@ -19,43 +19,84 @@ use Propel\Generator\Model\Column;
  */
 class VersionableBehaviorObjectBuilderModifier
 {
+    /**
+     * @var \Propel\Generator\Model\Behavior
+     */
     protected $behavior;
+    /**
+     * @var \Propel\Generator\Model\Table
+     */
     protected $table;
+    /**
+     * @var \Propel\Generator\Builder\Om\AbstractOMBuilder
+     */
     protected $builder;
+    /**
+     * @var string
+     */
     protected $objectClassName;
     protected $queryClassName;
 
+    /**
+     * @param \Propel\Generator\Model\Behavior $behavior
+     */
     public function __construct($behavior)
     {
         $this->behavior = $behavior;
         $this->table = $behavior->getTable();
     }
 
+    /**
+     * @param string $key
+     *
+     * @return array
+     */
     protected function getParameter($key)
     {
         return $this->behavior->getParameter($key);
     }
 
+    /**
+     * @param string $name
+     *
+     * @return string
+     */
     protected function getColumnAttribute($name = 'version_column')
     {
         return strtolower($this->behavior->getColumnForParameter($name)->getName());
     }
 
+    /**
+     * @param string $name
+     *
+     * @return string
+     */
     protected function getColumnPhpName($name = 'version_column')
     {
         return $this->behavior->getColumnForParameter($name)->getPhpName();
     }
 
+    /**
+     * @return string
+     */
     protected function getVersionQueryClassName()
     {
         return $this->builder->getClassNameFromBuilder($this->builder->getNewStubQueryBuilder($this->behavior->getVersionTable()));
     }
 
+    /**
+     * @return string
+     */
     protected function getActiveRecordClassName()
     {
         return $this->builder->getObjectClassName();
     }
 
+    /**
+     * @param \Propel\Generator\Builder\Om\AbstractOMBuilder $builder
+     *
+     * @return void
+     */
     protected function setBuilder($builder)
     {
         $this->builder         = $builder;
@@ -83,6 +124,11 @@ class VersionableBehaviorObjectBuilderModifier
         return 'set' . $this->getColumnPhpName($name);
     }
 
+    /**
+     * @param \Propel\Generator\Builder\Om\AbstractOMBuilder $builder
+     *
+     * @return string
+     */
     public function preSave($builder)
     {
         $script = "if (\$this->isVersioningNecessary()) {
@@ -101,6 +147,11 @@ class VersionableBehaviorObjectBuilderModifier
         return $script;
     }
 
+    /**
+     * @param \Propel\Generator\Builder\Om\AbstractOMBuilder $builder
+     *
+     * @return string
+     */
     public function postSave($builder)
     {
         return "if (isset(\$createVersion)) {
@@ -108,6 +159,11 @@ class VersionableBehaviorObjectBuilderModifier
 }";
     }
 
+    /**
+     * @param \Propel\Generator\Builder\Om\AbstractOMBuilder $builder
+     *
+     * @return string
+     */
     public function postDelete($builder)
     {
         $this->builder = $builder;
@@ -121,6 +177,11 @@ class VersionableBehaviorObjectBuilderModifier
         }
     }
 
+    /**
+     * @param \Propel\Generator\Builder\Om\AbstractOMBuilder $builder
+     *
+     * @return string
+     */
     public function objectAttributes($builder)
     {
         $script = '';
@@ -130,6 +191,11 @@ class VersionableBehaviorObjectBuilderModifier
         return $script;
     }
 
+    /**
+     * @param string $script
+     *
+     * @return void
+     */
     protected function addEnforceVersionAttribute(&$script)
     {
         $script .= "
@@ -141,6 +207,11 @@ protected \$enforceVersion = false;
         ";
     }
 
+    /**
+     * @param \Propel\Generator\Builder\Om\AbstractOMBuilder $builder
+     *
+     * @return string
+     */
     public function objectMethods($builder)
     {
         $this->setBuilder($builder);
@@ -166,6 +237,11 @@ protected \$enforceVersion = false;
         return $script;
     }
 
+    /**
+     * @param string $script
+     *
+     * @return void
+     */
     protected function addVersionSetter(&$script)
     {
         $script .= "
@@ -182,6 +258,11 @@ public function setVersion(\$v)
 ";
     }
 
+    /**
+     * @param string $script
+     *
+     * @return void
+     */
     protected function addVersionGetter(&$script)
     {
         $script .= "
@@ -197,6 +278,11 @@ public function getVersion()
 ";
     }
 
+    /**
+     * @param string $script
+     *
+     * @return void
+     */
     protected function addEnforceVersioning(&$script)
     {
         $objectClass = $this->builder->getStubObjectBuilder()->getClassname();
@@ -215,6 +301,11 @@ public function enforceVersioning()
         ";
     }
 
+    /**
+     * @param string $script
+     *
+     * @return void
+     */
     protected function addIsVersioningNecessary(&$script)
     {
         $queryClassName = $this->builder->getQueryClassName();
@@ -298,6 +389,11 @@ public function isVersioningNecessary(ConnectionInterface \$con = null)
 ";
     }
 
+    /**
+     * @param string $script
+     *
+     * @return void
+     */
     protected function addAddVersion(&$script)
     {
         $versionTable       = $this->behavior->getVersionTable();
@@ -366,6 +462,11 @@ public function addVersion(ConnectionInterface \$con = null)
 ";
     }
 
+    /**
+     * @param string $script
+     *
+     * @return void
+     */
     protected function addToVersion(&$script)
     {
         $ARclassName = $this->getActiveRecordClassName();
@@ -391,6 +492,11 @@ public function toVersion(\$versionNumber, ConnectionInterface \$con = null)
 ";
     }
 
+    /**
+     * @param string $script
+     *
+     * @return void
+     */
     protected function addPopulateFromVersion(&$script)
     {
         $ARclassName = $this->getActiveRecordClassName();
@@ -414,7 +520,8 @@ public function populateFromVersion(\$version, \$con = null, &\$loadedObjects = 
         $script .= "
     \$loadedObjects['{$ARclassName}'][\$version->get{$primaryKeyName}()][\$version->get{$versionColumnName}()] = \$this;";
 
-        foreach ($this->table->getColumns() as $col) {
+        $columns = $this->table->getColumns();
+        foreach ($columns as $col) {
             $script .= "
     \$this->set" . $col->getPhpName() . "(\$version->get" . $col->getPhpName() . "());";
         }
@@ -492,6 +599,11 @@ public function populateFromVersion(\$version, \$con = null, &\$loadedObjects = 
 ";
     }
 
+    /**
+     * @param string $script
+     *
+     * @return void
+     */
     protected function addGetLastVersionNumber(&$script)
     {
         $script .= "
@@ -517,6 +629,11 @@ public function getLastVersionNumber(ConnectionInterface \$con = null)
 ";
     }
 
+    /**
+     * @param string $script
+     *
+     * @return void
+     */
     protected function addIsLastVersion(&$script)
     {
         $script .= "
@@ -534,6 +651,11 @@ public function isLastVersion(ConnectionInterface \$con = null)
 ";
     }
 
+    /**
+     * @param string $script
+     *
+     * @return void
+     */
     protected function addGetOneVersion(&$script)
     {
         $versionARClassName = $this->builder->getClassNameFromBuilder($this->builder->getNewStubObjectBuilder($this->behavior->getVersionTable()));
@@ -556,6 +678,11 @@ public function getOneVersion(\$versionNumber, ConnectionInterface \$con = null)
 ";
     }
 
+    /**
+     * @param string $script
+     *
+     * @return void
+     */
     protected function addGetAllVersions(&$script)
     {
         $versionTable = $this->behavior->getVersionTable();
@@ -583,6 +710,11 @@ public function getAllVersions(ConnectionInterface \$con = null)
 ";
     }
 
+    /**
+     * @param string $script
+     *
+     * @return void
+     */
     protected function addComputeDiff(&$script)
     {
         $script .= "
@@ -649,6 +781,11 @@ protected function computeDiff(\$fromVersion, \$toVersion, \$keys = 'columns', \
 ";
     }
 
+    /**
+     * @param string $script
+     *
+     * @return void
+     */
     protected function addCompareVersion(&$script)
     {
         $script .= "
@@ -679,6 +816,11 @@ public function compareVersion(\$versionNumber, \$keys = 'columns', ConnectionIn
 ";
     }
 
+    /**
+     * @param string $script
+     *
+     * @return void
+     */
     protected function addCompareVersions(&$script)
     {
         $script .= "
@@ -710,6 +852,11 @@ public function compareVersions(\$fromVersionNumber, \$toVersionNumber, \$keys =
 ";
     }
 
+    /**
+     * @param string $script
+     *
+     * @return void
+     */
     protected function addGetLastVersions(&$script)
     {
         $plural = true;

--- a/src/Propel/Generator/Behavior/Versionable/VersionableBehaviorQueryBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/Versionable/VersionableBehaviorQueryBuilderModifier.php
@@ -17,22 +17,39 @@ namespace Propel\Generator\Behavior\Versionable;
  */
 class VersionableBehaviorQueryBuilderModifier
 {
+    /**
+     * @var \Propel\Generator\Model\Behavior
+     */
     protected $behavior;
-
+    /**
+     * @var \Propel\Generator\Model\Table
+     */
     protected $table;
-
+    /**
+     * @var \Propel\Generator\Builder\Om\AbstractOMBuilder
+     */
     protected $builder;
-
+    /**
+     * @var string
+     */
     protected $objectClassName;
-
+    /**
+     * @var string
+     */
     protected $queryClassName;
 
+    /**
+     * @param \Propel\Generator\Model\Behavior $behavior
+     */
     public function __construct($behavior)
     {
         $this->behavior = $behavior;
         $this->table    = $behavior->getTable();
     }
 
+    /**
+     * @return string
+     */
     public function queryAttributes()
     {
         return "
@@ -43,26 +60,49 @@ static \$isVersioningEnabled = true;
 ";
     }
 
+    /**
+     * @param string $key
+     *
+     * @return array
+     */
     protected function getParameter($key)
     {
         return $this->behavior->getParameter($key);
     }
 
+    /**
+     * @param string $name
+     *
+     * @return string
+     */
     protected function getColumnAttribute($name = 'version_column')
     {
         return strtolower($this->behavior->getColumnForParameter($name)->getName());
     }
 
+    /**
+     * @param string $name
+     *
+     * @return string
+     */
     protected function getColumnPhpName($name = 'version_column')
     {
         return $this->behavior->getColumnForParameter($name)->getPhpName();
     }
 
+    /**
+     * @return string
+     */
     protected function getVersionQueryClassName()
     {
         return $this->builder->getClassNameFromBuilder($this->builder->getNewStubQueryBuilder($this->behavior->getVersionTable()));
     }
 
+    /**
+     * @param \Propel\Generator\Builder\Om\AbstractOMBuilder $builder
+     *
+     * @return void
+     */
     protected function setBuilder($builder)
     {
         $this->builder = $builder;
@@ -90,6 +130,11 @@ static \$isVersioningEnabled = true;
         return 'set' . $this->getColumnPhpName($name);
     }
 
+    /**
+     * @param \Propel\Generator\Builder\Om\AbstractOMBuilder $builder
+     *
+     * @return string
+     */
     public function queryMethods($builder)
     {
         $this->setBuilder($builder);
@@ -106,6 +151,11 @@ static \$isVersioningEnabled = true;
         return $script;
     }
 
+    /**
+     * @param string $script
+     *
+     * @return void
+     */
     protected function addFilterByVersion(&$script)
     {
         $script .= "
@@ -123,6 +173,11 @@ public function filterByVersion(\$version = null, \$comparison = null)
 ";
     }
 
+    /**
+     * @param string $script
+     *
+     * @return void
+     */
     protected function addOrderByVersion(&$script)
     {
         $script .= "
@@ -139,6 +194,9 @@ public function orderByVersion(\$order = Criteria::ASC)
 ";
     }
 
+    /**
+     * @return string
+     */
     protected function addIsVersioningEnabled()
     {
         return "
@@ -154,6 +212,9 @@ static public function isVersioningEnabled()
 ";
     }
 
+    /**
+     * @return string
+     */
     protected function addEnableVersioning()
     {
         return "
@@ -167,6 +228,9 @@ static public function enableVersioning()
 ";
     }
 
+    /**
+     * @return string
+     */
     protected function addDisableVersioning()
     {
         return "


### PR DESCRIPTION
This is now removed from allow_failure list and part of normal travis run.

I also added docblocks to allow IDE discovery (auto complete / typehinting) as well as PHPStan to check those.