### PR TITLE
Bugfix/phpstan lev3

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -656,6 +656,11 @@ parameters:
 			path: src/Propel/Runtime/ActiveQuery/Criterion/LikeCriterion.php
 
 		-
+			message: "#^Method Propel\\\\Runtime\\\\ActiveQuery\\\\ModelCriteria\\:\\:filterBy\\(\\) should return Propel\\\\Runtime\\\\ActiveQuery\\\\ModelCriteria but returns Propel\\\\Runtime\\\\ActiveQuery\\\\Criteria\\.$#"
+			count: 1
+			path: src/Propel/Runtime/ActiveQuery/ModelCriteria.php
+
+		-
 			message: "#^Call to an undefined method Propel\\\\Runtime\\\\ActiveQuery\\\\Join\\:\\:getTableMap\\(\\)\\.$#"
 			count: 7
 			path: src/Propel/Runtime/ActiveQuery/ModelCriteria.php
@@ -701,7 +706,17 @@ parameters:
 			path: src/Propel/Runtime/ActiveQuery/ModelCriteria.php
 
 		-
+			message: "#^Parameter \\#1 \\$values \\(array\\) of method Propel\\\\Runtime\\\\ActiveQuery\\\\ModelCriteria\\:\\:doUpdate\\(\\) should be compatible with parameter \\$updateValues \\(Propel\\\\Runtime\\\\ActiveQuery\\\\Criteria\\) of method Propel\\\\Runtime\\\\ActiveQuery\\\\Criteria\\:\\:doUpdate\\(\\)$#"
+			count: 1
+			path: src/Propel/Runtime/ActiveQuery/ModelCriteria.php
+
+		-
 			message: "#^Call to an undefined method Propel\\\\Runtime\\\\ActiveQuery\\\\Criteria\\:\\:getTableMap\\(\\)\\.$#"
+			count: 1
+			path: src/Propel/Runtime/ActiveQuery/ModelCriteria.php
+
+		-
+			message: "#^Method Propel\\\\Runtime\\\\ActiveQuery\\\\ModelCriteria\\:\\:addUsingAlias\\(\\) should return Propel\\\\Runtime\\\\ActiveQuery\\\\ModelCriteria but returns Propel\\\\Runtime\\\\ActiveQuery\\\\Criteria\\.$#"
 			count: 1
 			path: src/Propel/Runtime/ActiveQuery/ModelCriteria.php
 
@@ -806,9 +821,24 @@ parameters:
 			path: src/Propel/Runtime/Collection/OnDemandCollection.php
 
 		-
+			message: "#^Return type \\(Propel\\\\Runtime\\\\Collection\\\\OnDemandIterator\\) of method Propel\\\\Runtime\\\\Collection\\\\OnDemandCollection\\:\\:getIterator\\(\\) should be compatible with return type \\(Propel\\\\Runtime\\\\Collection\\\\CollectionIterator\\) of method Propel\\\\Runtime\\\\Collection\\\\Collection\\:\\:getIterator\\(\\)$#"
+			count: 1
+			path: src/Propel/Runtime/Collection/OnDemandCollection.php
+
+		-
+			message: "#^Method Propel\\\\Runtime\\\\Collection\\\\OnDemandCollection\\:\\:getIterator\\(\\) should return Propel\\\\Runtime\\\\Collection\\\\OnDemandIterator but returns Iterator\\.$#"
+			count: 1
+			path: src/Propel/Runtime/Collection/OnDemandCollection.php
+
+		-
 			message: "#^Call to an undefined method Propel\\\\Runtime\\\\Connection\\\\ConnectionWrapper\\:\\:getProfiler\\(\\)\\.$#"
 			count: 3
 			path: src/Propel/Runtime/Connection/ProfilerStatementWrapper.php
+
+		-
+			message: "#^Return type \\(array\\) of method Propel\\\\Runtime\\\\Formatter\\\\ArrayFormatter\\:\\:formatRecord\\(\\) should be compatible with return type \\(Propel\\\\Runtime\\\\ActiveRecord\\\\ActiveRecordInterface\\) of method Propel\\\\Runtime\\\\Formatter\\\\AbstractFormatter\\:\\:formatRecord\\(\\)$#"
+			count: 1
+			path: src/Propel/Runtime/Formatter/ArrayFormatter.php
 
 		-
 			message: "#^Call to an undefined method Propel\\\\Runtime\\\\ActiveRecord\\\\ActiveRecordInterface\\:\\:toArray\\(\\)\\.$#"
@@ -834,6 +864,11 @@ parameters:
 			message: "#^Call to an undefined method Propel\\\\Runtime\\\\ActiveRecord\\\\ActiveRecordInterface\\:\\:setVirtualColumn\\(\\)\\.$#"
 			count: 1
 			path: src/Propel/Runtime/Formatter/OnDemandFormatter.php
+
+		-
+			message: "#^Return type \\(array\\) of method Propel\\\\Runtime\\\\Formatter\\\\SimpleArrayFormatter\\:\\:formatRecord\\(\\) should be compatible with return type \\(Propel\\\\Runtime\\\\ActiveRecord\\\\ActiveRecordInterface\\) of method Propel\\\\Runtime\\\\Formatter\\\\AbstractFormatter\\:\\:formatRecord\\(\\)$#"
+			count: 1
+			path: src/Propel/Runtime/Formatter/SimpleArrayFormatter.php
 
 		-
 			message: "#^Call to an undefined method Propel\\\\Runtime\\\\ActiveRecord\\\\ActiveRecordInterface\\:\\:toArray\\(\\)\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -466,11 +466,6 @@ parameters:
 			path: src/Propel/Generator/Manager/SqlManager.php
 
 		-
-			message: "#^Call to an undefined method Propel\\\\Generator\\\\Model\\\\ForeignKey\\:\\:getLocalForeignMapping\\(\\)\\.$#"
-			count: 1
-			path: src/Propel/Generator/Model/ForeignKey.php
-
-		-
 			message: "#^Call to an undefined method Propel\\\\Generator\\\\Model\\\\Behavior\\:\\:isEarly\\(\\)\\.$#"
 			count: 1
 			path: src/Propel/Generator/Model/Table.php
@@ -649,11 +644,6 @@ parameters:
 			message: "#^Variable \\$sql might not be defined\\.$#"
 			count: 3
 			path: src/Propel/Runtime/ActiveQuery/Criteria.php
-
-		-
-			message: "#^Call to private method getClauses\\(\\) of class Propel\\\\Runtime\\\\ActiveQuery\\\\Criterion\\\\AbstractCriterion\\.$#"
-			count: 2
-			path: src/Propel/Runtime/ActiveQuery/Criterion/AbstractModelCriterion.php
 
 		-
 			message: "#^Call to an undefined method Propel\\\\Runtime\\\\Adapter\\\\AdapterInterface\\:\\:ignoreCase\\(\\)\\.$#"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,7 @@
 includes:
     - phpstan-baseline.neon
 parameters:
-    level: 2
+    level: 3
     paths:
         - '%rootDir%/../../../src/'
     excludes_analyse:

--- a/src/Propel/Common/Config/ConfigurationManager.php
+++ b/src/Propel/Common/Config/ConfigurationManager.php
@@ -62,7 +62,7 @@ class ConfigurationManager
      * It ca be useful to get, in example, only 'generator' values.
      *
      * @param  string $section the section to be returned
-     * @return array
+     * @return array|null
      */
     public function getSection($section)
     {

--- a/src/Propel/Common/Util/SetColumnConverter.php
+++ b/src/Propel/Common/Util/SetColumnConverter.php
@@ -24,14 +24,13 @@ class SetColumnConverter
      *
      * @param mixed $val
      * @param array $valueSet
-     * @return int|null
+     * @return string|int
      *
      * @throws SetColumnConverterException
      */
     public static function convertToInt($val, array $valueSet)
     {
         if ($val === null) {
-
             return 0;
         }
         if (!is_array($val)) {
@@ -44,16 +43,16 @@ class SetColumnConverter
             }
             $bitValueArr[array_search($value, $valueSet)] = '1';
         }
-        
+
         return base_convert(implode(array_reverse($bitValueArr)), 2, 10);
     }
 
     /**
-     * Converts set column integer value to corresponding array. 
-     * 
+     * Converts set column integer value to corresponding array.
+     *
      * @param mixed $val
      * @param array $valueSet
-     * 
+     *
      * @return array
      *
      * @throws SetColumnConverterException
@@ -61,7 +60,7 @@ class SetColumnConverter
     public static function convertIntToArray($val, array $valueSet)
     {
         if ($val === null) {
-            
+
             return [];
         }
         $bitValueArr = array_reverse(str_split(base_convert($val, 10, 2)));

--- a/src/Propel/Generator/Builder/DataModelBuilder.php
+++ b/src/Propel/Generator/Builder/DataModelBuilder.php
@@ -59,43 +59,43 @@ abstract class DataModelBuilder
 
     /**
      * Object builder class for current table.
-     * @var DataModelBuilder
+     * @var ObjectBuilder
      */
     private $objectBuilder;
 
     /**
      * Stub Object builder class for current table.
-     * @var DataModelBuilder
+     * @var ObjectBuilder
      */
     private $stubObjectBuilder;
 
     /**
      * Query builder class for current table.
-     * @var DataModelBuilder
+     * @var ObjectBuilder
      */
     private $queryBuilder;
 
     /**
      * Stub Query builder class for current table.
-     * @var DataModelBuilder
+     * @var ObjectBuilder
      */
     private $stubQueryBuilder;
 
     /**
      * TableMap builder class for current table.
-     * @var DataModelBuilder
+     * @var TableMapBuilder
      */
     protected $tablemapBuilder;
 
     /**
      * Stub Interface builder class for current table.
-     * @var DataModelBuilder
+     * @var ObjectBuilder
      */
     private $interfaceBuilder;
 
     /**
      * Stub child object for current table.
-     * @var DataModelBuilder
+     * @var MultiExtendObjectBuilder
      */
     private $multiExtendObjectBuilder;
 
@@ -140,7 +140,9 @@ abstract class DataModelBuilder
     public function getObjectBuilder()
     {
         if (!isset($this->objectBuilder)) {
-            $this->objectBuilder = $this->getGeneratorConfig()->getConfiguredBuilder($this->getTable(), 'object');
+            /** @var ObjectBuilder $builder */
+            $builder = $this->getGeneratorConfig()->getConfiguredBuilder($this->getTable(), 'object');
+            $this->objectBuilder = $builder;
         }
 
         return $this->objectBuilder;
@@ -153,7 +155,9 @@ abstract class DataModelBuilder
     public function getStubObjectBuilder()
     {
         if (!isset($this->stubObjectBuilder)) {
-            $this->stubObjectBuilder = $this->getGeneratorConfig()->getConfiguredBuilder($this->getTable(), 'objectstub');
+            /** @var ObjectBuilder $builder */
+            $builder = $this->getGeneratorConfig()->getConfiguredBuilder($this->getTable(), 'objectstub');
+            $this->stubObjectBuilder = $builder;
         }
 
         return $this->stubObjectBuilder;
@@ -166,7 +170,9 @@ abstract class DataModelBuilder
     public function getQueryBuilder()
     {
         if (!isset($this->queryBuilder)) {
-            $this->queryBuilder = $this->getGeneratorConfig()->getConfiguredBuilder($this->getTable(), 'query');
+            /** @var ObjectBuilder $builder */
+            $builder = $this->getGeneratorConfig()->getConfiguredBuilder($this->getTable(), 'query');
+            $this->queryBuilder = $builder;
         }
 
         return $this->queryBuilder;
@@ -179,7 +185,9 @@ abstract class DataModelBuilder
     public function getStubQueryBuilder()
     {
         if (!isset($this->stubQueryBuilder)) {
-            $this->stubQueryBuilder = $this->getGeneratorConfig()->getConfiguredBuilder($this->getTable(), 'querystub');
+            /** @var ObjectBuilder $builder */
+            $builder = $this->getGeneratorConfig()->getConfiguredBuilder($this->getTable(), 'querystub');
+            $this->stubQueryBuilder = $builder;
         }
 
         return $this->stubQueryBuilder;
@@ -192,7 +200,9 @@ abstract class DataModelBuilder
     public function getTableMapBuilder()
     {
         if (!isset($this->tablemapBuilder)) {
-            $this->tablemapBuilder = $this->getGeneratorConfig()->getConfiguredBuilder($this->getTable(), 'tablemap');
+            /** @var TableMapBuilder $builder */
+            $builder = $this->getGeneratorConfig()->getConfiguredBuilder($this->getTable(), 'tablemap');
+            $this->tablemapBuilder = $builder;
         }
 
         return $this->tablemapBuilder;
@@ -205,7 +215,9 @@ abstract class DataModelBuilder
     public function getInterfaceBuilder()
     {
         if (!isset($this->interfaceBuilder)) {
-            $this->interfaceBuilder = $this->getGeneratorConfig()->getConfiguredBuilder($this->getTable(), 'interface');
+            /** @var ObjectBuilder $builder */
+            $builder = $this->getGeneratorConfig()->getConfiguredBuilder($this->getTable(), 'interface');
+            $this->interfaceBuilder = $builder;
         }
 
         return $this->interfaceBuilder;
@@ -218,7 +230,9 @@ abstract class DataModelBuilder
     public function getMultiExtendObjectBuilder()
     {
         if (!isset($this->multiExtendObjectBuilder)) {
-            $this->multiExtendObjectBuilder = $this->getGeneratorConfig()->getConfiguredBuilder($this->getTable(), 'objectmultiextend');
+            /** @var MultiExtendObjectBuilder $builder */
+            $builder = $this->getGeneratorConfig()->getConfiguredBuilder($this->getTable(), 'objectmultiextend');
+            $this->multiExtendObjectBuilder= $builder;
         }
 
         return $this->multiExtendObjectBuilder;
@@ -251,7 +265,10 @@ abstract class DataModelBuilder
      */
     public function getNewObjectBuilder(Table $table)
     {
-        return $this->getGeneratorConfig()->getConfiguredBuilder($table, 'object');
+        /** @var ObjectBuilder $builder */
+        $builder = $this->getGeneratorConfig()->getConfiguredBuilder($table, 'object');
+
+        return $builder;
     }
 
     /**
@@ -265,7 +282,10 @@ abstract class DataModelBuilder
      */
     public function getNewStubObjectBuilder(Table $table)
     {
-        return $this->getGeneratorConfig()->getConfiguredBuilder($table, 'objectstub');
+        /** @var ObjectBuilder $builder */
+        $builder = $this->getGeneratorConfig()->getConfiguredBuilder($table, 'objectstub');
+
+        return $builder;
     }
 
     /**
@@ -279,7 +299,10 @@ abstract class DataModelBuilder
      */
     public function getNewQueryBuilder(Table $table)
     {
-        return $this->getGeneratorConfig()->getConfiguredBuilder($table, 'query');
+        /** @var QueryBuilder $builder */
+        $builder = $this->getGeneratorConfig()->getConfiguredBuilder($table, 'query');
+
+        return $builder;
     }
 
     /**
@@ -293,14 +316,17 @@ abstract class DataModelBuilder
      */
     public function getNewStubQueryBuilder(Table $table)
     {
-        return $this->getGeneratorConfig()->getConfiguredBuilder($table, 'querystub');
+        /** @var QueryBuilder $builder */
+        $builder = $this->getGeneratorConfig()->getConfiguredBuilder($table, 'querystub');
+
+        return $builder;
     }
 
     /**
      * Returns new Query Inheritance builder class for this table.
      *
      * @param  Inheritance   $child
-     * @return ObjectBuilder
+     * @return QueryInheritanceBuilder
      */
     public function getNewQueryInheritanceBuilder(Inheritance $child)
     {
@@ -315,7 +341,7 @@ abstract class DataModelBuilder
      * Returns new stub Query Inheritance builder class for this table.
      *
      * @param  Inheritance   $child
-     * @return ObjectBuilder
+     * @return QueryInheritanceBuilder
      */
     public function getNewStubQueryInheritanceBuilder(Inheritance $child)
     {
@@ -328,11 +354,17 @@ abstract class DataModelBuilder
 
     /**
      * Returns new stub Query Inheritance builder class for this table.
-     * @return TableMapBuilder
+     *
+     * @param \Propel\Generator\Model\Table $table
+     *
+     * @return \Propel\Generator\Builder\Om\TableMapBuilder
      */
     public function getNewTableMapBuilder(Table $table)
     {
-        return $this->getGeneratorConfig()->getConfiguredBuilder($table, 'tablemap');
+        /** @var \Propel\Generator\Builder\Om\TableMapBuilder $builder */
+        $builder = $this->getGeneratorConfig()->getConfiguredBuilder($table, 'tablemap');
+
+        return $builder;
     }
 
     /**
@@ -355,7 +387,7 @@ abstract class DataModelBuilder
      * <code>'database.adapter.mysql.tableType</code>
      *
      * @param  string $name
-     * @return string
+     * @return string|null
      */
     public function getBuildProperty($name)
     {
@@ -363,7 +395,7 @@ abstract class DataModelBuilder
             return $this->getGeneratorConfig()->getConfigProperty($name);
         }
 
-        return null; // just to be explicit
+        return null;
     }
 
     /**

--- a/src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
@@ -174,7 +174,7 @@ abstract class AbstractObjectBuilder extends AbstractOMBuilder
      * @param  string  $hookName The name of the hook as called from one of this class methods, e.g. "preSave"
      * @return boolean
      */
-    public function hasBehaviorModifier($hookName, $modifier = null)
+    public function hasBehaviorModifier($hookName, $modifier = '')
     {
          return parent::hasBehaviorModifier($hookName, 'ObjectBuilderModifier');
     }

--- a/src/Propel/Generator/Builder/Om/ExtensionQueryBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ExtensionQueryBuilder.php
@@ -98,7 +98,7 @@ class ".$this->getUnqualifiedClassName()." extends $baseClassName
      * @param  string  $hookName The name of the hook as called from one of this class methods, e.g. "preSave"
      * @return boolean
      */
-    public function hasBehaviorModifier($hookName, $modifier = null)
+    public function hasBehaviorModifier($hookName, $modifier = '')
     {
          return parent::hasBehaviorModifier($hookName, 'QueryBuilderModifier');
     }

--- a/src/Propel/Generator/Builder/Om/QueryBuilder.php
+++ b/src/Propel/Generator/Builder/Om/QueryBuilder.php
@@ -1714,7 +1714,7 @@ abstract class ".$this->getUnqualifiedClassName()." extends " . $parentClass . "
      * @param  string  $hookName The name of the hook as called from one of this class methods, e.g. "preSave"
      * @return boolean
      */
-    public function hasBehaviorModifier($hookName, $modifier = null)
+    public function hasBehaviorModifier($hookName, $modifier = '')
     {
         return parent::hasBehaviorModifier($hookName, 'QueryBuilderModifier');
     }

--- a/src/Propel/Generator/Builder/Om/TableMapBuilder.php
+++ b/src/Propel/Generator/Builder/Om/TableMapBuilder.php
@@ -733,10 +733,10 @@ class ".$this->getUnqualifiedClassName()." extends TableMap
     /**
      * Checks whether any registered behavior on that table has a modifier for a hook
      * @param  string  $hookName The name of the hook as called from one of this class methods, e.g. "preSave"
-     * @param  null    $modifier
+     * @param  string  $modifier
      * @return boolean
      */
-    public function hasBehaviorModifier($hookName, $modifier = null)
+    public function hasBehaviorModifier($hookName, $modifier = '')
     {
         return parent::hasBehaviorModifier($hookName, 'TableMapBuilderModifier');
     }

--- a/src/Propel/Generator/Builder/Util/SchemaReader.php
+++ b/src/Propel/Generator/Builder/Util/SchemaReader.php
@@ -110,13 +110,13 @@ class SchemaReader
      * populated Schema structure.
      *
      * @param  string $xmlFile The input file to parse.
-     * @return Schema populated by <code>xmlFile</code>.
+     * @return Schema|null populated by <code>xmlFile</code>.
      */
     public function parseFile($xmlFile)
     {
         // we don't want infinite recursion
         if ($this->isAlreadyParsed($xmlFile)) {
-            return;
+            return null;
         }
 
         return $this->parseString(file_get_contents($xmlFile), $xmlFile);
@@ -128,14 +128,15 @@ class SchemaReader
      *
      * @param  string $xmlString The input string to parse.
      * @param  string $xmlFile   The input file name.
-     * @return Schema
+     * @return Schema|null
      */
     public function parseString($xmlString, $xmlFile = null)
     {
         // we don't want infinite recursion
         if ($this->isAlreadyParsed($xmlFile)) {
-            return;
+            return null;
         }
+
         // store current schema file path
         $this->schemasTagsStack[$xmlFile] = [];
         $this->currentXmlFile = $xmlFile;

--- a/src/Propel/Generator/Config/GeneratorConfigInterface.php
+++ b/src/Propel/Generator/Config/GeneratorConfigInterface.php
@@ -43,7 +43,7 @@ interface GeneratorConfigInterface
      *
      * @param  ConnectionInterface $con
      * @param  string              $database
-     * @return PlatformInterface
+     * @return PlatformInterface|null
      *
      * @throws \Propel\Generator\Exception\ClassNotFoundException if the platform class doesn't exists
      * @throws \Propel\Generator\Exception\BuildException         if the class isn't an implementation of PlatformInterface
@@ -56,7 +56,7 @@ interface GeneratorConfigInterface
      * @param  ConnectionInterface $con
      * @param  string              $database
      *
-     * @return SchemaParserInterface
+     * @return SchemaParserInterface|null
      *
      * @throws \Propel\Generator\Exception\ClassNotFoundException if the class doesn't exist
      * @throws \Propel\Generator\Exception\BuildException         if the class isn't an implementation of SchemaParserInterface

--- a/src/Propel/Generator/Model/BehaviorableTrait.php
+++ b/src/Propel/Generator/Model/BehaviorableTrait.php
@@ -115,7 +115,7 @@ trait BehaviorableTrait
      * Get behavior by id
      *
      * @param  string   $id the behavior id
-     * @return Behavior a behavior object or null if the behavior doesn't exist
+     * @return Behavior|null A behavior object or null if the behavior doesn't exist
      */
     public function getBehavior($id)
     {

--- a/src/Propel/Generator/Model/Column.php
+++ b/src/Propel/Generator/Model/Column.php
@@ -1292,7 +1292,7 @@ class Column extends MappingModel
         }
 
         if ($this->isNumericType()) {
-            return (float) $defaultValue->getValue();
+            return (string)$defaultValue->getValue();
         }
 
         if ($this->isTextType() || $this->getDefaultValue()->isExpression()) {

--- a/src/Propel/Generator/Model/Database.php
+++ b/src/Propel/Generator/Model/Database.php
@@ -433,7 +433,7 @@ class Database extends ScopedMappingModel
      *
      * @param  string  $name
      * @param  boolean $caseInsensitive
-     * @return Table
+     * @return Table|null
      */
     public function getTable($name, $caseInsensitive = false)
     {
@@ -469,7 +469,7 @@ class Database extends ScopedMappingModel
      * Returns the table object with the specified PHP name.
      *
      * @param  string $phpName
-     * @return Table
+     * @return Table|null
      */
     public function getTableByPhpName($phpName)
     {
@@ -477,7 +477,7 @@ class Database extends ScopedMappingModel
             return $this->tablesByPhpName[$phpName];
         }
 
-        return null; // just to be explicit
+        return null;
     }
 
     /**
@@ -708,7 +708,7 @@ class Database extends ScopedMappingModel
      * Returns the already configured domain object by its name.
      *
      * @param  string $name
-     * @return Domain
+     * @return Domain|null
      */
     public function getDomain($name)
     {

--- a/src/Propel/Generator/Model/ForeignKey.php
+++ b/src/Propel/Generator/Model/ForeignKey.php
@@ -86,12 +86,12 @@ class ForeignKey extends MappingModel
     private $localColumns;
 
     /**
-     * @var string[]
+     * @var (string|null)[]
      */
     private $foreignColumns;
 
     /**
-     * @var string[]
+     * @var (string|null)[]
      */
     private $localValues;
 
@@ -950,43 +950,6 @@ class ForeignKey extends MappingModel
         }
 
         return $fks;
-    }
-
-    /**
-     * Whether at least one foreign column is also the primary key of the foreign table.
-     *
-     * @return boolean True if there is at least one column that is a primary key of the foreign table
-     */
-    public function isAtLeastOneForeignPrimaryKey()
-    {
-        $cols = $this->getForeignPrimaryKeys();
-
-        return 0 !== count($cols);
-    }
-
-    /**
-     * Returns all foreign columns which are also a primary key of the foreign table.
-     *
-     * @return array Column[]
-     */
-    public function getForeignPrimaryKeys()
-    {
-        $lfmap = $this->getLocalForeignMapping();
-        $foreignTable = $this->getForeignTable();
-
-        $foreignPKCols = [];
-        foreach ($foreignTable->getPrimaryKey() as $fPKCol) {
-            $foreignPKCols[$fPKCol->getName()] = true;
-        }
-
-        $foreignCols = [];
-        foreach ($this->getLocalColumn() as $colName) {
-            if ($foreignPKCols[$lfmap[$colName]]) {
-                $foreignCols[] = $foreignTable->getColumn($lfmap[$colName]);
-            }
-        }
-
-        return $foreignCols;
     }
 
     /**

--- a/src/Propel/Generator/Model/Index.php
+++ b/src/Propel/Generator/Model/Index.php
@@ -42,7 +42,7 @@ class Index extends MappingModel
     protected $columnObjects = [];
 
     /**
-     * @var string[]
+     * @var int[]
      */
     protected $columnsSize;
 
@@ -237,7 +237,7 @@ class Index extends MappingModel
      *
      * @param  string  $name
      * @param  boolean $caseInsensitive
-     * @return integer
+     * @return int|null
      */
     public function getColumnSize($name, $caseInsensitive = false)
     {
@@ -249,6 +249,7 @@ class Index extends MappingModel
             }
             return null;
         }
+
         return isset($this->columnsSize[$name]) ? $this->columnsSize[$name] : null;
     }
 

--- a/src/Propel/Generator/Model/Table.php
+++ b/src/Propel/Generator/Model/Table.php
@@ -683,7 +683,7 @@ class Table extends ScopedMappingModel implements IdMethod
     /**
      * Returns the subclasses that can be created from this table.
      *
-     * @return array
+     * @return array|null
      */
     public function getChildrenNames()
     {
@@ -1665,12 +1665,12 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @param  string  $name            The name of the column (e.g. 'my_column')
      * @param  boolean $caseInsensitive Whether the check is case insensitive.
-     * @return Column
+     * @return Column|null
      */
     public function getColumn($name, $caseInsensitive = false)
     {
         if (!$this->hasColumn($name, $caseInsensitive)) {
-            return null; // just to be explicit
+            return null;
         }
 
         if ($caseInsensitive) {
@@ -1684,7 +1684,7 @@ class Table extends ScopedMappingModel implements IdMethod
      * Returns a specified column by its php name.
      *
      * @param  string $phpName
-     * @return Column
+     * @return Column|null
      */
     public function getColumnByPhpName($phpName)
     {

--- a/src/Propel/Generator/Platform/MssqlPlatform.php
+++ b/src/Propel/Generator/Platform/MssqlPlatform.php
@@ -165,12 +165,12 @@ END
     /**
      * @param \Propel\Generator\Model\ForeignKey $fk
      *
-     * @return string|null
+     * @return string
      */
     public function getAddForeignKeyDDL(ForeignKey $fk)
     {
         if ($fk->isSkipSql() || $fk->isPolymorphic()) {
-            return null;
+            return '';
         }
 
         $pattern = "
@@ -204,12 +204,12 @@ END
     /**
      * @param \Propel\Generator\Model\ForeignKey $fk
      *
-     * @return string|null
+     * @return string
      */
     public function getForeignKeyDDL(ForeignKey $fk)
     {
         if ($fk->isSkipSql() || $fk->isPolymorphic()) {
-            return null;
+            return '';
         }
 
         $pattern = 'CONSTRAINT %s FOREIGN KEY (%s) REFERENCES %s (%s)';

--- a/src/Propel/Generator/Platform/MysqlPlatform.php
+++ b/src/Propel/Generator/Platform/MysqlPlatform.php
@@ -551,11 +551,16 @@ DROP INDEX %s ON %s;
         return '';
     }
 
+    /**
+     * @param \Propel\Generator\Model\ForeignKey $fk
+     *
+     * @return string|null
+     */
     public function getDropForeignKeyDDL(ForeignKey $fk)
     {
         if (!$this->supportsForeignKeys($fk->getTable())) return '';
         if ($fk->isSkipSql() || $fk->isPolymorphic()) {
-            return;
+            return null;
         }
         $pattern = "
 ALTER TABLE %s DROP FOREIGN KEY %s;
@@ -567,6 +572,11 @@ ALTER TABLE %s DROP FOREIGN KEY %s;
         );
     }
 
+    /**
+     * @param string $comment
+     *
+     * @return string
+     */
     public function getCommentBlockDDL($comment)
     {
         $pattern = "

--- a/src/Propel/Generator/Platform/OraclePlatform.php
+++ b/src/Propel/Generator/Platform/OraclePlatform.php
@@ -220,12 +220,12 @@ DROP SEQUENCE " . $this->quoteIdentifier($this->getSequenceName($table)) . ";
     /**
      * @param \Propel\Generator\Model\ForeignKey $fk
      *
-     * @return string|null
+     * @return string
      */
     public function getForeignKeyDDL(ForeignKey $fk)
     {
         if ($fk->isSkipSql() || $fk->isPolymorphic()) {
-            return null;
+            return '';
         }
 
         $pattern = "CONSTRAINT %s

--- a/src/Propel/Generator/Platform/PgsqlPlatform.php
+++ b/src/Propel/Generator/Platform/PgsqlPlatform.php
@@ -242,6 +242,11 @@ SET search_path TO public;
         return $ret;
     }
 
+    /**
+     * @param \Propel\Generator\Model\ForeignKey $fk
+     *
+     * @return string
+     */
     public function getForeignKeyDDL(ForeignKey $fk) {
         $script = parent::getForeignKeyDDL($fk);
 

--- a/src/Propel/Generator/Platform/PlatformInterface.php
+++ b/src/Propel/Generator/Platform/PlatformInterface.php
@@ -256,6 +256,13 @@ interface PlatformInterface
      * Get the PHP snippet for binding a value to a column.
      * Warning: duplicates logic from AdapterInterface::bindValue().
      * Any code modification here must be ported there.
+     *
+     * @param \Propel\Generator\Model\Column $column
+     * @param string $identifier
+     * @param string $columnValueAccessor
+     * @param string $tab
+     *
+     * @return string
      */
     public function getColumnBindingPHP(Column $column, $identifier, $columnValueAccessor, $tab = "            ");
 

--- a/src/Propel/Generator/Platform/SqlitePlatform.php
+++ b/src/Propel/Generator/Platform/SqlitePlatform.php
@@ -214,7 +214,7 @@ DROP TABLE %s;
         }
 
         foreach ($tableDiff->getRenamedColumns() as $col) {
-            list ($from, $to) = $col;
+            [$from, $to] = $col;
             $fieldMap[$from->getName()] = $to->getName();
         }
 
@@ -285,6 +285,7 @@ PRAGMA foreign_keys = ON;
      * those UNIQUE is otherwise automatically created by the sqlite engine.
      *
      * @param Table $table
+     * @return void
      */
     public function normalizeTable(Table $table)
     {
@@ -496,10 +497,15 @@ PRAGMA foreign_keys = ON;
         );
     }
 
+    /**
+     * @param \Propel\Generator\Model\ForeignKey $fk
+     *
+     * @return string
+     */
     public function getForeignKeyDDL(ForeignKey $fk)
     {
         if ($fk->isSkipSql() || !$this->foreignKeySupport || $fk->isPolymorphic()) {
-            return;
+            return '';
         }
 
         $pattern = "FOREIGN KEY (%s) REFERENCES %s (%s)";

--- a/src/Propel/Generator/Reverse/AbstractSchemaParser.php
+++ b/src/Propel/Generator/Reverse/AbstractSchemaParser.php
@@ -173,7 +173,7 @@ abstract class AbstractSchemaParser implements SchemaParserInterface
      * Gets a mapped Propel type for specified native type.
      *
      * @param  string $nativeType
-     * @return string The mapped Propel type.
+     * @return string|null The mapped Propel type.
      */
     protected function getMappedPropelType($nativeType)
     {

--- a/src/Propel/Generator/Util/BehaviorLocator.php
+++ b/src/Propel/Generator/Util/BehaviorLocator.php
@@ -45,7 +45,7 @@ class BehaviorLocator
     /**
      * Searches a composer file
      *
-     * @return SplFileInfo the found composer file or null if composer file isn't found
+     * @return SplFileInfo|null The found composer file or null if composer file isn't found
      */
     private function findComposerFile($fileName)
     {
@@ -213,7 +213,7 @@ class BehaviorLocator
      *
      * @param  array          $package
      * @throws BuildException
-     * @return array          behavior data
+     * @return array|null Behavior data
      */
     private function loadBehavior($package)
     {
@@ -229,9 +229,9 @@ class BehaviorLocator
                         'class' => $extra['class'],
                         'package' => $package['name']
                     ];
-                } else {
-                    throw new BuildException(sprintf('Cannot read behavior name and class from package %s', $package['name']));
                 }
+
+                throw new BuildException(sprintf('Cannot read behavior name and class from package %s', $package['name']));
             }
         }
 

--- a/src/Propel/Generator/Util/PhpParser.php
+++ b/src/Propel/Generator/Util/PhpParser.php
@@ -38,7 +38,7 @@ class PhpParser
     /**
      * methodName => methodCode
      *
-     * @var string[]
+     * @var (string|false)[]
      */
     private $knownMethodCache = array();
 

--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -196,9 +196,9 @@ class Criteria
 
     /**
      * Storage of having data.
-     * @var AbstractCriterion
+     * @var AbstractCriterion|null
      */
-    protected $having = null;
+    protected $having;
 
     /**
      * Storage of join data. collection of Join objects.
@@ -535,7 +535,7 @@ class Criteria
     /**
      * Method to return the latest Criterion in a table.
      *
-     * @return AbstractCriterion A Criterion or null no Criterion is added.
+     * @return AbstractCriterion|null A Criterion or null no Criterion is added.
      */
     public function getLastCriterion()
     {
@@ -599,7 +599,7 @@ class Criteria
      * Method to return a String table name.
      *
      * @param  string $name Name of the key.
-     * @return string The value of the object at key.
+     * @return string|null The value of the object at key.
      */
     public function getColumnName($name)
     {
@@ -637,7 +637,7 @@ class Criteria
      * Method to return a comparison String.
      *
      * @param  string $key String name of the key.
-     * @return string A String with the value of the object at key.
+     * @return string|null A String with the value of the object at key.
      */
     public function getComparison($key)
     {
@@ -702,7 +702,7 @@ class Criteria
      * Method to return a String table name.
      *
      * @param  string $name The name of the key.
-     * @return string The value of table for criterion at key.
+     * @return string|null The value of table for criterion at key.
      */
     public function getTableName($name)
     {
@@ -1055,7 +1055,7 @@ class Criteria
     /**
      * @param string $name The name of the join clause
      *
-     * @return Join A join object
+     * @return bool
      */
     public function hasJoin($name)
     {

--- a/src/Propel/Runtime/ActiveQuery/Criterion/AbstractCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/AbstractCriterion.php
@@ -39,7 +39,7 @@ abstract class AbstractCriterion
 
     /**
      * Table name
-     * @var string
+     * @var string|null
      */
     protected $table;
 
@@ -213,7 +213,7 @@ abstract class AbstractCriterion
      * Get the list of clauses in this Criterion.
      * @return self[]
      */
-    private function getClauses()
+    public function getClauses()
     {
         return $this->clauses;
     }
@@ -268,8 +268,10 @@ abstract class AbstractCriterion
     public function appendPsTo(&$sb, array &$params)
     {
         if (!$this->clauses) {
-            return $this->appendPsForUniqueClauseTo($sb, $params);
+            $this->appendPsForUniqueClauseTo($sb, $params);
+            return;
         }
+
         // if there are sub criterions, they must be combined to this criterion
         $sb .= str_repeat('(', count($this->clauses));
         $this->appendPsForUniqueClauseTo($sb, $params);
@@ -280,6 +282,9 @@ abstract class AbstractCriterion
         }
     }
 
+    /**
+     * @return string
+     */
     public function __toString()
     {
         $sb = '';
@@ -337,7 +342,7 @@ abstract class AbstractCriterion
             $isEquiv &= $this->value === $crit->getValue();
         }
 
-        return $isEquiv;
+        return (bool)$isEquiv;
     }
 
     /**

--- a/src/Propel/Runtime/ActiveQuery/Criterion/AbstractModelCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/AbstractModelCriterion.php
@@ -88,6 +88,6 @@ Abstract class AbstractModelCriterion extends AbstractCriterion
             $isEquiv &= $this->value === $crit->getValue();
         }
 
-        return $isEquiv;
+        return (bool)$isEquiv;
     }
 }

--- a/src/Propel/Runtime/ActiveQuery/Criterion/RawCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/RawCriterion.php
@@ -23,7 +23,7 @@ class RawCriterion extends AbstractCriterion
 
     /**
      * Binding type to be used for Criteria::RAW comparison
-     * @var string any of the PDO::PARAM_ constant values
+     * @var int Any of the PDO::PARAM_ constant values
      */
     protected $type;
 

--- a/src/Propel/Runtime/ActiveQuery/Criterion/RawModelCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/RawModelCriterion.php
@@ -24,7 +24,7 @@ class RawModelCriterion extends AbstractModelCriterion
 {
     /**
      * Binding type to be used for Criteria::RAW comparison
-     * @var string any of the PDO::PARAM_ constant values
+     * @var int Any of the PDO::PARAM_ constant values
      */
     protected $type;
 

--- a/src/Propel/Runtime/Adapter/MSSQL/MssqlPropelPDO.php
+++ b/src/Propel/Runtime/Adapter/MSSQL/MssqlPropelPDO.php
@@ -26,14 +26,14 @@ class MssqlPropelPDO extends PropelPDO
      * It is necessary to override the abstract PDO transaction functions here, as
      * the PDO driver for MSSQL does not support transactions.
      *
-     * @return integer
+     * @return bool
      */
     public function beginTransaction()
     {
         $return = true;
         $opcount = $this->getNestedTransactionCount();
         if ($opcount === 0) {
-            $return = self::exec('BEGIN TRANSACTION');
+            $return = (bool)$this->exec('BEGIN TRANSACTION');
             if ($this->useDebug) {
                 $this->log('Begin transaction: ' . __METHOD__);
             }
@@ -50,7 +50,7 @@ class MssqlPropelPDO extends PropelPDO
      * It is necessary to override the abstract PDO transaction functions here, as
      * the PDO driver for MSSQL does not support transactions.
      *
-     * @return integer
+     * @return bool
      */
     public function commit()
     {
@@ -60,12 +60,11 @@ class MssqlPropelPDO extends PropelPDO
             if ($opcount === 1) {
                 if ($this->isUncommitable) {
                     throw new PropelException('Cannot commit because a nested transaction was rolled back');
-                } else {
-                    $return = self::exec('COMMIT TRANSACTION');
-                    if ($this->useDebug) {
-                        $this->log('Commit transaction: ' . __METHOD__);
-                    }
+                }
 
+                $return = (bool)$this->exec('COMMIT TRANSACTION');
+                if ($this->useDebug) {
+                    $this->log('Commit transaction: ' . __METHOD__);
                 }
             }
             $this->nestedTransactionCount--;
@@ -80,7 +79,7 @@ class MssqlPropelPDO extends PropelPDO
      * It is necessary to override the abstract PDO transaction functions here, as
      * the PDO driver for MSSQL does not support transactions.
      *
-     * @return integer
+     * @return bool
      */
     public function rollBack()
     {
@@ -88,7 +87,7 @@ class MssqlPropelPDO extends PropelPDO
         $opcount = $this->getNestedTransactionCount();
         if ($opcount > 0) {
             if ($opcount === 1) {
-                $return = self::exec('ROLLBACK TRANSACTION');
+                $return = (bool)$this->exec('ROLLBACK TRANSACTION');
                 if ($this->useDebug) {
                     $this->log('Rollback transaction: ' . __METHOD__);
                 }
@@ -108,7 +107,7 @@ class MssqlPropelPDO extends PropelPDO
      * It is necessary to override the abstract PDO transaction functions here, as
      * the PDO driver for MSSQL does not support transactions.
      *
-     * @return integer
+     * @return bool
      */
     public function forceRollBack()
     {
@@ -117,7 +116,7 @@ class MssqlPropelPDO extends PropelPDO
         if ($opcount > 0) {
             // If we're in a transaction, always roll it back
             // regardless of nesting level.
-            $return = self::exec('ROLLBACK TRANSACTION');
+            $return = (bool)$this->exec('ROLLBACK TRANSACTION');
 
             // reset nested transaction count to 0 so that we don't
             // try to commit (or rollback) the transaction outside this scope.
@@ -132,12 +131,12 @@ class MssqlPropelPDO extends PropelPDO
     }
 
     /**
-     * @param  string  $seqname
+     * @param  string|null  $seqname
      * @return integer
      */
     public function lastInsertId($seqname = null)
     {
-        $result = self::query('SELECT SCOPE_IDENTITY()');
+        $result = $this->query('SELECT SCOPE_IDENTITY()');
 
         return (int) $result->fetchColumn();
     }

--- a/src/Propel/Runtime/Collection/OnDemandIterator.php
+++ b/src/Propel/Runtime/Collection/OnDemandIterator.php
@@ -43,7 +43,7 @@ class OnDemandIterator implements \Iterator
     protected $enableInstancePoolingOnFinish;
 
     /**
-     * @param AbstractFormatter    $formatter
+     * @param ObjectFormatter    $formatter
      * @param DataFetcherInterface $dataFetcher
      */
     public function __construct(AbstractFormatter $formatter, DataFetcherInterface $dataFetcher)

--- a/src/Propel/Runtime/Connection/ConnectionInterface.php
+++ b/src/Propel/Runtime/Connection/ConnectionInterface.php
@@ -99,10 +99,10 @@ interface ConnectionInterface
      * object, depending on the underlying driver. For example, PDO_PGSQL()
      * requires you to specify the name of a sequence object for the name parameter.
      *
-     * @param string $name Name of the sequence object from which the ID should be
+     * @param string|null $name Name of the sequence object from which the ID should be
      *                     returned.
      *
-     * @return string If a sequence name was not specified for the name parameter,
+     * @return string|int If a sequence name was not specified for the name parameter,
      *                returns a string representing the row ID of the last row that was
      *                inserted into the database.
      *                If a sequence name was specified for the name parameter, returns

--- a/src/Propel/Runtime/Connection/ConnectionManagerPrimaryReplica.php
+++ b/src/Propel/Runtime/Connection/ConnectionManagerPrimaryReplica.php
@@ -28,7 +28,7 @@ class ConnectionManagerPrimaryReplica implements ConnectionManagerInterface
     protected $writeConfiguration = [];
 
     /**
-     * @var \Propel\Runtime\Connection\ConnectionInterface
+     * @var \Propel\Runtime\Connection\ConnectionInterface|null
      */
     protected $writeConnection;
 
@@ -38,7 +38,7 @@ class ConnectionManagerPrimaryReplica implements ConnectionManagerInterface
     protected $readConfiguration;
 
     /**
-     * @var \Propel\Runtime\Connection\ConnectionInterface
+     * @var \Propel\Runtime\Connection\ConnectionInterface|null
      */
     protected $readConnection;
 

--- a/src/Propel/Runtime/Connection/ConnectionManagerSingle.php
+++ b/src/Propel/Runtime/Connection/ConnectionManagerSingle.php
@@ -28,7 +28,7 @@ class ConnectionManagerSingle implements ConnectionManagerInterface
     protected $configuration = [];
 
     /**
-     * @var \Propel\Runtime\Connection\ConnectionInterface
+     * @var \Propel\Runtime\Connection\ConnectionInterface|null
      */
     protected $connection;
 

--- a/src/Propel/Runtime/Connection/ConnectionWrapper.php
+++ b/src/Propel/Runtime/Connection/ConnectionWrapper.php
@@ -53,7 +53,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
 
     /**
      * The wrapped connection class
-     * @var ConnectionInterface
+     * @var ConnectionInterface|null
      */
     protected $connection;
 
@@ -500,10 +500,10 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
      * object, depending on the underlying driver. For example, PDO_PGSQL()
      * requires you to specify the name of a sequence object for the name parameter.
      *
-     * @param string $name Name of the sequence object from which the ID should be
+     * @param string|null $name Name of the sequence object from which the ID should be
      *                     returned.
      *
-     * @return string If a sequence name was not specified for the name parameter,
+     * @return string|int If a sequence name was not specified for the name parameter,
      *                returns a string representing the row ID of the last row that was
      *                inserted into the database.
      *                If a sequence name was specified for the name parameter, returns

--- a/src/Propel/Runtime/Connection/PdoConnection.php
+++ b/src/Propel/Runtime/Connection/PdoConnection.php
@@ -132,8 +132,8 @@ class PdoConnection extends \PDO implements ConnectionInterface
     /**
      * Overwrite. Fixes HHVM strict issue.
      *
-     * @param  null        $name
-     * @return string|void
+     * @param  string|null        $name
+     * @return string|int
      */
     public function lastInsertId($name = null)
     {

--- a/src/Propel/Runtime/Connection/StatementWrapper.php
+++ b/src/Propel/Runtime/Connection/StatementWrapper.php
@@ -82,7 +82,9 @@ class StatementWrapper extends \PDOStatement implements \IteratorAggregate
      */
     public function query()
     {
-        $this->statement = $this->connection->getWrappedConnection()->query($this->sql);
+        /** @var \PDOStatement $statement */
+        $statement = $this->connection->getWrappedConnection()->query($this->sql);
+        $this->statement = $statement;
 
         return $this->connection->getWrappedConnection()->getDataFetcher($this);
     }

--- a/src/Propel/Runtime/DataFetcher/ArrayDataFetcher.php
+++ b/src/Propel/Runtime/DataFetcher/ArrayDataFetcher.php
@@ -66,7 +66,11 @@ class ArrayDataFetcher extends AbstractDataFetcher
      */
     public function rewind()
     {
-        return null === $this->dataObject ? null : reset($this->dataObject);
+        if ($this->dataObject === null) {
+            return;
+        }
+
+        reset($this->dataObject);
     }
 
     /**

--- a/src/Propel/Runtime/DataFetcher/PDODataFetcher.php
+++ b/src/Propel/Runtime/DataFetcher/PDODataFetcher.php
@@ -14,7 +14,7 @@ use Propel\Runtime\Map\TableMap;
 class PDODataFetcher extends AbstractDataFetcher
 {
     /**
-     * @var array
+     * @var array|null
      */
     private $current;
 

--- a/src/Propel/Runtime/Formatter/AbstractFormatter.php
+++ b/src/Propel/Runtime/Formatter/AbstractFormatter.php
@@ -200,6 +200,9 @@ abstract class AbstractFormatter
 
     abstract public function formatOne(DataFetcherInterface $dataFetcher = null);
 
+    /**
+     * @return bool
+     */
     abstract public function isObjectFormatter();
 
     public function checkInit()

--- a/src/Propel/Runtime/Formatter/ArrayFormatter.php
+++ b/src/Propel/Runtime/Formatter/ArrayFormatter.php
@@ -97,7 +97,7 @@ class ArrayFormatter extends AbstractFormatter
     /**
      * Formats an ActiveRecord object
      *
-     * @param ActiveRecordInterface $record the object to format
+     * @param ActiveRecordInterface|null $record the object to format
      *
      * @return array The original record turned into an array
      */
@@ -106,6 +106,9 @@ class ArrayFormatter extends AbstractFormatter
         return $record ? $record->toArray() : [];
     }
 
+    /**
+     * @return bool
+     */
     public function isObjectFormatter()
     {
         return false;

--- a/src/Propel/Runtime/Formatter/SimpleArrayFormatter.php
+++ b/src/Propel/Runtime/Formatter/SimpleArrayFormatter.php
@@ -82,7 +82,7 @@ class SimpleArrayFormatter extends AbstractFormatter
     /**
      * Formats an ActiveRecord object
      *
-     * @param ActiveRecordInterface $record the object to format
+     * @param ActiveRecordInterface|null $record the object to format
      *
      * @return array The original record turned into an array
      */
@@ -91,11 +91,19 @@ class SimpleArrayFormatter extends AbstractFormatter
         return $record ? $record->toArray() : [];
     }
 
+    /**
+     * @return bool
+     */
     public function isObjectFormatter()
     {
         return false;
     }
 
+    /**
+     * @param array $row
+     *
+     * @return array
+     */
     public function getStructuredArrayFromRow($row)
     {
         $columnNames = array_keys($this->getAsColumns());

--- a/src/Propel/Runtime/Map/RelationMap.php
+++ b/src/Propel/Runtime/Map/RelationMap.php
@@ -66,7 +66,7 @@ class RelationMap
     protected $localValues = [];
 
     /**
-     * @var ColumnMap[]
+     * @var (\Propel\Runtime\Map\ColumnMap|null)[]
      */
     protected $foreignColumns = [];
 

--- a/src/Propel/Runtime/Map/TableMap.php
+++ b/src/Propel/Runtime/Map/TableMap.php
@@ -279,7 +279,7 @@ class TableMap
         if (class_exists($collectionClass)) {
             return $collectionClass;
         }
-        
+
         return '\Propel\Runtime\Collection\ObjectCollection';
     }
 
@@ -752,7 +752,7 @@ class TableMap
     /**
      * Gets the ColumnMap for the primary string column.
      *
-     * @return \Propel\Runtime\Map\ColumnMap
+     * @return \Propel\Runtime\Map\ColumnMap|null
      */
     public function getPrimaryStringColumn()
     {

--- a/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
+++ b/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
@@ -57,6 +57,8 @@ class StandardServiceContainer implements ServiceContainerInterface
     protected $connectionManagers = [];
 
     /**
+     * @phpstan-var class-string<\Propel\Runtime\Util\Profiler>
+     *
      * @var string
      */
     protected $profilerClass = ServiceContainerInterface::DEFAULT_PROFILER_CLASS;
@@ -67,7 +69,7 @@ class StandardServiceContainer implements ServiceContainerInterface
     protected $profilerConfiguration = [];
 
     /**
-     * @var \Propel\Runtime\Util\Profiler
+     * @var \Propel\Runtime\Util\Profiler|null
      */
     protected $profiler;
 
@@ -432,6 +434,7 @@ class StandardServiceContainer implements ServiceContainerInterface
     {
         if (null === $this->profiler) {
             $class = $this->profilerClass;
+            /** @var \Propel\Runtime\Util\Profiler $profiler */
             $profiler = new $class();
             if (!empty($this->profilerConfiguration)) {
                 $profiler->setConfiguration($this->profilerConfiguration);

--- a/src/Propel/Runtime/Util/Profiler.php
+++ b/src/Propel/Runtime/Util/Profiler.php
@@ -290,16 +290,15 @@ class Profiler
     /**
      * Rounding to significant digits (sort of like JavaScript's toPrecision()).
      *
-     *
      * @param float   $number             Value to round
      * @param integer $significantFigures Number of significant figures
      *
-     * @return float
+     * @return string
      */
     public static function toPrecision($number, $significantFigures = 3)
     {
         if (0 === $number) {
-            return 0;
+            return '0';
         }
 
         $significantDecimals = (int) floor($significantFigures - log10(abs($number)));

--- a/tests/Propel/Tests/Generator/Model/ColumnTest.php
+++ b/tests/Propel/Tests/Generator/Model/ColumnTest.php
@@ -246,7 +246,7 @@ class ColumnTest extends ModelTestCase
     public function provideDefaultValues()
     {
         return [
-            ['DOUBLE', 3.14, 3.14],
+            ['DOUBLE', 3.14, '3.14'],
             ['VARCHAR', 'hello', "'hello'"],
             ['VARCHAR', "john's bike", "'john\\'s bike'"],
             ['BOOLEAN', 1, 'true'],

--- a/tests/Propel/Tests/Runtime/Util/ProfilerTest.php
+++ b/tests/Propel/Tests/Runtime/Util/ProfilerTest.php
@@ -22,9 +22,9 @@ class ProfilerTest extends BaseTestCase
         $profiler->setDetails([]);
         $profiler->setSlowTreshold(1000);
         $res = $profiler->getProfileBetween(['microtime' => 1000], ['microtime' => 1200]);
-        $this->assertEquals('     ', $res);
+        $this->assertSame('     ', $res);
         $res = $profiler->getProfileBetween(['microtime' => 1000], ['microtime' => 2200]);
-        $this->assertEquals('SLOW ', $res);
+        $this->assertSame('SLOW ', $res);
     }
 
     public function testGetProfileBetweenDoesNotAddSlowTresholdWhenValueIsNull()
@@ -33,9 +33,9 @@ class ProfilerTest extends BaseTestCase
         $profiler->setDetails([]);
         $profiler->setSlowTreshold(0);
         $res = $profiler->getProfileBetween(['microtime' => 1000], ['microtime' => 1200]);
-        $this->assertEquals('', $res);
+        $this->assertSame('', $res);
         $res = $profiler->getProfileBetween(['microtime' => 1000], ['microtime' => 2200]);
-        $this->assertEquals('', $res);
+        $this->assertSame('', $res);
     }
 
     public function testGetProfileBetweenAddsTime()
@@ -102,7 +102,7 @@ class ProfilerTest extends BaseTestCase
             ['microtime' => 1.000, 'memoryUsage' => 343245, 'memoryPeakUsage' => 314357],
             ['microtime' => 1.0345, 'memoryUsage' => 245643, 'memoryPeakUsage' => 343245]
         );
-        $this->assertEquals('     Time: 34.5ms | Memory: 240kB | Delta: -95.3kB | Peak: 335kB | ', $res);
+        $this->assertSame('     Time: 34.5ms | Memory: 240kB | Delta: -95.3kB | Peak: 335kB | ', $res);
     }
 
     public function providerForTestFormatMemory()
@@ -126,7 +126,7 @@ class ProfilerTest extends BaseTestCase
      */
     public function testFormatMemory($input, $output)
     {
-        $this->assertEquals(Profiler::formatMemory($input), $output);
+        $this->assertSame(Profiler::formatMemory($input), $output);
     }
 
     public function providerForTestFormatMemoryPrecision()
@@ -146,7 +146,7 @@ class ProfilerTest extends BaseTestCase
      */
     public function testFormatMemoryPrecision($input, $output)
     {
-        $this->assertEquals(Profiler::formatMemory(12345.6789, $input), $output);
+        $this->assertSame(Profiler::formatMemory(12345.6789, $input), $output);
     }
 
     public function providerForTestFormatDuration()
@@ -193,7 +193,7 @@ class ProfilerTest extends BaseTestCase
      */
     public function testFormatDurationPrecision($input, $output)
     {
-        $this->assertEquals(Profiler::formatDuration(123.456789, $input), $output);
+        $this->assertSame(Profiler::formatDuration(123.456789, $input), $output);
     }
 
     public function providerForTestToPrecision()
@@ -209,7 +209,7 @@ class ProfilerTest extends BaseTestCase
             [123.4567890, number_format(123)],
             [12.34567890, number_format(12.3, 1)],
             [1.234567890, number_format(1.23, 2)],
-            [0, 0],
+            [0, '0'],
             [0.123456789, number_format(0.123, 3)],
             [0.012345678, number_format(0.0123, 4)],
             [0.001234567, number_format(0.00123, 5)],
@@ -225,13 +225,13 @@ class ProfilerTest extends BaseTestCase
      */
     public function testToPrecision($input, $output)
     {
-        $this->assertEquals(Profiler::toPrecision($input), $output);
+        $this->assertSame(Profiler::toPrecision($input), $output);
     }
 
     public function providerForTestToPrecisionPrecision()
     {
         return [
-            [0, 0],
+            [0, '0'],
             [1, number_format(100)],
             [2, number_format(120)],
             [3, number_format(123)],
@@ -246,6 +246,6 @@ class ProfilerTest extends BaseTestCase
      */
     public function testToPrecisionPrecision($input, $output)
     {
-        $this->assertEquals(Profiler::toPrecision(123.456789, $input), $output);
+        $this->assertSame(Profiler::toPrecision(123.456789, $input), $output);
     }
 }


### PR DESCRIPTION
This will follow https://github.com/propelorm/Propel2/pull/1605

Correct me if I am wrong, but I don't think the remaining 7 errors are fixable at this time, and will have to become part of the baseline:
```
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   Propel/Runtime/ActiveQuery/ModelCriteria.php                                                                                                                                                   
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  135    Method Propel\Runtime\ActiveQuery\ModelCriteria::filterBy() should return Propel\Runtime\ActiveQuery\ModelCriteria but returns Propel\Runtime\ActiveQuery\Criteria.                            
  1697   Parameter #1 $values (array) of method Propel\Runtime\ActiveQuery\ModelCriteria::doUpdate() should be compatible with parameter $updateValues (Propel\Runtime\ActiveQuery\Criteria) of method  
         Propel\Runtime\ActiveQuery\Criteria::doUpdate()                                                                                                                                                
  2124   Method Propel\Runtime\ActiveQuery\ModelCriteria::addUsingAlias() should return Propel\Runtime\ActiveQuery\ModelCriteria but returns Propel\Runtime\ActiveQuery\Criteria.                       
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   Propel/Runtime/Collection/OnDemandCollection.php                                                                                                                                                                               
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  107    Return type (Propel\Runtime\Collection\OnDemandIterator) of method Propel\Runtime\Collection\OnDemandCollection::getIterator() should be compatible with return type (Propel\Runtime\Collection\CollectionIterator) of method  
         Propel\Runtime\Collection\Collection::getIterator()                                                                                                                                                                            
  109    Method Propel\Runtime\Collection\OnDemandCollection::getIterator() should return Propel\Runtime\Collection\OnDemandIterator but returns Iterator.                                                                              
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   Propel/Runtime/Formatter/ArrayFormatter.php                                                                                                                                                
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  104    Return type (array) of method Propel\Runtime\Formatter\ArrayFormatter::formatRecord() should be compatible with return type (Propel\Runtime\ActiveRecord\ActiveRecordInterface) of method  
         Propel\Runtime\Formatter\AbstractFormatter::formatRecord()                                                                                                                                 
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   Propel/Runtime/Formatter/SimpleArrayFormatter.php                                                                                                                                                
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  89     Return type (array) of method Propel\Runtime\Formatter\SimpleArrayFormatter::formatRecord() should be compatible with return type (Propel\Runtime\ActiveRecord\ActiveRecordInterface) of method  
         Propel\Runtime\Formatter\AbstractFormatter::formatRecord()                                                                                                                                       
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 

 [ERROR] Found 7 errors                                                                                                 
```