### PR TITLE
Do not try to fetch related objects of new object

### DIFF
--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -4166,10 +4166,12 @@ abstract class ".$this->getUnqualifiedClassName().$parentClass." implements Acti
     public function get$relCol(Criteria \$criteria = null, ConnectionInterface \$con = null)
     {
         \$partial = \$this->{$collName}Partial && !\$this->isNew();
-        if (null === \$this->$collName || null !== \$criteria  || \$partial) {
-            if (\$this->isNew() && null === \$this->$collName) {
-                // return empty collection
-                \$this->init" . $this->getRefFKPhpNameAffix($refFK, $plural = true) . "();
+        if (null === \$this->$collName || null !== \$criteria || \$partial) {
+            if (\$this->isNew()) {
+                if (null === \$this->$collName) {
+                    // return empty collection
+                    \$this->init" . $this->getRefFKPhpNameAffix($refFK, $plural = true) . "();
+                }
             } else {
                 \$$collName = $fkQueryClassName::create(null, \$criteria)
                     ->filterBy" . $this->getFKPhpNameAffix($refFK) . "(\$this)


### PR DESCRIPTION
This PR is a rebase of the original PR https://github.com/propelorm/Propel2/pull/1493

> Example database:
> 
> ```
>     <table name="book" description="Book Table">
>         <column name="id" required="true" primaryKey="true" autoIncrement="true" type="INTEGER" description="Book Id" />
>         <column name="title" type="VARCHAR" required="true" description="Book Title" primaryString="true" />
>         <column name="author_id" required="false" type="INTEGER" description="Foreign Key Author" />
>         <foreign-key foreignTable="author" onDelete="setnull" onUpdate="cascade">
>             <reference local="author_id" foreign="id" />
>         </foreign-key>
>     </table>
> 
>     <table name="author" description="Author Table">
>         <column name="id" required="true" primaryKey="true" autoIncrement="true" type="INTEGER" description="Author Id" />
>         <column name="first_name" required="true" type="VARCHAR" size="128" description="First Name" />
>         <column name="last_name" required="true" type="VARCHAR" size="128" description="Last Name" />
>     </table>
> ```
> 
> Example code:
> 
> ```
> $author = new Author();
> // ...
> $author->getBooks(); // $author->collBooks is initialized
> // ...
> $author->setBooks(new Collection());
> $author->save();
> ```
> 
> In `setBooks` there is this line:
> https://github.com/propelorm/Propel2/blob/6c4996fc130c7555d82d9dca04396c6f3eeef306/src/Propel/Generator/Builder/Om/ObjectBuilder.php#L4231
> 
> 
> (the previous books are scheduled for deletion)
> But while fetching the previous books the [`else` part](https://github.com/propelorm/Propel2/blob/6c4996fc130c7555d82d9dca04396c6f3eeef306/src/Propel/Generator/Builder/Om/ObjectBuilder.php#L4165-L4168) is used, because `$this->collBooks` is not null any more. So `BookQuery::create()->filterByAuthor($this)->find()` is used. This will result in a query with `WHERE author_id IS NULL`, because `$this->getId()` is null.
> So all books without an author will be scheduled for deletion!
> So for a new object (id is null), the query for fetching the related objects should be never used.

