### PR TITLE
Fix return value for "no migration needed" case

### DIFF
--- a/src/Propel/Generator/Command/MigrationMigrateCommand.php
+++ b/src/Propel/Generator/Command/MigrationMigrateCommand.php
@@ -81,7 +81,7 @@ class MigrationMigrateCommand extends AbstractCommand
         if (!$manager->getFirstUpMigrationTimestamp()) {
             $output->writeln('All migrations were already executed - nothing to migrate.');
 
-            return static::CODE_ERROR;
+            return static::CODE_SUCCESS;
         }
 
         $timestamps = $manager->getValidMigrationTimestamps();


### PR DESCRIPTION
https://github.com/propelorm/Propel2/pull/1595/files#diff-1ccdce29404b8984d1b2101f0069a564R84
it looks like this change was "correct in the sense of what was before and the transition towards int",
as false means 1 (error)

But if you look more deeply the already existing false should have been true (and thus 0) as return value.
This code, if no migration has to be done, should actually say "all good" and not report an error here.

//cc @Incognito 