### PR TITLE
Fix PHP8 warning.

### DIFF
--- a/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
+++ b/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
@@ -532,7 +532,7 @@ class StandardServiceContainer implements ServiceContainerInterface
         $this->loggerConfigurations[$name] = $loggerConfiguration;
     }
 
-    final private function __clone()
+    private function __clone()
     {
     }
 }


### PR DESCRIPTION
> PHP Warning:  Private methods cannot be final as they are never overridden by other classes in /home/travis/build/propelorm/Propel2/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php on line 538
Warning: Private methods cannot be final as they are never overridden by other classes in /home/travis/build/propelorm/Propel2/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php on line 538
