### PR TITLE
always create unique indices by constraint (for pgsql platform)

### DIFF
--- a/src/Propel/Generator/Platform/PgsqlPlatform.php
+++ b/src/Propel/Generator/Platform/PgsqlPlatform.php
@@ -683,8 +683,8 @@ DROP SEQUENCE %s CASCADE;
     {
         if ($index instanceof Unique) {
             $pattern = "
-    ALTER TABLE %s DROP CONSTRAINT %s;
-    ";
+ALTER TABLE %s DROP CONSTRAINT %s;
+";
 
             return sprintf($pattern,
                 $this->quoteIdentifier($index->getTable()->getName()),

--- a/src/Propel/Generator/Platform/PgsqlPlatform.php
+++ b/src/Propel/Generator/Platform/PgsqlPlatform.php
@@ -718,4 +718,26 @@ DROP SEQUENCE %s CASCADE;
         return preg_replace('/^/m', $tab, $script);
     }
 
+    /**
+     * @param \Propel\Generator\Model\Index $index
+     *
+     * @return string
+     */
+    public function getAddIndexDDL(Index $index)
+    {
+        if (!$index->isUnique()) {
+            return parent::getAddIndexDDL($index);
+        }
+
+        $pattern = "
+ALTER TABLE %s ADD CONSTRAINT %s UNIQUE (%s);
+";
+
+        return sprintf(
+            $pattern,
+            $this->quoteIdentifier($index->getTable()->getName()),
+            $this->quoteIdentifier($index->getName()),
+            $this->getColumnListDDL($index->getColumnObjects())
+        );
+    }
 }

--- a/tests/Propel/Tests/Generator/Platform/MysqlPlatformMigrationMyISAMTest.php
+++ b/tests/Propel/Tests/Generator/Platform/MysqlPlatformMigrationMyISAMTest.php
@@ -175,7 +175,11 @@ ALTER TABLE `foo` ADD PRIMARY KEY (`id`,`bar`);
         $expected = "
 DROP INDEX `bar_fk` ON `foo`;
 
+DROP INDEX `bax_unique` ON `foo`;
+
 CREATE INDEX `baz_fk` ON `foo` (`baz`);
+
+CREATE UNIQUE INDEX `bax_bay_unique` ON `foo` (`bax`, `bay`);
 
 DROP INDEX `bar_baz_fk` ON `foo`;
 

--- a/tests/Propel/Tests/Generator/Platform/MysqlPlatformMigrationTest.php
+++ b/tests/Propel/Tests/Generator/Platform/MysqlPlatformMigrationTest.php
@@ -184,7 +184,11 @@ ALTER TABLE `foo` ADD PRIMARY KEY (`id`,`bar`);
         $expected = "
 DROP INDEX `bar_fk` ON `foo`;
 
+DROP INDEX `bax_unique` ON `foo`;
+
 CREATE INDEX `baz_fk` ON `foo` (`baz`);
+
+CREATE UNIQUE INDEX `bax_bay_unique` ON `foo` (`bax`, `bay`);
 
 DROP INDEX `bar_baz_fk` ON `foo`;
 

--- a/tests/Propel/Tests/Generator/Platform/OraclePlatformMigrationTest.php
+++ b/tests/Propel/Tests/Generator/Platform/OraclePlatformMigrationTest.php
@@ -164,7 +164,11 @@ ALTER TABLE foo ADD CONSTRAINT foo_pk PRIMARY KEY (id,bar);
         $expected = "
 DROP INDEX bar_fk;
 
+DROP INDEX bax_unique;
+
 CREATE INDEX baz_fk ON foo (baz);
+
+CREATE UNIQUE INDEX bax_bay_unique ON foo (bax,bay);
 
 DROP INDEX bar_baz_fk;
 

--- a/tests/Propel/Tests/Generator/Platform/PgsqlPlatformMigrationTest.php
+++ b/tests/Propel/Tests/Generator/Platform/PgsqlPlatformMigrationTest.php
@@ -155,7 +155,11 @@ END;
 
 DROP INDEX "bar_fk";
 
+    ALTER TABLE "foo" DROP CONSTRAINT "bax_unique";
+
 CREATE INDEX "baz_fk" ON "foo" ("baz");
+
+ALTER TABLE "foo" ADD CONSTRAINT "bax_bay_unique" UNIQUE ("bax","bay");
 
 DROP INDEX "bar_baz_fk";
 

--- a/tests/Propel/Tests/Generator/Platform/PgsqlPlatformMigrationTest.php
+++ b/tests/Propel/Tests/Generator/Platform/PgsqlPlatformMigrationTest.php
@@ -155,7 +155,7 @@ END;
 
 DROP INDEX "bar_fk";
 
-    ALTER TABLE "foo" DROP CONSTRAINT "bax_unique";
+ALTER TABLE "foo" DROP CONSTRAINT "bax_unique";
 
 CREATE INDEX "baz_fk" ON "foo" ("baz");
 

--- a/tests/Propel/Tests/Generator/Platform/PgsqlPlatformTest.php
+++ b/tests/Propel/Tests/Generator/Platform/PgsqlPlatformTest.php
@@ -601,6 +601,17 @@ CREATE INDEX "babar" ON "foo" ("bar1","bar2");
     }
 
     /**
+     * @dataProvider providerForTestGetUniqueIndexDDL
+     */
+    public function testAddUniqueIndexDDL($index)
+    {
+        $expected = '
+ALTER TABLE "foo" ADD CONSTRAINT "babar" UNIQUE ("bar1");
+';
+        $this->assertEquals($expected, $this->getPlatform()->getAddIndexDDL($index));
+    }
+
+    /**
      * @dataProvider providerForTestGetIndicesDDL
      */
     public function testAddIndicesDDL($table)

--- a/tests/Propel/Tests/Generator/Platform/PgsqlPlatformTest.php
+++ b/tests/Propel/Tests/Generator/Platform/PgsqlPlatformTest.php
@@ -17,6 +17,7 @@ use Propel\Generator\Model\IdMethod;
 use Propel\Generator\Model\IdMethodParameter;
 use Propel\Generator\Model\PropelTypes;
 use Propel\Generator\Model\Table;
+use Propel\Generator\Model\Unique;
 use Propel\Generator\Platform\PgsqlPlatform;
 
 /**
@@ -602,8 +603,12 @@ CREATE INDEX "babar" ON "foo" ("bar1","bar2");
 
     /**
      * @dataProvider providerForTestGetUniqueIndexDDL
+     *
+     * @param \Propel\Generator\Model\Unique $index
+     *
+     * @return void
      */
-    public function testAddUniqueIndexDDL($index)
+    public function testAddUniqueIndexDDL(Unique $index): void
     {
         $expected = '
 ALTER TABLE "foo" ADD CONSTRAINT "babar" UNIQUE ("bar1");

--- a/tests/Propel/Tests/Generator/Platform/PlatformMigrationTestProvider.php
+++ b/tests/Propel/Tests/Generator/Platform/PlatformMigrationTestProvider.php
@@ -198,6 +198,7 @@ EOF;
     <table name="foo">
         <column name="id" primaryKey="true" type="INTEGER" autoIncrement="true" />
         <column name="bar" type="INTEGER" />
+        <column name="bax" type="VARCHAR" size="12" required="true" />
         <column name="baz" type="VARCHAR" size="12" required="true" />
         <index name="bar_fk">
             <index-column name="bar"/>
@@ -206,6 +207,9 @@ EOF;
             <index-column name="bar"/>
             <index-column name="baz"/>
         </index>
+        <unique name="bax_unique">
+            <unique-column name="bax"/>
+        </unique>
     </table>
 </database>
 EOF;
@@ -214,6 +218,8 @@ EOF;
     <table name="foo">
         <column name="id" primaryKey="true" type="INTEGER" autoIncrement="true" />
         <column name="bar" type="INTEGER" />
+        <column name="bax" type="VARCHAR" size="12" required="true" />
+        <column name="bay" type="VARCHAR" size="12" required="true" />
         <column name="baz" type="VARCHAR" size="12" required="true" />
         <index name="bar_baz_fk">
             <index-column name="id"/>
@@ -223,6 +229,10 @@ EOF;
         <index name="baz_fk">
             <index-column name="baz"/>
         </index>
+        <unique name="bax_bay_unique">
+            <unique-column name="bax"/>
+            <unique-column name="bay"/>
+        </unique>
     </table>
 </database>
 EOF;

--- a/tests/Propel/Tests/Generator/Platform/PlatformMigrationTestProvider.php
+++ b/tests/Propel/Tests/Generator/Platform/PlatformMigrationTestProvider.php
@@ -198,8 +198,8 @@ EOF;
     <table name="foo">
         <column name="id" primaryKey="true" type="INTEGER" autoIncrement="true" />
         <column name="bar" type="INTEGER" />
-        <column name="bax" type="VARCHAR" size="12" required="true" />
         <column name="baz" type="VARCHAR" size="12" required="true" />
+        <column name="bax" type="VARCHAR" size="12" required="true" />
         <index name="bar_fk">
             <index-column name="bar"/>
         </index>
@@ -218,9 +218,9 @@ EOF;
     <table name="foo">
         <column name="id" primaryKey="true" type="INTEGER" autoIncrement="true" />
         <column name="bar" type="INTEGER" />
-        <column name="bax" type="VARCHAR" size="12" required="true" />
-        <column name="bay" type="VARCHAR" size="12" required="true" />
         <column name="baz" type="VARCHAR" size="12" required="true" />
+        <column name="bay" type="VARCHAR" size="12" required="true" />
+        <column name="bax" type="VARCHAR" size="12" required="true" />
         <index name="bar_baz_fk">
             <index-column name="id"/>
             <index-column name="bar"/>

--- a/tests/Propel/Tests/Generator/Platform/PlatformTestProvider.php
+++ b/tests/Propel/Tests/Generator/Platform/PlatformTestProvider.php
@@ -247,6 +247,22 @@ EOF;
         ];
     }
 
+    public function providerForTestGetUniqueIndexDDL()
+    {
+        $table = new Table('foo');
+        $table->setIdentifierQuoting(true);
+        $column1 = new Column('bar1');
+        $column1->getDomain()->copy(new Domain('FOOTYPE'));
+        $table->addColumn($column1);
+        $index = new Unique('babar');
+        $index->addColumn($column1);
+        $table->addIndex($index);
+
+        return [
+            [$index]
+        ];
+    }
+
     public function providerForTestPrimaryKeyDDL()
     {
         $table = new Table('foo');

--- a/tests/Propel/Tests/Generator/Platform/PlatformTestProvider.php
+++ b/tests/Propel/Tests/Generator/Platform/PlatformTestProvider.php
@@ -247,7 +247,10 @@ EOF;
         ];
     }
 
-    public function providerForTestGetUniqueIndexDDL()
+    /**
+     * @return array
+     */
+    public function providerForTestGetUniqueIndexDDL(): array
     {
         $table = new Table('foo');
         $table->setIdentifierQuoting(true);


### PR DESCRIPTION
Unique indices are currently generated in two different ways:

- "getAddTableDDL" creates it over an unique constraint

- "getAddIndexDDL" creates it without unique constraint

The Problem is, that the method "getDropIndexDDL" will remove unique indices always by constraint.