### PR TITLE
Run config queries on sql:insert

### DIFF
--- a/src/Propel/Generator/Manager/SqlManager.php
+++ b/src/Propel/Generator/Manager/SqlManager.php
@@ -187,6 +187,7 @@ class SqlManager extends AbstractManager
             }
 
             $con = $this->getConnectionInstance($database);
+            
             if (isset($this->connections[$database]['settings']['queries']) &&
             count($this->connections[$database]['settings']['queries'])) {
                 $initQueries = $this->connections[$database]['settings']['queries'];
@@ -200,7 +201,7 @@ class SqlManager extends AbstractManager
                             throw new Exception($message, 0, $e);
                         }
                     }
-                }
+                });
             }
             
             $con->transaction(function () use ($con, $sqls) {


### PR DESCRIPTION
Included solution, which was proposed in [Issue 959 - propel sql:insert ignore ['settings']['queries'] database config parameter](https://github.com/propelorm/Propel2/issues/959).

It needs to be checked and tested. If anything should be changed, please write a comment.
These changes would be important for me, as I can't insert UTF-8 content via sql:insert.