### PR TITLE
CS for tests

### DIFF
--- a/config/phpcs.xml
+++ b/config/phpcs.xml
@@ -30,8 +30,4 @@
         <severity>0</severity>
     </rule>
 
-    <rule ref="Spryker.Commenting.DocBlockReturnSelf">
-        <severity>0</severity>
-    </rule>
-
 </ruleset>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -471,11 +471,6 @@ parameters:
 			path: src/Propel/Runtime/ActiveQuery/Criteria.php
 
 		-
-			message: "#^Method Propel\\\\Runtime\\\\ActiveQuery\\\\Criteria\\:\\:_endif\\(\\) should return \\$this\\(Propel\\\\Runtime\\\\ActiveQuery\\\\Criteria\\) but returns Propel\\\\Runtime\\\\ActiveQuery\\\\Criteria\\|Propel\\\\Runtime\\\\Util\\\\PropelConditionalProxy\\.$#"
-			count: 1
-			path: src/Propel/Runtime/ActiveQuery/Criteria.php
-
-		-
 			message: "#^Result of && is always false\\.$#"
 			count: 1
 			path: src/Propel/Runtime/ActiveQuery/Criterion/AbstractCriterion.php
@@ -527,11 +522,6 @@ parameters:
 
 		-
 			message: "#^Strict comparison using \\=\\=\\= between Propel\\\\Runtime\\\\ActiveQuery\\\\ModelCriteria and null will always evaluate to false\\.$#"
-			count: 1
-			path: src/Propel/Runtime/ActiveQuery/ModelCriteria.php
-
-		-
-			message: "#^Method Propel\\\\Runtime\\\\ActiveQuery\\\\ModelCriteria\\:\\:getPrimaryCriteria\\(\\) should return \\$this\\(Propel\\\\Runtime\\\\ActiveQuery\\\\ModelCriteria\\)\\|null but returns Propel\\\\Runtime\\\\ActiveQuery\\\\ModelCriteria\\|null\\.$#"
 			count: 1
 			path: src/Propel/Runtime/ActiveQuery/ModelCriteria.php
 

--- a/resources/dtd/database.dtd
+++ b/resources/dtd/database.dtd
@@ -1,6 +1,5 @@
 <!--
     Propel XML database schema DTD
-    $Id: database.dtd,v 1.7 2005/03/30 11:38:18 hlellelid Exp $
 
     This is based very closely on the schema DTD for Torque, but
     some differences do exist.

--- a/src/Propel/Generator/Behavior/QueryCache/QueryCacheBehavior.php
+++ b/src/Propel/Generator/Behavior/QueryCache/QueryCacheBehavior.php
@@ -325,7 +325,6 @@ public function doCount(ConnectionInterface \$con = null)
             \$this->cacheStore(\$key, \$sql);
     }
 
-
     return \$con->getDataFetcher(\$stmt);
 }
 ";

--- a/src/Propel/Generator/Builder/Util/SchemaReader.php
+++ b/src/Propel/Generator/Builder/Util/SchemaReader.php
@@ -96,20 +96,18 @@ class SchemaReader
     private $defaultPackage;
 
     /**
-     * @var bool
-     */
-    private $firstPass;
-
-    /**
+     * @deprecated Unused.
+     *
      * @var string
      */
     private $encoding;
 
     /**
-     * @var array
-     * two-dimensional array,
+     * Two-dimensional array,
      * first dimension is for schemas(key is the path to the schema file),
-     * second is for tags within the schema
+     * second is for tags within the schema.
+     *
+     * @var array
      */
     private $schemasTagsStack = [];
 
@@ -124,7 +122,6 @@ class SchemaReader
     {
         $this->schema = new Schema($defaultPlatform);
         $this->defaultPackage = $defaultPackage;
-        $this->firstPass = true;
         $this->encoding = $encoding;
     }
 

--- a/src/Propel/Generator/Command/Console/Input/ArrayInput.php
+++ b/src/Propel/Generator/Command/Console/Input/ArrayInput.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Symfony package.
  *
  * (c) Fabien Potencier <fabien@symfony.com>

--- a/src/Propel/Generator/Util/BehaviorLocator.php
+++ b/src/Propel/Generator/Util/BehaviorLocator.php
@@ -35,6 +35,8 @@ class BehaviorLocator
     private $composerDir;
 
     /**
+     * @deprecated Unused.
+     *
      * @var \Propel\Generator\Config\GeneratorConfigInterface
      */
     private $generatorConfig;

--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -771,11 +771,13 @@ class Criteria
      * @param string $key
      * @param mixed $value
      *
-     * @return $this Instance of self.
+     * @return $this
      */
     public function put($key, $value)
     {
-        return $this->add($key, $value);
+        $this->add($key, $value);
+
+        return $this;
     }
 
     /**
@@ -936,7 +938,9 @@ class Criteria
                 $conditions[] = $condition;
             }
 
-            return $this->addMultipleJoin($conditions, $joinType);
+            $this->addMultipleJoin($conditions, $joinType);
+
+            return $this;
         }
 
         $join = new Join();
@@ -966,7 +970,9 @@ class Criteria
 
         $join->setJoinType($joinType);
 
-        return $this->addJoinObject($join);
+        $this->addJoinObject($join);
+
+        return $this;
     }
 
     /**
@@ -1042,7 +1048,9 @@ class Criteria
         $join->setJoinType($joinType);
         $join->setJoinCondition($joinCondition);
 
-        return $this->addJoinObject($join);
+        $this->addJoinObject($join);
+
+        return $this;
     }
 
     /**
@@ -1886,10 +1894,14 @@ class Criteria
         if ($this->defaultCombineOperator === Criteria::LOGICAL_OR) {
             $this->defaultCombineOperator = Criteria::LOGICAL_AND;
 
-            return $this->addOr($p1, $value, $operator, $preferColumnCondition);
+            $this->addOr($p1, $value, $operator, $preferColumnCondition);
+
+            return $this;
         }
 
-        return $this->addAnd($p1, $value, $operator, $preferColumnCondition);
+        $this->addAnd($p1, $value, $operator, $preferColumnCondition);
+
+        return $this;
     }
 
     /**
@@ -2808,7 +2820,7 @@ class Criteria
      *
      * @throws \Propel\Runtime\Exception\LogicException
      *
-     * @return \Propel\Runtime\Util\PropelConditionalProxy|$this
+     * @return \Propel\Runtime\Util\PropelConditionalProxy|static
      */
     public function _else()
     {
@@ -2825,7 +2837,7 @@ class Criteria
      *
      * @throws \Propel\Runtime\Exception\LogicException
      *
-     * @return $this
+     * @return $this|\Propel\Runtime\ActiveQuery\Criteria
      */
     public function _endif()
     {

--- a/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
@@ -154,7 +154,9 @@ class ModelCriteria extends BaseModelCriteria
      */
     public function filterBy($column, $value, $comparison = Criteria::EQUAL)
     {
-        return $this->add($this->getRealColumnName($column), $value, $comparison);
+        $this->add($this->getRealColumnName($column), $value, $comparison);
+
+        return $this;
     }
 
     /**
@@ -2240,7 +2242,9 @@ class ModelCriteria extends BaseModelCriteria
      */
     public function addUsingAlias($column, $value = null, $operator = null)
     {
-        return $this->addUsingOperator($this->getAliasedColName($column), $value, $operator);
+        $this->addUsingOperator($this->getAliasedColName($column), $value, $operator);
+
+        return $this;
     }
 
     /**

--- a/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
@@ -884,7 +884,7 @@ class ModelCriteria extends BaseModelCriteria
     /**
      * Gets the primary criteria for this secondary Criteria
      *
-     * @return $this|null The primary criteria
+     * @return \Propel\Runtime\ActiveQuery\ModelCriteria|null The primary criteria
      */
     public function getPrimaryCriteria()
     {

--- a/src/Propel/Runtime/ActiveQuery/ModelJoin.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelJoin.php
@@ -156,7 +156,9 @@ class ModelJoin extends Join
      */
     public function setRelationAlias($relationAlias)
     {
-        return $this->setRightTableAlias($relationAlias);
+        $this->setRightTableAlias($relationAlias);
+
+        return $this;
     }
 
     /**

--- a/tests/Propel/Tests/Bookstore/AuthorCollection.php
+++ b/tests/Propel/Tests/Bookstore/AuthorCollection.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Bookstore;
 
 use Propel\Runtime\Collection\ObjectCollection;

--- a/tests/Propel/Tests/BookstoreLoggingTest.php
+++ b/tests/Propel/Tests/BookstoreLoggingTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests;

--- a/tests/Propel/Tests/BookstoreTest.php
+++ b/tests/Propel/Tests/BookstoreTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests;

--- a/tests/Propel/Tests/CharacterEncodingTest.php
+++ b/tests/Propel/Tests/CharacterEncodingTest.php
@@ -39,13 +39,6 @@ use Propel\Tests\Helpers\Bookstore\BookstoreTestBase;
 class CharacterEncodingTest extends BookstoreTestBase
 {
     /**
-     * Database adapter.
-     *
-     * @var DBAdapter
-     */
-    private $adapter;
-
-    /**
      * @throws \Exception
      *
      * @return void

--- a/tests/Propel/Tests/CharacterEncodingTest.php
+++ b/tests/Propel/Tests/CharacterEncodingTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests;

--- a/tests/Propel/Tests/Common/Config/ConfigTestCase.php
+++ b/tests/Propel/Tests/Common/Config/ConfigTestCase.php
@@ -21,11 +21,13 @@ use Symfony\Component\Filesystem\Filesystem;
 class ConfigTestCase extends TestCase
 {
     /**
-     * @var null
-     * Symfony\Component\Filesystem\Filesystem instance
+     * @var \Symfony\Component\Filesystem\Filesystem|null
      */
     private $fileSystem;
 
+    /**
+     * @return \Symfony\Component\Filesystem\Filesystem
+     */
     public function getFilesystem()
     {
         if (null === $this->fileSystem) {

--- a/tests/Propel/Tests/Common/Config/ConfigTestCase.php
+++ b/tests/Propel/Tests/Common/Config/ConfigTestCase.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Common\Config;

--- a/tests/Propel/Tests/Common/Config/ConfigurationManagerTest.php
+++ b/tests/Propel/Tests/Common/Config/ConfigurationManagerTest.php
@@ -114,6 +114,7 @@ EOF;
         $this->getFilesystem()->dumpFile('doctrine.yaml', $yamlConf);
 
         $manager = new TestableConfigurationManager();
+        $this->assertInstanceOf(ConfigurationManager::class, $manager);
     }
 
     /**
@@ -154,7 +155,7 @@ EOF;
     }
 
     /**
-     * @expectedException Propel\Common\Config\Exception\InvalidArgumentException
+     * @expectedException \Propel\Common\Config\Exception\InvalidArgumentException
      *
      * @exceptionMessage Propel expects only one configuration file
      *
@@ -177,7 +178,7 @@ EOF;
     }
 
     /**
-     * @expectedException Propel\Common\Config\Exception\InvalidArgumentException
+     * @expectedException \Propel\Common\Config\Exception\InvalidArgumentException
      *
      * @exceptionMessage Propel expects only one configuration file
      *
@@ -385,7 +386,7 @@ EOF;
     }
 
     /**
-     * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      * @expectedExceptionMessage Unrecognized options "foo, bar" under "propel"
      *
      * @return void
@@ -439,7 +440,7 @@ EOF;
     }
 
     /**
-     * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      * @expectedExceptionMessage The child node "database" at path "propel" must be configured
      *
      * @return void
@@ -458,7 +459,7 @@ EOF;
     }
 
     /**
-     * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      * @expectedExceptionMessage Dots are not allowed in connection names
      *
      * @return void
@@ -648,7 +649,7 @@ EOF;
     }
 
     /**
-     * @expectedException Propel\Common\Config\Exception\InvalidArgumentException
+     * @expectedException \Propel\Common\Config\Exception\InvalidArgumentException
      * @expectedExceptionMessage Invalid configuration property name
      *
      * @return void

--- a/tests/Propel/Tests/Common/Config/ConfigurationManagerTest.php
+++ b/tests/Propel/Tests/Common/Config/ConfigurationManagerTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Common\Config;

--- a/tests/Propel/Tests/Common/Config/DataProviderTrait.php
+++ b/tests/Propel/Tests/Common/Config/DataProviderTrait.php
@@ -352,7 +352,7 @@ EOF;
             'table' => [
                 'name' => 'book',
                 'phpName' => 'Book',
-            ]
+            ],
         ];
 
         return [

--- a/tests/Propel/Tests/Common/Config/DataProviderTrait.php
+++ b/tests/Propel/Tests/Common/Config/DataProviderTrait.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Common\Config;

--- a/tests/Propel/Tests/Common/Config/Loader/FileLoaderTest.php
+++ b/tests/Propel/Tests/Common/Config/Loader/FileLoaderTest.php
@@ -192,7 +192,7 @@ class FileLoaderTest extends TestCase
     }
 
     /**
-     * @expectedException Propel\Common\Config\Exception\InvalidArgumentException
+     * @expectedException \Propel\Common\Config\Exception\InvalidArgumentException
      * @expectedExceptionMessage Parameter 'baz' not found in configuration file.
      *
      * @return void
@@ -203,7 +203,7 @@ class FileLoaderTest extends TestCase
     }
 
     /**
-     * @expectedException Propel\Common\Config\Exception\InvalidArgumentException
+     * @expectedException \Propel\Common\Config\Exception\InvalidArgumentException
      * @expectedExceptionMessage Parameter 'foobar' not found in configuration file.
      *
      * @return void
@@ -214,7 +214,7 @@ class FileLoaderTest extends TestCase
     }
 
     /**
-     * @expectedException Propel\Common\Config\Exception\RuntimeException
+     * @expectedException \Propel\Common\Config\Exception\RuntimeException
      * @expectedExceptionMessage Circular reference detected for parameter 'bar'.
      *
      * @return void
@@ -225,7 +225,7 @@ class FileLoaderTest extends TestCase
     }
 
     /**
-     * @expectedException Propel\Common\Config\Exception\RuntimeException
+     * @expectedException \Propel\Common\Config\Exception\RuntimeException
      * @expectedExceptionMessage Circular reference detected for parameter 'bar'.
      *
      * @return void

--- a/tests/Propel/Tests/Common/Config/Loader/FileLoaderTest.php
+++ b/tests/Propel/Tests/Common/Config/Loader/FileLoaderTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Common\Config\Loader;

--- a/tests/Propel/Tests/Common/Config/Loader/IniFileLoaderTest.php
+++ b/tests/Propel/Tests/Common/Config/Loader/IniFileLoaderTest.php
@@ -68,7 +68,7 @@ EOF;
     }
 
     /**
-     * @expectedException Propel\Common\Config\Exception\InvalidArgumentException
+     * @expectedException \Propel\Common\Config\Exception\InvalidArgumentException
      * @expectedExceptionMessage The configuration file 'nonvalid.ini' has invalid content.
      *
      * @return void
@@ -228,7 +228,7 @@ EOF;
     }
 
     /**
-     * @expectedException Propel\Common\Config\Exception\InputOutputException
+     * @expectedException \Propel\Common\Config\Exception\InputOutputException
      * @expectedExceptionMessage You don't have permissions to access configuration file notreadable.ini.
      *
      * @requires OS ^(?!Win.*)

--- a/tests/Propel/Tests/Common/Config/Loader/IniFileLoaderTest.php
+++ b/tests/Propel/Tests/Common/Config/Loader/IniFileLoaderTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Common\Config\Loader;

--- a/tests/Propel/Tests/Common/Config/Loader/JsonFileLoaderTest.php
+++ b/tests/Propel/Tests/Common/Config/Loader/JsonFileLoaderTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Common\Config\Loader;

--- a/tests/Propel/Tests/Common/Config/Loader/JsonFileLoaderTest.php
+++ b/tests/Propel/Tests/Common/Config/Loader/JsonFileLoaderTest.php
@@ -67,7 +67,7 @@ EOF;
     }
 
     /**
-     * @expectedException Propel\Common\Config\Exception\JsonParseException
+     * @expectedException \Propel\Common\Config\Exception\JsonParseException
      *
      * @return void
      */
@@ -97,7 +97,7 @@ EOF;
     }
 
     /**
-     * @expectedException Propel\Common\Config\Exception\InputOutputException
+     * @expectedException \Propel\Common\Config\Exception\InputOutputException
      * @expectedExceptionMessage You don't have permissions to access configuration file notreadable.json.
      *
      * @requires OS ^(?!Win.*)

--- a/tests/Propel/Tests/Common/Config/Loader/PhpFileLoaderTest.php
+++ b/tests/Propel/Tests/Common/Config/Loader/PhpFileLoaderTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Common\Config\Loader;

--- a/tests/Propel/Tests/Common/Config/Loader/PhpFileLoaderTest.php
+++ b/tests/Propel/Tests/Common/Config/Loader/PhpFileLoaderTest.php
@@ -68,7 +68,7 @@ EOF;
     }
 
     /**
-     * @expectedException Propel\Common\Config\Exception\InvalidArgumentException
+     * @expectedException \Propel\Common\Config\Exception\InvalidArgumentException
      * @expectedExceptionMessage The configuration file 'nonvalid.php' has invalid content.
      *
      * @return void
@@ -85,7 +85,7 @@ EOF;
     }
 
     /**
-     * @expectedException Propel\Common\Config\Exception\InvalidArgumentException
+     * @expectedException \Propel\Common\Config\Exception\InvalidArgumentException
      * @expectedExceptionMessage The configuration file 'empty.php' has invalid content.
      *
      * @return void
@@ -99,7 +99,7 @@ EOF;
     }
 
     /**
-     * @expectedException Propel\Common\Config\Exception\InputOutputException
+     * @expectedException \Propel\Common\Config\Exception\InputOutputException
      * @expectedExceptionMessage You don't have permissions to access configuration file notreadable.php.
      *
      * @requires OS ^(?!Win.*)

--- a/tests/Propel/Tests/Common/Config/Loader/XmlFileLoaderTest.php
+++ b/tests/Propel/Tests/Common/Config/Loader/XmlFileLoaderTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Common\Config\Loader;

--- a/tests/Propel/Tests/Common/Config/Loader/XmlFileLoaderTest.php
+++ b/tests/Propel/Tests/Common/Config/Loader/XmlFileLoaderTest.php
@@ -69,7 +69,7 @@ XML;
     }
 
     /**
-     * @expectedException Propel\Common\Config\Exception\InvalidArgumentException
+     * @expectedException \Propel\Common\Config\Exception\InvalidArgumentException
      * @expectedExceptionMessage Invalid xml content
      *
      * @return void
@@ -100,7 +100,7 @@ EOF;
     }
 
     /**
-     * @expectedException Propel\Common\Config\Exception\InputOutputException
+     * @expectedException \Propel\Common\Config\Exception\InputOutputException
      * @expectedExceptionMessage You don't have permissions to access configuration file notreadable.xml.
      *
      * @requires OS ^(?!Win.*)

--- a/tests/Propel/Tests/Common/Config/Loader/YamlFileLoaderTest.php
+++ b/tests/Propel/Tests/Common/Config/Loader/YamlFileLoaderTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Common\Config\Loader;

--- a/tests/Propel/Tests/Common/Config/Loader/YamlFileLoaderTest.php
+++ b/tests/Propel/Tests/Common/Config/Loader/YamlFileLoaderTest.php
@@ -68,7 +68,7 @@ EOF;
     }
 
     /**
-     * @expectedException Symfony\Component\Yaml\Exception\ParseException
+     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
      * @expectedExceptionMessage Unable to parse
      *
      * @return void
@@ -98,7 +98,7 @@ EOF;
     }
 
     /**
-     * @expectedException Propel\Common\Config\Exception\InputOutputException
+     * @expectedException \Propel\Common\Config\Exception\InputOutputException
      * @expectedExceptionMessage You don't have permissions to access configuration file notreadable.yaml.
      *
      * @requires OS ^(?!Win.*)

--- a/tests/Propel/Tests/Common/Config/XmlToArrayConverterTest.php
+++ b/tests/Propel/Tests/Common/Config/XmlToArrayConverterTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Common\Config;

--- a/tests/Propel/Tests/Common/Pluralizer/EnglishPluralizerTest.php
+++ b/tests/Propel/Tests/Common/Pluralizer/EnglishPluralizerTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Common\Pluralizer;

--- a/tests/Propel/Tests/Common/Util/SetColumnConverterTest.php
+++ b/tests/Propel/Tests/Common/Util/SetColumnConverterTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Common\Util;

--- a/tests/Propel/Tests/FieldnameRelatedTest.php
+++ b/tests/Propel/Tests/FieldnameRelatedTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests;

--- a/tests/Propel/Tests/Generator/Behavior/AddClass/AddClassBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/AddClass/AddClassBehaviorTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior\AddClass;

--- a/tests/Propel/Tests/Generator/Behavior/AggregateColumn/AggregateColumnBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/AggregateColumn/AggregateColumnBehaviorTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior\AggregateColumn;

--- a/tests/Propel/Tests/Generator/Behavior/AggregateColumn/AggregateColumnBehaviorWithSchemaTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/AggregateColumn/AggregateColumnBehaviorWithSchemaTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior\AggregateColumn;

--- a/tests/Propel/Tests/Generator/Behavior/AggregateColumn/AggregateColumnsBehaviorTestClasses.php
+++ b/tests/Propel/Tests/Generator/Behavior/AggregateColumn/AggregateColumnsBehaviorTestClasses.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Generator\Behavior\AggregateColumn;
 
 use Propel\Runtime\ActiveQuery\Criteria;

--- a/tests/Propel/Tests/Generator/Behavior/Archivable/ArchivableBehaviorObjectBuilderModifierTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Archivable/ArchivableBehaviorObjectBuilderModifierTest.php
@@ -9,6 +9,12 @@
  * @license MIT License
  */
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Generator\Behavior\Archivable;
 
 use ArchivableTest10;

--- a/tests/Propel/Tests/Generator/Behavior/Archivable/ArchivableBehaviorQueryBuilderModifierTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Archivable/ArchivableBehaviorQueryBuilderModifierTest.php
@@ -9,6 +9,12 @@
  * @license MIT License
  */
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Generator\Behavior\Archivable;
 
 use ArchivableTest100;

--- a/tests/Propel/Tests/Generator/Behavior/Archivable/ArchivableBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Archivable/ArchivableBehaviorTest.php
@@ -9,6 +9,12 @@
  * @license MIT License
  */
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Generator\Behavior\Archivable;
 
 use Map\ArchivableTest1ArchiveTableMap;

--- a/tests/Propel/Tests/Generator/Behavior/Archivable/ArchivableBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Archivable/ArchivableBehaviorTest.php
@@ -234,9 +234,14 @@ EOF;
 EOF;
         $builder = new QuickBuilder();
         $builder->setSchema($schema);
-        $builder->getSQL();
+        $sql = $builder->getSQL();
+
+        $this->assertNotEmpty($sql);
     }
 
+    /**
+     * @return array
+     */
     public function tablePrefixDataProvider()
     {
         $schema = <<<XML

--- a/tests/Propel/Tests/Generator/Behavior/Archivable/FooArchive.php
+++ b/tests/Propel/Tests/Generator/Behavior/Archivable/FooArchive.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Generator\Behavior\Archivable;
 
 class FooArchive

--- a/tests/Propel/Tests/Generator/Behavior/Archivable/FooArchiveCollection.php
+++ b/tests/Propel/Tests/Generator/Behavior/Archivable/FooArchiveCollection.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Generator\Behavior\Archivable;
 
 class FooArchiveCollection

--- a/tests/Propel/Tests/Generator/Behavior/Archivable/FooArchiveQuery.php
+++ b/tests/Propel/Tests/Generator/Behavior/Archivable/FooArchiveQuery.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Generator\Behavior\Archivable;
 
 class FooArchiveQuery

--- a/tests/Propel/Tests/Generator/Behavior/AutoAddPk/AutoAddPkBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/AutoAddPk/AutoAddPkBehaviorTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior\AutoAddPk;

--- a/tests/Propel/Tests/Generator/Behavior/BehaviorLocatorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/BehaviorLocatorTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior;

--- a/tests/Propel/Tests/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceBehaviorTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior;

--- a/tests/Propel/Tests/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceBehaviorWithBehaviorExclusionTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceBehaviorWithBehaviorExclusionTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior;

--- a/tests/Propel/Tests/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceBehaviorWithSchemaTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceBehaviorWithSchemaTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior;

--- a/tests/Propel/Tests/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceBehaviorWithSchemaTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceBehaviorWithSchemaTest.php
@@ -1,7 +1,6 @@
 <?php
 
-/*
- *	$Id: ConcreteInheritanceBehaviorTest.php 1458 2010-01-13 16:09:51Z francois $
+/**
  * This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Propel/Tests/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceParentBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceParentBehaviorTest.php
@@ -1,7 +1,6 @@
 <?php
 
-/*
- *	$Id: ConcreteInheritanceBehaviorTest.php 1458 2010-01-13 16:09:51Z francois $
+/**
  * This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Propel/Tests/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceParentBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceParentBehaviorTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior\ConcreteInheritance;

--- a/tests/Propel/Tests/Generator/Behavior/Delegate/DelegateBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Delegate/DelegateBehaviorTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior\Delegate;

--- a/tests/Propel/Tests/Generator/Behavior/I18n/I18nBehaviorObjectBuilderModifierTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/I18n/I18nBehaviorObjectBuilderModifierTest.php
@@ -1,23 +1,28 @@
 <?php
 
-/*
- *	$Id: VersionableBehaviorTest.php 1460 2010-01-17 22:36:48Z francois $
+/**
  * This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior\I18n;
 
-use Propel\Tests\Bookstore\Behavior\Movie;
-use Propel\Tests\Bookstore\Behavior\MovieQuery;
-use Propel\Tests\Bookstore\Behavior\MovieI18nQuery;
+use I18nBehaviorTest1;
+use I18nBehaviorTest1I18n;
+use I18nBehaviorTest1I18nQuery;
+use I18nBehaviorTest1Query;
+use I18nBehaviorTest2;
+use I18nBehaviorTestLocalColumn;
+use I18nBehaviorTestLocalColumnI18n;
+use Movie;
+use MovieI18nQuery;
+use MovieQuery;
 use Propel\Generator\Util\QuickBuilder;
-use Propel\Generator\Behavior\I18n\I18nBehavior;
-use Propel\Runtime\Propel;
 use Propel\Tests\TestCase;
+use Toy;
+use ToyI18nQuery;
+use ToyQuery;
 
 /**
  * Tests for I18nBehavior class object modifier
@@ -26,6 +31,9 @@ use Propel\Tests\TestCase;
  */
 class I18nBehaviorObjectBuilderModifierTest extends TestCase
 {
+    /**
+     * @return void
+     */
     public function setUp(): void
     {
         if (!class_exists('\I18nBehaviorTest1')) {
@@ -91,62 +99,80 @@ EOF;
         }
     }
 
+    /**
+     * @return void
+     */
     public function testPostDeleteEmulatesOnDeleteCascade()
     {
-        \I18nBehaviorTest1Query::create()->deleteAll();
-        \I18nBehaviorTest1I18nQuery::create()->deleteAll();
-        $o = new \I18nBehaviorTest1();
+        I18nBehaviorTest1Query::create()->deleteAll();
+        I18nBehaviorTest1I18nQuery::create()->deleteAll();
+        $o = new I18nBehaviorTest1();
         $o->setFoo(123);
         $o->setLocale('en_US');
         $o->setBar('hello');
         $o->setLocale('fr_FR');
         $o->setBar('bonjour');
         $o->save();
-        $this->assertEquals(2, \I18nBehaviorTest1I18nQuery::create()->count());
+        $this->assertEquals(2, I18nBehaviorTest1I18nQuery::create()->count());
         $o->clearI18nBehaviorTest1I18ns();
         $o->delete();
-        $this->assertEquals(0, \I18nBehaviorTest1I18nQuery::create()->count());
+        $this->assertEquals(0, I18nBehaviorTest1I18nQuery::create()->count());
     }
 
+    /**
+     * @return void
+     */
     public function testGetTranslationReturnsTranslationObject()
     {
-        $o = new \I18nBehaviorTest1();
+        $o = new I18nBehaviorTest1();
         $translation = $o->getTranslation();
-        $this->assertTrue($translation instanceof \I18nBehaviorTest1I18n);
+        $this->assertTrue($translation instanceof I18nBehaviorTest1I18n);
     }
 
+    /**
+     * @return void
+     */
     public function testGetTranslationOnNewObjectReturnsNewTranslation()
     {
-        $o = new \I18nBehaviorTest1();
+        $o = new I18nBehaviorTest1();
         $translation = $o->getTranslation();
         $this->assertTrue($translation->isNew());
     }
 
+    /**
+     * @return void
+     */
     public function testGetTranslationOnPersistedObjectReturnsNewTranslation()
     {
-        $o = new \I18nBehaviorTest1();
+        $o = new I18nBehaviorTest1();
         $o->save();
         $translation = $o->getTranslation();
         $this->assertTrue($translation->isNew());
     }
 
+    /**
+     * @return void
+     */
     public function testGetTranslationOnPersistedObjectWithTranslationReturnsExistingTranslation()
     {
-        $o = new \I18nBehaviorTest1();
-        $translation = new \I18nBehaviorTest1I18n();
+        $o = new I18nBehaviorTest1();
+        $translation = new I18nBehaviorTest1I18n();
         $o->addI18nBehaviorTest1I18n($translation);
         $o->save();
         $translation = $o->getTranslation();
         $this->assertFalse($translation->isNew());
     }
 
+    /**
+     * @return void
+     */
     public function testGetTranslationAcceptsALocaleParameter()
     {
-        $o = new \I18nBehaviorTest1();
-        $translation1 = new \I18nBehaviorTest1I18n();
+        $o = new I18nBehaviorTest1();
+        $translation1 = new I18nBehaviorTest1I18n();
         $translation1->setLocale('en_US');
         $o->addI18nBehaviorTest1I18n($translation1);
-        $translation2 = new \I18nBehaviorTest1I18n();
+        $translation2 = new I18nBehaviorTest1I18n();
         $translation2->setLocale('fr_FR');
         $o->addI18nBehaviorTest1I18n($translation2);
         $o->save();
@@ -154,38 +180,47 @@ EOF;
         $this->assertEquals($translation2, $o->getTranslation('fr_FR'));
     }
 
+    /**
+     * @return void
+     */
     public function testGetTranslationSetsTheLocaleOnTheTranslation()
     {
-        $o = new \I18nBehaviorTest1();
+        $o = new I18nBehaviorTest1();
         $o->save();
         $translation = $o->getTranslation();
         $this->assertEquals('en_US', $translation->getLocale());
-        $o = new \I18nBehaviorTest2();
+        $o = new I18nBehaviorTest2();
         $o->save();
         $translation = $o->getTranslation();
         $this->assertEquals('fr_FR', $translation->getLocale());
     }
 
+    /**
+     * @return void
+     */
     public function testGetTranslationUsesInternalCollectionIfAvailable()
     {
-        $o = new \I18nBehaviorTest1();
-        $translation1 = new \I18nBehaviorTest1I18n();
+        $o = new I18nBehaviorTest1();
+        $translation1 = new I18nBehaviorTest1I18n();
         $translation1->setLocale('en_US');
         $o->addI18nBehaviorTest1I18n($translation1);
-        $translation2 = new \I18nBehaviorTest1I18n();
+        $translation2 = new I18nBehaviorTest1I18n();
         $translation2->setLocale('fr_FR');
         $o->addI18nBehaviorTest1I18n($translation2);
         $translation = $o->getTranslation('en_US');
         $this->assertEquals($translation1, $translation);
     }
 
+    /**
+     * @return void
+     */
     public function testRemoveTranslation()
     {
-        $o = new \I18nBehaviorTest1();
-        $translation1 = new \I18nBehaviorTest1I18n();
+        $o = new I18nBehaviorTest1();
+        $translation1 = new I18nBehaviorTest1I18n();
         $translation1->setLocale('en_US');
         $o->addI18nBehaviorTest1I18n($translation1);
-        $translation2 = new \I18nBehaviorTest1I18n();
+        $translation2 = new I18nBehaviorTest1I18n();
         $translation2->setLocale('fr_FR');
         $translation2->setBar('bonjour');
         $o->addI18nBehaviorTest1I18n($translation2);
@@ -197,76 +232,106 @@ EOF;
         $this->assertNotEquals($translation->getBar(), $translation2->getBar());
     }
 
+    /**
+     * @return void
+     */
     public function testLocaleSetterAndGetterExist()
     {
         $this->assertTrue(method_exists('\I18nBehaviorTest1', 'setLocale'));
         $this->assertTrue(method_exists('\I18nBehaviorTest1', 'getLocale'));
     }
 
+    /**
+     * @return void
+     */
     public function testGetLocaleReturnsDefaultLocale()
     {
-        $o = new \I18nBehaviorTest1();
+        $o = new I18nBehaviorTest1();
         $this->assertEquals('en_US', $o->getLocale());
-        $o = new \I18nBehaviorTest2();
+        $o = new I18nBehaviorTest2();
         $this->assertEquals('fr_FR', $o->getLocale());
     }
 
+    /**
+     * @return void
+     */
     public function testSetLocale()
     {
-        $o = new \I18nBehaviorTest1();
+        $o = new I18nBehaviorTest1();
         $o->setLocale('fr_FR');
         $this->assertEquals('fr_FR', $o->getLocale());
     }
 
+    /**
+     * @return void
+     */
     public function testSetLocaleUsesDefaultLocale()
     {
-        $o = new \I18nBehaviorTest1();
+        $o = new I18nBehaviorTest1();
         $o->setLocale('fr_FR');
         $o->setLocale();
         $this->assertEquals('en_US', $o->getLocale());
     }
 
+    /**
+     * @return void
+     */
     public function testLocaleSetterAndGetterAliasesExist()
     {
         $this->assertTrue(method_exists('\I18nBehaviorTest2', 'setCulture'));
         $this->assertTrue(method_exists('\I18nBehaviorTest2', 'getCulture'));
     }
 
+    /**
+     * @return void
+     */
     public function testGetLocaleAliasReturnsDefaultLocale()
     {
-        $o = new \I18nBehaviorTest2();
+        $o = new I18nBehaviorTest2();
         $this->assertEquals('fr_FR', $o->getCulture());
     }
 
+    /**
+     * @return void
+     */
     public function testSetLocaleAlias()
     {
-        $o = new \I18nBehaviorTest2();
+        $o = new I18nBehaviorTest2();
         $o->setCulture('en_US');
         $this->assertEquals('en_US', $o->getCulture());
     }
 
+    /**
+     * @return void
+     */
     public function testGetCurrentTranslationUsesDefaultLocale()
     {
-        $o = new \I18nBehaviorTest1();
+        $o = new I18nBehaviorTest1();
         $t = $o->getCurrentTranslation();
         $this->assertEquals('en_US', $t->getLocale());
-        $o = new \I18nBehaviorTest2();
+        $o = new I18nBehaviorTest2();
         $t = $o->getCurrentTranslation();
         $this->assertEquals('fr_FR', $t->getLocale());
     }
 
+    /**
+     * @return void
+     */
     public function testGetCurrentTranslationUsesCurrentLocale()
     {
-        $o = new \I18nBehaviorTest1();
+        $o = new I18nBehaviorTest1();
         $o->setLocale('fr_FR');
         $this->assertEquals('fr_FR', $o->getCurrentTranslation()->getLocale());
         $o->setLocale('pt_PT');
         $this->assertEquals('pt_PT', $o->getCurrentTranslation()->getLocale());
     }
 
+    /**
+     * @return void
+     */
     public function testI18nColumnGetterUsesCurrentTranslation()
     {
-        $o = new \I18nBehaviorTest1();
+        $o = new I18nBehaviorTest1();
         $t1 = $o->getCurrentTranslation();
         $t1->setBar('hello');
         $o->setLocale('fr_FR');
@@ -279,9 +344,12 @@ EOF;
         $this->assertEquals('bonjour', $o->getBar());
     }
 
+    /**
+     * @return void
+     */
     public function testI18nColumnSetterUsesCurrentTranslation()
     {
-        $o = new \I18nBehaviorTest1();
+        $o = new I18nBehaviorTest1();
         $o->setBar('hello');
         $o->setLocale('fr_FR');
         $o->setBar('bonjour');
@@ -291,11 +359,14 @@ EOF;
         $this->assertEquals('bonjour', $o->getBar());
     }
 
+    /**
+     * @return void
+     */
     public function testTranslationsArePersisted()
     {
-        $o = new \I18nBehaviorTest1();
+        $o = new I18nBehaviorTest1();
         $o->save();
-        $count = \I18nBehaviorTest1I18nQuery::create()
+        $count = I18nBehaviorTest1I18nQuery::create()
             ->filterById($o->getId())
             ->count();
         $this->assertEquals(0, $count);
@@ -303,16 +374,19 @@ EOF;
         $o->setLocale('fr_FR');
         $o->setBar('bonjour');
         $o->save();
-        $count = \I18nBehaviorTest1I18nQuery::create()
+        $count = I18nBehaviorTest1I18nQuery::create()
             ->filterById($o->getId())
             ->count();
         $this->assertEquals(2, $count);
     }
 
+    /**
+     * @return void
+     */
     public function testClearRemovesExistingTranslations()
     {
-        $o = new \I18nBehaviorTest1();
-        $translation1 = new \I18nBehaviorTest1I18n();
+        $o = new I18nBehaviorTest1();
+        $translation1 = new I18nBehaviorTest1I18n();
         $translation1->setBar('baz');
         $translation1->setLocale('fr_FR');
         $o->addI18nBehaviorTest1I18n($translation1);
@@ -322,19 +396,22 @@ EOF;
         $this->assertEquals('', $t1->getBar());
     }
 
+    /**
+     * @return void
+     */
     public function testI18nWithRelations()
     {
-        \MovieQuery::create()->deleteAll();
-        $count = \MovieQuery::create()->count();
+        MovieQuery::create()->deleteAll();
+        $count = MovieQuery::create()->count();
         $this->assertEquals(0, $count, 'No movie before the test');
-        \ToyQuery::create()->deleteAll();
-        $count = \ToyQuery::create()->count();
+        ToyQuery::create()->deleteAll();
+        $count = ToyQuery::create()->count();
         $this->assertEquals(0, $count, 'No toy before the test');
-        \MovieI18nQuery::create()->deleteAll();
-        $count = \MovieI18nQuery::create()->count();
+        MovieI18nQuery::create()->deleteAll();
+        $count = MovieI18nQuery::create()->count();
         $this->assertEquals(0, $count, 'No i18n movies before the test');
 
-        $m = new \Movie();
+        $m = new Movie();
         $m->setLocale('en');
         $m->setTitle('V For Vendetta');
         $m->setLocale('fr');
@@ -345,37 +422,40 @@ EOF;
         $m->setLocale('fr');
         $this->assertEquals('V Pour Vendetta', $m->getTitle());
 
-        $t = new \Toy();
+        $t = new Toy();
         $t->setMovie($m);
         $t->save();
 
-        $count = \MovieQuery::create()->count();
+        $count = MovieQuery::create()->count();
         $this->assertEquals(1, $count, '1 movie');
-        $count = \ToyQuery::create()->count();
+        $count = ToyQuery::create()->count();
         $this->assertEquals(1, $count, '1 toy');
-        $count = \MovieI18nQuery::create()->count();
+        $count = MovieI18nQuery::create()->count();
         $this->assertEquals(2, $count, '2 i18n movies');
-        $count = \ToyI18nQuery::create()->count();
+        $count = ToyI18nQuery::create()->count();
         $this->assertEquals(0, $count, '0 i18n toys');
     }
 
+    /**
+     * @return void
+     */
     public function testI18nWithRelations2()
     {
-        \MovieI18nQuery::create()->deleteAll();
-        \MovieQuery::create()->deleteAll();
-        $count = \MovieQuery::create()->count();
+        MovieI18nQuery::create()->deleteAll();
+        MovieQuery::create()->deleteAll();
+        $count = MovieQuery::create()->count();
         $this->assertEquals(0, $count, 'No movie before the test');
-        \ToyQuery::create()->deleteAll();
-        $count = \ToyQuery::create()->count();
+        ToyQuery::create()->deleteAll();
+        $count = ToyQuery::create()->count();
         $this->assertEquals(0, $count, 'No toy before the test');
-        \ToyI18nQuery::create()->deleteAll();
-        $count = \ToyI18nQuery::create()->count();
+        ToyI18nQuery::create()->deleteAll();
+        $count = ToyI18nQuery::create()->count();
         $this->assertEquals(0, $count, 'No i18n toys before the test');
-        \MovieI18nQuery::create()->deleteAll();
-        $count = \MovieI18nQuery::create()->count();
+        MovieI18nQuery::create()->deleteAll();
+        $count = MovieI18nQuery::create()->count();
         $this->assertEquals(0, $count, 'No i18n movies before the test');
 
-        $t = new \Toy();
+        $t = new Toy();
         $t->setLocale('en');
         $t->setName('My Name');
         $t->setLocale('fr');
@@ -386,27 +466,30 @@ EOF;
         $t->setLocale('fr');
         $this->assertEquals('Mon Nom', $t->getName());
 
-        $m = new \Movie();
+        $m = new Movie();
         $m->addToy($t);
         $m->save();
 
-        $count = \MovieQuery::create()->count();
+        $count = MovieQuery::create()->count();
         $this->assertEquals(1, $count, '1 movie');
-        $count = \ToyQuery::create()->count();
+        $count = ToyQuery::create()->count();
         $this->assertEquals(1, $count, '1 toy');
-        $count = \ToyI18nQuery::create()->count();
+        $count = ToyI18nQuery::create()->count();
         $this->assertEquals(2, $count, '2 i18n toys');
-        $count = \MovieI18nQuery::create()->count();
+        $count = MovieI18nQuery::create()->count();
         $this->assertEquals(0, $count, '0 i18n movies');
     }
 
+    /**
+     * @return void
+     */
     public function testUseLocalColumnParameter()
     {
-        $o = new \I18nBehaviorTestLocalColumn();
-        $translation1 = new \I18nBehaviorTestLocalColumnI18n();
+        $o = new I18nBehaviorTestLocalColumn();
+        $translation1 = new I18nBehaviorTestLocalColumnI18n();
         $translation1->setMyLang('en_US');
         $o->addI18nBehaviorTestLocalColumnI18n($translation1);
-        $translation2 = new \I18nBehaviorTestLocalColumnI18n();
+        $translation2 = new I18nBehaviorTestLocalColumnI18n();
         $translation2->setMyLang('fr_FR');
         $o->addI18nBehaviorTestLocalColumnI18n($translation2);
         $o->save();

--- a/tests/Propel/Tests/Generator/Behavior/I18n/I18nBehaviorObjectBuilderModifierTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/I18n/I18nBehaviorObjectBuilderModifierTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */

--- a/tests/Propel/Tests/Generator/Behavior/I18n/I18nBehaviorQueryBuilderModifierTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/I18n/I18nBehaviorQueryBuilderModifierTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Propel/Tests/Generator/Behavior/I18n/I18nBehaviorQueryBuilderModifierTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/I18n/I18nBehaviorQueryBuilderModifierTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior\I18n;

--- a/tests/Propel/Tests/Generator/Behavior/I18n/I18nBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/I18n/I18nBehaviorTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior\I18n;

--- a/tests/Propel/Tests/Generator/Behavior/NestedSet/Fixtures/PublicTable10.php
+++ b/tests/Propel/Tests/Generator/Behavior/NestedSet/Fixtures/PublicTable10.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Generator\Behavior\NestedSet\Fixtures;
 
 use NestedSetTable10;

--- a/tests/Propel/Tests/Generator/Behavior/NestedSet/Fixtures/PublicTable9.php
+++ b/tests/Propel/Tests/Generator/Behavior/NestedSet/Fixtures/PublicTable9.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Generator\Behavior\NestedSet\Fixtures;
 
 use NestedSetTable9;

--- a/tests/Propel/Tests/Generator/Behavior/NestedSet/NestedSetBehaviorObjectBuilderModifierTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/NestedSet/NestedSetBehaviorObjectBuilderModifierTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior\NestedSet;

--- a/tests/Propel/Tests/Generator/Behavior/NestedSet/NestedSetBehaviorObjectBuilderModifierWithScopeTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/NestedSet/NestedSetBehaviorObjectBuilderModifierWithScopeTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior\NestedSet;

--- a/tests/Propel/Tests/Generator/Behavior/NestedSet/NestedSetBehaviorQueryBuilderModifierTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/NestedSet/NestedSetBehaviorQueryBuilderModifierTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior\NestedSet;

--- a/tests/Propel/Tests/Generator/Behavior/NestedSet/NestedSetBehaviorQueryBuilderModifierWithScopeTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/NestedSet/NestedSetBehaviorQueryBuilderModifierWithScopeTest.php
@@ -215,7 +215,17 @@ class NestedSetBehaviorQueryBuilderModifierWithScopeTest extends TestCase
             ->ancestorsOf($t5)
             ->orderByBranch()
             ->find();
-        $coll = $this->buildCollection([$t1, $t3], 'ancestorsOf() filters by ancestors of the same scope');
+        $coll = $this->buildCollection([$t1, $t3]);
+        /*
+         * FIXME
+         * -    'model' => 'Table10'
+         * -    'fullyQualifiedModel' => '\Table10'
+         * -    'formatter' => null
+         * +    'model' => 'NestedSetTable10'
+         * +    'fullyQualifiedModel' => '\NestedSetTable10'
+         * +    'formatter' => Propel\Runtime\Formatter\ObjectFormatter Object (...)
+         */
+        //$this->assertEquals($coll, $objs, 'ancestorsOf() filters by ancestors of the same scope');
     }
 
     /**
@@ -244,7 +254,17 @@ class NestedSetBehaviorQueryBuilderModifierWithScopeTest extends TestCase
             ->rootsOf($t5)
             ->orderByBranch()
             ->find();
-        $coll = $this->buildCollection([$t1, $t3, $t5], 'rootsOf() filters by ancestors of the same scope');
+        $coll = $this->buildCollection([$t1, $t3, $t5]);
+        /*
+         * FIXME
+         * -    'model' => 'Table10'
+         * -    'fullyQualifiedModel' => '\Table10'
+         * -    'formatter' => null
+         * +    'model' => 'NestedSetTable10'
+         * +    'fullyQualifiedModel' => '\NestedSetTable10'
+         * +    'formatter' => Propel\Runtime\Formatter\ObjectFormatter Object (...)
+         */
+        //$this->assertEquals($coll, $objs, 'rootsOf() filters by ancestors of the same scope');
     }
 
     /**
@@ -325,6 +345,11 @@ class NestedSetBehaviorQueryBuilderModifierWithScopeTest extends TestCase
         $this->assertEquals([$t8, $t9, $t10], iterator_to_array($tree), 'findTree() retrieves the tree of a scope, ordered by branch');
     }
 
+    /**
+     * @param array $arr
+     *
+     * @return \Propel\Runtime\Collection\ObjectCollection
+     */
     protected function buildCollection($arr)
     {
         $coll = new ObjectCollection();

--- a/tests/Propel/Tests/Generator/Behavior/NestedSet/NestedSetBehaviorQueryBuilderModifierWithScopeTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/NestedSet/NestedSetBehaviorQueryBuilderModifierWithScopeTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior\NestedSet;

--- a/tests/Propel/Tests/Generator/Behavior/NestedSet/NestedSetBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/NestedSet/NestedSetBehaviorTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior\NestedSet;

--- a/tests/Propel/Tests/Generator/Behavior/NestedSet/TestCase.php
+++ b/tests/Propel/Tests/Generator/Behavior/NestedSet/TestCase.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior\NestedSet;

--- a/tests/Propel/Tests/Generator/Behavior/ObjectBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/ObjectBehaviorTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior;

--- a/tests/Propel/Tests/Generator/Behavior/QueryBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/QueryBehaviorTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior;

--- a/tests/Propel/Tests/Generator/Behavior/QueryCache/QueryCacheTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/QueryCache/QueryCacheTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Propel/Tests/Generator/Behavior/QueryCache/QueryCacheTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/QueryCache/QueryCacheTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior\QueryCache;

--- a/tests/Propel/Tests/Generator/Behavior/Sluggable/SluggableBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Sluggable/SluggableBehaviorTest.php
@@ -104,6 +104,9 @@ class SluggableBehaviorTest extends BookstoreTestBase
         $this->assertEquals('/foo/hello-world/bar', $t->createRawSlug(), 'createRawSlug() returns a slug based on a pattern');
     }
 
+    /**
+     * @return string[][]
+     */
     public static function cleanupSlugProvider()
     {
         return [
@@ -122,6 +125,9 @@ class SluggableBehaviorTest extends BookstoreTestBase
     /**
      * @dataProvider cleanupSlugProvider
      *
+     * @param string $in
+     * @param string $out
+     *
      * @return void
      */
     public function testObjectCleanupSlugPart($in, $out)
@@ -130,6 +136,9 @@ class SluggableBehaviorTest extends BookstoreTestBase
         $this->assertEquals($out, $t->cleanupSlugPart($in), 'cleanupSlugPart() cleans up the slug part');
     }
 
+    /**
+     * @return array
+     */
     public static function limitSlugSizeProvider()
     {
         return [

--- a/tests/Propel/Tests/Generator/Behavior/Sluggable/SluggableBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Sluggable/SluggableBehaviorTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior\Sluggable;

--- a/tests/Propel/Tests/Generator/Behavior/Sluggable/SluggableBehaviorTestClasses.php
+++ b/tests/Propel/Tests/Generator/Behavior/Sluggable/SluggableBehaviorTestClasses.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior\Sluggable;

--- a/tests/Propel/Tests/Generator/Behavior/Sortable/SortableBehaviorObjectBuilderModifierTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Sortable/SortableBehaviorObjectBuilderModifierTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior\Sortable;

--- a/tests/Propel/Tests/Generator/Behavior/Sortable/SortableBehaviorObjectBuilderModifierWithScopeTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Sortable/SortableBehaviorObjectBuilderModifierWithScopeTest.php
@@ -480,7 +480,7 @@ class SortableBehaviorObjectBuilderModifierWithScopeTest extends TestCase
     }
 
     /**
-     * @expectedException Propel\Runtime\Exception\PropelException
+     * @expectedException \Propel\Runtime\Exception\PropelException
      *
      * @return void
      */

--- a/tests/Propel/Tests/Generator/Behavior/Sortable/SortableBehaviorObjectBuilderModifierWithScopeTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Sortable/SortableBehaviorObjectBuilderModifierWithScopeTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior\Sortable;

--- a/tests/Propel/Tests/Generator/Behavior/Sortable/SortableBehaviorQueryBuilderModifierTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Sortable/SortableBehaviorQueryBuilderModifierTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior\Sortable;

--- a/tests/Propel/Tests/Generator/Behavior/Sortable/SortableBehaviorQueryBuilderModifierWithScopeTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Sortable/SortableBehaviorQueryBuilderModifierWithScopeTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior\Sortable;

--- a/tests/Propel/Tests/Generator/Behavior/Sortable/SortableBehaviorQueryUtilsBuilderModifierTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Sortable/SortableBehaviorQueryUtilsBuilderModifierTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior\Sortable;

--- a/tests/Propel/Tests/Generator/Behavior/Sortable/SortableBehaviorQueryUtilsBuilderModifierWithScopeTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Sortable/SortableBehaviorQueryUtilsBuilderModifierWithScopeTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior\Sortable;

--- a/tests/Propel/Tests/Generator/Behavior/Sortable/SortableBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Sortable/SortableBehaviorTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior\Sortable;

--- a/tests/Propel/Tests/Generator/Behavior/Sortable/SortableBehaviorWithEnumScopeTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Sortable/SortableBehaviorWithEnumScopeTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior\Sortable;

--- a/tests/Propel/Tests/Generator/Behavior/Sortable/SortableBehaviorWithSetScopeTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Sortable/SortableBehaviorWithSetScopeTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior\Sortable;

--- a/tests/Propel/Tests/Generator/Behavior/Sortable/TestCase.php
+++ b/tests/Propel/Tests/Generator/Behavior/Sortable/TestCase.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior\Sortable;

--- a/tests/Propel/Tests/Generator/Behavior/TableBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/TableBehaviorTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior;

--- a/tests/Propel/Tests/Generator/Behavior/Timestampable/TimestampableBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Timestampable/TimestampableBehaviorTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior\Timestampable;

--- a/tests/Propel/Tests/Generator/Behavior/Validate/I18nConcreteInheritanceHandleValidateBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Validate/I18nConcreteInheritanceHandleValidateBehaviorTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior\Validate;

--- a/tests/Propel/Tests/Generator/Behavior/Validate/UniqueConstraintTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Validate/UniqueConstraintTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior\Validate;

--- a/tests/Propel/Tests/Generator/Behavior/Validate/ValidateBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Validate/ValidateBehaviorTest.php
@@ -105,7 +105,7 @@ class ValidateBehaviorTest extends BookstoreTestBase
     }
 
     /**
-     * @expectedException Propel\Generator\Exception\InvalidArgumentException
+     * @expectedException \Propel\Generator\Exception\InvalidArgumentException
      * @expectedExceptionMessage Please, define your rules for validation.
      *
      * @return void
@@ -125,7 +125,7 @@ EOF;
     }
 
     /**
-     * @expectedException Propel\Generator\Exception\InvalidArgumentException
+     * @expectedException \Propel\Generator\Exception\InvalidArgumentException
      * @expectedExceptionMessage Please, define the column to validate.
      *
      * @return void
@@ -148,7 +148,7 @@ EOF;
     }
 
     /**
-     * @expectedException Propel\Generator\Exception\InvalidArgumentException
+     * @expectedException \Propel\Generator\Exception\InvalidArgumentException
      * @expectedExceptionMessage Please, define the validator constraint.
      *
      * @return void
@@ -171,7 +171,7 @@ EOF;
     }
 
     /**
-     * @expectedException Propel\Generator\Exception\ConstraintNotFoundException
+     * @expectedException \Propel\Generator\Exception\ConstraintNotFoundException
      * @expectedExceptionMessage The constraint class MaximumLength does not exist.
      *
      * @return void
@@ -194,7 +194,7 @@ EOF;
     }
 
     /**
-     * @expectedException Propel\Generator\Exception\InvalidArgumentException
+     * @expectedException \Propel\Generator\Exception\InvalidArgumentException
      * @expectedExceptionMessage The options value, in <parameter> tag must be an array
      *
      * @return void

--- a/tests/Propel/Tests/Generator/Behavior/Validate/ValidateBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Validate/ValidateBehaviorTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior\Validate;

--- a/tests/Propel/Tests/Generator/Behavior/Versionable/TestCase.php
+++ b/tests/Propel/Tests/Generator/Behavior/Versionable/TestCase.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior\Versionable;

--- a/tests/Propel/Tests/Generator/Behavior/Versionable/VersionableBehaviorObjectBuilderModifierTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Versionable/VersionableBehaviorObjectBuilderModifierTest.php
@@ -12,6 +12,36 @@ namespace Propel\Tests\Generator\Behavior\Versionable;
 
 use Propel\Generator\Util\QuickBuilder;
 use Propel\Runtime\Collection\ObjectCollection;
+use VersionableBehaviorTest1;
+use VersionableBehaviorTest10;
+use VersionableBehaviorTest11;
+use VersionableBehaviorTest12;
+use VersionableBehaviorTest1Query;
+use VersionableBehaviorTest1Version;
+use VersionableBehaviorTest1VersionQuery;
+use VersionableBehaviorTest2Query;
+use VersionableBehaviorTest3;
+use VersionableBehaviorTest3Query;
+use VersionableBehaviorTest3VersionQuery;
+use VersionableBehaviorTest4;
+use VersionableBehaviorTest4VersionQuery;
+use VersionableBehaviorTest5;
+use VersionableBehaviorTest6;
+use VersionableBehaviorTest7;
+use VersionableBehaviorTest8Foo;
+use Versionablebehaviortest8Version;
+use VersionableBehaviorTestCustomField;
+use VersionableBehaviorTestCustomFieldKey;
+use VersionableBehaviorTestCustomFieldKeyQuery;
+use VersionableBehaviorTestCustomFieldKeyVersionQuery;
+use VersionableBehaviorTestCustomFieldQuery;
+use VersionableBehaviorTestCustomFieldVersionQuery;
+use VersionableBehaviorTestOneToOne;
+use VersionableBehaviorTestOneToOneKey;
+use VersionableBehaviorTestOneToOneKeyQuery;
+use VersionableBehaviorTestOneToOneKeyVersionQuery;
+use VersionableBehaviorTestOneToOneQuery;
+use VersionableBehaviorTestOneToOneVersionQuery;
 
 /**
  * Tests for VersionableBehavior class
@@ -20,6 +50,9 @@ use Propel\Runtime\Collection\ObjectCollection;
  */
 class VersionableBehaviorObjectBuilderModifierTest extends TestCase
 {
+    /**
+     * @return void
+     */
     public static function setUpBeforeClass(): void
     {
         $schema = <<<EOF
@@ -115,7 +148,6 @@ EOF;
 EOF;
         QuickBuilder::buildSchema($schema3);
 
-
         $schema4 = <<<EOF
 <database name="versionable_behavior_test_4">
     <table name="VersionableBehaviorTest10">
@@ -152,7 +184,7 @@ EOF;
     /**
      *  Schema to test relation 1:1 versionable
      */
-    $schema5 = <<<XML
+        $schema5 = <<<XML
 <database name="versionable_behavior_test_one_to_one_database">
     <table name="versionable_behavior_test_one_to_one">
         <column name="id" type="integer" primaryKey="true" autoIncrement="true"/>
@@ -171,7 +203,6 @@ EOF;
 </database>
 XML;
         QuickBuilder::buildSchema($schema5);
-
 
         $schemaCustomName = <<<EOF
 <database name="versionable_behavior_test_custom_field_database">
@@ -203,6 +234,9 @@ EOF;
         QuickBuilder::buildSchema($schemaCustomName);
     }
 
+    /**
+     * @return void
+     */
     public function testGetVersionExists()
     {
         $this->assertTrue(method_exists('VersionableBehaviorTest1', 'getVersion'));
@@ -210,6 +244,9 @@ EOF;
         $this->assertTrue(method_exists('VersionableBehaviorTestCustomField', 'getCustomVersion'));
     }
 
+    /**
+     * @return void
+     */
     public function testSetVersionExists()
     {
         $this->assertTrue(method_exists('VersionableBehaviorTest1', 'setVersion'));
@@ -217,6 +254,9 @@ EOF;
         $this->assertTrue(method_exists('VersionableBehaviorTestCustomField', 'setCustomVersion'));
     }
 
+    /**
+     * @return void
+     */
     public function testMethodsExistsNoChangeNaming()
     {
         $this->assertTrue(method_exists('VersionableBehaviorTest6', 'setFooBar'));
@@ -228,7 +268,6 @@ EOF;
         $this->assertTrue(method_exists('VersionableBehaviorTest7', 'setVersionCreatedAt'));
         $this->assertTrue(method_exists('VersionableBehaviorTest7', 'setVersionCreatedBy'));
         $this->assertTrue(method_exists('VersionableBehaviorTest7', 'setMyComment'));
-
     }
 
     public function providerForNewActiveRecordTests()
@@ -237,45 +276,53 @@ EOF;
             ['\VersionableBehaviorTest1'],
             ['VersionableBehaviorTest2'],
             ['VersionableBehaviorTestCustomField'],
-            ['VersionableBehaviorTestOneToOne']
+            ['VersionableBehaviorTestOneToOne'],
         ];
     }
 
     /**
      * @dataProvider providerForNewActiveRecordTests
+     *
+     * @return void
      */
     public function testVersionGetterAndSetter($class)
     {
-        $o = new $class;
+        $o = new $class();
         $o->setVersion(1234);
         $this->assertEquals(1234, $o->getVersion());
     }
 
     /**
      * @dataProvider providerForNewActiveRecordTests
+     *
+     * @return void
      */
     public function testVersionDefaultValue($class)
     {
-        $o = new $class;
+        $o = new $class();
         $this->assertEquals(0, $o->getVersion());
     }
 
     /**
      * @dataProvider providerForNewActiveRecordTests
+     *
+     * @return void
      */
     public function testVersionValueInitializesOnInsert($class)
     {
-        $o = new $class;
+        $o = new $class();
         $o->save();
         $this->assertEquals(1, $o->getVersion());
     }
 
     /**
      * @dataProvider providerForNewActiveRecordTests
+     *
+     * @return void
      */
     public function testVersionValueIncrementsOnUpdate($class)
     {
-        $o = new $class;
+        $o = new $class();
         $o->save();
         $this->assertEquals(1, $o->getVersion());
         $o->setBar(12);
@@ -289,17 +336,20 @@ EOF;
         $this->assertEquals(4, $o->getVersion());
     }
 
+    /**
+     * @return void
+     */
     public function testVersionValueIncrementsOnDeleteManyToMany()
     {
-        $bar = new \VersionableBehaviorTest10();
+        $bar = new VersionableBehaviorTest10();
         $bar->setBar(42);
         $bar->save();
 
-        $foo = new \VersionableBehaviorTest11();
+        $foo = new VersionableBehaviorTest11();
         $foo->setFoo('Marvin');
         $foo->save();
 
-        $baz = new \VersionableBehaviorTest12();
+        $baz = new VersionableBehaviorTest12();
         $baz->setVersionablebehaviortest11($foo);
         $baz->setBaz('So long and thanks for all the fish');
 
@@ -317,10 +367,12 @@ EOF;
 
     /**
      * @dataProvider providerForNewActiveRecordTests
+     *
+     * @return void
      */
     public function testVersionDoesNotIncrementOnUpdateWithNoChange($class)
     {
-        $o = new $class;
+        $o = new $class();
         $o->setBar(12);
         $o->save();
         $this->assertEquals(1, $o->getVersion());
@@ -331,43 +383,47 @@ EOF;
 
     /**
      * @dataProvider providerForNewActiveRecordTests
+     *
+     * @return void
      */
     public function testVersionDoesNotIncrementWhenVersioningIsDisabled($class)
     {
-        $o = new $class;
+        $o = new $class();
 
-        \VersionableBehaviorTest1Query::disableVersioning();
-        \VersionableBehaviorTest2Query::disableVersioning();
-        \VersionableBehaviorTestCustomFieldQuery::disableVersioning();
-        \VersionableBehaviorTestOneToOneQuery::disableVersioning();
+        VersionableBehaviorTest1Query::disableVersioning();
+        VersionableBehaviorTest2Query::disableVersioning();
+        VersionableBehaviorTestCustomFieldQuery::disableVersioning();
+        VersionableBehaviorTestOneToOneQuery::disableVersioning();
         $o->setBar(12);
         $o->save();
         $this->assertEquals(0, $o->getVersion());
         $o->setBar(13);
         $o->save();
         $this->assertEquals(0, $o->getVersion());
-        \VersionableBehaviorTest1Query::enableVersioning();
-        \VersionableBehaviorTest1Query::enableVersioning();
-        \VersionableBehaviorTestCustomFieldQuery::enableVersioning();
-        \VersionableBehaviorTestOneToOneQuery::enableVersioning();
-
+        VersionableBehaviorTest1Query::enableVersioning();
+        VersionableBehaviorTest1Query::enableVersioning();
+        VersionableBehaviorTestCustomFieldQuery::enableVersioning();
+        VersionableBehaviorTestOneToOneQuery::enableVersioning();
     }
 
+    /**
+     * @return void
+     */
     public function testNewVersionCreatesRecordInVersionTable()
     {
-        \VersionableBehaviorTest1Query::create()->deleteAll();
-        \VersionableBehaviorTest1VersionQuery::create()->deleteAll();
-        $o = new \VersionableBehaviorTest1();
+        VersionableBehaviorTest1Query::create()->deleteAll();
+        VersionableBehaviorTest1VersionQuery::create()->deleteAll();
+        $o = new VersionableBehaviorTest1();
         $o->save();
-        $versions = \VersionableBehaviorTest1VersionQuery::create()->find();
+        $versions = VersionableBehaviorTest1VersionQuery::create()->find();
         $this->assertEquals(1, $versions->count());
         $this->assertEquals($o, $versions[0]->getVersionableBehaviorTest1());
         $o->save();
-        $versions = \VersionableBehaviorTest1VersionQuery::create()->find();
+        $versions = VersionableBehaviorTest1VersionQuery::create()->find();
         $this->assertEquals(1, $versions->count());
         $o->setBar(123);
         $o->save();
-        $versions = \VersionableBehaviorTest1VersionQuery::create()->orderByVersion()->find();
+        $versions = VersionableBehaviorTest1VersionQuery::create()->orderByVersion()->find();
         $this->assertEquals(2, $versions->count());
         $this->assertEquals($o->getId(), $versions[0]->getId());
         $this->assertNull($versions[0]->getBar());
@@ -375,21 +431,24 @@ EOF;
         $this->assertEquals(123, $versions[1]->getBar());
     }
 
+    /**
+     * @return void
+     */
     public function testNewVersionCreatesRecordInVersionTableWithCustomName()
     {
-        \VersionableBehaviorTest3Query::create()->deleteAll();
-        \VersionableBehaviorTest3VersionQuery::create()->deleteAll();
-        $o = new \VersionableBehaviorTest3();
+        VersionableBehaviorTest3Query::create()->deleteAll();
+        VersionableBehaviorTest3VersionQuery::create()->deleteAll();
+        $o = new VersionableBehaviorTest3();
         $o->save();
-        $versions = \VersionableBehaviorTest3VersionQuery::create()->find();
+        $versions = VersionableBehaviorTest3VersionQuery::create()->find();
         $this->assertEquals(1, $versions->count());
         $this->assertEquals($o, $versions[0]->getVersionableBehaviorTest3());
         $o->save();
-        $versions = \VersionableBehaviorTest3VersionQuery::create()->find();
+        $versions = VersionableBehaviorTest3VersionQuery::create()->find();
         $this->assertEquals(1, $versions->count());
         $o->setBar(123);
         $o->save();
-        $versions = \VersionableBehaviorTest3VersionQuery::create()->orderByVersion()->find();
+        $versions = VersionableBehaviorTest3VersionQuery::create()->orderByVersion()->find();
         $this->assertEquals(2, $versions->count());
         $this->assertEquals($o->getId(), $versions[0]->getId());
         $this->assertNull($versions[0]->getBar());
@@ -397,23 +456,26 @@ EOF;
         $this->assertEquals(123, $versions[1]->getBar());
     }
 
+    /**
+     * @return void
+     */
     public function testNewVersionCreatesRecordInVersionTableWithFieldCustomName()
     {
-        \VersionableBehaviorTestCustomFieldQuery::create()->deleteAll();
-        \VersionableBehaviorTestCustomFieldVersionQuery::create()->deleteAll();
-        \VersionableBehaviorTestCustomFieldKeyQuery::create()->deleteAll();
-        \VersionableBehaviorTestCustomFieldKeyVersionQuery::create()->deleteAll();
+        VersionableBehaviorTestCustomFieldQuery::create()->deleteAll();
+        VersionableBehaviorTestCustomFieldVersionQuery::create()->deleteAll();
+        VersionableBehaviorTestCustomFieldKeyQuery::create()->deleteAll();
+        VersionableBehaviorTestCustomFieldKeyVersionQuery::create()->deleteAll();
 
-        $o = new \VersionableBehaviorTestCustomField();
+        $o = new VersionableBehaviorTestCustomField();
         $o->setBar(150);
         $o->save();
 
-        $k = new \VersionableBehaviorTestCustomFieldKey();
+        $k = new VersionableBehaviorTestCustomFieldKey();
         $k->setVersionableBehaviorTestCustomField($o);
         $k->save();
 
-        $versions     = \VersionableBehaviorTestCustomFieldVersionQuery::create()->find();
-        $versionsKeys = \VersionableBehaviorTestCustomFieldKeyVersionQuery::create()->find();
+        $versions = VersionableBehaviorTestCustomFieldVersionQuery::create()->find();
+        $versionsKeys = VersionableBehaviorTestCustomFieldKeyVersionQuery::create()->find();
 
         $this->assertEquals(1, $versions->count());
         $this->assertEquals(1, $versionsKeys->count());
@@ -423,12 +485,12 @@ EOF;
         $o->setBar(150);
         $o->save();
 
-        $versions = \VersionableBehaviorTestCustomFieldVersionQuery::create()->find();
+        $versions = VersionableBehaviorTestCustomFieldVersionQuery::create()->find();
         $this->assertEquals(1, $versions->count());
         $o->setBar(123);
         $o->save();
 
-        $versions = \VersionableBehaviorTestCustomFieldVersionQuery::create()->orderByCustomVersion()->find();
+        $versions = VersionableBehaviorTestCustomFieldVersionQuery::create()->orderByCustomVersion()->find();
 
         $this->assertEquals(2, $versions->count());
         $this->assertEquals($o->getId(), $versions[0]->getId());
@@ -443,51 +505,63 @@ EOF;
         $this->assertEquals($o->getId(), $versions[0]->getId());
     }
 
+    /**
+     * @return void
+     */
     public function testNewVersionDoesNotCreateRecordInVersionTableWhenVersioningIsDisabled()
     {
-        \VersionableBehaviorTest1Query::create()->deleteAll();
-        \VersionableBehaviorTest1VersionQuery::create()->deleteAll();
-        \VersionableBehaviorTest1Query::disableVersioning();
-        $o = new \VersionableBehaviorTest1();
+        VersionableBehaviorTest1Query::create()->deleteAll();
+        VersionableBehaviorTest1VersionQuery::create()->deleteAll();
+        VersionableBehaviorTest1Query::disableVersioning();
+        $o = new VersionableBehaviorTest1();
         $o->save();
-        $versions = \VersionableBehaviorTest1VersionQuery::create()->find();
+        $versions = VersionableBehaviorTest1VersionQuery::create()->find();
         $this->assertEquals(0, $versions->count());
-        \VersionableBehaviorTest1Query::enableVersioning();
+        VersionableBehaviorTest1Query::enableVersioning();
     }
 
+    /**
+     * @return void
+     */
     public function testDeleteObjectDeletesRecordInVersionTable()
     {
-        \VersionableBehaviorTest1Query::create()->deleteAll();
-        \VersionableBehaviorTest1VersionQuery::create()->deleteAll();
-        $o = new \VersionableBehaviorTest1();
+        VersionableBehaviorTest1Query::create()->deleteAll();
+        VersionableBehaviorTest1VersionQuery::create()->deleteAll();
+        $o = new VersionableBehaviorTest1();
         $o->save();
         $o->setBar(123);
         $o->save();
-        $nbVersions = \VersionableBehaviorTest1VersionQuery::create()->count();
+        $nbVersions = VersionableBehaviorTest1VersionQuery::create()->count();
         $this->assertEquals(2, $nbVersions);
         $o->delete();
-        $nbVersions = \VersionableBehaviorTest1VersionQuery::create()->count();
+        $nbVersions = VersionableBehaviorTest1VersionQuery::create()->count();
         $this->assertEquals(0, $nbVersions);
     }
 
+    /**
+     * @return void
+     */
     public function testDeleteObjectDeletesRecordInVersionTableWithCustomName()
     {
-        \VersionableBehaviorTest3Query::create()->deleteAll();
-        \VersionableBehaviorTest3VersionQuery::create()->deleteAll();
-        $o = new \VersionableBehaviorTest3();
+        VersionableBehaviorTest3Query::create()->deleteAll();
+        VersionableBehaviorTest3VersionQuery::create()->deleteAll();
+        $o = new VersionableBehaviorTest3();
         $o->save();
         $o->setBar(123);
         $o->save();
-        $nbVersions = \VersionableBehaviorTest3VersionQuery::create()->count();
+        $nbVersions = VersionableBehaviorTest3VersionQuery::create()->count();
         $this->assertEquals(2, $nbVersions);
         $o->delete();
-        $nbVersions = \VersionableBehaviorTest3VersionQuery::create()->count();
+        $nbVersions = VersionableBehaviorTest3VersionQuery::create()->count();
         $this->assertEquals(0, $nbVersions);
     }
 
+    /**
+     * @return void
+     */
     public function testToVersion()
     {
-        $o = new \VersionableBehaviorTest1();
+        $o = new VersionableBehaviorTest1();
         $o->setBar(123); // version 1
         $o->save();
         $o->setBar(456); // version 2
@@ -498,9 +572,12 @@ EOF;
         $this->assertEquals(456, $o->getBar());
     }
 
+    /**
+     * @return void
+     */
     public function testToVersionAllowsFurtherSave()
     {
-        $o = new \VersionableBehaviorTest1();
+        $o = new VersionableBehaviorTest1();
         $o->setBar(123); // version 1
         $o->save();
         $o->setBar(456); // version 2
@@ -513,20 +590,25 @@ EOF;
 
     /**
      * @expectedException \Propel\Runtime\Exception\PropelException
+     *
+     * @return void
      */
     public function testToVersionThrowsExceptionOnIncorrectVersion()
     {
-        $o = new \VersionableBehaviorTest1();
+        $o = new VersionableBehaviorTest1();
         $o->setBar(123); // version 1
         $o->save();
         $o->toVersion(2);
     }
 
+    /**
+     * @return void
+     */
     public function testToVersionPreservesVersionedFkObjects()
     {
-        $a = new \VersionableBehaviorTest4();
+        $a = new VersionableBehaviorTest4();
         $a->setBar(123); // a1
-        $b = new \VersionableBehaviorTest5();
+        $b = new VersionableBehaviorTest5();
         $b->setFoo('Hello');
         $b->setVersionableBehaviorTest4($a);
         $b->save(); //b1
@@ -545,13 +627,16 @@ EOF;
         $this->assertEquals($b->getVersionableBehaviorTest4()->getVersion(), 2);
     }
 
+    /**
+     * @return void
+     */
     public function testToVersionPreservesVersionedReferrerObjects()
     {
-        $b1 = new \VersionableBehaviorTest5();
+        $b1 = new VersionableBehaviorTest5();
         $b1->setFoo('Hello');
-        $b2 = new \VersionableBehaviorTest5();
+        $b2 = new VersionableBehaviorTest5();
         $b2->setFoo('World');
-        $a = new \VersionableBehaviorTest4();
+        $a = new VersionableBehaviorTest4();
         $a->setBar(123); // a1
         $a->addVersionableBehaviorTest5($b1);
         $a->addVersionableBehaviorTest5($b2);
@@ -566,7 +651,7 @@ EOF;
         $bs = $a->getVersionableBehaviorTest5s();
         $this->assertEquals(2, $bs[0]->getVersion());
         $this->assertEquals(1, $bs[1]->getVersion());
-        $b3 = new \VersionableBehaviorTest5();
+        $b3 = new VersionableBehaviorTest5();
         $b3->setFoo('Yep');
         $a->clearVersionableBehaviorTest5s();
         $a->addVersionableBehaviorTest5($b3);
@@ -588,9 +673,12 @@ EOF;
         $this->assertEquals(2, $a->getVersion());
     }
 
+    /**
+     * @return void
+     */
     public function testGetLastVersionNumber()
     {
-        $o = new \VersionableBehaviorTest1();
+        $o = new VersionableBehaviorTest1();
         $this->assertEquals(0, $o->getLastVersionNumber());
         $o->setBar(123); // version 1
         $o->save();
@@ -603,9 +691,12 @@ EOF;
         $this->assertEquals(3, $o->getLastVersionNumber());
     }
 
+    /**
+     * @return void
+     */
     public function testIsLastVersion()
     {
-        $o = new \VersionableBehaviorTest1();
+        $o = new VersionableBehaviorTest1();
         $this->assertTrue($o->isLastVersion());
         $o->setBar(123); // version 1
         $o->save();
@@ -619,9 +710,12 @@ EOF;
         $this->assertTrue($o->isLastVersion());
     }
 
+    /**
+     * @return void
+     */
     public function testIsVersioningNecessary()
     {
-        $o = new \VersionableBehaviorTest1();
+        $o = new VersionableBehaviorTest1();
         $this->assertTrue($o->isVersioningNecessary());
         $o->save();
         $this->assertFalse($o->isVersioningNecessary());
@@ -630,8 +724,8 @@ EOF;
         $o->save();
         $this->assertFalse($o->isVersioningNecessary());
 
-        \VersionableBehaviorTest1Query::disableVersioning();
-        $o = new \VersionableBehaviorTest1();
+        VersionableBehaviorTest1Query::disableVersioning();
+        $o = new VersionableBehaviorTest1();
         $this->assertFalse($o->isVersioningNecessary());
         $o->save();
         $this->assertFalse($o->isVersioningNecessary());
@@ -639,13 +733,13 @@ EOF;
         $this->assertFalse($o->isVersioningNecessary());
         $o->save();
         $this->assertFalse($o->isVersioningNecessary());
-        \VersionableBehaviorTest1Query::enableVersioning();
+        VersionableBehaviorTest1Query::enableVersioning();
 
-        $b1 = new \VersionableBehaviorTest5();
+        $b1 = new VersionableBehaviorTest5();
         $b1->setFoo('Hello');
-        $b2 = new \VersionableBehaviorTest5();
+        $b2 = new VersionableBehaviorTest5();
         $b2->setFoo('World');
-        $a = new \VersionableBehaviorTest4();
+        $a = new VersionableBehaviorTest4();
         $a->setBar(123); // a1
         $this->assertTrue($a->isVersioningNecessary());
         $a->save();
@@ -666,11 +760,14 @@ EOF;
         $this->assertFalse($a->isVersioningNecessary());
     }
 
+    /**
+     * @return void
+     */
     public function testIsVersioningNecessaryWithNullFk()
     {
         // the purpose of this tests is to highlight a bug with FK
         // and isVersioningNecessary()
-        $b1 = new \VersionableBehaviorTest5();
+        $b1 = new VersionableBehaviorTest5();
         $b1->setNew(false);
 
         // this time, the object isn't modified, so the
@@ -681,55 +778,67 @@ EOF;
         $this->assertTrue(true, 'getting here means that nothing went wrong');
     }
 
+    /**
+     * @return void
+     */
     public function testAddVersionNewObject()
     {
-        \VersionableBehaviorTest1Query::disableVersioning();
-        \VersionableBehaviorTest1Query::create()->deleteAll();
-        \VersionableBehaviorTest1VersionQuery::create()->deleteAll();
-        $o = new \VersionableBehaviorTest1();
+        VersionableBehaviorTest1Query::disableVersioning();
+        VersionableBehaviorTest1Query::create()->deleteAll();
+        VersionableBehaviorTest1VersionQuery::create()->deleteAll();
+        $o = new VersionableBehaviorTest1();
         $o->addVersion();
         $o->save();
-        $versions = \VersionableBehaviorTest1VersionQuery::create()->find();
+        $versions = VersionableBehaviorTest1VersionQuery::create()->find();
         $this->assertEquals(1, $versions->count());
         $this->assertEquals($o, $versions[0]->getVersionableBehaviorTest1());
-        \VersionableBehaviorTest1Query::enableVersioning();
+        VersionableBehaviorTest1Query::enableVersioning();
     }
 
+    /**
+     * @return void
+     */
     public function testVersionCreatedAt()
     {
-        $o = new \VersionableBehaviorTest4();
+        $o = new VersionableBehaviorTest4();
         $t = time();
         $o->save();
-        $version = \VersionableBehaviorTest4VersionQuery::create()
+        $version = VersionableBehaviorTest4VersionQuery::create()
             ->filterByVersionableBehaviorTest4($o)
             ->findOne();
         $this->assertEquals($t, $version->getVersionCreatedAt('U'));
 
-        $o = new \VersionableBehaviorTest4();
+        $o = new VersionableBehaviorTest4();
         $inThePast = time() - 123456;
         $o->setVersionCreatedAt($inThePast);
         $o->save();
         $this->assertEquals($inThePast, $o->getVersionCreatedAt('U'));
-        $version = \VersionableBehaviorTest4VersionQuery::create()
+        $version = VersionableBehaviorTest4VersionQuery::create()
             ->filterByVersionableBehaviorTest4($o)
             ->findOne();
         $this->assertEquals($o->getVersionCreatedAt(), $version->getVersionCreatedAt());
     }
 
+    /**
+     * @return void
+     */
     public function testVersionCreatedBy()
     {
-        $o = new \VersionableBehaviorTest4();
+        $o = new VersionableBehaviorTest4();
         $o->setVersionCreatedBy('me me me');
         $o->save();
-        $version = \VersionableBehaviorTest4VersionQuery::create()
+        $version = VersionableBehaviorTest4VersionQuery::create()
             ->filterByVersionableBehaviorTest4($o)
             ->findOne();
         $this->assertEquals('me me me', $version->getVersionCreatedBy());
     }
 
+    /**
+     * @return void
+     */
     public function testSaveAndModifyWithNoChangeSchema()
     {
-        $o = new \VersionableBehaviorTest7();
+        $o = new VersionableBehaviorTest7();
         //$o->setVersionCreatedBy('You and I');
         $o->save();
         $this->assertEquals(1, $o->getVersion());
@@ -737,7 +846,7 @@ EOF;
         $o->save();
         $this->assertEquals(2, $o->getVersion());
 
-        $o = new \VersionableBehaviorTest6();
+        $o = new VersionableBehaviorTest6();
         //$o->setVersionCreatedBy('You and I');
         $o->save();
         $this->assertEquals(1, $o->getVersion());
@@ -746,21 +855,27 @@ EOF;
         $this->assertEquals(2, $o->getVersion());
     }
 
+    /**
+     * @return void
+     */
     public function testVersionComment()
     {
-        $o = new \VersionableBehaviorTest4();
+        $o = new VersionableBehaviorTest4();
 
         $o->setVersionComment('Because you deserve it');
         $o->save();
-        $version = \VersionableBehaviorTest4VersionQuery::create()
+        $version = VersionableBehaviorTest4VersionQuery::create()
             ->filterByVersionableBehaviorTest4($o)
             ->findOne();
         $this->assertEquals('Because you deserve it', $version->getVersionComment());
     }
 
+    /**
+     * @return void
+     */
     public function testToVersionWorksWithComments()
     {
-        $o = new \VersionableBehaviorTest4();
+        $o = new VersionableBehaviorTest4();
         $o->setVersionComment('Because you deserve it');
         $o->setBar(123); // version 1
         $o->save();
@@ -773,15 +888,18 @@ EOF;
         $this->assertEquals('Unless I change my mind', $o->getVersionComment());
     }
 
+    /**
+     * @return void
+     */
     public function testGetOneVersion()
     {
-        $o = new \VersionableBehaviorTest1();
+        $o = new VersionableBehaviorTest1();
         $o->setBar(123); // version 1
         $o->save();
         $o->setBar(456); // version 2
         $o->save();
         $version = $o->getOneVersion(1);
-        $this->assertTrue($version instanceof \VersionableBehaviorTest1Version);
+        $this->assertTrue($version instanceof VersionableBehaviorTest1Version);
         $this->assertEquals(1, $version->getVersion());
         $this->assertEquals(123, $version->getBar());
         $version = $o->getOneVersion(2);
@@ -789,9 +907,12 @@ EOF;
         $this->assertEquals(456, $version->getBar());
     }
 
+    /**
+     * @return void
+     */
     public function testGetAllVersions()
     {
-        $o = new \VersionableBehaviorTest1();
+        $o = new VersionableBehaviorTest1();
         $versions = $o->getAllVersions();
         $this->assertTrue($versions->isEmpty());
         $o->setBar(123); // version 1
@@ -807,9 +928,12 @@ EOF;
         $this->assertEquals(456, $versions[1]->getBar());
     }
 
+    /**
+     * @return void
+     */
     public function testGetLastVersions()
     {
-        $o = new \VersionableBehaviorTest1();
+        $o = new VersionableBehaviorTest1();
         $versions = $o->getAllVersions();
         $this->assertTrue($versions->isEmpty());
         $o->setBar(123); // version 1
@@ -842,9 +966,12 @@ EOF;
         $this->assertEquals(789, $versions[1]->getBar());
     }
 
+    /**
+     * @return void
+     */
     public function testCompareVersion()
     {
-        $o = new \VersionableBehaviorTest4();
+        $o = new VersionableBehaviorTest4();
         $versions = $o->getAllVersions();
         $this->assertTrue($versions->isEmpty());
         $o->setBar(123); // version 1
@@ -870,9 +997,12 @@ EOF;
         $this->assertEquals($expected, $diff);
     }
 
+    /**
+     * @return void
+     */
     public function testCompareVersions()
     {
-        $o = new \VersionableBehaviorTest4();
+        $o = new VersionableBehaviorTest4();
         $versions = $o->getAllVersions();
         $this->assertTrue($versions->isEmpty());
         $o->setBar(123); // version 1
@@ -884,22 +1014,25 @@ EOF;
         $o->save();
         $diff = $o->compareVersions(1, 3);
         $expected = [
-            'Bar' => [1 => 123, 3 => 789]
+            'Bar' => [1 => 123, 3 => 789],
         ];
         $this->assertEquals($expected, $diff);
         $diff = $o->compareVersions(1, 3, 'versions');
         $expected = [
             1 => ['Bar' => 123],
-            3 => ['Bar' => 789]
+            3 => ['Bar' => 789],
         ];
         $this->assertEquals($expected, $diff);
     }
 
+    /**
+     * @return void
+     */
     public function testForeignKeyVersion()
     {
-        $a = new \VersionableBehaviorTest4();
+        $a = new VersionableBehaviorTest4();
         $a->setBar(123); // a1
-        $b = new \VersionableBehaviorTest5();
+        $b = new VersionableBehaviorTest5();
         $b->setFoo('Hello');
         $b->setVersionableBehaviorTest4($a);
         $b->save(); //b1
@@ -915,13 +1048,16 @@ EOF;
         $this->assertEquals($b->getVersionableBehaviorTest4()->getVersion(), 2);
     }
 
+    /**
+     * @return void
+     */
     public function testReferrerVersion()
     {
-        $b1 = new \VersionableBehaviorTest5();
+        $b1 = new VersionableBehaviorTest5();
         $b1->setFoo('Hello');
-        $b2 = new \VersionableBehaviorTest5();
+        $b2 = new VersionableBehaviorTest5();
         $b2->setFoo('World');
-        $a = new \VersionableBehaviorTest4();
+        $a = new VersionableBehaviorTest4();
         $a->setBar(123); // a1
         $a->addVersionableBehaviorTest5($b1);
         $a->addVersionableBehaviorTest5($b2);
@@ -932,7 +1068,7 @@ EOF;
         $a->save();
         $this->assertEquals(2, $a->getVersion());
         $this->assertEquals([2, 1], $a->getOneVersion(2)->getVersionableBehaviorTest5Versions());
-        $b3 = new \VersionableBehaviorTest5();
+        $b3 = new VersionableBehaviorTest5();
         $b3->setFoo('Yep');
         $a->clearVersionableBehaviorTest5s();
         $a->addVersionableBehaviorTest5($b3);
@@ -942,9 +1078,12 @@ EOF;
         $this->assertEquals([2, 1, 1], $a->getOneVersion(3)->getVersionableBehaviorTest5Versions());
     }
 
+    /**
+     * @return void
+     */
     public function testEnumField()
     {
-        $o = new \VersionableBehaviorTest7();
+        $o = new VersionableBehaviorTest7();
         $o->setStyle('novel');
         $o->save();
 
@@ -961,9 +1100,12 @@ EOF;
         $this->assertEquals('essay', $o->getOneVersion(2)->getStyle(), 'Second version is an essay');
     }
 
+    /**
+     * @return void
+     */
     public function testSetField()
     {
-        $o = new \VersionableBehaviorTest7();
+        $o = new VersionableBehaviorTest7();
         $o->setStyle2(['novel', 'essay']);
         $o->save();
 
@@ -980,21 +1122,27 @@ EOF;
         $this->assertEquals(['essay'], $o->getOneVersion(2)->getStyle2(), 'Second version is an essay');
     }
 
+    /**
+     * @return void
+     */
     public function testWithInheritance()
     {
-        $b1 = new \VersionableBehaviorTest8Foo();
+        $b1 = new VersionableBehaviorTest8Foo();
         $b1->save();
 
         $b1->setFoobar('name');
         $b1->save();
 
         $object = $b1->getOneVersion($b1->getVersion());
-        $this->assertTrue($object instanceof \Versionablebehaviortest8Version);
+        $this->assertTrue($object instanceof Versionablebehaviortest8Version);
     }
 
+    /**
+     * @return void
+     */
     public function testEnforceVersioning()
     {
-        $bar = new \VersionableBehaviorTest10();
+        $bar = new VersionableBehaviorTest10();
         $bar->setBar(42);
         $bar->save();
 
@@ -1008,26 +1156,29 @@ EOF;
         $this->assertEquals(2, $bar->getVersion());
     }
 
+    /**
+     * @return void
+     */
     public function testOneToOneCreatesValidRecord()
     {
-        \VersionableBehaviorTestOneToOneQuery::create()->deleteAll();
-        \VersionableBehaviorTestOneToOneKeyQuery::create()->deleteAll();
-        \VersionableBehaviorTestOneToOneVersionQuery::create()->deleteAll();
-        \VersionableBehaviorTestOneToOneKeyVersionQuery::create()->deleteAll();
+        VersionableBehaviorTestOneToOneQuery::create()->deleteAll();
+        VersionableBehaviorTestOneToOneKeyQuery::create()->deleteAll();
+        VersionableBehaviorTestOneToOneVersionQuery::create()->deleteAll();
+        VersionableBehaviorTestOneToOneKeyVersionQuery::create()->deleteAll();
 
-        $x = new \VersionableBehaviorTestOneToOne();
-        $x->setBar("One To....");
+        $x = new VersionableBehaviorTestOneToOne();
+        $x->setBar('One To....');
         $x->save();
 
-        $y = new \VersionableBehaviorTestOneToOneKey();
+        $y = new VersionableBehaviorTestOneToOneKey();
         $y->setVersionableBehaviorTestOneToOne($x);
-        $y->setBar("One");
+        $y->setBar('One');
         $y->save();
 
         $this->assertEquals(1, $x->getVersion());
         $this->assertEquals(1, $y->getVersion());
 
-        $newX = \VersionableBehaviorTestOneToOneQuery::create()->findOne();
+        $newX = VersionableBehaviorTestOneToOneQuery::create()->findOne();
         $this->assertInstanceOf('VersionableBehaviorTestOneToOne', $x);
         $this->assertInstanceOf('VersionableBehaviorTestOneToOne', $newX);
         $this->assertEquals($x, $newX);
@@ -1048,6 +1199,5 @@ EOF;
 
         $this->assertEquals('One To....', $x->getBar());
         $this->assertEquals('One', $x->getVersionableBehaviorTestOneToOneKey()->getBar());//$y
-
     }
 }

--- a/tests/Propel/Tests/Generator/Behavior/Versionable/VersionableBehaviorObjectBuilderModifierTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Versionable/VersionableBehaviorObjectBuilderModifierTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior\Versionable;

--- a/tests/Propel/Tests/Generator/Behavior/Versionable/VersionableBehaviorQueryBuilderModifierTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Versionable/VersionableBehaviorQueryBuilderModifierTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior\Versionable;

--- a/tests/Propel/Tests/Generator/Behavior/Versionable/VersionableBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Versionable/VersionableBehaviorTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Behavior\Versionable;

--- a/tests/Propel/Tests/Generator/Builder/NamespaceTest.php
+++ b/tests/Propel/Tests/Generator/Builder/NamespaceTest.php
@@ -298,6 +298,12 @@ class NamespaceTest extends TestCaseFixturesDatabase
             ->joinWith('NamespacedBookListRel')
             ->joinWith('NamespacedBookListRel.NamespacedBookClub')
             ->find($con);
+
+        $array = $books->toArray();
+        $this->assertCount(2, $array);
+
+        $expected = 'Someone1';
+        $this->assertSame($expected, $array[0]['NamespacedBookListRels'][0]['NamespacedBookClub']['GroupLeader']);
     }
 
     /**

--- a/tests/Propel/Tests/Generator/Builder/NamespaceTest.php
+++ b/tests/Propel/Tests/Generator/Builder/NamespaceTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Builder;

--- a/tests/Propel/Tests/Generator/Builder/Om/AbstractOMBuilderNamespaceTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/AbstractOMBuilderNamespaceTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Builder\Om;

--- a/tests/Propel/Tests/Generator/Builder/Om/AbstractOMBuilderNamespaceTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/AbstractOMBuilderNamespaceTest.php
@@ -20,7 +20,6 @@ use Propel\Tests\TestCase;
  * Test class for OMBuilder.
  *
  * @author François Zaninotto
- * @version $Id: OMBuilderBuilderTest.php 1347 2009-12-03 21:06:36Z francois $
  */
 class AbstractOMBuilderNamespaceTest extends TestCase
 {

--- a/tests/Propel/Tests/Generator/Builder/Om/AbstractOMBuilderRelatedByTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/AbstractOMBuilderRelatedByTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Builder\Om;

--- a/tests/Propel/Tests/Generator/Builder/Om/AbstractOMBuilderRelatedByTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/AbstractOMBuilderRelatedByTest.php
@@ -20,7 +20,6 @@ use Propel\Tests\TestCase;
  * Test class for OMBuilder.
  *
  * @author François Zaninotto
- * @version $Id: OMBuilderBuilderTest.php 1347 2009-12-03 21:06:36Z francois $
  */
 class AbstractOMBuilderRelatedByTest extends TestCase
 {

--- a/tests/Propel/Tests/Generator/Builder/Om/AbstractOMBuilderTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/AbstractOMBuilderTest.php
@@ -20,7 +20,6 @@ use Propel\Tests\TestCase;
  * Test class for OMBuilder.
  *
  * @author François Zaninotto
- * @version $Id: OMBuilderBuilderTest.php 1347 2009-12-03 21:06:36Z francois $
  */
 class AbstractOMBuilderTest extends TestCase
 {

--- a/tests/Propel/Tests/Generator/Builder/Om/AbstractOMBuilderTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/AbstractOMBuilderTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Builder\Om;

--- a/tests/Propel/Tests/Generator/Builder/Om/Fixtures/ComplexColumnTypeEntityWithConstructor.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/Fixtures/ComplexColumnTypeEntityWithConstructor.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Builder\Om\Fixtures;

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectArrayColumnTypeTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectArrayColumnTypeTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Builder\Om;

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectBooleanColumnTypeTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectBooleanColumnTypeTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Builder\Om;

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectBooleanColumnTypeTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectBooleanColumnTypeTest.php
@@ -8,6 +8,9 @@
  * @license MIT License
  */
 
+namespace Propel\Tests\Generator\Builder\Om;
+
+use ComplexColumnTypeEntity4;
 use Propel\Generator\Util\QuickBuilder;
 use Propel\Tests\TestCase;
 
@@ -50,6 +53,9 @@ EOF;
         $this->assertTrue(method_exists('ComplexColumnTypeEntity4', 'hasXy'));
     }
 
+    /**
+     * @return array
+     */
     public function providerForSetter()
     {
         return [

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectEnumColumnTypeTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectEnumColumnTypeTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Builder\Om;

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectJsonColumnTypeTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectJsonColumnTypeTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Builder\Om;

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectLazyLoadTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectLazyLoadTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Builder\Om;

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectLobTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectLobTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Builder\Om;

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectLobTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectLobTest.php
@@ -10,6 +10,7 @@
 
 namespace Propel\Tests\Generator\Builder\Om;
 
+use Exception;
 use Propel\Tests\Bookstore\BookQuery;
 use Propel\Tests\Bookstore\Map\MediaTableMap;
 use Propel\Tests\Bookstore\Media;
@@ -64,7 +65,7 @@ class GeneratedObjectLobTest extends BookstoreEmptyTestBase
      *
      * @param string|null $basename Basename of LOB filename to return (if left blank, will choose random file).
      *
-     * @throws Exception - if specified basename doesn't correspond to a registered LOB filename
+     * @throws \Exception - if specified basename doesn't correspond to a registered LOB filename
      *
      * @return string
      */
@@ -76,9 +77,9 @@ class GeneratedObjectLobTest extends BookstoreEmptyTestBase
 
         if (isset($this->sampleLobFiles[$basename])) {
             return $this->sampleLobFiles[$basename];
-        } else {
-            throw new Exception("Invalid base LOB filename: $basename");
         }
+
+        throw new Exception("Invalid base LOB filename: $basename");
     }
 
     /**

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectM2MRelationSimpleTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectM2MRelationSimpleTest.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Generator\Builder\Om;
 
 use Map\Relation1UserTableMap;

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectM2MRelationThreePKs2Test.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectM2MRelationThreePKs2Test.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Generator\Builder\Om;
 
 use Base\RelationpkUserGroupQuery;

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectM2MRelationThreePKsTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectM2MRelationThreePKsTest.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Generator\Builder\Om;
 
 use Map\Relation2UserTableMap;

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectM2MRelationThreePKsTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectM2MRelationThreePKsTest.php
@@ -2,11 +2,38 @@
 
 namespace Propel\Tests\Generator\Builder\Om;
 
-use Propel\Generator\Platform\MysqlPlatform;
-use Propel\Generator\Util\QuickBuilder;
-use Propel\Runtime\Collection\ObjectCollection;
+use Map\Relation2UserTableMap;
 use Propel\Runtime\Collection\ObjectCombinationCollection;
 use Propel\Tests\Helpers\PlatformDatabaseBuildTimeBase;
+use Relation2Group;
+use Relation2GroupQuery;
+use Relation2Position;
+use Relation2PositionQuery;
+use Relation2User;
+use Relation2UserGroupQuery;
+use Relation2UserQuery;
+use Relation3Group;
+use Relation3GroupQuery;
+use Relation3Relation;
+use Relation3RelationQuery;
+use Relation3User;
+use Relation3UserGroupQuery;
+use Relation3UserQuery;
+use Relation4Group;
+use Relation4GroupQuery;
+use Relation4User;
+use Relation4UserGroupQuery;
+use Relation4UserQuery;
+use Relation5Group;
+use Relation5GroupQuery;
+use Relation5User;
+use Relation5UserGroupQuery;
+use Relation5UserQuery;
+use Relation6Group;
+use Relation6GroupQuery;
+use Relation6User;
+use Relation6UserGroupQuery;
+use Relation6UserQuery;
 
 /**
  * Tests for a M2M relation with three pks where each is a FK.
@@ -17,6 +44,9 @@ class GeneratedObjectM2MRelationThreePKsTest extends PlatformDatabaseBuildTimeBa
 {
     protected $databaseName = 'migration';
 
+    /**
+     * @return void
+     */
     public function setUp(): void
     {
         parent::setUp();
@@ -64,36 +94,35 @@ class GeneratedObjectM2MRelationThreePKsTest extends PlatformDatabaseBuildTimeBa
     }
 
     /**
-     *
-     *           add     |    remove     |    set     |    get
+     *           add | remove | set | get
      *        +---------------------------------------------------
-     * add    |    1             2             3            4
-     * remove |    5             6             7            8
-     * set    |    9            10            11           12
-     *
+     * add | 1 2 3 4
+     * remove | 5 6 7 8
+     * set | 9 10 11 12
      */
-
-
 
     /*
      * ####################################
      * 1. add, add
      */
+
+    /**
+     * @return void
+     */
     public function test1()
     {
+        Relation2UserQuery::create()->deleteAll();
+        Relation2GroupQuery::create()->deleteAll();
+        Relation2UserGroupQuery::create()->deleteAll();
+        Relation2PositionQuery::create()->deleteAll();
 
-        \Relation2UserQuery::create()->deleteAll();
-        \Relation2GroupQuery::create()->deleteAll();
-        \Relation2UserGroupQuery::create()->deleteAll();
-        \Relation2PositionQuery::create()->deleteAll();
-
-        $hans = new \Relation2User();
+        $hans = new Relation2User();
         $hans->setName('hans');
 
-        $admins = new \Relation2Group();
+        $admins = new Relation2Group();
         $admins->setName('Admins');
 
-        $position = new \Relation2Position();
+        $position = new Relation2Position();
         $position->setName('Trainee');
 
         $hans->addGroup($admins, $position);
@@ -101,195 +130,209 @@ class GeneratedObjectM2MRelationThreePKsTest extends PlatformDatabaseBuildTimeBa
         $this->assertCount(1, $admins->getUserPositions());
         $hans->save();
 
-        $this->assertEquals(1, \Relation2UserGroupQuery::create()->count(), 'We have one connection.');
-        $this->assertEquals(1, \Relation2UserQuery::create()->count(), 'We have one user.');
-        $this->assertEquals(1, \Relation2GroupQuery::create()->count(), 'We have one group.');
-        $this->assertEquals(1, \Relation2PositionQuery::create()->count(), 'We have one position.');
+        $this->assertEquals(1, Relation2UserGroupQuery::create()->count(), 'We have one connection.');
+        $this->assertEquals(1, Relation2UserQuery::create()->count(), 'We have one user.');
+        $this->assertEquals(1, Relation2GroupQuery::create()->count(), 'We have one group.');
+        $this->assertEquals(1, Relation2PositionQuery::create()->count(), 'We have one position.');
 
-        $positionLead = new \Relation2Position();
+        $positionLead = new Relation2Position();
         $positionLead->setName('Lead');
         $hans->addGroup($admins, $positionLead);
         $this->assertCount(2, $hans->getGroupPositions());
         $this->assertCount(2, $admins->getUserPositions());
         $hans->save();
 
-        $this->assertEquals(2, \Relation2UserGroupQuery::create()->count(), 'We have two connections.');
-        $this->assertEquals(1, \Relation2UserQuery::create()->count(), 'We have one user.');
-        $this->assertEquals(1, \Relation2GroupQuery::create()->count(), 'We have one group.');
-        $this->assertEquals(2, \Relation2PositionQuery::create()->count(), 'We have two positions.');
+        $this->assertEquals(2, Relation2UserGroupQuery::create()->count(), 'We have two connections.');
+        $this->assertEquals(1, Relation2UserQuery::create()->count(), 'We have one user.');
+        $this->assertEquals(1, Relation2GroupQuery::create()->count(), 'We have one group.');
+        $this->assertEquals(2, Relation2PositionQuery::create()->count(), 'We have two positions.');
 
         //try to add the same combination on a new instance
-        \Map\Relation2UserTableMap::clearInstancePool();
-        /** @var $newHansObject \Relation2User */
-        $newHansObject = \Relation2UserQuery::create()->findOneByName('hans');
+        Relation2UserTableMap::clearInstancePool();
+        /** @var \Relation2User $newHansObject */
+        $newHansObject = Relation2UserQuery::create()->findOneByName('hans');
 
         $newHansObject->addGroup($admins, $positionLead);
         $this->assertCount(2, $newHansObject->getGroupPositions());
         $this->assertCount(2, $admins->getUserPositions()); //wrong
         $newHansObject->save();
 
-        $this->assertEquals(2, \Relation2UserGroupQuery::create()->count(), 'We have two connections.');
-        $this->assertEquals(1, \Relation2UserQuery::create()->count(), 'We have one user.');
-        $this->assertEquals(1, \Relation2GroupQuery::create()->count(), 'We have one group.');
-        $this->assertEquals(2, \Relation2PositionQuery::create()->count(), 'We have two positions.');
+        $this->assertEquals(2, Relation2UserGroupQuery::create()->count(), 'We have two connections.');
+        $this->assertEquals(1, Relation2UserQuery::create()->count(), 'We have one user.');
+        $this->assertEquals(1, Relation2GroupQuery::create()->count(), 'We have one group.');
+        $this->assertEquals(2, Relation2PositionQuery::create()->count(), 'We have two positions.');
     }
-
 
     /*
      * ####################################
      * 2. add, remove
      */
+
+    /**
+     * @return void
+     */
     public function test2()
     {
-        \Relation2UserQuery::create()->deleteAll();
-        \Relation2GroupQuery::create()->deleteAll();
-        \Relation2UserGroupQuery::create()->deleteAll();
-        \Relation2PositionQuery::create()->deleteAll();
+        Relation2UserQuery::create()->deleteAll();
+        Relation2GroupQuery::create()->deleteAll();
+        Relation2UserGroupQuery::create()->deleteAll();
+        Relation2PositionQuery::create()->deleteAll();
 
-        $hans = new \Relation2User();
+        $hans = new Relation2User();
         $hans->setName('hans');
 
-        $admins = new \Relation2Group();
+        $admins = new Relation2Group();
         $admins->setName('Admins');
 
-        $position = new \Relation2Position();
+        $position = new Relation2Position();
         $position->setName('Trainee');
 
         $hans->addGroup($admins, $position);
         $this->assertCount(1, $hans->getGroupPositions());
         $hans->save();
 
-        $this->assertEquals(1, \Relation2UserGroupQuery::create()->count(), 'We have one connection.');
-        $this->assertEquals(1, \Relation2UserQuery::create()->count(), 'We have one user.');
-        $this->assertEquals(1, \Relation2GroupQuery::create()->count(), 'We have one group.');
-        $this->assertEquals(1, \Relation2PositionQuery::create()->count(), 'We have one position.');
+        $this->assertEquals(1, Relation2UserGroupQuery::create()->count(), 'We have one connection.');
+        $this->assertEquals(1, Relation2UserQuery::create()->count(), 'We have one user.');
+        $this->assertEquals(1, Relation2GroupQuery::create()->count(), 'We have one group.');
+        $this->assertEquals(1, Relation2PositionQuery::create()->count(), 'We have one position.');
 
         $hans->removeGroupPosition($admins, $position);
         $this->assertCount(0, $hans->getGroupPositions());
         $hans->save();
 
-        $this->assertEquals(0, \Relation2UserGroupQuery::create()->count(), 'We have zero connections.');
-        $this->assertEquals(1, \Relation2UserQuery::create()->count(), 'We have one user.');
-        $this->assertEquals(1, \Relation2GroupQuery::create()->count(), 'We have one group.');
-        $this->assertEquals(1, \Relation2PositionQuery::create()->count(), 'We have one position.');
-
+        $this->assertEquals(0, Relation2UserGroupQuery::create()->count(), 'We have zero connections.');
+        $this->assertEquals(1, Relation2UserQuery::create()->count(), 'We have one user.');
+        $this->assertEquals(1, Relation2GroupQuery::create()->count(), 'We have one group.');
+        $this->assertEquals(1, Relation2PositionQuery::create()->count(), 'We have one position.');
     }
 
     /*
      * ####################################
      * 3. add, set
      */
+
+    /**
+     * @return void
+     */
     public function test3()
     {
-        \Relation2UserQuery::create()->deleteAll();
-        \Relation2GroupQuery::create()->deleteAll();
-        \Relation2UserGroupQuery::create()->deleteAll();
-        \Relation2PositionQuery::create()->deleteAll();
+        Relation2UserQuery::create()->deleteAll();
+        Relation2GroupQuery::create()->deleteAll();
+        Relation2UserGroupQuery::create()->deleteAll();
+        Relation2PositionQuery::create()->deleteAll();
 
-        $hans = new \Relation2User();
+        $hans = new Relation2User();
         $hans->setName('hans');
 
-        $admins = new \Relation2Group();
+        $admins = new Relation2Group();
         $admins->setName('Admins');
 
-        $position = new \Relation2Position();
+        $position = new Relation2Position();
         $position->setName('Trainee');
 
         $hans->addGroup($admins, $position);
         $this->assertCount(1, $hans->getGroupPositions());
         $hans->save();
 
-        $this->assertEquals(1, \Relation2UserGroupQuery::create()->count(), 'We have one connection.');
-        $this->assertEquals(1, \Relation2UserQuery::create()->count(), 'We have one user.');
-        $this->assertEquals(1, \Relation2GroupQuery::create()->count(), 'We have one group.');
-        $this->assertEquals(1, \Relation2PositionQuery::create()->count(), 'We have one position.');
+        $this->assertEquals(1, Relation2UserGroupQuery::create()->count(), 'We have one connection.');
+        $this->assertEquals(1, Relation2UserQuery::create()->count(), 'We have one user.');
+        $this->assertEquals(1, Relation2GroupQuery::create()->count(), 'We have one group.');
+        $this->assertEquals(1, Relation2PositionQuery::create()->count(), 'We have one position.');
 
         $emptyColl = new ObjectCombinationCollection();
         $hans->setGroupPositions($emptyColl);
         $this->assertCount(0, $hans->getGroupPositions());
         $hans->save();
 
-        $this->assertEquals(0, \Relation2UserGroupQuery::create()->count(), 'We have zero connections.');
-        $this->assertEquals(1, \Relation2UserQuery::create()->count(), 'We have one user.');
-        $this->assertEquals(1, \Relation2GroupQuery::create()->count(), 'We have one group.');
-        $this->assertEquals(1, \Relation2PositionQuery::create()->count(), 'We have one position.');
+        $this->assertEquals(0, Relation2UserGroupQuery::create()->count(), 'We have zero connections.');
+        $this->assertEquals(1, Relation2UserQuery::create()->count(), 'We have one user.');
+        $this->assertEquals(1, Relation2GroupQuery::create()->count(), 'We have one group.');
+        $this->assertEquals(1, Relation2PositionQuery::create()->count(), 'We have one position.');
     }
 
     /*
      * ####################################
      * 4. and 5. add, get
      */
+
+    /**
+     * @return void
+     */
     public function test4_5()
     {
-        \Relation2UserQuery::create()->deleteAll();
-        \Relation2GroupQuery::create()->deleteAll();
-        \Relation2UserGroupQuery::create()->deleteAll();
-        \Relation2PositionQuery::create()->deleteAll();
+        Relation2UserQuery::create()->deleteAll();
+        Relation2GroupQuery::create()->deleteAll();
+        Relation2UserGroupQuery::create()->deleteAll();
+        Relation2PositionQuery::create()->deleteAll();
 
-        $hans = new \Relation2User();
+        $hans = new Relation2User();
         $hans->setName('hans');
 
-        $admins = new \Relation2Group();
+        $admins = new Relation2Group();
         $admins->setName('Admins');
 
-        $position = new \Relation2Position();
+        $position = new Relation2Position();
         $position->setName('Trainee');
         $hans->addGroup($admins, $position);
         $this->assertCount(1, $hans->getGroupPositions());
         $hans->save();
 
-        $this->assertEquals(1, \Relation2UserGroupQuery::create()->count(), 'We have one connection.');
-        $this->assertEquals(1, \Relation2UserQuery::create()->count(), 'We have one user.');
-        $this->assertEquals(1, \Relation2GroupQuery::create()->count(), 'We have one group.');
-        $this->assertEquals(1, \Relation2PositionQuery::create()->count(), 'We have one position.');
+        $this->assertEquals(1, Relation2UserGroupQuery::create()->count(), 'We have one connection.');
+        $this->assertEquals(1, Relation2UserQuery::create()->count(), 'We have one user.');
+        $this->assertEquals(1, Relation2GroupQuery::create()->count(), 'We have one group.');
+        $this->assertEquals(1, Relation2PositionQuery::create()->count(), 'We have one position.');
 
-        \Map\Relation2UserTableMap::clearInstancePool();
-        $newHansObject = \Relation2UserQuery::create()->findOneByName('hans');
+        Relation2UserTableMap::clearInstancePool();
+        $newHansObject = Relation2UserQuery::create()->findOneByName('hans');
         $this->assertCount(1, $newHansObject->getGroupPositions(), 'Makes a extra query and returns the correct one group list');
 
-        \Map\Relation2UserTableMap::clearInstancePool();
-        $newHansObject = \Relation2UserQuery::create()->findOneByName('hans');
+        Relation2UserTableMap::clearInstancePool();
+        $newHansObject = Relation2UserQuery::create()->findOneByName('hans');
 
-        $cleaner = new \Relation2Group();
+        $cleaner = new Relation2Group();
         $cleaner->setName('Cleaner');
 
-        $position2 = new \Relation2Position();
+        $position2 = new Relation2Position();
         $position2->setName('Chef');
 
         $newHansObject->addGroup($cleaner, $position2);
         $this->assertCount(2, $newHansObject->getGroupPositions(), 'getGroupPositions makes a query and adds then the added group, thus we have 2');
         $newHansObject->save();
 
-        $this->assertEquals(2, \Relation2UserGroupQuery::create()->count(), 'We have two connections.');
-        $this->assertEquals(1, \Relation2UserQuery::create()->count(), 'We have one user.');
-        $this->assertEquals(2, \Relation2GroupQuery::create()->count(), 'We have two groups.');
-        $this->assertEquals(2, \Relation2PositionQuery::create()->count(), 'We have two positions.');
+        $this->assertEquals(2, Relation2UserGroupQuery::create()->count(), 'We have two connections.');
+        $this->assertEquals(1, Relation2UserQuery::create()->count(), 'We have one user.');
+        $this->assertEquals(2, Relation2GroupQuery::create()->count(), 'We have two groups.');
+        $this->assertEquals(2, Relation2PositionQuery::create()->count(), 'We have two positions.');
     }
 
     /*
      * ####################################
      * 6. remove, remove
      */
+
+    /**
+     * @return void
+     */
     public function test6()
     {
-        \Relation2UserQuery::create()->deleteAll();
-        \Relation2GroupQuery::create()->deleteAll();
-        \Relation2UserGroupQuery::create()->deleteAll();
-        \Relation2PositionQuery::create()->deleteAll();
+        Relation2UserQuery::create()->deleteAll();
+        Relation2GroupQuery::create()->deleteAll();
+        Relation2UserGroupQuery::create()->deleteAll();
+        Relation2PositionQuery::create()->deleteAll();
 
-        $hans = new \Relation2User();
+        $hans = new Relation2User();
         $hans->setName('hans');
 
-        $admins = new \Relation2Group();
+        $admins = new Relation2Group();
         $admins->setName('Admins');
 
-        $position = new \Relation2Position();
+        $position = new Relation2Position();
         $position->setName('Trainee');
 
-        $cleaner = new \Relation2Group();
+        $cleaner = new Relation2Group();
         $cleaner->setName('Cleaner');
 
-        $position2 = new \Relation2Position();
+        $position2 = new Relation2Position();
         $position2->setName('Chef');
 
         $hans->addGroup($admins, $position);
@@ -297,97 +340,99 @@ class GeneratedObjectM2MRelationThreePKsTest extends PlatformDatabaseBuildTimeBa
         $this->assertCount(2, $hans->getGroupPositions());
         $hans->save();
 
-        $this->assertEquals(2, \Relation2UserGroupQuery::create()->count(), 'We have two connections.');
-        $this->assertEquals(1, \Relation2UserQuery::create()->count(), 'We have one user.');
-        $this->assertEquals(2, \Relation2GroupQuery::create()->count(), 'We have two groups.');
-        $this->assertEquals(2, \Relation2PositionQuery::create()->count(), 'We have two positions.');
+        $this->assertEquals(2, Relation2UserGroupQuery::create()->count(), 'We have two connections.');
+        $this->assertEquals(1, Relation2UserQuery::create()->count(), 'We have one user.');
+        $this->assertEquals(2, Relation2GroupQuery::create()->count(), 'We have two groups.');
+        $this->assertEquals(2, Relation2PositionQuery::create()->count(), 'We have two positions.');
 
         $hans->removeGroupPosition($admins, $position);
         $this->assertCount(1, $hans->getGroupPositions());
         $hans->save();
 
-        $this->assertEquals(1, \Relation2UserGroupQuery::create()->count(), 'We have one connection.');
-        $this->assertEquals(1, \Relation2UserQuery::create()->count(), 'We have one user.');
-        $this->assertEquals(2, \Relation2GroupQuery::create()->count(), 'We have two groups.');
-        $this->assertEquals(2, \Relation2PositionQuery::create()->count(), 'We have two positions.');
+        $this->assertEquals(1, Relation2UserGroupQuery::create()->count(), 'We have one connection.');
+        $this->assertEquals(1, Relation2UserQuery::create()->count(), 'We have one user.');
+        $this->assertEquals(2, Relation2GroupQuery::create()->count(), 'We have two groups.');
+        $this->assertEquals(2, Relation2PositionQuery::create()->count(), 'We have two positions.');
 
         $hans->removeGroupPosition($cleaner, $position2);
         $this->assertCount(0, $hans->getGroupPositions());
         $hans->save();
 
-        $this->assertEquals(0, \Relation2UserGroupQuery::create()->count(), 'We have zero connections.');
-        $this->assertEquals(1, \Relation2UserQuery::create()->count(), 'We have one user.');
-        $this->assertEquals(2, \Relation2GroupQuery::create()->count(), 'We have two groups.');
-        $this->assertEquals(2, \Relation2PositionQuery::create()->count(), 'We have two positions.');
+        $this->assertEquals(0, Relation2UserGroupQuery::create()->count(), 'We have zero connections.');
+        $this->assertEquals(1, Relation2UserQuery::create()->count(), 'We have one user.');
+        $this->assertEquals(2, Relation2GroupQuery::create()->count(), 'We have two groups.');
+        $this->assertEquals(2, Relation2PositionQuery::create()->count(), 'We have two positions.');
 
         //add two groupPositions again and made the same removing with a complete new object instance each time
         $hans->addGroup($admins, $position);
         $hans->addGroup($cleaner, $position2);
         $this->assertCount(2, $hans->getGroupPositions());
         $hans->save();
-        $this->assertEquals(2, \Relation2UserGroupQuery::create()->count(), 'We have two connections.');
-        $this->assertEquals(1, \Relation2UserQuery::create()->count(), 'We have one user.');
-        $this->assertEquals(2, \Relation2GroupQuery::create()->count(), 'We have two groups.');
-        $this->assertEquals(2, \Relation2PositionQuery::create()->count(), 'We have two positions.');
+        $this->assertEquals(2, Relation2UserGroupQuery::create()->count(), 'We have two connections.');
+        $this->assertEquals(1, Relation2UserQuery::create()->count(), 'We have one user.');
+        $this->assertEquals(2, Relation2GroupQuery::create()->count(), 'We have two groups.');
+        $this->assertEquals(2, Relation2PositionQuery::create()->count(), 'We have two positions.');
 
-        \Map\Relation2UserTableMap::clearInstancePool();
-        $newHansObject = \Relation2UserQuery::create()->findOneByName('hans');
+        Relation2UserTableMap::clearInstancePool();
+        $newHansObject = Relation2UserQuery::create()->findOneByName('hans');
 
         $newHansObject->removeGroupPosition($admins, $position);
         $this->assertCount(1, $newHansObject->getGroupPositions());
         $newHansObject->save();
 
-        $this->assertEquals(1, \Relation2UserGroupQuery::create()->count(), 'We have one connection.');
-        $this->assertEquals(1, \Relation2UserQuery::create()->count(), 'We have one user.');
-        $this->assertEquals(2, \Relation2GroupQuery::create()->count(), 'We have two groups.');
-        $this->assertEquals(2, \Relation2PositionQuery::create()->count(), 'We have two positions.');
+        $this->assertEquals(1, Relation2UserGroupQuery::create()->count(), 'We have one connection.');
+        $this->assertEquals(1, Relation2UserQuery::create()->count(), 'We have one user.');
+        $this->assertEquals(2, Relation2GroupQuery::create()->count(), 'We have two groups.');
+        $this->assertEquals(2, Relation2PositionQuery::create()->count(), 'We have two positions.');
 
-        \Map\Relation2UserTableMap::clearInstancePool();
-        $newHansObject = \Relation2UserQuery::create()->findOneByName('hans');
+        Relation2UserTableMap::clearInstancePool();
+        $newHansObject = Relation2UserQuery::create()->findOneByName('hans');
         $newHansObject->removeGroupPosition($cleaner, $position2);
         $this->assertCount(0, $newHansObject->getGroupPositions());
         $newHansObject->save();
 
-        $this->assertEquals(0, \Relation2UserGroupQuery::create()->count(), 'We have zero connections.');
-        $this->assertEquals(1, \Relation2UserQuery::create()->count(), 'We have one user.');
-        $this->assertEquals(2, \Relation2GroupQuery::create()->count(), 'We have two groups.');
-        $this->assertEquals(2, \Relation2PositionQuery::create()->count(), 'We have two positions.');
+        $this->assertEquals(0, Relation2UserGroupQuery::create()->count(), 'We have zero connections.');
+        $this->assertEquals(1, Relation2UserQuery::create()->count(), 'We have one user.');
+        $this->assertEquals(2, Relation2GroupQuery::create()->count(), 'We have two groups.');
+        $this->assertEquals(2, Relation2PositionQuery::create()->count(), 'We have two positions.');
     }
 
     /**
      * 7. remove, set
+     *
+     * @return void
      */
-    public function test7(){
+    public function test7()
+    {
+        Relation2UserQuery::create()->deleteAll();
+        Relation2GroupQuery::create()->deleteAll();
+        Relation2UserGroupQuery::create()->deleteAll();
+        Relation2PositionQuery::create()->deleteAll();
 
-        \Relation2UserQuery::create()->deleteAll();
-        \Relation2GroupQuery::create()->deleteAll();
-        \Relation2UserGroupQuery::create()->deleteAll();
-        \Relation2PositionQuery::create()->deleteAll();
-
-        $hans = new \Relation2User();
+        $hans = new Relation2User();
         $hans->setName('hans');
 
-        $admins = new \Relation2Group();
+        $admins = new Relation2Group();
         $admins->setName('Admins');
 
-        $position = new \Relation2Position();
+        $position = new Relation2Position();
         $position->setName('Trainee');
 
         $hans->addGroup($admins, $position);
         $this->assertCount(1, $hans->getGroupPositions());
         $hans->save();
 
-        $this->assertEquals(1, \Relation2UserGroupQuery::create()->count(), 'We have one connection.');
-        $this->assertEquals(1, \Relation2UserQuery::create()->count(), 'We have one user.');
-        $this->assertEquals(1, \Relation2GroupQuery::create()->count(), 'We have one group.');
-        $this->assertEquals(1, \Relation2PositionQuery::create()->count(), 'We have one position.');
+        $this->assertEquals(1, Relation2UserGroupQuery::create()->count(), 'We have one connection.');
+        $this->assertEquals(1, Relation2UserQuery::create()->count(), 'We have one user.');
+        $this->assertEquals(1, Relation2GroupQuery::create()->count(), 'We have one group.');
+        $this->assertEquals(1, Relation2PositionQuery::create()->count(), 'We have one position.');
 
         $hans->removeGroupPosition($admins, $position);
 
-        $cleaner = new \Relation2Group();
+        $cleaner = new Relation2Group();
         $cleaner->setName('Cleaner');
 
-        $position2 = new \Relation2Position();
+        $position2 = new Relation2Position();
         $position2->setName('Chef');
         $col = new ObjectCombinationCollection();
         $col[] = [$cleaner, $position2];
@@ -396,39 +441,41 @@ class GeneratedObjectM2MRelationThreePKsTest extends PlatformDatabaseBuildTimeBa
         $this->assertEquals([$cleaner, $position2], $hans->getGroupPositions()->getFirst());
         $hans->save();
 
-        $this->assertEquals(1, \Relation2UserGroupQuery::create()->count(), 'We have still one connection.');
-        $this->assertEquals(1, \Relation2UserQuery::create()->count(), 'We have one user.');
-        $this->assertEquals(2, \Relation2GroupQuery::create()->count(), 'We have two groups.');
-        $this->assertEquals(2, \Relation2PositionQuery::create()->count(), 'We have two positions.');
+        $this->assertEquals(1, Relation2UserGroupQuery::create()->count(), 'We have still one connection.');
+        $this->assertEquals(1, Relation2UserQuery::create()->count(), 'We have one user.');
+        $this->assertEquals(2, Relation2GroupQuery::create()->count(), 'We have two groups.');
+        $this->assertEquals(2, Relation2PositionQuery::create()->count(), 'We have two positions.');
 
-        $userGroup = \Relation2UserGroupQuery::create()->filterByUser($hans)->findOne();
+        $userGroup = Relation2UserGroupQuery::create()->filterByUser($hans)->findOne();
         $this->assertEquals($position2->getId(), $userGroup->getPositionId());
         $this->assertEquals($cleaner->getId(), $userGroup->getGroupId());
     }
 
     /**
      * 8. remove, get
+     *
+     * @return void
      */
-    public function test8(){
+    public function test8()
+    {
+        Relation2UserQuery::create()->deleteAll();
+        Relation2GroupQuery::create()->deleteAll();
+        Relation2UserGroupQuery::create()->deleteAll();
+        Relation2PositionQuery::create()->deleteAll();
 
-        \Relation2UserQuery::create()->deleteAll();
-        \Relation2GroupQuery::create()->deleteAll();
-        \Relation2UserGroupQuery::create()->deleteAll();
-        \Relation2PositionQuery::create()->deleteAll();
-
-        $hans = new \Relation2User();
+        $hans = new Relation2User();
         $hans->setName('hans');
 
-        $admins = new \Relation2Group();
+        $admins = new Relation2Group();
         $admins->setName('Admins');
 
-        $position = new \Relation2Position();
+        $position = new Relation2Position();
         $position->setName('Trainee');
 
-        $cleaner = new \Relation2Group();
+        $cleaner = new Relation2Group();
         $cleaner->setName('Cleaner');
 
-        $position2 = new \Relation2Position();
+        $position2 = new Relation2Position();
         $position2->setName('Chef');
 
         $hans->addGroup($admins, $position);
@@ -436,42 +483,44 @@ class GeneratedObjectM2MRelationThreePKsTest extends PlatformDatabaseBuildTimeBa
         $this->assertCount(2, $hans->getGroupPositions());
         $hans->save();
 
-        $this->assertEquals(2, \Relation2UserGroupQuery::create()->count(), 'We have still two connections.');
-        $this->assertEquals(1, \Relation2UserQuery::create()->count(), 'We have one user.');
-        $this->assertEquals(2, \Relation2GroupQuery::create()->count(), 'We have two groups.');
-        $this->assertEquals(2, \Relation2PositionQuery::create()->count(), 'We have two positions.');
+        $this->assertEquals(2, Relation2UserGroupQuery::create()->count(), 'We have still two connections.');
+        $this->assertEquals(1, Relation2UserQuery::create()->count(), 'We have one user.');
+        $this->assertEquals(2, Relation2GroupQuery::create()->count(), 'We have two groups.');
+        $this->assertEquals(2, Relation2PositionQuery::create()->count(), 'We have two positions.');
 
         $hans->removeGroupPosition($admins, $position);
         $hans->save();
 
-        \Map\Relation2UserTableMap::clearInstancePool();
-        $newHansObject = \Relation2UserQuery::create()->findOneByName('hans');
+        Relation2UserTableMap::clearInstancePool();
+        $newHansObject = Relation2UserQuery::create()->findOneByName('hans');
         $this->assertCount(1, $newHansObject->getGroupPositions());
     }
 
     /**
      * 9. set, add
+     *
+     * @return void
      */
-    public function test9(){
+    public function test9()
+    {
+        Relation2UserQuery::create()->deleteAll();
+        Relation2GroupQuery::create()->deleteAll();
+        Relation2UserGroupQuery::create()->deleteAll();
+        Relation2PositionQuery::create()->deleteAll();
 
-        \Relation2UserQuery::create()->deleteAll();
-        \Relation2GroupQuery::create()->deleteAll();
-        \Relation2UserGroupQuery::create()->deleteAll();
-        \Relation2PositionQuery::create()->deleteAll();
-
-        $hans = new \Relation2User();
+        $hans = new Relation2User();
         $hans->setName('hans');
 
-        $admins = new \Relation2Group();
+        $admins = new Relation2Group();
         $admins->setName('Admins');
 
-        $position = new \Relation2Position();
+        $position = new Relation2Position();
         $position->setName('Trainee');
 
-        $cleaner = new \Relation2Group();
+        $cleaner = new Relation2Group();
         $cleaner->setName('Cleaner');
 
-        $position2 = new \Relation2Position();
+        $position2 = new Relation2Position();
         $position2->setName('Chef');
 
         $col = new ObjectCombinationCollection();
@@ -481,35 +530,37 @@ class GeneratedObjectM2MRelationThreePKsTest extends PlatformDatabaseBuildTimeBa
         $this->assertCount(2, $hans->getGroupPositions());
         $hans->save();
 
-        $this->assertEquals(2, \Relation2UserGroupQuery::create()->count(), 'We have still two connections.');
-        $this->assertEquals(1, \Relation2UserQuery::create()->count(), 'We have one user.');
-        $this->assertEquals(2, \Relation2GroupQuery::create()->count(), 'We have two groups.');
-        $this->assertEquals(2, \Relation2PositionQuery::create()->count(), 'We have two positions.');
+        $this->assertEquals(2, Relation2UserGroupQuery::create()->count(), 'We have still two connections.');
+        $this->assertEquals(1, Relation2UserQuery::create()->count(), 'We have one user.');
+        $this->assertEquals(2, Relation2GroupQuery::create()->count(), 'We have two groups.');
+        $this->assertEquals(2, Relation2PositionQuery::create()->count(), 'We have two positions.');
     }
 
     /**
      * 10. set, remove
+     *
+     * @return void
      */
-    public function test10(){
+    public function test10()
+    {
+        Relation2UserQuery::create()->deleteAll();
+        Relation2GroupQuery::create()->deleteAll();
+        Relation2UserGroupQuery::create()->deleteAll();
+        Relation2PositionQuery::create()->deleteAll();
 
-        \Relation2UserQuery::create()->deleteAll();
-        \Relation2GroupQuery::create()->deleteAll();
-        \Relation2UserGroupQuery::create()->deleteAll();
-        \Relation2PositionQuery::create()->deleteAll();
-
-        $hans = new \Relation2User();
+        $hans = new Relation2User();
         $hans->setName('hans');
 
-        $admins = new \Relation2Group();
+        $admins = new Relation2Group();
         $admins->setName('Admins');
 
-        $position = new \Relation2Position();
+        $position = new Relation2Position();
         $position->setName('Trainee');
 
-        $cleaner = new \Relation2Group();
+        $cleaner = new Relation2Group();
         $cleaner->setName('Cleaner');
 
-        $position2 = new \Relation2Position();
+        $position2 = new Relation2Position();
         $position2->setName('Chef');
 
         $col = new ObjectCombinationCollection();
@@ -521,29 +572,31 @@ class GeneratedObjectM2MRelationThreePKsTest extends PlatformDatabaseBuildTimeBa
         $this->assertCount(1, $hans->getGroupPositions());
         $hans->save();
 
-        $this->assertEquals(1, \Relation2UserGroupQuery::create()->count(), 'We have one connection.');
-        $this->assertEquals(1, \Relation2UserQuery::create()->count(), 'We have one user.');
-        $this->assertEquals(1, \Relation2GroupQuery::create()->count(), 'We have one group.');
-        $this->assertEquals(1, \Relation2PositionQuery::create()->count(), 'We have one position.');
+        $this->assertEquals(1, Relation2UserGroupQuery::create()->count(), 'We have one connection.');
+        $this->assertEquals(1, Relation2UserQuery::create()->count(), 'We have one user.');
+        $this->assertEquals(1, Relation2GroupQuery::create()->count(), 'We have one group.');
+        $this->assertEquals(1, Relation2PositionQuery::create()->count(), 'We have one position.');
     }
 
     /**
      * 11-12. set, set - set, get
+     *
+     * @return void
      */
-    public function test11_12(){
+    public function test11_12()
+    {
+        Relation2UserQuery::create()->deleteAll();
+        Relation2GroupQuery::create()->deleteAll();
+        Relation2UserGroupQuery::create()->deleteAll();
+        Relation2PositionQuery::create()->deleteAll();
 
-        \Relation2UserQuery::create()->deleteAll();
-        \Relation2GroupQuery::create()->deleteAll();
-        \Relation2UserGroupQuery::create()->deleteAll();
-        \Relation2PositionQuery::create()->deleteAll();
-
-        $hans = new \Relation2User();
+        $hans = new Relation2User();
         $hans->setName('hans');
 
-        $admins = new \Relation2Group();
+        $admins = new Relation2Group();
         $admins->setName('Admins');
 
-        $position = new \Relation2Position();
+        $position = new Relation2Position();
         $position->setName('Trainee');
 
         $col = new ObjectCombinationCollection();
@@ -552,15 +605,15 @@ class GeneratedObjectM2MRelationThreePKsTest extends PlatformDatabaseBuildTimeBa
         $this->assertCount(1, $hans->getGroupPositions());
         $hans->save();
 
-        $this->assertEquals(1, \Relation2UserGroupQuery::create()->count(), 'We have one connection.');
-        $this->assertEquals(1, \Relation2UserQuery::create()->count(), 'We have one user.');
-        $this->assertEquals(1, \Relation2GroupQuery::create()->count(), 'We have one group.');
-        $this->assertEquals(1, \Relation2PositionQuery::create()->count(), 'We have one position.');
+        $this->assertEquals(1, Relation2UserGroupQuery::create()->count(), 'We have one connection.');
+        $this->assertEquals(1, Relation2UserQuery::create()->count(), 'We have one user.');
+        $this->assertEquals(1, Relation2GroupQuery::create()->count(), 'We have one group.');
+        $this->assertEquals(1, Relation2PositionQuery::create()->count(), 'We have one position.');
 
-        $cleaner = new \Relation2Group();
+        $cleaner = new Relation2Group();
         $cleaner->setName('Cleaner');
 
-        $position2 = new \Relation2Position();
+        $position2 = new Relation2Position();
         $position2->setName('Chef');
 
         $col = new ObjectCombinationCollection();
@@ -569,17 +622,19 @@ class GeneratedObjectM2MRelationThreePKsTest extends PlatformDatabaseBuildTimeBa
         $this->assertCount(1, $hans->getGroupPositions());
         $hans->save();
 
-        $this->assertEquals(1, \Relation2UserGroupQuery::create()->count(), 'We have one connection.');
-        $this->assertEquals(1, \Relation2UserQuery::create()->count(), 'We have one user.');
-        $this->assertEquals(2, \Relation2GroupQuery::create()->count(), 'We have two groups.');
-        $this->assertEquals(2, \Relation2PositionQuery::create()->count(), 'We have two positions.');
+        $this->assertEquals(1, Relation2UserGroupQuery::create()->count(), 'We have one connection.');
+        $this->assertEquals(1, Relation2UserQuery::create()->count(), 'We have one user.');
+        $this->assertEquals(2, Relation2GroupQuery::create()->count(), 'We have two groups.');
+        $this->assertEquals(2, Relation2PositionQuery::create()->count(), 'We have two positions.');
 
-        $userGroup = \Relation2UserGroupQuery::create()->filterByUser($hans)->findOne();
+        $userGroup = Relation2UserGroupQuery::create()->filterByUser($hans)->findOne();
         $this->assertEquals($position2->getId(), $userGroup->getPositionId());
         $this->assertEquals($cleaner->getId(), $userGroup->getGroupId());
     }
 
-
+    /**
+     * @return void
+     */
     public function testRelationThree3()
     {
         $schema = '
@@ -624,19 +679,19 @@ class GeneratedObjectM2MRelationThreePKsTest extends PlatformDatabaseBuildTimeBa
 
         $this->buildAndMigrate($schema);
 
-        \Relation3UserGroupQuery::create()->deleteAll();
-        \Relation3UserQuery::create()->deleteAll();
-        \Relation3GroupQuery::create()->deleteAll();
-        \Relation3RelationQuery::create()->deleteAll();
+        Relation3UserGroupQuery::create()->deleteAll();
+        Relation3UserQuery::create()->deleteAll();
+        Relation3GroupQuery::create()->deleteAll();
+        Relation3RelationQuery::create()->deleteAll();
 
-        $hans = new \Relation3User();
+        $hans = new Relation3User();
         $hans->setName('hans');
 
-        $admins = new \Relation3Group();
+        $admins = new Relation3Group();
         $admins->setName('Admins');
         $admins->setId2(1);
 
-        $relation = new \Relation3Relation();
+        $relation = new Relation3Relation();
         $relation->setName('Leader');
 
         $this->assertCount(0, $hans->getGroupRelations(), 'no groups');
@@ -645,22 +700,23 @@ class GeneratedObjectM2MRelationThreePKsTest extends PlatformDatabaseBuildTimeBa
 
         $hans->save();
 
-        $this->assertEquals(1, \Relation3UserQuery::create()->count(), 'We have one user.');
-        $this->assertEquals(1, \Relation3UserGroupQuery::create()->count(), 'We have one connection.');
-        $this->assertEquals(1, \Relation3UserQuery::create()->filterByGroup($admins)->count(), 'Hans has one group.');
+        $this->assertEquals(1, Relation3UserQuery::create()->count(), 'We have one user.');
+        $this->assertEquals(1, Relation3UserGroupQuery::create()->count(), 'We have one connection.');
+        $this->assertEquals(1, Relation3UserQuery::create()->filterByGroup($admins)->count(), 'Hans has one group.');
 
         $hans->removeGroupRelation($admins, $relation);
         $this->assertCount(0, $hans->getGroupRelations(), 'no groups');
 
         $hans->save();
 
-        $this->assertEquals(1, \Relation3UserQuery::create()->count(), 'We have one user.');
-        $this->assertEquals(0, \Relation3UserGroupQuery::create()->count(), 'We have zero connection.');
-        $this->assertEquals(0, \Relation3UserQuery::create()->filterByGroup($admins)->count(), 'Hans has zero groups.');
-
+        $this->assertEquals(1, Relation3UserQuery::create()->count(), 'We have one user.');
+        $this->assertEquals(0, Relation3UserGroupQuery::create()->count(), 'We have zero connection.');
+        $this->assertEquals(0, Relation3UserQuery::create()->filterByGroup($admins)->count(), 'Hans has zero groups.');
     }
 
-
+    /**
+     * @return void
+     */
     public function testRelationThree4()
     {
         $schema = '
@@ -697,14 +753,14 @@ class GeneratedObjectM2MRelationThreePKsTest extends PlatformDatabaseBuildTimeBa
 
         $this->buildAndMigrate($schema);
 
-        \Relation4UserGroupQuery::create()->deleteAll();
-        \Relation4UserQuery::create()->deleteAll();
-        \Relation4GroupQuery::create()->deleteAll();
+        Relation4UserGroupQuery::create()->deleteAll();
+        Relation4UserQuery::create()->deleteAll();
+        Relation4GroupQuery::create()->deleteAll();
 
-        $hans = new \Relation4User();
+        $hans = new Relation4User();
         $hans->setName('hans');
 
-        $admins = new \Relation4Group();
+        $admins = new Relation4Group();
         $admins->setName('Admins');
         $admins->setId2(1);
 
@@ -714,20 +770,23 @@ class GeneratedObjectM2MRelationThreePKsTest extends PlatformDatabaseBuildTimeBa
 
         $hans->save();
 
-        $this->assertEquals(1, \Relation4UserQuery::create()->count(), 'We have one user.');
-        $this->assertEquals(1, \Relation4UserGroupQuery::create()->count(), 'We have one connection.');
-        $this->assertEquals(1, \Relation4UserQuery::create()->filterByGroup($admins)->count(), 'Hans has one group.');
+        $this->assertEquals(1, Relation4UserQuery::create()->count(), 'We have one user.');
+        $this->assertEquals(1, Relation4UserGroupQuery::create()->count(), 'We have one connection.');
+        $this->assertEquals(1, Relation4UserQuery::create()->filterByGroup($admins)->count(), 'Hans has one group.');
 
         $hans->removeGroupRelation($admins, 'teamLeader');
         $this->assertCount(0, $hans->getGroupRelations(), 'no groups');
 
         $hans->save();
 
-        $this->assertEquals(1, \Relation4UserQuery::create()->count(), 'We have one user.');
-        $this->assertEquals(0, \Relation4UserGroupQuery::create()->count(), 'We have zero connection.');
-        $this->assertEquals(0, \Relation4UserQuery::create()->filterByGroup($admins)->count(), 'Hans has zero groups.');
+        $this->assertEquals(1, Relation4UserQuery::create()->count(), 'We have one user.');
+        $this->assertEquals(0, Relation4UserGroupQuery::create()->count(), 'We have zero connection.');
+        $this->assertEquals(0, Relation4UserQuery::create()->filterByGroup($admins)->count(), 'Hans has zero groups.');
     }
 
+    /**
+     * @return void
+     */
     public function testRelationThree5()
     {
         $schema = '
@@ -764,14 +823,14 @@ class GeneratedObjectM2MRelationThreePKsTest extends PlatformDatabaseBuildTimeBa
 
         $this->buildAndMigrate($schema);
 
-        \Relation5UserGroupQuery::create()->deleteAll();
-        \Relation5UserQuery::create()->deleteAll();
-        \Relation5GroupQuery::create()->deleteAll();
+        Relation5UserGroupQuery::create()->deleteAll();
+        Relation5UserQuery::create()->deleteAll();
+        Relation5GroupQuery::create()->deleteAll();
 
-        $hans = new \Relation5User();
+        $hans = new Relation5User();
         $hans->setName('hans');
 
-        $admins = new \Relation5Group();
+        $admins = new Relation5Group();
         $admins->setName('Admins');
         $admins->setId2(1);
 
@@ -781,20 +840,23 @@ class GeneratedObjectM2MRelationThreePKsTest extends PlatformDatabaseBuildTimeBa
 
         $hans->save();
 
-        $this->assertEquals(1, \Relation5UserQuery::create()->count(), 'We have one user.');
-        $this->assertEquals(1, \Relation5UserGroupQuery::create()->count(), 'We have one connection.');
-        $this->assertEquals(1, \Relation5UserQuery::create()->filterByGroup($admins)->count(), 'Hans has one group.');
+        $this->assertEquals(1, Relation5UserQuery::create()->count(), 'We have one user.');
+        $this->assertEquals(1, Relation5UserGroupQuery::create()->count(), 'We have one connection.');
+        $this->assertEquals(1, Relation5UserQuery::create()->filterByGroup($admins)->count(), 'Hans has one group.');
 
         $hans->removeGroupRelation($admins, 'teamLeader');
         $this->assertCount(0, $hans->getGroupRelations(), 'no groups');
 
         $hans->save();
 
-        $this->assertEquals(1, \Relation5UserQuery::create()->count(), 'We have one user.');
-        $this->assertEquals(0, \Relation5UserGroupQuery::create()->count(), 'We have zero connection.');
-        $this->assertEquals(0, \Relation5UserQuery::create()->filterByGroup($admins)->count(), 'Hans has zero groups.');
+        $this->assertEquals(1, Relation5UserQuery::create()->count(), 'We have one user.');
+        $this->assertEquals(0, Relation5UserGroupQuery::create()->count(), 'We have zero connection.');
+        $this->assertEquals(0, Relation5UserQuery::create()->filterByGroup($admins)->count(), 'Hans has zero groups.');
     }
 
+    /**
+     * @return void
+     */
     public function testRelationThree6()
     {
         $schema = '
@@ -830,14 +892,14 @@ class GeneratedObjectM2MRelationThreePKsTest extends PlatformDatabaseBuildTimeBa
 
         $this->buildAndMigrate($schema);
 
-        \Relation6UserGroupQuery::create()->deleteAll();
-        \Relation6UserQuery::create()->deleteAll();
-        \Relation6GroupQuery::create()->deleteAll();
+        Relation6UserGroupQuery::create()->deleteAll();
+        Relation6UserQuery::create()->deleteAll();
+        Relation6GroupQuery::create()->deleteAll();
 
-        $hans = new \Relation6User();
+        $hans = new Relation6User();
         $hans->setName('hans');
 
-        $admins = new \Relation6Group();
+        $admins = new Relation6Group();
         $admins->setName('Admins');
         $admins->setId2(1);
 
@@ -847,18 +909,17 @@ class GeneratedObjectM2MRelationThreePKsTest extends PlatformDatabaseBuildTimeBa
 
         $hans->save();
 
-        $this->assertEquals(1, \Relation6UserQuery::create()->count(), 'We have one user.');
-        $this->assertEquals(1, \Relation6UserGroupQuery::create()->count(), 'We have one connection.');
-        $this->assertEquals(1, \Relation6UserQuery::create()->filterByGroup($admins)->count(), 'Hans has one group.');
+        $this->assertEquals(1, Relation6UserQuery::create()->count(), 'We have one user.');
+        $this->assertEquals(1, Relation6UserGroupQuery::create()->count(), 'We have one connection.');
+        $this->assertEquals(1, Relation6UserQuery::create()->filterByGroup($admins)->count(), 'Hans has one group.');
 
         $hans->removeGroup($admins);
         $this->assertCount(0, $hans->getGroups(), 'no groups');
 
         $hans->save();
 
-        $this->assertEquals(1, \Relation6UserQuery::create()->count(), 'We have one user.');
-        $this->assertEquals(0, \Relation6UserGroupQuery::create()->count(), 'We have zero connection.');
-        $this->assertEquals(0, \Relation6UserQuery::create()->filterByGroup($admins)->count(), 'Hans has zero groups.');
+        $this->assertEquals(1, Relation6UserQuery::create()->count(), 'We have one user.');
+        $this->assertEquals(0, Relation6UserGroupQuery::create()->count(), 'We have zero connection.');
+        $this->assertEquals(0, Relation6UserQuery::create()->filterByGroup($admins)->count(), 'Hans has zero groups.');
     }
-
 }

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectMoreRelationTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectMoreRelationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectMoreRelationTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectMoreRelationTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license    MIT License
  */
 
 namespace Propel\Tests\Generator\Builder\Om;

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectObjectColumnTypeTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectObjectColumnTypeTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Builder\Om;

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectRelTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectRelTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Builder\Om;

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectSetColumnTypeTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectSetColumnTypeTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Builder\Om;

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectTemporalColumnTypeTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectTemporalColumnTypeTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Builder\Om;

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Builder\Om;

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectTest.php
@@ -361,7 +361,6 @@ class GeneratedObjectTest extends BookstoreTestBase
         $this->assertSame($emp, $retrieved, 'Expected same object (from instance pool)');
     }
 
-    
     /**
      * @return void
      */
@@ -505,7 +504,6 @@ class GeneratedObjectTest extends BookstoreTestBase
         $this->assertNotNull($b->getId());
     }
 
-    
     /**
      * @return void
      */
@@ -523,6 +521,7 @@ class GeneratedObjectTest extends BookstoreTestBase
         $super->addSubordinate($e2);
 
         $affected = $super->save();
+        $this->assertSame(3, $affected); // Why 3 and not 0?
     }
 
     /**

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectWithDateImmutableClassTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectWithDateImmutableClassTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Builder\Om;

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectWithDateImmutableClassTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectWithDateImmutableClassTest.php
@@ -8,6 +8,11 @@
  * @license MIT License
  */
 
+namespace Propel\Tests\Generator\Builder\Om;
+
+use DateTime;
+use Foo\SomeTableA;
+use Foo\SomeTableB;
 use Propel\Generator\Config\QuickGeneratorConfig;
 use Propel\Generator\Util\QuickBuilder;
 use Propel\Tests\TestCase;
@@ -62,11 +67,11 @@ EOF;
      */
     public function testDateTimeInterface()
     {
-        $ModelA = new \Foo\SomeTableA();
+        $ModelA = new SomeTableA();
         $ModelA->setCreatedAt('today');
         $this->assertInstanceOf('\DateTimeInterface', $ModelA->getCreatedAt());
 
-        $ModelB = new \Foo\SomeTableB();
+        $ModelB = new SomeTableB();
         $ModelB->setCreatedAt('today');
         $this->assertInstanceOf('\DateTimeInterface', $ModelB->getCreatedAt());
     }
@@ -76,11 +81,11 @@ EOF;
      */
     public function testFieldTypes()
     {
-        $ModelA = new \Foo\SomeTableA();
+        $ModelA = new SomeTableA();
         $ModelA->setCreatedAt('today');
         $this->assertInstanceOf('\DateTimeImmutable', $ModelA->getCreatedAt());
 
-        $ModelB = new \Foo\SomeTableB();
+        $ModelB = new SomeTableB();
         $ModelB->setCreatedAt('today');
         $this->assertInstanceOf('\DateTime', $ModelB->getCreatedAt());
     }
@@ -92,11 +97,11 @@ EOF;
     {
         $Date = new DateTime('now');
 
-        $ModelA = new \Foo\SomeTableA();
+        $ModelA = new SomeTableA();
         $ModelA->setCreatedAt(clone $Date);
         $this->assertSame(['Id' => null, 'CreatedAt' => $Date->format('c')], $ModelA->toArray());
 
-        $ModelB = new \Foo\SomeTableB();
+        $ModelB = new SomeTableB();
         $ModelB->setCreatedAt(clone $Date);
         $this->assertSame(['Id' => null, 'CreatedAt' => $Date->format('c')], $ModelB->toArray());
     }

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectWithFixturesTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectWithFixturesTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Builder\Om;

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectWithInterfaceTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectWithInterfaceTest.php
@@ -1,15 +1,14 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Builder\Om;
 
+use Foo\MyClassWithInterface;
 use Propel\Generator\Util\QuickBuilder;
 use Propel\Tests\TestCase;
 
@@ -38,6 +37,6 @@ EOF;
      */
     public function testClassHasInterface()
     {
-          $this->assertInstanceOf('Foo\MyInterface', new \Foo\MyClassWithInterface());
+          $this->assertInstanceOf('Foo\MyInterface', new MyClassWithInterface());
     }
 }

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectWithInterfaceTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectWithInterfaceTest.php
@@ -8,6 +8,8 @@
  * @license MIT License
  */
 
+namespace Propel\Tests\Generator\Builder\Om;
+
 use Propel\Generator\Util\QuickBuilder;
 use Propel\Tests\TestCase;
 

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedPKLessQueryBuilderTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedPKLessQueryBuilderTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Builder\Om;

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedPKLessTableMapTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedPKLessTableMapTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Builder\Om;

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedQueryArrayColumnTypeTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedQueryArrayColumnTypeTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Builder\Om;

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedQueryDoDeleteTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedQueryDoDeleteTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Builder\Om;

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedQueryDoSelectTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedQueryDoSelectTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Builder\Om;

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedQueryEnumColumnTypeTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedQueryEnumColumnTypeTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Builder\Om;

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedQueryObjectColumnTypeTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedQueryObjectColumnTypeTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Builder\Om;

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedQuerySetColumnTypeTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedQuerySetColumnTypeTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Builder\Om;

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedTableMapEnumColumnTypeTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedTableMapEnumColumnTypeTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Builder\Om;

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedTableMapLazyLoadTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedTableMapLazyLoadTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Builder\Om;

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedTableMapSetColumnTypeTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedTableMapSetColumnTypeTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Builder\Om;

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedTableMapTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedTableMapTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Builder\Om;

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilderTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilderTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Builder\Om;

--- a/tests/Propel/Tests/Generator/Builder/Om/PoisonedCacheBugTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/PoisonedCacheBugTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license    MIT License
  */
 
 namespace Propel\Tests\Generator\Builder\Om;

--- a/tests/Propel/Tests/Generator/Builder/Om/QueryBuilderInheritanceTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/QueryBuilderInheritanceTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Builder\Om;

--- a/tests/Propel/Tests/Generator/Builder/Om/QueryBuilderTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/QueryBuilderTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Builder\Om;

--- a/tests/Propel/Tests/Generator/Builder/Om/QueryBuilderTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/QueryBuilderTest.php
@@ -99,13 +99,13 @@ class QueryBuilderTest extends BookstoreTestBase
     public function testCreateCustom()
     {
         // see the myBookQuery class definition at the end of this file
-        $query = myCustomBookQuery::create();
-        $this->assertTrue($query instanceof myCustomBookQuery, 'create() returns an object of its class');
+        $query = MyCustomBookQuery::create();
+        $this->assertTrue($query instanceof MyCustomBookQuery, 'create() returns an object of its class');
         $this->assertTrue($query instanceof BookQuery, 'create() returns an object of its class');
         $this->assertEquals('bookstore', $query->getDbName(), 'create() sets dabatase name');
         $this->assertEquals('Propel\Tests\Bookstore\Book', $query->getModelName(), 'create() sets model name');
-        $query = myCustomBookQuery::create('foo');
-        $this->assertTrue($query instanceof myCustomBookQuery, 'create() returns an object of its class');
+        $query = MyCustomBookQuery::create('foo');
+        $this->assertTrue($query instanceof MyCustomBookQuery, 'create() returns an object of its class');
         $this->assertEquals('bookstore', $query->getDbName(), 'create() sets dabatase name');
         $this->assertEquals('Propel\Tests\Bookstore\Book', $query->getModelName(), 'create() sets model name');
         $this->assertEquals('foo', $query->getModelAlias(), 'create() can set the model alias');
@@ -339,7 +339,7 @@ class QueryBuilderTest extends BookstoreTestBase
      */
     public function testFindPkCallsPreSelect()
     {
-        $q = new mySecondBookQuery();
+        $q = new MySecondBookQuery();
         $this->assertFalse($q::$preSelectWasCalled);
         $q->findPk(123);
         $this->assertTrue($q::$preSelectWasCalled);

--- a/tests/Propel/Tests/Generator/Builder/Om/QueryBuilderTestClasses.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/QueryBuilderTestClasses.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Builder\Om;

--- a/tests/Propel/Tests/Generator/Builder/Om/QueryBuilderTestClasses.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/QueryBuilderTestClasses.php
@@ -14,14 +14,14 @@ use Propel\Runtime\ActiveQuery\Criteria;
 use Propel\Runtime\Connection\ConnectionInterface;
 use Propel\Tests\Bookstore\BookQuery;
 
-class myCustomBookQuery extends BookQuery
+class MyCustomBookQuery extends BookQuery
 {
     public static function create($modelAlias = null, ?Criteria $criteria = null)
     {
-        if ($criteria instanceof myCustomBookQuery) {
+        if ($criteria instanceof MyCustomBookQuery) {
             return $criteria;
         }
-        $query = new myCustomBookQuery();
+        $query = new MyCustomBookQuery();
         if (null !== $modelAlias) {
             $query->setModelAlias($modelAlias);
         }
@@ -33,7 +33,7 @@ class myCustomBookQuery extends BookQuery
     }
 }
 
-class mySecondBookQuery extends BookQuery
+class MySecondBookQuery extends BookQuery
 {
     public static $preSelectWasCalled = false;
 

--- a/tests/Propel/Tests/Generator/Builder/Om/TableMapBuilderTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/TableMapBuilderTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Builder\Om;

--- a/tests/Propel/Tests/Generator/Builder/Util/PropelTemplateTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Util/PropelTemplateTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Builder\Util;

--- a/tests/Propel/Tests/Generator/Builder/Util/SchemaReaderJoinSchemaTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Util/SchemaReaderJoinSchemaTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Builder\Util;

--- a/tests/Propel/Tests/Generator/Builder/Util/SchemaReaderTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Util/SchemaReaderTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Builder\Util;

--- a/tests/Propel/Tests/Generator/Command/AbstractCommandTest.php
+++ b/tests/Propel/Tests/Generator/Command/AbstractCommandTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Command;

--- a/tests/Propel/Tests/Generator/Command/DatabaseReverseTest.php
+++ b/tests/Propel/Tests/Generator/Command/DatabaseReverseTest.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Generator\Command;
 
 use Propel\Generator\Command\AbstractCommand;

--- a/tests/Propel/Tests/Generator/Command/GraphvizGenerateTest.php
+++ b/tests/Propel/Tests/Generator/Command/GraphvizGenerateTest.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Generator\Command;
 
 use Propel\Generator\Command\GraphvizGenerateCommand;

--- a/tests/Propel/Tests/Generator/Command/InitCommandTest.php
+++ b/tests/Propel/Tests/Generator/Command/InitCommandTest.php
@@ -112,6 +112,11 @@ class InitCommandTest extends TestCaseFixtures
         $this->assertContains('Process aborted', $commandTester->getDisplay());
     }
 
+    /**
+     * @param string $lastAnswer
+     *
+     * @return array
+     */
     private function getInputsArray($lastAnswer = 'yes')
     {
         $dsn = $this->getConnectionDsn('bookstore', true);

--- a/tests/Propel/Tests/Generator/Command/InitCommandTest.php
+++ b/tests/Propel/Tests/Generator/Command/InitCommandTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Command;

--- a/tests/Propel/Tests/Generator/Command/MigrationTest.php
+++ b/tests/Propel/Tests/Generator/Command/MigrationTest.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Generator\Command;
 
 use Propel\Generator\Command\MigrationCreateCommand;

--- a/tests/Propel/Tests/Generator/Config/ArrayToPhpConverterTest.php
+++ b/tests/Propel/Tests/Generator/Config/ArrayToPhpConverterTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Config;

--- a/tests/Propel/Tests/Generator/Config/GeneratorConfigTest.php
+++ b/tests/Propel/Tests/Generator/Config/GeneratorConfigTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Config;

--- a/tests/Propel/Tests/Generator/Config/GeneratorConfigTest.php
+++ b/tests/Propel/Tests/Generator/Config/GeneratorConfigTest.php
@@ -116,7 +116,7 @@ class GeneratorConfigTest extends ConfigTestCase
     }
 
     /**
-     * @expectedException Propel\Generator\Exception\InvalidArgumentException
+     * @expectedException \Propel\Generator\Exception\InvalidArgumentException
      * @expectedExceptionMessage Invalid database name: no configured connection named `badsource`.
      *
      * @return void
@@ -171,7 +171,7 @@ class GeneratorConfigTest extends ConfigTestCase
     }
 
     /**
-     * @expectedException Propel\Generator\Exception\BuildException
+     * @expectedException \Propel\Generator\Exception\BuildException
      * @expectedExceptionMessage Specified class (\Propel\Generator\Platform\MysqlPlatform) does not implement \Propel\Generator\Reverse\SchemaParserInterface interface.
      *
      * @return void
@@ -192,7 +192,7 @@ class GeneratorConfigTest extends ConfigTestCase
     }
 
     /**
-     * @expectedException Propel\Generator\Exception\ClassNotFoundException
+     * @expectedException \Propel\Generator\Exception\ClassNotFoundException
      * @expectedExceptionMessage Reverse SchemaParser class for `\Propel\Generator\Reverse\BadSchemaParser` not found.
      *
      * @return void
@@ -224,7 +224,7 @@ class GeneratorConfigTest extends ConfigTestCase
     }
 
     /**
-     * @expectedException Propel\Generator\Exception\ClassNotFoundException
+     * @expectedException \Propel\Generator\Exception\ClassNotFoundException
      *
      * @return void
      */
@@ -250,7 +250,7 @@ class GeneratorConfigTest extends ConfigTestCase
     }
 
     /**
-     * @expectedException Propel\Generator\Exception\ClassNotFoundException
+     * @expectedException \Propel\Generator\Exception\ClassNotFoundException
      * @expectedExceptionMessage Class \Propel\Common\Pluralizer\WrongEnglishPluralizer not found.
      *
      * @return void
@@ -264,7 +264,7 @@ class GeneratorConfigTest extends ConfigTestCase
     }
 
     /**
-     * @expectedException Propel\Generator\Exception\BuildException
+     * @expectedException \Propel\Generator\Exception\BuildException
      * @expectedExceptionMessage Specified class (\Propel\Common\Config\PropelConfiguration) does not implement
      *
      * @return void
@@ -357,7 +357,7 @@ class GeneratorConfigTest extends ConfigTestCase
     }
 
     /**
-     * @expectedException Propel\Generator\Exception\InvalidArgumentException
+     * @expectedException \Propel\Generator\Exception\InvalidArgumentException
      * @expectedExceptionMessage Invalid database name: no configured connection named `wrongsource`.
      *
      * @return void
@@ -388,7 +388,7 @@ class GeneratorConfigTest extends ConfigTestCase
     }
 
     /**
-     * @expectedException Propel\Generator\Exception\InvalidArgumentException
+     * @expectedException \Propel\Generator\Exception\InvalidArgumentException
      * @expectedExceptionMessage Invalid database name: no configured connection named `badsource`.
      *
      * @return void

--- a/tests/Propel/Tests/Generator/Config/QuickGeneratorConfigTest.php
+++ b/tests/Propel/Tests/Generator/Config/QuickGeneratorConfigTest.php
@@ -37,7 +37,7 @@ class QuickGeneratorConfigTest extends TestCase
     }
 
     /**
-     * @expectedException Propel\Generator\Exception\InvalidArgumentException
+     * @expectedException \Propel\Generator\Exception\InvalidArgumentException
      * @expectedExceptionMessage Invalid data model builder type `bad_type`
      *
      * @return void

--- a/tests/Propel/Tests/Generator/Config/QuickGeneratorConfigTest.php
+++ b/tests/Propel/Tests/Generator/Config/QuickGeneratorConfigTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Config;

--- a/tests/Propel/Tests/Generator/Manager/MigrationManagerTest.php
+++ b/tests/Propel/Tests/Generator/Manager/MigrationManagerTest.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Generator\Manager;
 
 use Propel\Generator\Config\GeneratorConfig;

--- a/tests/Propel/Tests/Generator/Migration/BaseTest.php
+++ b/tests/Propel/Tests/Generator/Migration/BaseTest.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Generator\Migration;
 
 /**

--- a/tests/Propel/Tests/Generator/Migration/ForeignKeyTest.php
+++ b/tests/Propel/Tests/Generator/Migration/ForeignKeyTest.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Generator\Migration;
 
 /**

--- a/tests/Propel/Tests/Generator/Migration/IndexTest.php
+++ b/tests/Propel/Tests/Generator/Migration/IndexTest.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Generator\Migration;
 
 /**

--- a/tests/Propel/Tests/Generator/Migration/MigrationTestCase.php
+++ b/tests/Propel/Tests/Generator/Migration/MigrationTestCase.php
@@ -64,6 +64,7 @@ class MigrationTestCase extends TestCaseFixturesDatabase
 
     /**
      * @param string $xml
+     * @param bool $changeRequired
      *
      * @throws \Propel\Generator\Exception\BuildException
      *

--- a/tests/Propel/Tests/Generator/Migration/MigrationTestCase.php
+++ b/tests/Propel/Tests/Generator/Migration/MigrationTestCase.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Generator\Migration;
 
 use Exception;

--- a/tests/Propel/Tests/Generator/Migration/PrimaryKeyAITest.php
+++ b/tests/Propel/Tests/Generator/Migration/PrimaryKeyAITest.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Generator\Migration;
 
 /**

--- a/tests/Propel/Tests/Generator/Migration/PrimaryKeyTest.php
+++ b/tests/Propel/Tests/Generator/Migration/PrimaryKeyTest.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Generator\Migration;
 
 /**

--- a/tests/Propel/Tests/Generator/Model/BehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Model/BehaviorTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Model;

--- a/tests/Propel/Tests/Generator/Model/BehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Model/BehaviorTest.php
@@ -8,9 +8,12 @@
  * @license MIT License
  */
 
+namespace Propel\Tests\Generator\Model;
+
 use Propel\Generator\Builder\Util\SchemaReader;
 use Propel\Generator\Model\Behavior;
 use Propel\Generator\Model\Table;
+use Propel\Tests\Helpers\MultipleBehavior;
 use Propel\Tests\TestCase;
 
 /**
@@ -20,10 +23,6 @@ use Propel\Tests\TestCase;
  */
 class BehaviorTest extends TestCase
 {
-    private $schemaReader;
-
-    private $appData;
-
     /**
      * @return void
      */
@@ -39,7 +38,7 @@ class BehaviorTest extends TestCase
      */
     public function testSetupObjectWithMultipleBehaviorWithNoId()
     {
-        $b = new Propel\Tests\Helpers\MultipleBehavior();
+        $b = new MultipleBehavior();
         $b->loadMapping(['name' => 'foo']);
 
         $this->assertEquals($b->getName(), 'foo', 'setupObject() sets the Behavior name from XML attributes');
@@ -51,7 +50,7 @@ class BehaviorTest extends TestCase
      */
     public function testSetupObjectWithMultipleBehaviorWithId()
     {
-        $b = new Propel\Tests\Helpers\MultipleBehavior();
+        $b = new MultipleBehavior();
         $b->loadMapping(['name' => 'foo', 'id' => 'bar']);
 
         $this->assertEquals($b->getName(), 'foo', 'setupObject() sets the Behavior name from XML attributes');
@@ -59,7 +58,7 @@ class BehaviorTest extends TestCase
     }
 
     /**
-     * @expectedException Propel\Generator\Exception\LogicException
+     * @expectedException \Propel\Generator\Exception\LogicException
      *
      * @return void
      */
@@ -162,7 +161,7 @@ EOF;
   </table>
 </database>
 EOF;
-        $appData = $schemaReader->parseString($schema);
+        $schemaReader->parseString($schema);
     }
 
     /**

--- a/tests/Propel/Tests/Generator/Model/ColumnDefaultValueTest.php
+++ b/tests/Propel/Tests/Generator/Model/ColumnDefaultValueTest.php
@@ -8,6 +8,8 @@
  * @license MIT License
  */
 
+namespace Propel\Tests\Generator\Model;
+
 use Propel\Generator\Model\ColumnDefaultValue;
 use Propel\Tests\TestCase;
 

--- a/tests/Propel/Tests/Generator/Model/ColumnDefaultValueTest.php
+++ b/tests/Propel/Tests/Generator/Model/ColumnDefaultValueTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Model;

--- a/tests/Propel/Tests/Generator/Model/ColumnTest.php
+++ b/tests/Propel/Tests/Generator/Model/ColumnTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Model;

--- a/tests/Propel/Tests/Generator/Model/ConstantNameTest.php
+++ b/tests/Propel/Tests/Generator/Model/ConstantNameTest.php
@@ -99,6 +99,8 @@ XML;
     }
 
     /**
+     * @param string $schema
+     *
      * @return void
      */
     protected function buildClasses($schema)

--- a/tests/Propel/Tests/Generator/Model/ConstantNameTest.php
+++ b/tests/Propel/Tests/Generator/Model/ConstantNameTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Model;

--- a/tests/Propel/Tests/Generator/Model/DatabaseTest.php
+++ b/tests/Propel/Tests/Generator/Model/DatabaseTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Model;

--- a/tests/Propel/Tests/Generator/Model/Diff/ColumnComparatorTest.php
+++ b/tests/Propel/Tests/Generator/Model/Diff/ColumnComparatorTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Model\Diff;

--- a/tests/Propel/Tests/Generator/Model/Diff/ColumnComparatorTest.php
+++ b/tests/Propel/Tests/Generator/Model/Diff/ColumnComparatorTest.php
@@ -1,13 +1,14 @@
 <?php
 
-/*
- *	$Id: TableTest.php 1891 2010-08-09 15:03:18Z francois $
+/**
  * This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
  * @license MIT License
  */
+
+namespace Propel\Tests\Generator\Model\Diff;
 
 use Propel\Generator\Model\Column;
 use Propel\Generator\Model\ColumnDefaultValue;

--- a/tests/Propel/Tests/Generator/Model/Diff/DatabaseTableComparatorTest.php
+++ b/tests/Propel/Tests/Generator/Model/Diff/DatabaseTableComparatorTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license    MIT License
  */
 
 namespace Propel\Tests\Generator\Model\Diff;

--- a/tests/Propel/Tests/Generator/Model/Diff/DatabaseTableComparatorTest.php
+++ b/tests/Propel/Tests/Generator/Model/Diff/DatabaseTableComparatorTest.php
@@ -8,7 +8,7 @@
  * @license    MIT License
  */
 
-namespace Propel\Tests\Generator\Model\Diff\DatabaseTableComparatorTest;
+namespace Propel\Tests\Generator\Model\Diff;
 
 use Propel\Generator\Model\Column;
 use Propel\Generator\Model\ColumnDefaultValue;
@@ -23,7 +23,7 @@ use Propel\Tests\TestCase;
 /**
  * Tests for the Table method of the DatabaseComparator service class.
  */
-class PropelDatabaseTableComparatorTest extends TestCase
+class DatabaseTableComparatorTest extends TestCase
 {
     /**
      * @return void

--- a/tests/Propel/Tests/Generator/Model/Diff/ForeignKeyComparatorTest.php
+++ b/tests/Propel/Tests/Generator/Model/Diff/ForeignKeyComparatorTest.php
@@ -1,13 +1,14 @@
 <?php
 
-/*
- *	$Id: TableTest.php 1891 2010-08-09 15:03:18Z francois $
+/**
  * This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
  * @license MIT License
  */
+
+namespace Propel\Tests\Generator\Model\Diff;
 
 use Propel\Generator\Model\Column;
 use Propel\Generator\Model\Diff\ForeignKeyComparator;
@@ -18,7 +19,7 @@ use Propel\Tests\TestCase;
 /**
  * Tests for the ColumnComparator service class.
  */
-class PropelForeignComparatorTest extends TestCase
+class ForeignKeyComparatorTest extends TestCase
 {
     /**
      * @return void

--- a/tests/Propel/Tests/Generator/Model/Diff/ForeignKeyComparatorTest.php
+++ b/tests/Propel/Tests/Generator/Model/Diff/ForeignKeyComparatorTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Model\Diff;

--- a/tests/Propel/Tests/Generator/Model/Diff/IndexComparatorTest.php
+++ b/tests/Propel/Tests/Generator/Model/Diff/IndexComparatorTest.php
@@ -1,13 +1,14 @@
 <?php
 
-/*
- *	$Id: TableTest.php 1891 2010-08-09 15:03:18Z francois $
+/**
  * This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
  * @license MIT License
  */
+
+namespace Propel\Tests\Generator\Model\Diff;
 
 use Propel\Generator\Model\Column;
 use Propel\Generator\Model\Diff\IndexComparator;

--- a/tests/Propel/Tests/Generator/Model/Diff/IndexComparatorTest.php
+++ b/tests/Propel/Tests/Generator/Model/Diff/IndexComparatorTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Model\Diff;

--- a/tests/Propel/Tests/Generator/Model/Diff/PropelTableColumnComparatorTest.php
+++ b/tests/Propel/Tests/Generator/Model/Diff/PropelTableColumnComparatorTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Model\Diff;

--- a/tests/Propel/Tests/Generator/Model/Diff/PropelTableColumnComparatorTest.php
+++ b/tests/Propel/Tests/Generator/Model/Diff/PropelTableColumnComparatorTest.php
@@ -1,13 +1,14 @@
 <?php
 
-/*
- *	$Id: TableTest.php 1891 2010-08-09 15:03:18Z francois $
+/**
  * This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
  * @license MIT License
  */
+
+namespace Propel\Tests\Generator\Model\Diff;
 
 use Propel\Generator\Model\Column;
 use Propel\Generator\Model\ColumnDefaultValue;

--- a/tests/Propel/Tests/Generator/Model/Diff/PropelTableForeignKeyComparatorTest.php
+++ b/tests/Propel/Tests/Generator/Model/Diff/PropelTableForeignKeyComparatorTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Model\Diff;

--- a/tests/Propel/Tests/Generator/Model/Diff/PropelTableForeignKeyComparatorTest.php
+++ b/tests/Propel/Tests/Generator/Model/Diff/PropelTableForeignKeyComparatorTest.php
@@ -1,13 +1,14 @@
 <?php
 
-/*
- *	$Id: TableTest.php 1891 2010-08-09 15:03:18Z francois $
+/**
  * This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
  * @license MIT License
  */
+
+namespace Propel\Tests\Generator\Model\Diff;
 
 use Propel\Generator\Model\Column;
 use Propel\Generator\Model\Database;

--- a/tests/Propel/Tests/Generator/Model/Diff/PropelTableIndexComparatorTest.php
+++ b/tests/Propel/Tests/Generator/Model/Diff/PropelTableIndexComparatorTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Model\Diff;

--- a/tests/Propel/Tests/Generator/Model/Diff/PropelTableIndexComparatorTest.php
+++ b/tests/Propel/Tests/Generator/Model/Diff/PropelTableIndexComparatorTest.php
@@ -1,13 +1,14 @@
 <?php
 
-/*
- *	$Id: TableTest.php 1891 2010-08-09 15:03:18Z francois $
+/**
  * This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
  * @license MIT License
  */
+
+namespace Propel\Tests\Generator\Model\Diff;
 
 use Propel\Generator\Model\Column;
 use Propel\Generator\Model\ColumnDefaultValue;

--- a/tests/Propel/Tests/Generator/Model/Diff/PropelTablePkColumnComparatorTest.php
+++ b/tests/Propel/Tests/Generator/Model/Diff/PropelTablePkColumnComparatorTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Model\Diff;

--- a/tests/Propel/Tests/Generator/Model/Diff/PropelTablePkColumnComparatorTest.php
+++ b/tests/Propel/Tests/Generator/Model/Diff/PropelTablePkColumnComparatorTest.php
@@ -1,13 +1,14 @@
 <?php
 
-/*
- *	$Id: TableTest.php 1891 2010-08-09 15:03:18Z francois $
+/**
  * This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
  * @license MIT License
  */
+
+namespace Propel\Tests\Generator\Model\Diff;
 
 use Propel\Generator\Model\Column;
 use Propel\Generator\Model\ColumnDefaultValue;

--- a/tests/Propel/Tests/Generator/Model/Diff/TableDiffTest.php
+++ b/tests/Propel/Tests/Generator/Model/Diff/TableDiffTest.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Generator\Model\Diff;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Propel/Tests/Generator/Model/DomainTest.php
+++ b/tests/Propel/Tests/Generator/Model/DomainTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Model;

--- a/tests/Propel/Tests/Generator/Model/ForeignKeyTest.php
+++ b/tests/Propel/Tests/Generator/Model/ForeignKeyTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Model;

--- a/tests/Propel/Tests/Generator/Model/IndexTest.php
+++ b/tests/Propel/Tests/Generator/Model/IndexTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Model;

--- a/tests/Propel/Tests/Generator/Model/InheritanceTest.php
+++ b/tests/Propel/Tests/Generator/Model/InheritanceTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Model;

--- a/tests/Propel/Tests/Generator/Model/MappingModelTest.php
+++ b/tests/Propel/Tests/Generator/Model/MappingModelTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license    MIT License
  */
 
 namespace Propel\Tests\Generator\Model;

--- a/tests/Propel/Tests/Generator/Model/ModelTestCase.php
+++ b/tests/Propel/Tests/Generator/Model/ModelTestCase.php
@@ -25,7 +25,7 @@ abstract class ModelTestCase extends TestCase
      * @param string $name The behavior name
      * @param array $options An array of options
      *
-     * @return Behavior
+     * @return \Propel\Generator\Model\Behavior
      */
     protected function getBehaviorMock($name, array $options = [])
     {
@@ -85,7 +85,7 @@ abstract class ModelTestCase extends TestCase
      * @param string|null $name The foreign key name
      * @param array $options An array of options
      *
-     * @return ForeignKey
+     * @return \Propel\Generator\Model\ForeignKey
      */
     protected function getForeignKeyMock($name = null, array $options = [])
     {
@@ -168,7 +168,7 @@ abstract class ModelTestCase extends TestCase
      * @param string|null $name The unique index name
      * @param array $options An array of options
      *
-     * @return Unique
+     * @return \Propel\Generator\Model\Unique
      */
     protected function getUniqueIndexMock($name = null, array $options = [])
     {
@@ -193,7 +193,7 @@ abstract class ModelTestCase extends TestCase
      * @param string|null $name The schema name
      * @param array $options An array of options
      *
-     * @return Schema
+     * @return \Propel\Generator\Model\Schema
      */
     protected function getSchemaMock($name = null, array $options = [])
     {
@@ -226,7 +226,7 @@ abstract class ModelTestCase extends TestCase
      * @param array $options An array of options
      * @param string $schemaDelimiter
      *
-     * @return PlatformInterface
+     * @return \Propel\Generator\Platform\PlatformInterface
      */
     protected function getPlatformMock($supportsSchemas = true, array $options = [], $schemaDelimiter = '.')
     {
@@ -265,7 +265,7 @@ abstract class ModelTestCase extends TestCase
      * @param string|null $name
      * @param array $options An array of options
      *
-     * @return Domain
+     * @return \Propel\Generator\Model\Domain
      */
     protected function getDomainMock($name = null, array $options = [])
     {
@@ -292,7 +292,7 @@ abstract class ModelTestCase extends TestCase
      * @param string $name The table name
      * @param array $options An array of options
      *
-     * @return Table
+     * @return \Propel\Generator\Model\Table
      */
     protected function getTableMock($name, array $options = [])
     {
@@ -368,7 +368,7 @@ abstract class ModelTestCase extends TestCase
      * @param string $name The database name
      * @param array $options An array of options
      *
-     * @return Database
+     * @return \Propel\Generator\Model\Database
      */
     protected function getDatabaseMock($name, array $options = [])
     {
@@ -400,7 +400,7 @@ abstract class ModelTestCase extends TestCase
      * @param string $name The column name
      * @param array $options An array of options
      *
-     * @return Column
+     * @return \Propel\Generator\Model\Column
      */
     protected function getColumnMock($name, array $options = [])
     {

--- a/tests/Propel/Tests/Generator/Model/ModelTestCase.php
+++ b/tests/Propel/Tests/Generator/Model/ModelTestCase.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Model;

--- a/tests/Propel/Tests/Generator/Model/NameFactoryTest.php
+++ b/tests/Propel/Tests/Generator/Model/NameFactoryTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Model;
@@ -80,7 +78,6 @@ class NameFactoryTest extends BaseTestCase
         return $buf;
     }
 
-
     /**
      * @return void
      */
@@ -115,7 +112,6 @@ class NameFactoryTest extends BaseTestCase
         $this->database = new Database();
         $schema->addDatabase($this->database);
     }
-
 
     /**
      * @return void

--- a/tests/Propel/Tests/Generator/Model/NameFactoryTest.php
+++ b/tests/Propel/Tests/Generator/Model/NameFactoryTest.php
@@ -68,7 +68,7 @@ class NameFactoryTest extends BaseTestCase
      *
      * @param int $len the number of characters to include in the string
      *
-     * @return a string of length <code>len</code> with every character an 'A'
+     * @return string A string of length <code>len</code> with every character an 'A'
      */
     private static function makeString($len)
     {
@@ -80,7 +80,7 @@ class NameFactoryTest extends BaseTestCase
         return $buf;
     }
 
-    
+
     /**
      * @return void
      */
@@ -116,7 +116,7 @@ class NameFactoryTest extends BaseTestCase
         $schema->addDatabase($this->database);
     }
 
-    
+
     /**
      * @return void
      */
@@ -140,16 +140,16 @@ class NameFactoryTest extends BaseTestCase
      * Creates the list of arguments to pass to the specified type of
      * <code>NameGeneratorInterface</code> implementation.
      *
-     * @param algo The class name of the <code>NameGeneratorInterface</code> to
+     * @param string $algo The class name of the <code>NameGeneratorInterface</code> to
      * create an argument list for.
-     * @param inputs The (possibly partial) list inputs from which to
+     * @param array $inputs The (possibly partial) list inputs from which to
      * generate the final list.
      *
-     * @return the list of arguments to pass to the <code>NameGeneratorInterface</code>
+     * @return array The list of arguments to pass to the <code>NameGeneratorInterface</code>
      */
-    private function makeInputs($algo, $inputs)
+    private function makeInputs($algo, array $inputs)
     {
-        if (NameFactory::CONSTRAINT_GENERATOR == $algo) {
+        if (NameFactory::CONSTRAINT_GENERATOR === $algo) {
             array_unshift($inputs, $this->database);
         }
 

--- a/tests/Propel/Tests/Generator/Model/PhpNameGeneratorTest.php
+++ b/tests/Propel/Tests/Generator/Model/PhpNameGeneratorTest.php
@@ -8,6 +8,8 @@
  * @license MIT License
  */
 
+namespace Propel\Tests\Generator\Model;
+
 use Propel\Generator\Model\PhpNameGenerator;
 use Propel\Tests\TestCase;
 

--- a/tests/Propel/Tests/Generator/Model/PhpNameGeneratorTest.php
+++ b/tests/Propel/Tests/Generator/Model/PhpNameGeneratorTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Model;

--- a/tests/Propel/Tests/Generator/Model/SchemaTest.php
+++ b/tests/Propel/Tests/Generator/Model/SchemaTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Model;

--- a/tests/Propel/Tests/Generator/Model/TableTest.php
+++ b/tests/Propel/Tests/Generator/Model/TableTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Model;

--- a/tests/Propel/Tests/Generator/Model/UniqueTest.php
+++ b/tests/Propel/Tests/Generator/Model/UniqueTest.php
@@ -22,6 +22,10 @@ class UniqueTest extends ModelTestCase
     /**
      * @dataProvider provideTableSpecificAttributes
      *
+     * @param string $tableName
+     * @param int $maxColumnNameLength
+     * @param string $indexName
+     *
      * @return void
      */
     public function testCreateDefaultUniqueIndexName($tableName, $maxColumnNameLength, $indexName)
@@ -45,6 +49,9 @@ class UniqueTest extends ModelTestCase
         $this->assertSame($indexName, $index->getName());
     }
 
+    /**
+     * @return array
+     */
     public function provideTableSpecificAttributes()
     {
         return [

--- a/tests/Propel/Tests/Generator/Model/UniqueTest.php
+++ b/tests/Propel/Tests/Generator/Model/UniqueTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Model;

--- a/tests/Propel/Tests/Generator/Model/VendorInfoTest.php
+++ b/tests/Propel/Tests/Generator/Model/VendorInfoTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Model;

--- a/tests/Propel/Tests/Generator/Platform/DefaultPlatformTest.php
+++ b/tests/Propel/Tests/Generator/Platform/DefaultPlatformTest.php
@@ -8,6 +8,8 @@
  * @license MIT License
  */
 
+namespace Propel\Tests\Generator\Platform;
+
 use Propel\Generator\Model\Column;
 use Propel\Generator\Model\PropelTypes;
 use Propel\Generator\Platform\DefaultPlatform;
@@ -20,7 +22,7 @@ class DefaultPlatformTest extends TestCase
     /**
      * Get the Platform object for this class
      *
-     * @return Platform
+     * @return \Propel\Generator\Platform\PlatformInterface
      */
     protected function getPlatform()
     {

--- a/tests/Propel/Tests/Generator/Platform/DefaultPlatformTest.php
+++ b/tests/Propel/Tests/Generator/Platform/DefaultPlatformTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Platform;

--- a/tests/Propel/Tests/Generator/Platform/MssqlPlatformTest.php
+++ b/tests/Propel/Tests/Generator/Platform/MssqlPlatformTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Platform;

--- a/tests/Propel/Tests/Generator/Platform/MysqlPlatformMigrationMyISAMTest.php
+++ b/tests/Propel/Tests/Generator/Platform/MysqlPlatformMigrationMyISAMTest.php
@@ -20,7 +20,7 @@ class MysqlPlatformMigrationMyISAMTest extends PlatformMigrationTestProvider
     /**
      * Get the Platform object for this class
      *
-     * @return Platform
+     * @return \Propel\Generator\Platform\PlatformInterface
      */
     protected function getPlatform()
     {

--- a/tests/Propel/Tests/Generator/Platform/MysqlPlatformMigrationMyISAMTest.php
+++ b/tests/Propel/Tests/Generator/Platform/MysqlPlatformMigrationMyISAMTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Platform;

--- a/tests/Propel/Tests/Generator/Platform/MysqlPlatformMigrationTest.php
+++ b/tests/Propel/Tests/Generator/Platform/MysqlPlatformMigrationTest.php
@@ -16,12 +16,15 @@ use Propel\Generator\Platform\MysqlPlatform;
 
 class MysqlPlatformMigrationTest extends MysqlPlatformMigrationTestProvider
 {
+    /**
+     * @var \Propel\Generator\Platform\PlatformInterface|null
+     */
     protected $platform;
 
     /**
      * Get the Platform object for this class
      *
-     * @return Platform
+     * @return \Propel\Generator\Platform\PlatformInterface
      */
     protected function getPlatform()
     {

--- a/tests/Propel/Tests/Generator/Platform/MysqlPlatformMigrationTest.php
+++ b/tests/Propel/Tests/Generator/Platform/MysqlPlatformMigrationTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Platform;

--- a/tests/Propel/Tests/Generator/Platform/MysqlPlatformMigrationTestProvider.php
+++ b/tests/Propel/Tests/Generator/Platform/MysqlPlatformMigrationTestProvider.php
@@ -15,6 +15,9 @@ namespace Propel\Tests\Generator\Platform;
  */
 class MysqlPlatformMigrationTestProvider extends PlatformMigrationTestProvider
 {
+    /**
+     * @return array
+     */
     public function providerForTestGetAddColumnFirstDDL()
     {
         $schema = <<<EOF

--- a/tests/Propel/Tests/Generator/Platform/MysqlPlatformMigrationTestProvider.php
+++ b/tests/Propel/Tests/Generator/Platform/MysqlPlatformMigrationTestProvider.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Platform;

--- a/tests/Propel/Tests/Generator/Platform/MysqlPlatformMyISAMTest.php
+++ b/tests/Propel/Tests/Generator/Platform/MysqlPlatformMyISAMTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Platform;

--- a/tests/Propel/Tests/Generator/Platform/MysqlPlatformTest.php
+++ b/tests/Propel/Tests/Generator/Platform/MysqlPlatformTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Platform;

--- a/tests/Propel/Tests/Generator/Platform/OraclePlatformMigrationTest.php
+++ b/tests/Propel/Tests/Generator/Platform/OraclePlatformMigrationTest.php
@@ -18,7 +18,7 @@ class OraclePlatformMigrationTest extends PlatformMigrationTestProvider
     /**
      * Get the Platform object for this class
      *
-     * @return Platform
+     * @return \Propel\Generator\Platform\PlatformInterface
      */
     protected function getPlatform()
     {

--- a/tests/Propel/Tests/Generator/Platform/OraclePlatformMigrationTest.php
+++ b/tests/Propel/Tests/Generator/Platform/OraclePlatformMigrationTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Platform;

--- a/tests/Propel/Tests/Generator/Platform/OraclePlatformTest.php
+++ b/tests/Propel/Tests/Generator/Platform/OraclePlatformTest.php
@@ -22,7 +22,7 @@ class OraclePlatformTest extends PlatformTestProvider
     /**
      * Get the Platform object for this class
      *
-     * @return Platform
+     * @return \Propel\Generator\Platform\PlatformInterface
      */
     protected function getPlatform()
     {

--- a/tests/Propel/Tests/Generator/Platform/OraclePlatformTest.php
+++ b/tests/Propel/Tests/Generator/Platform/OraclePlatformTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Platform;

--- a/tests/Propel/Tests/Generator/Platform/PgsqlPlatformMigrationTest.php
+++ b/tests/Propel/Tests/Generator/Platform/PgsqlPlatformMigrationTest.php
@@ -22,7 +22,7 @@ class PgsqlPlatformMigrationTest extends PlatformMigrationTestProvider
     /**
      * Get the Platform object for this class
      *
-     * @return Platform
+     * @return \Propel\Generator\Platform\PlatformInterface
      */
     protected function getPlatform()
     {

--- a/tests/Propel/Tests/Generator/Platform/PgsqlPlatformMigrationTest.php
+++ b/tests/Propel/Tests/Generator/Platform/PgsqlPlatformMigrationTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Platform;

--- a/tests/Propel/Tests/Generator/Platform/PgsqlPlatformTest.php
+++ b/tests/Propel/Tests/Generator/Platform/PgsqlPlatformTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Platform;

--- a/tests/Propel/Tests/Generator/Platform/PlatformMigrationTestProvider.php
+++ b/tests/Propel/Tests/Generator/Platform/PlatformMigrationTestProvider.php
@@ -21,6 +21,9 @@ use Propel\Generator\Model\Table;
  */
 abstract class PlatformMigrationTestProvider extends PlatformTestBase
 {
+    /**
+     * @return array
+     */
     public function providerForTestGetModifyDatabaseDDL()
     {
         $schema1 = <<<EOF

--- a/tests/Propel/Tests/Generator/Platform/PlatformMigrationTestProvider.php
+++ b/tests/Propel/Tests/Generator/Platform/PlatformMigrationTestProvider.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Platform;

--- a/tests/Propel/Tests/Generator/Platform/PlatformTestBase.php
+++ b/tests/Propel/Tests/Generator/Platform/PlatformTestBase.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Platform;

--- a/tests/Propel/Tests/Generator/Platform/PlatformTestProvider.php
+++ b/tests/Propel/Tests/Generator/Platform/PlatformTestProvider.php
@@ -23,6 +23,9 @@ use Propel\Generator\Model\Unique;
  */
 abstract class PlatformTestProvider extends PlatformTestBase
 {
+    /**
+     * @return string[][]
+     */
     public function providerForTestGetAddTablesDDL()
     {
         $schema = <<<EOF

--- a/tests/Propel/Tests/Generator/Platform/PlatformTestProvider.php
+++ b/tests/Propel/Tests/Generator/Platform/PlatformTestProvider.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Platform;

--- a/tests/Propel/Tests/Generator/Platform/SqlitePlatformTest.php
+++ b/tests/Propel/Tests/Generator/Platform/SqlitePlatformTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Platform;

--- a/tests/Propel/Tests/Generator/Platform/SqlitePlatformTest.php
+++ b/tests/Propel/Tests/Generator/Platform/SqlitePlatformTest.php
@@ -24,7 +24,7 @@ class SqlitePlatformTest extends PlatformTestProvider
     /**
      * Get the Platform object for this class
      *
-     * @return Platform
+     * @return \Propel\Generator\Platform\PlatformInterface
      */
     protected function getPlatform()
     {

--- a/tests/Propel/Tests/Generator/Reverse/MssqlSchemaParserTest.php
+++ b/tests/Propel/Tests/Generator/Reverse/MssqlSchemaParserTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Reverse;

--- a/tests/Propel/Tests/Generator/Reverse/MysqlSchemaParserTest.php
+++ b/tests/Propel/Tests/Generator/Reverse/MysqlSchemaParserTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Reverse;

--- a/tests/Propel/Tests/Generator/Reverse/PgsqlSchemaParserTest.php
+++ b/tests/Propel/Tests/Generator/Reverse/PgsqlSchemaParserTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Reverse;

--- a/tests/Propel/Tests/Generator/Schema/Dumper/XmlDumperTest.php
+++ b/tests/Propel/Tests/Generator/Schema/Dumper/XmlDumperTest.php
@@ -34,6 +34,11 @@ class XmlDumperTest extends TestCase
         $this->assertSame($this->getExpectedXml('blog-schema.xml'), $this->dumper->dumpSchema($schema, true));
     }
 
+    /**
+     * @param string $filename
+     *
+     * @return string
+     */
     protected function getExpectedXml($filename)
     {
         return trim(file_get_contents(realpath(__DIR__ . '/../../../Resources/' . $filename)));

--- a/tests/Propel/Tests/Generator/Schema/Dumper/XmlDumperTest.php
+++ b/tests/Propel/Tests/Generator/Schema/Dumper/XmlDumperTest.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Generator\Schema\Dumper;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Propel/Tests/Generator/Util/PhpParserTest.php
+++ b/tests/Propel/Tests/Generator/Util/PhpParserTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Util;

--- a/tests/Propel/Tests/Generator/Util/QuickBuilderTest.php
+++ b/tests/Propel/Tests/Generator/Util/QuickBuilderTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Util;

--- a/tests/Propel/Tests/Generator/Util/SchemaValidatorTest.php
+++ b/tests/Propel/Tests/Generator/Util/SchemaValidatorTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Generator\Util;

--- a/tests/Propel/Tests/Generator/Util/SqlParserTest.php
+++ b/tests/Propel/Tests/Generator/Util/SqlParserTest.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Generator\Util;
 
 /**

--- a/tests/Propel/Tests/Helpers/BaseTestCase.php
+++ b/tests/Propel/Tests/Helpers/BaseTestCase.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Helpers;

--- a/tests/Propel/Tests/Helpers/Bookstore/Behavior/AddClassBehavior.php
+++ b/tests/Propel/Tests/Helpers/Bookstore/Behavior/AddClassBehavior.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Helpers\Bookstore\Behavior;

--- a/tests/Propel/Tests/Helpers/Bookstore/Behavior/AddClassBehaviorBuilder.php
+++ b/tests/Propel/Tests/Helpers/Bookstore/Behavior/AddClassBehaviorBuilder.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Helpers\Bookstore\Behavior;
 
 use Propel\Generator\Builder\Om\AbstractOMBuilder;

--- a/tests/Propel/Tests/Helpers/Bookstore/Behavior/DonothingBehavior.php
+++ b/tests/Propel/Tests/Helpers/Bookstore/Behavior/DonothingBehavior.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Helpers\Bookstore\Behavior;

--- a/tests/Propel/Tests/Helpers/Bookstore/Behavior/TestAuthor.php
+++ b/tests/Propel/Tests/Helpers/Bookstore/Behavior/TestAuthor.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Helpers\Bookstore\Behavior;

--- a/tests/Propel/Tests/Helpers/Bookstore/Behavior/TestAuthorDeleteFalse.php
+++ b/tests/Propel/Tests/Helpers/Bookstore/Behavior/TestAuthorDeleteFalse.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Helpers\Bookstore\Behavior;
 
 use Propel\Runtime\Connection\ConnectionInterface;

--- a/tests/Propel/Tests/Helpers/Bookstore/Behavior/TestAuthorSaveFalse.php
+++ b/tests/Propel/Tests/Helpers/Bookstore/Behavior/TestAuthorSaveFalse.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Helpers\Bookstore\Behavior;
 
 use Propel\Runtime\Connection\ConnectionInterface;

--- a/tests/Propel/Tests/Helpers/Bookstore/Behavior/Testallhooksbehavior.php
+++ b/tests/Propel/Tests/Helpers/Bookstore/Behavior/Testallhooksbehavior.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Helpers\Bookstore\Behavior;

--- a/tests/Propel/Tests/Helpers/Bookstore/BookstoreDataPopulator.php
+++ b/tests/Propel/Tests/Helpers/Bookstore/BookstoreDataPopulator.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Helpers\Bookstore;

--- a/tests/Propel/Tests/Helpers/Bookstore/BookstoreEmptyTestBase.php
+++ b/tests/Propel/Tests/Helpers/Bookstore/BookstoreEmptyTestBase.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Helpers\Bookstore;

--- a/tests/Propel/Tests/Helpers/Bookstore/BookstoreTestBase.php
+++ b/tests/Propel/Tests/Helpers/Bookstore/BookstoreTestBase.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Helpers\Bookstore;

--- a/tests/Propel/Tests/Helpers/MultipleBehavior.php
+++ b/tests/Propel/Tests/Helpers/MultipleBehavior.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Helpers;

--- a/tests/Propel/Tests/Helpers/MultipleBehavior.php
+++ b/tests/Propel/Tests/Helpers/MultipleBehavior.php
@@ -14,6 +14,9 @@ use Propel\Generator\Model\Behavior;
 
 class MultipleBehavior extends Behavior
 {
+    /**
+     * @return bool
+     */
     public function allowMultiple()
     {
         return true;

--- a/tests/Propel/Tests/Helpers/Namespaces/NamespacesTestBase.php
+++ b/tests/Propel/Tests/Helpers/Namespaces/NamespacesTestBase.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Helpers\Namespaces;

--- a/tests/Propel/Tests/Helpers/NoSchemaPlatform.php
+++ b/tests/Propel/Tests/Helpers/NoSchemaPlatform.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Helpers;
 
 class NoSchemaPlatform

--- a/tests/Propel/Tests/Helpers/PlatformDatabaseBuildTimeBase.php
+++ b/tests/Propel/Tests/Helpers/PlatformDatabaseBuildTimeBase.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Helpers;
 
 use Propel\Generator\Config\QuickGeneratorConfig;

--- a/tests/Propel/Tests/Helpers/SchemaPlatform.php
+++ b/tests/Propel/Tests/Helpers/SchemaPlatform.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Helpers;
 
 class SchemaPlatform

--- a/tests/Propel/Tests/Issues/Issue1033Book.php
+++ b/tests/Propel/Tests/Issues/Issue1033Book.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Issues;
 
 use Base\Issue1033Book as BaseIssue1033Book;

--- a/tests/Propel/Tests/Issues/Issue1033Test.php
+++ b/tests/Propel/Tests/Issues/Issue1033Test.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Issues;
 
 use Exception;

--- a/tests/Propel/Tests/Issues/Issue1133Test.php
+++ b/tests/Propel/Tests/Issues/Issue1133Test.php
@@ -7,18 +7,30 @@ use Propel\Tests\TestCase;
 
 class DummyObject
 {
+    /**
+     * @var mixed
+     */
     private $id;
 
+    /**
+     * @param mixed $id
+     */
     public function __construct($id)
     {
         $this->id = $id;
     }
 
+    /**
+     * @return mixed
+     */
     public function getId()
     {
         return $this->id;
     }
 
+    /**
+     * @return string
+     */
     public function hashCode()
     {
         return (string)$this->id;

--- a/tests/Propel/Tests/Issues/Issue1133Test.php
+++ b/tests/Propel/Tests/Issues/Issue1133Test.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Issues;
 
 use Propel\Runtime\Collection\ObjectCollection;

--- a/tests/Propel/Tests/Issues/Issue1192Test.php
+++ b/tests/Propel/Tests/Issues/Issue1192Test.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Issues;
 
 use Issue1192ItemQuery;

--- a/tests/Propel/Tests/Issues/Issue1463Test.php
+++ b/tests/Propel/Tests/Issues/Issue1463Test.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Issues;
 
 use Issue1463ItemQuery;

--- a/tests/Propel/Tests/Issues/Issue617Test.php
+++ b/tests/Propel/Tests/Issues/Issue617Test.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Issues;
 
 use Propel\Generator\Model\Diff\DatabaseComparator;

--- a/tests/Propel/Tests/Issues/Issue646Test.php
+++ b/tests/Propel/Tests/Issues/Issue646Test.php
@@ -1,10 +1,9 @@
 <?php
+
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Issues;

--- a/tests/Propel/Tests/Issues/Issue656Test.php
+++ b/tests/Propel/Tests/Issues/Issue656Test.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Issues;
 
 use Issue656TestObject;

--- a/tests/Propel/Tests/Issues/Issue675Test.php
+++ b/tests/Propel/Tests/Issues/Issue675Test.php
@@ -1,10 +1,9 @@
 <?php
+
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Issues;

--- a/tests/Propel/Tests/Issues/Issue730Test.php
+++ b/tests/Propel/Tests/Issues/Issue730Test.php
@@ -1,10 +1,9 @@
 <?php
+
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Issues;

--- a/tests/Propel/Tests/Issues/Issue733Test.php
+++ b/tests/Propel/Tests/Issues/Issue733Test.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Issues;
 
 use Issue733Test1;

--- a/tests/Propel/Tests/Issues/Issue768Test.php
+++ b/tests/Propel/Tests/Issues/Issue768Test.php
@@ -1,10 +1,9 @@
 <?php
+
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Issues;

--- a/tests/Propel/Tests/Issues/Issue829Test.php
+++ b/tests/Propel/Tests/Issues/Issue829Test.php
@@ -1,10 +1,9 @@
 <?php
+
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Issues;

--- a/tests/Propel/Tests/Issues/Issue915Book.php
+++ b/tests/Propel/Tests/Issues/Issue915Book.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Issues;
 
 use Base\Issue915Book as BaseIssue915Book;

--- a/tests/Propel/Tests/Issues/Issue915Test.php
+++ b/tests/Propel/Tests/Issues/Issue915Test.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Issues;
 
 use Propel\Generator\Util\QuickBuilder;

--- a/tests/Propel/Tests/Issues/Issue989Test.php
+++ b/tests/Propel/Tests/Issues/Issue989Test.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Issues;
 
 use Nature;

--- a/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaCombineTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaCombineTest.php
@@ -35,7 +35,7 @@ class CriteriaCombineTest extends BaseTestCase
     /**
      * DB adapter saved for later.
      *
-     * @var AbstractAdapter
+     * @var \Propel\Runtime\Adapter\AdapterInterface
      */
     private $savedAdapter;
 

--- a/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaCombineTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaCombineTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\ActiveQuery;

--- a/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaFluidConditionTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaFluidConditionTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\ActiveQuery;

--- a/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaFluidConditionTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaFluidConditionTest.php
@@ -17,7 +17,6 @@ use Propel\Tests\Helpers\BaseTestCase;
  * Test class for Criteria fluid conditions.
  *
  * @author Francois Zaninotto
- * @version $Id: CriteriaCombineTest.php 1347 2009-12-03 21:06:36Z francois $
  */
 class CriteriaFluidConditionTest extends BaseTestCase
 {

--- a/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaFluidOperatorTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaFluidOperatorTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\ActiveQuery;

--- a/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaMergeTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaMergeTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\ActiveQuery;

--- a/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\ActiveQuery;

--- a/tests/Propel/Tests/Runtime/ActiveQuery/Criterion/BasicCriterionTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/Criterion/BasicCriterionTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\ActiveQuery\Criterion;

--- a/tests/Propel/Tests/Runtime/ActiveQuery/Criterion/BasicCriterionTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/Criterion/BasicCriterionTest.php
@@ -135,7 +135,7 @@ class BasicCriterionTest extends BaseTestCase
     }
 
     /**
-     * @expectedException Propel\Runtime\ActiveQuery\Criterion\Exception\InvalidValueException
+     * @expectedException \Propel\Runtime\ActiveQuery\Criterion\Exception\InvalidValueException
      *
      * @return void
      */

--- a/tests/Propel/Tests/Runtime/ActiveQuery/Criterion/BasicModelCriterionTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/Criterion/BasicModelCriterionTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\ActiveQuery\Criterion;

--- a/tests/Propel/Tests/Runtime/ActiveQuery/Criterion/BasicModelCriterionTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/Criterion/BasicModelCriterionTest.php
@@ -40,7 +40,7 @@ class BasicModelCriterionTest extends BaseTestCase
     }
 
     /**
-     * @expectedException Propel\Runtime\ActiveQuery\Criterion\Exception\InvalidClauseException
+     * @expectedException \Propel\Runtime\ActiveQuery\Criterion\Exception\InvalidClauseException
      *
      * @return void
      */

--- a/tests/Propel/Tests/Runtime/ActiveQuery/Criterion/CustomCriterionTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/Criterion/CustomCriterionTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\ActiveQuery\Criterion;

--- a/tests/Propel/Tests/Runtime/ActiveQuery/Criterion/InCriterionTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/Criterion/InCriterionTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\ActiveQuery\Criterion;

--- a/tests/Propel/Tests/Runtime/ActiveQuery/Criterion/InModelCriterionTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/Criterion/InModelCriterionTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\ActiveQuery\Criterion;

--- a/tests/Propel/Tests/Runtime/ActiveQuery/Criterion/LikeCriterionTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/Criterion/LikeCriterionTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\ActiveQuery\Criterion;

--- a/tests/Propel/Tests/Runtime/ActiveQuery/Criterion/LikeModelCriterionTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/Criterion/LikeModelCriterionTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\ActiveQuery\Criterion;

--- a/tests/Propel/Tests/Runtime/ActiveQuery/Criterion/LikeModelCriterionTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/Criterion/LikeModelCriterionTest.php
@@ -60,7 +60,7 @@ class LikeModelCriterionTest extends BaseTestCase
     }
 
     /**
-     * @expectedException Propel\Runtime\ActiveQuery\Criterion\Exception\InvalidClauseException
+     * @expectedException \Propel\Runtime\ActiveQuery\Criterion\Exception\InvalidClauseException
      *
      * @return void
      */

--- a/tests/Propel/Tests/Runtime/ActiveQuery/Criterion/RawCriterionTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/Criterion/RawCriterionTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\ActiveQuery\Criterion;

--- a/tests/Propel/Tests/Runtime/ActiveQuery/Criterion/RawCriterionTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/Criterion/RawCriterionTest.php
@@ -23,7 +23,7 @@ use Propel\Tests\Helpers\BaseTestCase;
 class RawCriterionTest extends BaseTestCase
 {
     /**
-     * @expectedException Propel\Runtime\ActiveQuery\Criterion\Exception\InvalidClauseException
+     * @expectedException \Propel\Runtime\ActiveQuery\Criterion\Exception\InvalidClauseException
      *
      * @return void
      */

--- a/tests/Propel/Tests/Runtime/ActiveQuery/Criterion/RawModelCriterionTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/Criterion/RawModelCriterionTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\ActiveQuery\Criterion;

--- a/tests/Propel/Tests/Runtime/ActiveQuery/Criterion/RawModelCriterionTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/Criterion/RawModelCriterionTest.php
@@ -23,7 +23,7 @@ use Propel\Tests\Helpers\BaseTestCase;
 class RawModelCriterionTest extends BaseTestCase
 {
     /**
-     * @expectedException Propel\Runtime\ActiveQuery\Criterion\Exception\InvalidClauseException
+     * @expectedException \Propel\Runtime\ActiveQuery\Criterion\Exception\InvalidClauseException
      *
      * @return void
      */

--- a/tests/Propel/Tests/Runtime/ActiveQuery/Criterion/SeveralModelCriterionTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/Criterion/SeveralModelCriterionTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\ActiveQuery\Criterion;

--- a/tests/Propel/Tests/Runtime/ActiveQuery/Criterion/SeveralModelCriterionTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/Criterion/SeveralModelCriterionTest.php
@@ -41,7 +41,7 @@ class SeveralModelCriterionTest extends BaseTestCase
     }
 
     /**
-     * @expectedException Propel\Runtime\ActiveQuery\Criterion\Exception\InvalidValueException
+     * @expectedException \Propel\Runtime\ActiveQuery\Criterion\Exception\InvalidValueException
      *
      * @return void
      */
@@ -55,7 +55,7 @@ class SeveralModelCriterionTest extends BaseTestCase
     }
 
     /**
-     * @expectedException Propel\Runtime\ActiveQuery\Criterion\Exception\InvalidValueException
+     * @expectedException \Propel\Runtime\ActiveQuery\Criterion\Exception\InvalidValueException
      *
      * @return void
      */

--- a/tests/Propel/Tests/Runtime/ActiveQuery/JoinTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/JoinTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\ActiveQuery;

--- a/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaForUseQuery.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaForUseQuery.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Runtime\ActiveQuery;
 
 use Propel\Runtime\ActiveQuery\Criteria;

--- a/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaGroupByArrayTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaGroupByArrayTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\ActiveQuery;

--- a/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaHooksTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaHooksTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\ActiveQuery;

--- a/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaSelectTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaSelectTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\ActiveQuery;

--- a/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaTest.php
@@ -1880,7 +1880,7 @@ class ModelCriteriaTest extends BookstoreTestBase
     }
 
     /**
-     * @expectedException Propel\Runtime\Exception\PropelException
+     * @expectedException \Propel\Runtime\Exception\PropelException
      *
      * @return void
      */

--- a/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\ActiveQuery;

--- a/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaWithNamespaceTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaWithNamespaceTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\ActiveQuery;

--- a/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaWithSchemaTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaWithSchemaTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\ActiveQuery;

--- a/tests/Propel/Tests/Runtime/ActiveQuery/ModelJoinTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/ModelJoinTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\ActiveQuery;

--- a/tests/Propel/Tests/Runtime/ActiveQuery/ModelWithTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/ModelWithTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\ActiveQuery;

--- a/tests/Propel/Tests/Runtime/ActiveQuery/PropelQueryTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/PropelQueryTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\ActiveQuery;

--- a/tests/Propel/Tests/Runtime/ActiveQuery/PropelQueryTestClasses.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/PropelQueryTestClasses.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\ActiveQuery;

--- a/tests/Propel/Tests/Runtime/ActiveQuery/QuotingTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/QuotingTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\ActiveQuery;

--- a/tests/Propel/Tests/Runtime/ActiveQuery/SubQueryTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/SubQueryTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\ActiveQuery;

--- a/tests/Propel/Tests/Runtime/ActiveQuery/SubQueryTestClasses.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/SubQueryTestClasses.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\ActiveQuery;

--- a/tests/Propel/Tests/Runtime/ActiveQuery/TestableModelCriteria.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/TestableModelCriteria.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Runtime\ActiveQuery;
 
 use Propel\Runtime\ActiveQuery\ModelCriteria;

--- a/tests/Propel/Tests/Runtime/ActiveRecordConvertTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveRecordConvertTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\ActiveRecord;

--- a/tests/Propel/Tests/Runtime/ActiveRecordSerializeTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveRecordSerializeTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\ActiveRecord;

--- a/tests/Propel/Tests/Runtime/ActiveRecordTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveRecordTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\ActiveRecord;

--- a/tests/Propel/Tests/Runtime/ActiveRecordTestClasses.php
+++ b/tests/Propel/Tests/Runtime/ActiveRecordTestClasses.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\ActiveRecord;

--- a/tests/Propel/Tests/Runtime/Adapter/AbstractAdapterTest.php
+++ b/tests/Propel/Tests/Runtime/Adapter/AbstractAdapterTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Adapter;

--- a/tests/Propel/Tests/Runtime/Adapter/Pdo/MssqlAdapterTest.php
+++ b/tests/Propel/Tests/Runtime/Adapter/Pdo/MssqlAdapterTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Adapter\Pdo;

--- a/tests/Propel/Tests/Runtime/Adapter/Pdo/MssqlAdapterTest.php
+++ b/tests/Propel/Tests/Runtime/Adapter/Pdo/MssqlAdapterTest.php
@@ -25,16 +25,9 @@ use Propel\Tests\TestCase;
 class MssqlAdapterTest extends TestCase
 {
     /**
-     * The criteria to use in the test.
-     *
-     * @var \Propel\Runtime\ActiveQuery\Criteria
-     */
-    private $c;
-
-    /**
      * DB adapter saved for later.
      *
-     * @var AbstractAdapter
+     * @var \Propel\Runtime\Adapter\AdapterInterface
      */
     private $savedAdapter;
 
@@ -72,6 +65,9 @@ class MssqlAdapterTest extends TestCase
         parent::tearDown();
     }
 
+    /**
+     * @return string
+     */
     protected function getDriver()
     {
         return 'mssql';

--- a/tests/Propel/Tests/Runtime/Adapter/Pdo/MysqlAdapterTest.php
+++ b/tests/Propel/Tests/Runtime/Adapter/Pdo/MysqlAdapterTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Adapter\Pdo;

--- a/tests/Propel/Tests/Runtime/Adapter/Pdo/MysqlAdapterTest.php
+++ b/tests/Propel/Tests/Runtime/Adapter/Pdo/MysqlAdapterTest.php
@@ -21,6 +21,9 @@ use Propel\Tests\TestCaseFixtures;
  */
 class MysqlAdapterTest extends TestCaseFixtures
 {
+    /**
+     * @return array
+     */
     public static function getConParams()
     {
         return [
@@ -38,12 +41,16 @@ class MysqlAdapterTest extends TestCaseFixtures
     /**
      * @dataProvider getConParams
      *
+     * @param array $conparams
+     *
      * @return void
      */
     public function testPrepareParamsThrowsException($conparams)
     {
         $db = new TestableMysqlAdapter();
-        $db->prepareParams($conparams);
+        $result = $db->prepareParams($conparams);
+
+        $this->assertIsArray($result);
     }
 
     /**
@@ -94,6 +101,11 @@ class MysqlAdapterTest extends TestCaseFixtures
 
 class TestableMysqlAdapter extends MysqlAdapter
 {
+    /**
+     * @param array $conparams
+     *
+     * @return array
+     */
     public function prepareParams($conparams)
     {
         return parent::prepareParams($conparams);

--- a/tests/Propel/Tests/Runtime/Adapter/Pdo/OracleAdapterTest.php
+++ b/tests/Propel/Tests/Runtime/Adapter/Pdo/OracleAdapterTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Adapter\Pdo;

--- a/tests/Propel/Tests/Runtime/Adapter/Pdo/PgsqlAdapter.php
+++ b/tests/Propel/Tests/Runtime/Adapter/Pdo/PgsqlAdapter.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Adapter\Pdo;

--- a/tests/Propel/Tests/Runtime/Collection/ArrayCollectionTest.php
+++ b/tests/Propel/Tests/Runtime/Collection/ArrayCollectionTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Collection;

--- a/tests/Propel/Tests/Runtime/Collection/CollectionConvertTest.php
+++ b/tests/Propel/Tests/Runtime/Collection/CollectionConvertTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Collection;

--- a/tests/Propel/Tests/Runtime/Collection/CollectionConvertTest.php
+++ b/tests/Propel/Tests/Runtime/Collection/CollectionConvertTest.php
@@ -19,7 +19,6 @@ use Propel\Tests\TestCaseFixtures;
  * Test class for Collection.
  *
  * @author Francois Zaninotto
- * @version $Id: CollectionTest.php 1348 2009-12-03 21:49:00Z francois $
  */
 class CollectionConvertTest extends TestCaseFixtures
 {

--- a/tests/Propel/Tests/Runtime/Collection/CollectionIteratorTest.php
+++ b/tests/Propel/Tests/Runtime/Collection/CollectionIteratorTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Collection;

--- a/tests/Propel/Tests/Runtime/Collection/CollectionTest.php
+++ b/tests/Propel/Tests/Runtime/Collection/CollectionTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\collection;

--- a/tests/Propel/Tests/Runtime/Collection/ObjectCollectionTest.php
+++ b/tests/Propel/Tests/Runtime/Collection/ObjectCollectionTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Collection;

--- a/tests/Propel/Tests/Runtime/Collection/ObjectCollectionWithFixturesTest.php
+++ b/tests/Propel/Tests/Runtime/Collection/ObjectCollectionWithFixturesTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\collection;

--- a/tests/Propel/Tests/Runtime/Collection/OnDemandCollectionTest.php
+++ b/tests/Propel/Tests/Runtime/Collection/OnDemandCollectionTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Collection;

--- a/tests/Propel/Tests/Runtime/Collection/OnDemandIteratorTest.php
+++ b/tests/Propel/Tests/Runtime/Collection/OnDemandIteratorTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\collection;

--- a/tests/Propel/Tests/Runtime/Connection/ConnectionFactoryTest.php
+++ b/tests/Propel/Tests/Runtime/Connection/ConnectionFactoryTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Connection;

--- a/tests/Propel/Tests/Runtime/Connection/ConnectionManagerMasterSlaveTest.php
+++ b/tests/Propel/Tests/Runtime/Connection/ConnectionManagerMasterSlaveTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Connection;

--- a/tests/Propel/Tests/Runtime/Connection/ConnectionManagerPrimaryReplicaTest.php
+++ b/tests/Propel/Tests/Runtime/Connection/ConnectionManagerPrimaryReplicaTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Connection;

--- a/tests/Propel/Tests/Runtime/Connection/ConnectionManagerSingleTest.php
+++ b/tests/Propel/Tests/Runtime/Connection/ConnectionManagerSingleTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Connection;

--- a/tests/Propel/Tests/Runtime/Connection/PropelPDOTest.php
+++ b/tests/Propel/Tests/Runtime/Connection/PropelPDOTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Connection;

--- a/tests/Propel/Tests/Runtime/Connection/TransactionTraitTest.php
+++ b/tests/Propel/Tests/Runtime/Connection/TransactionTraitTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Connection;

--- a/tests/Propel/Tests/Runtime/Exception/PropelExceptionTest.php
+++ b/tests/Propel/Tests/Runtime/Exception/PropelExceptionTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Exception;

--- a/tests/Propel/Tests/Runtime/Exception/PropelExceptionTest.php
+++ b/tests/Propel/Tests/Runtime/Exception/PropelExceptionTest.php
@@ -44,6 +44,8 @@ class PropelExceptionTest extends TestCase
     /**
      * @expectedException \Propel\Runtime\Exception\PropelException
      *
+     * @throws \Propel\Runtime\Exception\PropelException
+     *
      * @return void
      */
     public function testIsThrowable()

--- a/tests/Propel/Tests/Runtime/Formatter/ArrayFormatterTest.php
+++ b/tests/Propel/Tests/Runtime/Formatter/ArrayFormatterTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Formatter;

--- a/tests/Propel/Tests/Runtime/Formatter/ArrayFormatterWithTest.php
+++ b/tests/Propel/Tests/Runtime/Formatter/ArrayFormatterWithTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Formatter;

--- a/tests/Propel/Tests/Runtime/Formatter/DataFetcherTest.php
+++ b/tests/Propel/Tests/Runtime/Formatter/DataFetcherTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Formatter;

--- a/tests/Propel/Tests/Runtime/Formatter/ObjectFormatterInheritanceTest.php
+++ b/tests/Propel/Tests/Runtime/Formatter/ObjectFormatterInheritanceTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Formatter;

--- a/tests/Propel/Tests/Runtime/Formatter/ObjectFormatterTest.php
+++ b/tests/Propel/Tests/Runtime/Formatter/ObjectFormatterTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Formatter;

--- a/tests/Propel/Tests/Runtime/Formatter/ObjectFormatterWithTest.php
+++ b/tests/Propel/Tests/Runtime/Formatter/ObjectFormatterWithTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Formatter;

--- a/tests/Propel/Tests/Runtime/Formatter/OnDemandFormatterTest.php
+++ b/tests/Propel/Tests/Runtime/Formatter/OnDemandFormatterTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Formatter;

--- a/tests/Propel/Tests/Runtime/Formatter/OnDemandFormatterWithTest.php
+++ b/tests/Propel/Tests/Runtime/Formatter/OnDemandFormatterWithTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Formatter;

--- a/tests/Propel/Tests/Runtime/Formatter/SimpleArrayFormatterTest.php
+++ b/tests/Propel/Tests/Runtime/Formatter/SimpleArrayFormatterTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Formatter;

--- a/tests/Propel/Tests/Runtime/Formatter/StatementFormatterTest.php
+++ b/tests/Propel/Tests/Runtime/Formatter/StatementFormatterTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Formatter;

--- a/tests/Propel/Tests/Runtime/Map/ColumnMapTest.php
+++ b/tests/Propel/Tests/Runtime/Map/ColumnMapTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Map;

--- a/tests/Propel/Tests/Runtime/Map/DatabaseMapTest.php
+++ b/tests/Propel/Tests/Runtime/Map/DatabaseMapTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Map;

--- a/tests/Propel/Tests/Runtime/Map/GeneratedRelationMapTest.php
+++ b/tests/Propel/Tests/Runtime/Map/GeneratedRelationMapTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Map;

--- a/tests/Propel/Tests/Runtime/Map/GeneratedRelationMapWithSchemasTest.php
+++ b/tests/Propel/Tests/Runtime/Map/GeneratedRelationMapWithSchemasTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Map;

--- a/tests/Propel/Tests/Runtime/Map/RelatedMapSymmetricalTest.php
+++ b/tests/Propel/Tests/Runtime/Map/RelatedMapSymmetricalTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Map;

--- a/tests/Propel/Tests/Runtime/Map/RelatedMapSymmetricalWithSchemasTest.php
+++ b/tests/Propel/Tests/Runtime/Map/RelatedMapSymmetricalWithSchemasTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Map;

--- a/tests/Propel/Tests/Runtime/Map/RelationMapTest.php
+++ b/tests/Propel/Tests/Runtime/Map/RelationMapTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Map;

--- a/tests/Propel/Tests/Runtime/Map/TableMapTest.php
+++ b/tests/Propel/Tests/Runtime/Map/TableMapTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Map;

--- a/tests/Propel/Tests/Runtime/Parser/AbstractParserTest.php
+++ b/tests/Propel/Tests/Runtime/Parser/AbstractParserTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Parser;

--- a/tests/Propel/Tests/Runtime/Parser/CsvParserTest.php
+++ b/tests/Propel/Tests/Runtime/Parser/CsvParserTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Parser;

--- a/tests/Propel/Tests/Runtime/Parser/JsonParserTest.php
+++ b/tests/Propel/Tests/Runtime/Parser/JsonParserTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Parser;

--- a/tests/Propel/Tests/Runtime/Parser/XmlParserTest.php
+++ b/tests/Propel/Tests/Runtime/Parser/XmlParserTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Parser;

--- a/tests/Propel/Tests/Runtime/Parser/YamlParserTest.php
+++ b/tests/Propel/Tests/Runtime/Parser/YamlParserTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Parser;

--- a/tests/Propel/Tests/Runtime/PropelTest.php
+++ b/tests/Propel/Tests/Runtime/PropelTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime;

--- a/tests/Propel/Tests/Runtime/ServiceContainer/StandardServiceContainerTest.php
+++ b/tests/Propel/Tests/Runtime/ServiceContainer/StandardServiceContainerTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\ServiceContainer;

--- a/tests/Propel/Tests/Runtime/ServiceContainer/StandardServiceContainerTest.php
+++ b/tests/Propel/Tests/Runtime/ServiceContainer/StandardServiceContainerTest.php
@@ -458,9 +458,9 @@ class StandardServiceContainerTest extends BaseTestCase
      */
     public function testGetProfilerUsesProfilerClass()
     {
-        $this->sc->setProfilerClass('\Propel\Tests\Runtime\ServiceContainer\myProfiler');
+        $this->sc->setProfilerClass('\Propel\Tests\Runtime\ServiceContainer\MyProfiler');
         $profiler = $this->sc->getProfiler();
-        $this->assertInstanceOf('\Propel\Tests\Runtime\ServiceContainer\myProfiler', $profiler);
+        $this->assertInstanceOf('\Propel\Tests\Runtime\ServiceContainer\MyProfiler', $profiler);
     }
 
     /**
@@ -596,7 +596,7 @@ class MyDatabaseMap extends DatabaseMap
 {
 }
 
-class myProfiler extends Profiler
+class MyProfiler extends Profiler
 {
 }
 

--- a/tests/Propel/Tests/Runtime/TypeTest.php
+++ b/tests/Propel/Tests/Runtime/TypeTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime;

--- a/tests/Propel/Tests/Runtime/TypeTest.php
+++ b/tests/Propel/Tests/Runtime/TypeTest.php
@@ -14,9 +14,9 @@ use Propel\Tests\Bookstore\Map\TypeObjectTableMap;
 use Propel\Tests\Bookstore\TypeObject;
 use Propel\Tests\Bookstore\TypeObjectQuery;
 use Propel\Tests\Helpers\Bookstore\BookstoreTestBase;
+use Propel\Tests\Runtime\TypeTests\DummyObjectClass;
 use Propel\Tests\Runtime\TypeTests\TypeObjectInterface;
 use ReflectionClass;
-use Propel\Tests\Runtime\TypeTests\DummyObjectClass;
 
 /**
  * @group database
@@ -97,7 +97,6 @@ class TypeTest extends BookstoreTestBase
 
         $typeObjectEntity->setDetails($clone);
         $this->assertTrue($typeObjectEntity->isModified('details'));
-
 
         TypeObjectTableMap::clearInstancePool();
         $typeObjectEntity = TypeObjectQuery::create()->findOne();

--- a/tests/Propel/Tests/Runtime/TypeTests/DummyObjectClass.php
+++ b/tests/Propel/Tests/Runtime/TypeTests/DummyObjectClass.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Runtime\TypeTests;
 
 class DummyObjectClass

--- a/tests/Propel/Tests/Runtime/TypeTests/TypeObjectInterface.php
+++ b/tests/Propel/Tests/Runtime/TypeTests/TypeObjectInterface.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Propel\Tests\Runtime\TypeTests;
 
 interface TypeObjectInterface

--- a/tests/Propel/Tests/Runtime/Util/ProfilerTest.php
+++ b/tests/Propel/Tests/Runtime/Util/ProfilerTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Util;

--- a/tests/Propel/Tests/Runtime/Util/PropelConditionalProxyTest.php
+++ b/tests/Propel/Tests/Runtime/Util/PropelConditionalProxyTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Util;

--- a/tests/Propel/Tests/Runtime/Util/PropelConditionalProxyTest.php
+++ b/tests/Propel/Tests/Runtime/Util/PropelConditionalProxyTest.php
@@ -18,7 +18,6 @@ use Propel\Tests\Helpers\BaseTestCase;
  * Test class for PropelConditionalProxy.
  *
  * @author Julien Muetton <julien_muetton@carpe-hora.com>
- * @version $Id: CriteriaCombineTest.php 1347 2009-12-03 21:06:36Z francois $
  */
 class PropelConditionalProxyTest extends BaseTestCase
 {

--- a/tests/Propel/Tests/Runtime/Util/PropelDateTimeTest.php
+++ b/tests/Propel/Tests/Runtime/Util/PropelDateTimeTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Util;

--- a/tests/Propel/Tests/Runtime/Util/PropelModelPagerTest.php
+++ b/tests/Propel/Tests/Runtime/Util/PropelModelPagerTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Util;

--- a/tests/Propel/Tests/Runtime/Util/TableMapExceptionsTest.php
+++ b/tests/Propel/Tests/Runtime/Util/TableMapExceptionsTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Util;

--- a/tests/Propel/Tests/Runtime/Util/TableMapTest.php
+++ b/tests/Propel/Tests/Runtime/Util/TableMapTest.php
@@ -126,7 +126,6 @@ class TableMapTest extends BookstoreTestBase
         $this->assertEquals('SortTest4', $rows[3]->getStoreName());
     }
 
-    
     /**
      * @return void
      */

--- a/tests/Propel/Tests/Runtime/Util/TableMapTest.php
+++ b/tests/Propel/Tests/Runtime/Util/TableMapTest.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests\Runtime\Util;

--- a/tests/Propel/Tests/TestCase.php
+++ b/tests/Propel/Tests/TestCase.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests;

--- a/tests/Propel/Tests/TestCaseFixtures.php
+++ b/tests/Propel/Tests/TestCaseFixtures.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests;

--- a/tests/Propel/Tests/TestCaseFixturesDatabase.php
+++ b/tests/Propel/Tests/TestCaseFixturesDatabase.php
@@ -18,5 +18,8 @@ namespace Propel\Tests;
  */
 class TestCaseFixturesDatabase extends TestCaseFixtures
 {
+    /**
+     * @var bool
+     */
     protected static $withDatabaseSchema = true;
 }

--- a/tests/Propel/Tests/TestCaseFixturesDatabase.php
+++ b/tests/Propel/Tests/TestCaseFixturesDatabase.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests;

--- a/tests/Propel/Tests/Ticket520Test.php
+++ b/tests/Propel/Tests/Ticket520Test.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
 namespace Propel\Tests;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,11 +1,13 @@
 <?php
 
-require_once __DIR__.'/../autoload.php.dist';
+require_once __DIR__ . '/../autoload.php.dist';
 
 // check if user is root and
 if (function_exists("posix_getuid")) {
-    if (posix_getuid() == 0)
-        die("You must run tests suite with an unprivileged user.");
+    if (posix_getuid() === 0) {
+        echo('You must run tests suite with an unprivileged user.');
+        die(1);
+    }
 }
 
 define('DS', DIRECTORY_SEPARATOR);


### PR DESCRIPTION
Follow https://github.com/propelorm/Propel2/pull/1640

Especially:
- Adds namespaces for classes
- Fixes class names
- Removes a few risky tests by asserting sth
- Unsilence $this sniffer by fixing chainable methods up to be true chainable.

Issues left (~500):
- Fixture classes inside tests => should be moved to Fixture folder with valid psr autoload name (file name matching class name)
- Manual issues (missing docblocks)