### PR TITLE
Updates Generator Model Table composite primary check to check null

### DIFF
--- a/src/Propel/Generator/Model/Table.php
+++ b/src/Propel/Generator/Model/Table.php
@@ -921,7 +921,7 @@ class Table extends ScopedMappingModel implements IdMethod
 
             // check for incomplete foreign key references when foreign table
             // has a composite primary key
-            if ($foreignTable->hasCompositePrimaryKey()) {
+            if ($foreignTable !== null && $foreignTable->hasCompositePrimaryKey()) {
                 // get composite foreign key's keys
                 $foreignPrimaryKeys = $foreignTable->getPrimaryKey();
                 // check all keys are referenced in foreign key


### PR DESCRIPTION
I have noticed an issue in propel/propel/src/Propel/Generator/Model/Table.php - involving hasCompositeKey and when a table is missing it, it never makes it to its exception (foreignTable is null).

if ($foreignTable->hasCompositePrimaryKey()) is the check that is the issue in the scenario. I am going to try and send a MR in for it, but its pretty edge - but debugging it required diving as the exception / error was useless to indicate where it happens.

With the notNull assertion check this ensures this does not fail, and allows propel to proceed to the needed exception which results in: 

`[Propel\Generator\Exception\BuildException]
Table "my_table" contains a foreign key to nonexistent table "non_existant_table"`

To reproduce create a table with a foreign key to a table that does not exist. The resulting Exception is the failure in the code, not the failure of processing the schema or what the cause may be.
