### PR TITLE
Fixes transaction handling when \Throwable is thrown

### DIFF
--- a/src/Propel/Common/Util/SetColumnConverter.php
+++ b/src/Propel/Common/Util/SetColumnConverter.php
@@ -43,7 +43,7 @@ class SetColumnConverter
             $bitValueArr[array_search($value, $valueSet)] = '1';
         }
 
-        return base_convert(implode(array_reverse($bitValueArr)), 2, 10);
+        return base_convert(implode('', array_reverse($bitValueArr)), 2, 10);
     }
 
     /**

--- a/src/Propel/Generator/Builder/Om/AbstractOMBuilder.php
+++ b/src/Propel/Generator/Builder/Om/AbstractOMBuilder.php
@@ -688,7 +688,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
                     $names[] = $this->getFKPhpNameAffix($fk, $needPlural);
                 }
 
-                return implode($names);
+                return implode('', $names);
             }
         } else {
             // no plural, so $plural=false
@@ -701,7 +701,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
             $names[] = $pk->getPhpName();
         }
 
-        $name = implode($names);
+        $name = implode('', $names);
 
         return ($plural === true ? $this->getPluralizer()->getPluralForm($name) : $name);
     }
@@ -728,7 +728,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
             $names[] = $pk->getPhpName();
         }
 
-        $name = implode($names);
+        $name = implode('', $names);
 
         return $this->getPluralizer()->getPluralForm($name);
     }
@@ -757,7 +757,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
         }
 
         $names = implode(', ', $names) . (1 < count($names) ? ' combination' : '');
-        $phpDoc = implode($phpDoc);
+        $phpDoc = implode('', $phpDoc);
         $signatures = implode(', ', $signatures);
         $shortSignature = implode(', ', $shortSignature);
 

--- a/src/Propel/Runtime/Connection/TransactionTrait.php
+++ b/src/Propel/Runtime/Connection/TransactionTrait.php
@@ -8,7 +8,7 @@
 
 namespace Propel\Runtime\Connection;
 
-use Exception;
+use Throwable;
 
 /**
  * Transaction helper trait
@@ -19,11 +19,11 @@ trait TransactionTrait
      * Executes the given callable within a transaction.
      * This helper method takes care to commit or rollback the transaction.
      *
-     * In case you want the transaction to rollback just throw an Exception of any type.
+     * In case you want the transaction to rollback just throw an Throwable of any type.
      *
      * @param callable $callable A callable to be wrapped in a transaction
      *
-     * @throws \Exception Re-throws a possible <code>Exception</code> triggered by the callable.
+     * @throws \Throwable Re-throws a possible <code>Throwable</code> triggered by the callable.
      *
      * @return mixed Returns the result of the callable.
      */
@@ -37,7 +37,7 @@ trait TransactionTrait
             $this->commit();
 
             return $result;
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             $this->rollBack();
 
             throw $e;


### PR DESCRIPTION
fixes #1653

Situation that is being fixed:
```php
$con = Propel::getConnection('some_connection');

try
{
	$con->transaction(function() {
		throw new \Error('boom');
	});
}
// my code is handling both errors and exceptions and can continue doing its work ...
catch (\Throwable $throwable)
{
	// .. yet we're now in a never-ending transaction
	assert(false === $con->inTransaction()); // this assertion fails
}
```