### PR TITLE
Fix travis.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "monolog/monolog": "^1.3",
         "phpstan/phpstan": "^0.12.4",
         "phpunit/phpunit": "^7.5.15",
-        "spryker/code-sniffer": "^0.15.4"
+        "spryker/code-sniffer": "^0.15.6"
     },
     "suggest": {
         "monolog/monolog": "The recommended logging library to use with Propel."

--- a/config/phpcs.xml
+++ b/config/phpcs.xml
@@ -10,6 +10,11 @@
 
     <exclude-pattern>*/templates/*</exclude-pattern>
 
+    <!-- exclude until PHP8 -->
+    <rule ref="Spryker.PHP.DisallowFunctions">
+        <severity>0</severity>
+    </rule>
+
     <!-- exclude for now -->
     <rule ref="Spryker.ControlStructures.NoInlineAssignment">
         <severity>0</severity>


### PR DESCRIPTION
Fix travis by excluding unfixable rule for now

Revert requires PHP8 fixes ( https://github.com/propelorm/Propel2/pull/1645 ) to be resolved/merged.