### PR TITLE
Locking reads

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -451,6 +451,11 @@ parameters:
 			path: src/Propel/Runtime/ActiveQuery/Criteria.php
 
 		-
+			message: "#^Call to an undefined method Propel\\\\Runtime\\\\Adapter\\\\AdapterInterface\\:\\:applyLock\\(\\)\\.$#"
+			count: 1
+			path: src/Propel/Runtime/ActiveQuery/Criteria.php
+
+		-
 			message: "#^Call to an undefined method Propel\\\\Runtime\\\\Adapter\\\\AdapterInterface\\:\\:bindValues\\(\\)\\.$#"
 			count: 3
 			path: src/Propel/Runtime/ActiveQuery/Criteria.php

--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -144,6 +144,13 @@ class Criteria
     protected $selectModifiers = [];
 
     /**
+     * Lock to be used to retrieve rows (if any).
+     *
+     * @var \Propel\Runtime\ActiveQuery\Lock|null
+     */
+    protected $lock;
+
+    /**
      * Storage of conditions data. Collection of Criterion objects.
      *
      * @var \Propel\Runtime\ActiveQuery\Criterion\AbstractCriterion[]
@@ -306,6 +313,7 @@ class Criteria
         $this->ignoreCase = false;
         $this->singleRecord = false;
         $this->selectModifiers = [];
+        $this->lock = null;
         $this->selectColumns = [];
         $this->orderByColumns = [];
         $this->groupByColumns = [];
@@ -1248,6 +1256,75 @@ class Criteria
     }
 
     /**
+     * @return \Propel\Runtime\ActiveQuery\Lock|null Get read lock value.
+     */
+    public function getLock(): ?Lock
+    {
+        return $this->lock;
+    }
+
+    /**
+     * Apply a shared read lock to be used to retrieve rows.
+     *
+     * @param string[] $tableNames
+     * @param bool $noWait
+     *
+     * @return $this Modified Criteria object (for fluent API)
+     */
+    public function lockForShare(array $tableNames = [], bool $noWait = false)
+    {
+        $this->withLock(Lock::SHARED, $tableNames, $noWait);
+
+        return $this;
+    }
+
+    /**
+     * Apply an exclusive read lock to be used to retrieve rows.
+     *
+     * @param string[] $tableNames
+     * @param bool $noWait
+     *
+     * @return $this Modified Criteria object (for fluent API)
+     */
+    public function lockForUpdate(array $tableNames = [], bool $noWait = false)
+    {
+        $this->withLock(Lock::EXCLUSIVE, $tableNames, $noWait);
+
+        return $this;
+    }
+
+    /**
+     * Apply a read lock to be used to retrieve rows.
+     *
+     * @see Lock::SHARED
+     * @see Lock::EXCLUSIVE
+     *
+     * @param string $lockType
+     * @param string[] $tableNames
+     * @param bool $noWait
+     *
+     * @return $this Modified Criteria object (for fluent API)
+     */
+    protected function withLock(string $lockType, array $tableNames = [], bool $noWait = false)
+    {
+        $this->lock = new Lock($lockType, $tableNames, $noWait);
+
+        return $this;
+    }
+
+    /**
+     * Retrieve rows without any read locking.
+     *
+     * @return $this Modified Criteria object (for fluent API)
+     */
+    public function withoutLock()
+    {
+        $this->lock = null;
+
+        return $this;
+    }
+
+    /**
      * Sets ignore case.
      *
      * @param bool $b True if case should be ignored.
@@ -1646,6 +1723,15 @@ class Criteria
                     }
                 }
 
+                $aLock = $this->lock;
+                $bLock = $criteria->getLock();
+                if ($aLock instanceof Lock && !$aLock->equals($bLock)) {
+                    return false;
+                }
+                if ($bLock instanceof Lock && !$bLock->equals($aLock)) {
+                    return false;
+                }
+
                 return true;
             } else {
                 return false;
@@ -1686,6 +1772,12 @@ class Criteria
         $selectModifiers = $criteria->getSelectModifiers();
         if ($selectModifiers && !$this->selectModifiers) {
             $this->selectModifiers = $selectModifiers;
+        }
+
+        // merge lock
+        $lock = $criteria->getLock();
+        if ($lock && !$this->lock) {
+            $this->lock = $lock;
         }
 
         // merge select columns
@@ -2112,6 +2204,10 @@ class Criteria
 
         if ($this->getLimit() >= 0 || $this->getOffset()) {
             $adapter->applyLimit($sql, $this->getOffset(), $this->getLimit(), $this);
+        }
+
+        if (null !== $this->lock) {
+            $adapter->applyLock($sql, $this->lock);
         }
 
         return $sql;

--- a/src/Propel/Runtime/ActiveQuery/Lock.php
+++ b/src/Propel/Runtime/ActiveQuery/Lock.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace Propel\Runtime\ActiveQuery;
+
+/**
+ * Class represents a query lock
+ *
+ * @author Tomasz Wójcik <tomasz.prgtw.wojcik@gmail.com>
+ */
+class Lock
+{
+    public const SHARED = 'SHARED';
+
+    public const EXCLUSIVE = 'EXCLUSIVE';
+
+    /**
+     * Lock type, either shared or exclusive
+     *
+     * @see self::SHARED
+     * @see self::EXCLUSIVE
+     *
+     * @var string
+     */
+    protected $type;
+
+    /**
+     * Table names to lock
+     *
+     * @var string[]
+     */
+    protected $tableNames;
+
+    /**
+     * Whether to issue a non-blocking lock
+     *
+     * @var bool
+     */
+    protected $noWait;
+
+    /**
+     * @param string $type Lock type
+     * @param array $tableNames Table names to lock
+     * @param bool $noWait Whether to issue a non-blocking lock
+     */
+    public function __construct(string $type, array $tableNames = [], bool $noWait = false)
+    {
+        $this->type = $type;
+        $this->tableNames = $tableNames;
+        $this->noWait = $noWait;
+    }
+
+    /**
+     * Lock type
+     *
+     * @see self::SHARED
+     * @see self::EXCLUSIVE
+     *
+     * @return string
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * Returns table names to lock
+     *
+     * @return string[]
+     */
+    public function getTableNames(): array
+    {
+        return $this->tableNames;
+    }
+
+    /**
+     * Whether to issue a non-blocking lock
+     *
+     * @return bool
+     */
+    public function isNoWait(): bool
+    {
+        return $this->noWait;
+    }
+
+    /**
+     * Checks whether a lock equals another lock object
+     *
+     * @param \Propel\Runtime\ActiveQuery\Lock|mixed $lock
+     *
+     * @return bool
+     */
+    public function equals($lock): bool
+    {
+        if (!($lock instanceof self)) {
+            return false;
+        }
+
+        $aTableNames = $this->getTableNames();
+        $bTableNames = $lock->getTableNames();
+
+        return $this->getType() === $lock->getType()
+            && $this->isNoWait() === $lock->isNoWait()
+            && $aTableNames === array_intersect($aTableNames, $bTableNames)
+            && $bTableNames === array_intersect($bTableNames, $aTableNames);
+    }
+}

--- a/src/Propel/Runtime/Adapter/Pdo/MssqlAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/MssqlAdapter.php
@@ -9,6 +9,7 @@
 namespace Propel\Runtime\Adapter\Pdo;
 
 use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\ActiveQuery\Lock;
 use Propel\Runtime\Adapter\Exception\ColumnNotFoundException;
 use Propel\Runtime\Adapter\Exception\MalformedClauseException;
 use Propel\Runtime\Adapter\SqlAdapterInterface;
@@ -327,5 +328,17 @@ class MssqlAdapter extends PdoAdapter implements SqlAdapterInterface
                 $sql = str_replace($match, ':p' . ($key + 1), $sql);
             }
         }
+    }
+
+    /**
+     * @see AdapterInterface::applyLock()
+     *
+     * @param string $sql
+     * @param \Propel\Runtime\ActiveQuery\Lock $lock
+     *
+     * @return void
+     */
+    public function applyLock(&$sql, Lock $lock): void
+    {
     }
 }

--- a/src/Propel/Runtime/Adapter/Pdo/MysqlAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/MysqlAdapter.php
@@ -9,6 +9,7 @@
 namespace Propel\Runtime\Adapter\Pdo;
 
 use PDO;
+use Propel\Runtime\ActiveQuery\Lock;
 use Propel\Runtime\Adapter\SqlAdapterInterface;
 use Propel\Runtime\Connection\StatementInterface;
 use Propel\Runtime\Map\ColumnMap;
@@ -200,5 +201,24 @@ class MysqlAdapter extends PdoAdapter implements SqlAdapterInterface
         }
 
         return parent::prepareParams($params);
+    }
+
+    /**
+     * @see AdapterInterface::applyLock()
+     *
+     * @param string $sql
+     * @param \Propel\Runtime\ActiveQuery\Lock $lock
+     *
+     * @return void
+     */
+    public function applyLock(&$sql, Lock $lock): void
+    {
+        $type = $lock->getType();
+
+        if (Lock::SHARED === $type) {
+            $sql .= ' LOCK IN SHARE MODE';
+        } elseif (Lock::EXCLUSIVE === $type) {
+            $sql .= ' FOR UPDATE';
+        }
     }
 }

--- a/src/Propel/Runtime/Adapter/Pdo/OracleAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/OracleAdapter.php
@@ -10,6 +10,7 @@ namespace Propel\Runtime\Adapter\Pdo;
 
 use Propel\Generator\Model\PropelTypes;
 use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\ActiveQuery\Lock;
 use Propel\Runtime\Adapter\AdapterInterface;
 use Propel\Runtime\Adapter\SqlAdapterInterface;
 use Propel\Runtime\Connection\ConnectionInterface;
@@ -252,5 +253,24 @@ class OracleAdapter extends PdoAdapter implements SqlAdapterInterface
         }
 
         return parent::prepareParams($params);
+    }
+
+    /**
+     * @see AdapterInterface::applyLock()
+     *
+     * @param string $sql
+     * @param \Propel\Runtime\ActiveQuery\Lock $lock
+     *
+     * @return void
+     */
+    public function applyLock(&$sql, Lock $lock): void
+    {
+        $type = $lock->getType();
+
+        if (Lock::SHARED === $type) {
+            $sql .= ' LOCK IN SHARE MODE';
+        } elseif (Lock::EXCLUSIVE === $type) {
+            $sql .= ' FOR UPDATE';
+        }
     }
 }

--- a/src/Propel/Runtime/Adapter/Pdo/SqliteAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/SqliteAdapter.php
@@ -8,6 +8,7 @@
 
 namespace Propel\Runtime\Adapter\Pdo;
 
+use Propel\Runtime\ActiveQuery\Lock;
 use Propel\Runtime\Adapter\SqlAdapterInterface;
 use Propel\Runtime\Connection\ConnectionInterface;
 
@@ -127,5 +128,17 @@ class SqliteAdapter extends PdoAdapter implements SqlAdapterInterface
     public function random($seed = null)
     {
         return 'random()';
+    }
+
+    /**
+     * @see AdapterInterface::applyLock()
+     *
+     * @param string $sql
+     * @param \Propel\Runtime\ActiveQuery\Lock $lock
+     *
+     * @return void
+     */
+    public function applyLock(&$sql, Lock $lock): void
+    {
     }
 }

--- a/src/Propel/Runtime/Adapter/SqlAdapterInterface.php
+++ b/src/Propel/Runtime/Adapter/SqlAdapterInterface.php
@@ -9,6 +9,7 @@
 namespace Propel\Runtime\Adapter;
 
 use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\ActiveQuery\Lock;
 use Propel\Runtime\Connection\StatementInterface;
 use Propel\Runtime\Map\ColumnMap;
 use Propel\Runtime\Map\DatabaseMap;
@@ -58,6 +59,16 @@ interface SqlAdapterInterface extends AdapterInterface
      * @return void
      */
     public function applyLimit(&$sql, $offset, $limit);
+
+    /**
+     * Modifies the passed-in SQL to add locking capabilities
+     *
+     * @param string $sql
+     * @param \Propel\Runtime\ActiveQuery\Lock $lock
+     *
+     * @return void
+     */
+    public function applyLock(&$sql, Lock $lock): void;
 
     /**
      * Gets the SQL string that this adapter uses for getting a random number.

--- a/tests/Propel/Tests/Runtime/Adapter/Pdo/PgsqlAdapterTest.php
+++ b/tests/Propel/Tests/Runtime/Adapter/Pdo/PgsqlAdapterTest.php
@@ -9,15 +9,25 @@
 namespace Propel\Tests\Runtime\Adapter\Pdo;
 
 use Propel\Runtime\Adapter\Pdo\PgsqlAdapter;
-use Propel\Tests\TestCase;
+use Propel\Tests\Bookstore\BookQuery;
+use Propel\Tests\Bookstore\Map\BookTableMap;
+use Propel\Tests\TestCaseFixtures;
 
 /**
  * Tests the Pgsql adapter
  *
  * @author Kévin Gomez <contact@kevingomez.fr>
  */
-class PgsqlAdapterTest extends TestCase
+class PgsqlAdapterTest extends TestCaseFixtures
 {
+    /**
+     * @return string
+     */
+    protected function getDriver()
+    {
+        return 'pgsql';
+    }
+
     /**
      * @return void
      */
@@ -28,5 +38,69 @@ class PgsqlAdapterTest extends TestCase
         $expected = 'EXPLAIN SELECT B.* FROM (SELECT A.*, rownum AS PROPEL_ROWNUM FROM (SELECT book.ID AS ORA_COL_ALIAS_0, book.TITLE AS ORA_COL_ALIAS_1, book.ISBN AS ORA_COL_ALIAS_2, book.PRICE AS ORA_COL_ALIAS_3, book.PUBLISHER_ID AS ORA_COL_ALIAS_4, book.AUTHOR_ID AS ORA_COL_ALIAS_5, author.ID AS ORA_COL_ALIAS_6, author.FIRST_NAME AS ORA_COL_ALIAS_7, author.LAST_NAME AS ORA_COL_ALIAS_8, author.EMAIL AS ORA_COL_ALIAS_9, author.AGE AS ORA_COL_ALIAS_10, book.PRICE AS BOOK_PRICE FROM book, author) A ) B WHERE  B.PROPEL_ROWNUM <= 1';
 
         $this->assertEquals($expected, $db->getExplainPlanQuery($query), 'getExplainPlanQuery() returns a SQL Explain query');
+    }
+
+    /**
+     * Test `applyLock`
+     *
+     * @return void
+     *
+     * @group pgsql
+     */
+    public function testSimpleLock(): void
+    {
+        $c = new BookQuery();
+        $c->addSelectColumn(BookTableMap::COL_ID);
+        $c->lockForShare();
+
+        $params = [];
+        $result = $c->createSelectSql($params);
+
+        $expected = 'SELECT book.id FROM book FOR SHARE';
+
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test `applyLock`
+     *
+     * @return void
+     *
+     * @group pgsql
+     */
+    public function testComplexLock(): void
+    {
+        $c = new BookQuery();
+        $c->addSelectColumn(BookTableMap::COL_ID);
+        $c->lockForUpdate([BookTableMap::TABLE_NAME], true);
+
+        $params = [];
+        $result = $c->createSelectSql($params);
+
+        $expected = 'SELECT book.id FROM book FOR UPDATE OF "book" NOWAIT';
+
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * @return void
+     *
+     * @group pgsql
+     */
+    public function testSubQueryWithSharedLock()
+    {
+        $subCriteria = new BookQuery();
+        $subCriteria->addSelectColumn(BookTableMap::COL_ID);
+        $subCriteria->lockForShare([BookTableMap::TABLE_NAME]);
+
+        $c = new BookQuery();
+        $c->addSelectColumn(BookTableMap::COL_ID);
+        $c->addSelectQuery($subCriteria, 'subCriteriaAlias', false);
+        $c->lockForShare([BookTableMap::TABLE_NAME], true);
+
+        $expected ='SELECT subCriteriaAlias.id FROM (SELECT book.id FROM book FOR SHARE of "book") AS subCriteriaAlias FOR SHARE OF "book" NOWAIT';
+
+        $params = [];
+        $this->assertSame($expected, $c->createSelectSql($params), 'Subquery contains shared read lock');
     }
 }


### PR DESCRIPTION
This PR adds ability for locking reads, either shared or exclusive

Compatibility with:
- [MySQL 5.6+](https://dev.mysql.com/doc/refman/5.6/en/innodb-locking-reads.html)
- [PostgreSQL 8.1+](https://www.postgresql.org/docs/8.1/sql-select.html#SQL-FOR-UPDATE-SHARE)


Example:
```php
$booksReadInShareMode = (new BookQuery)
    ->filterById(123)
    ->forShare()
    ->find();
// SELECT ... FROM book LOCK IN SHARE MODE -- mysql
// SELECT ... FROM book FOR SHARE -- pgsql

$booksToBeUpdated = (new BookQuery)
  ->filterById(123)
  ->forUpdate()
  ->find();
// SELECT ... FROM book FOR UPDATE
```