### PR TITLE
Unable to use Collection suffix for table name

### DIFF
--- a/src/Propel/Runtime/Map/TableMap.php
+++ b/src/Propel/Runtime/Map/TableMap.php
@@ -287,7 +287,7 @@ class TableMap
     public function getCollectionClassName()
     {
         $collectionClass = $this->getClassName() . 'Collection';
-        if (class_exists($collectionClass)) {
+        if (class_exists($collectionClass) && !is_subclass_of($collectionClass, '\Propel\Runtime\ActiveRecord\ActiveRecordInterface')) {
             return $collectionClass;
         }
 

--- a/src/Propel/Runtime/Map/TableMap.php
+++ b/src/Propel/Runtime/Map/TableMap.php
@@ -287,7 +287,7 @@ class TableMap
     public function getCollectionClassName()
     {
         $collectionClass = $this->getClassName() . 'Collection';
-        if (class_exists($collectionClass) && !is_subclass_of($collectionClass, '\Propel\Runtime\ActiveRecord\ActiveRecordInterface')) {
+        if (class_exists($collectionClass) && !($collectionClass instanceof \Propel\Runtime\ActiveRecord\ActiveRecordInterface)) {
             return $collectionClass;
         }
 


### PR DESCRIPTION
I couldn't find this limitation documented anywhere, apologies if I've overlooked something obvious.

I have a Book table and a BookCollection table, with an FK from BookCollection.ID <-> Book.CollectionId. 

When getting a list of books (`$bookCollection->getBooks()`) , propel attempts to load my BookCollection class, assuming it's the class for a "collection of Books". This breaks with an error `Uncaught Propel\Runtime\Exception\BadMethodCallException: Call to undefined method: "setModel"` since my collection class doesn't implement setModel().

I added a check to explicitly not consider classes that implement ActiveRecordInterface as "collection of object" classes.

Originally I was going to check if the $collectionClass is a subclass of \Propel\Runtime\Collection, but I suppose someone could implement a collection class that isn't a subclass of \Propel\Runtime\Collection. It seemed less likely that someone would implement a collection class that also implements ActiveRecordInterface.