### PR TITLE
Compatibility with Symfony 4.0+ instead of 4.3+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
     ],
     "require": {
         "php": ">=7.2",
-        "symfony/yaml": "^3.4.0||^4.3.0||^5.0.0",
-        "symfony/config": "^3.4.0||^4.3.0||^5.0.0",
-        "symfony/console": "^3.4.0||^4.3.0||^5.0.0",
-        "symfony/filesystem": "^3.4.0||^4.3.0||^5.0.0",
-        "symfony/finder": "^3.4.0||^4.3.0||^5.0.0",
-        "symfony/translation": "^3.4.0||^4.3.0||^5.0.0",
-        "symfony/validator": "^3.4.0||^4.3.0||^5.0.0",
+        "symfony/yaml": "^3.4.0||^4.0.0||^5.0.0",
+        "symfony/config": "^3.4.0||^4.0.0||^5.0.0",
+        "symfony/console": "^3.4.0||^4.0.0||^5.0.0",
+        "symfony/filesystem": "^3.4.0||^4.0.0||^5.0.0",
+        "symfony/finder": "^3.4.0||^4.0.0||^5.0.0",
+        "symfony/translation": "^3.4.0||^4.0.0||^5.0.0",
+        "symfony/validator": "^3.4.0||^4.0.0||^5.0.0",
         "psr/log": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Lowering the requirements for `symfony/*` libs from  4.3+ to 4.0+.

According to current dependencies definitions in `composer-symfony4-min.json` tests of such are passing:

https://github.com/propelorm/Propel2/blob/3087361bd27f3598f3ecd70e9fd272a5c2575b88/tests/composer/composer-symfony4-min.json#L20-L26

https://travis-ci.org/github/propelorm/Propel2/jobs/726959500
![image](https://user-images.githubusercontent.com/203249/97110910-05272600-16dc-11eb-8c21-81bcd39f09e1.png)