### PR TITLE
Remove dead code

### DIFF
--- a/src/Propel/Generator/Model/MappingModel.php
+++ b/src/Propel/Generator/Model/MappingModel.php
@@ -153,9 +153,6 @@ abstract class MappingModel implements MappingModelInterface
         foreach (explode(',', $stringValue) as $v) {
             $values[] = trim($v);
         }
-        if (count($values) === 0) {
-            return null;
-        }
 
         return $values;
     }


### PR DESCRIPTION
This dead section was correctly identified by PHPstan: empty `$stringValue` arguments would have been handled by the section in line 148-150, and `explode` with any string value will always return an array with at least one element. Minimal example:
```php
php > var_dump(explode(',', ''));
array(1) {
  [0]=>
  string(0) ""
}
```