### PR TITLE
Add `withXyzQuery` function to aid static type checking

### DIFF
--- a/src/Propel/Generator/Builder/Om/QueryBuilder.php
+++ b/src/Propel/Generator/Builder/Om/QueryBuilder.php
@@ -1604,7 +1604,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
             ->useQuery(\$relationAlias ? \$relationAlias : '$relationName', '$queryClass');
     }
 ";
-}
+    }
 
     /**
      * Adds a withRelatedQuery method for this object.

--- a/src/Propel/Generator/Builder/Om/QueryBuilder.php
+++ b/src/Propel/Generator/Builder/Om/QueryBuilder.php
@@ -1625,16 +1625,16 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
      *
      * @param callable({$queryClass}):{$queryClass} \$callable A function working on the related query
      *
-     * @param string \$relationAlias optional alias for the relation
+     * @param string|null \$relationAlias optional alias for the relation
      *
-     * @param string \$joinType Accepted values are null, 'left join', 'right join', 'inner join'
+     * @param string|null \$joinType Accepted values are null, 'left join', 'right join', 'inner join'
      *
      * @return \$this
      */
     public function with{$relationName}Query(
         callable \$callable,
         string \$relationAlias = null,
-        \$joinType = {$joinType}
+        ?string \$joinType = {$joinType}
     ) {
         \$relatedQuery = \$this->use{$relationName}Query(
             \$relationAlias,
@@ -1642,6 +1642,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
         );
         \$callable(\$relatedQuery);
         \$relatedQuery->endUse();
+
         return \$this;
     }
 ";

--- a/src/Propel/Generator/Builder/Om/QueryBuilder.php
+++ b/src/Propel/Generator/Builder/Om/QueryBuilder.php
@@ -1549,6 +1549,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
         $joinType = $this->getJoinType($fk);
 
         $this->addUseRelatedQuery($script, $fkTable, $queryClass, $relationName, $joinType);
+        $this->addWithRelatedQuery($script, $fkTable, $queryClass, $relationName, $joinType);
     }
 
     /**
@@ -1568,6 +1569,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
         $joinType = $this->getJoinType($fk);
 
         $this->addUseRelatedQuery($script, $fkTable, $queryClass, $relationName, $joinType);
+        $this->addWithRelatedQuery($script, $fkTable, $queryClass, $relationName, $joinType);
     }
 
     /**
@@ -1600,6 +1602,47 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
         return \$this
             ->join" . $relationName . "(\$relationAlias, \$joinType)
             ->useQuery(\$relationAlias ? \$relationAlias : '$relationName', '$queryClass');
+    }
+";
+}
+
+    /**
+     * Adds a withRelatedQuery method for this object.
+     *
+     * @param string $script The script will be modified in this method.
+     * @param \Propel\Generator\Model\Table $fkTable
+     * @param string $queryClass
+     * @param string $relationName
+     * @param string $joinType
+     *
+     * @return void
+     */
+    protected function addWithRelatedQuery(&$script, Table $fkTable, $queryClass, $relationName, $joinType)
+    {
+        $script .= "
+    /**
+     * Use the {$relationName} relation {$fkTable->getPhpName()} object
+     *
+     * @param callable({$queryClass}):{$queryClass} \$callable A function working on the related query
+     *
+     * @param string \$relationAlias optional alias for the relation
+     *
+     * @param string \$joinType Accepted values are null, 'left join', 'right join', 'inner join'
+     *
+     * @return \$this
+     */
+    public function with{$relationName}Query(
+        callable \$callable,
+        string \$relationAlias = null,
+        \$joinType = {$joinType}
+    ) {
+        \$relatedQuery = \$this->use{$relationName}Query(
+            \$relationAlias,
+            \$joinType
+        );
+        \$callable(\$relatedQuery);
+        \$relatedQuery->endUse();
+        return \$this;
     }
 ";
     }

--- a/tests/Propel/Tests/Generator/Builder/Om/QueryBuilderTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/QueryBuilderTest.php
@@ -23,7 +23,6 @@ use Propel\Tests\Bookstore\BookQuery;
 use Propel\Tests\Bookstore\BookstoreEmployeeAccountQuery;
 use Propel\Tests\Bookstore\BookSummaryQuery;
 use Propel\Tests\Bookstore\EssayQuery;
-use Propel\Tests\Bookstore\SummarizedBookQuery;
 use Propel\Tests\Bookstore\Map\AcctAuditLogTableMap;
 use Propel\Tests\Bookstore\Map\AuthorTableMap;
 use Propel\Tests\Bookstore\Map\BookListRelTableMap;
@@ -1093,9 +1092,11 @@ class QueryBuilderTest extends BookstoreTestBase
     public function testUseFkQueryWith()
     {
         $q = BookQuery::create()
-            ->withAuthorQuery(function (AuthorQuery $q) {
-                return $q->filterByFirstName('Leo');
-            });
+            ->withAuthorQuery(
+                function (AuthorQuery $q) {
+                    return $q->filterByFirstName('Leo');
+                }
+            );
         $q1 = BookQuery::create()
             ->useAuthorQuery()
             ->filterByFirstName('Leo')
@@ -1103,9 +1104,11 @@ class QueryBuilderTest extends BookstoreTestBase
         $this->assertTrue($q->equals($q1), 'useFkQuery() translates to a condition on a left join on non-required columns');
 
         $q = BookSummaryQuery::create()
-            ->withSummarizedBookQuery(function (BookQuery $q) {
-                return $q->filterByTitle('War and Peace');
-            });
+            ->withSummarizedBookQuery(
+                function (BookQuery $q) {
+                    return $q->filterByTitle('War and Peace');
+                }
+            );
         $q1 = BookSummaryQuery::create()
             ->useSummarizedBookQuery()
             ->filterByTitle('War and Peace')

--- a/tests/Propel/Tests/Generator/Builder/Om/QueryBuilderTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/QueryBuilderTest.php
@@ -23,6 +23,7 @@ use Propel\Tests\Bookstore\BookQuery;
 use Propel\Tests\Bookstore\BookstoreEmployeeAccountQuery;
 use Propel\Tests\Bookstore\BookSummaryQuery;
 use Propel\Tests\Bookstore\EssayQuery;
+use Propel\Tests\Bookstore\SummarizedBookQuery;
 use Propel\Tests\Bookstore\Map\AcctAuditLogTableMap;
 use Propel\Tests\Bookstore\Map\AuthorTableMap;
 use Propel\Tests\Bookstore\Map\BookListRelTableMap;
@@ -1080,6 +1081,30 @@ class QueryBuilderTest extends BookstoreTestBase
             ->useSummarizedBookQuery()
                 ->filterByTitle('War And Peace')
             ->endUse();
+        $q1 = BookSummaryQuery::create()
+            ->join('BookSummary.SummarizedBook', Criteria::INNER_JOIN)
+            ->add(BookTableMap::COL_TITLE, 'War And Peace', Criteria::EQUAL);
+        $this->assertTrue($q->equals($q1), 'useFkQuery() translates to a condition on an inner join on required columns');
+    }
+
+    /**
+     * @return void
+     */
+    public function testUseFkQueryWith()
+    {
+        $q = BookQuery::create()
+            ->withAuthorQuery(function (AuthorQuery $q) {
+                return $q->filterByFirstName('Leo');
+            });
+        $q1 = BookQuery::create()
+            ->join('Book.Author', Criteria::LEFT_JOIN)
+            ->add(AuthorTableMap::COL_FIRST_NAME, 'Leo', Criteria::EQUAL);
+        $this->assertTrue($q->equals($q1), 'useFkQuery() translates to a condition on a left join on non-required columns');
+
+        $q = BookSummaryQuery::create()
+            ->withSummarizedBookQuery(function (SummarizedBookQuery $q) {
+                return $q->filterByTitle('War and Peace');
+            });
         $q1 = BookSummaryQuery::create()
             ->join('BookSummary.SummarizedBook', Criteria::INNER_JOIN)
             ->add(BookTableMap::COL_TITLE, 'War And Peace', Criteria::EQUAL);

--- a/tests/Propel/Tests/Generator/Builder/Om/QueryBuilderTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/QueryBuilderTest.php
@@ -1097,18 +1097,20 @@ class QueryBuilderTest extends BookstoreTestBase
                 return $q->filterByFirstName('Leo');
             });
         $q1 = BookQuery::create()
-            ->join('Book.Author', Criteria::LEFT_JOIN)
-            ->add(AuthorTableMap::COL_FIRST_NAME, 'Leo', Criteria::EQUAL);
+            ->useAuthorQuery()
+            ->filterByFirstName('Leo')
+            ->endUse();
         $this->assertTrue($q->equals($q1), 'useFkQuery() translates to a condition on a left join on non-required columns');
 
         $q = BookSummaryQuery::create()
-            ->withSummarizedBookQuery(function (SummarizedBookQuery $q) {
+            ->withSummarizedBookQuery(function (BookQuery $q) {
                 return $q->filterByTitle('War and Peace');
             });
         $q1 = BookSummaryQuery::create()
-            ->join('BookSummary.SummarizedBook', Criteria::INNER_JOIN)
-            ->add(BookTableMap::COL_TITLE, 'War And Peace', Criteria::EQUAL);
-        $this->assertTrue($q->equals($q1), 'useFkQuery() translates to a condition on an inner join on required columns');
+            ->useSummarizedBookQuery()
+            ->filterByTitle('War and Peace')
+            ->endUse();
+        $this->assertEquals($q1, $q, 'useFkQuery() translates to a condition on an inner join on required columns');
     }
 
     /**


### PR DESCRIPTION
The `withXyzQuery` function neatly wraps the calls to `useQuery` and `endUse`
in a single function call, taking a callable working on the correct
subquery type.

Projects using propel2 can use it like this:
```php
$bookQuery
    ->withAuthorQuery(
        fn (AuthorQuery $q) => $q->filterByFirstName('Lev')
    )
    ->filterByTitle('Anna Karenina');
```

without type checkers like phpstan and psalm getting confused about the
actual return type of `endUse()`.

An extra `@phpstan-param` phpdoc line is provided for static type
checkers to check whether the argument to the callable and the return
type actually match.