### PR TITLE
[BUGFIX] PdoStatement::setFetchMode compatibility

### DIFF
--- a/src/Propel/Runtime/Connection/StatementWrapper.php
+++ b/src/Propel/Runtime/Connection/StatementWrapper.php
@@ -405,7 +405,16 @@ class StatementWrapper implements StatementInterface, IteratorAggregate
      */
     public function setFetchMode($mode, $classNameObject = null, array $ctorarfg = [])
     {
-        return $this->statement->setFetchMode($mode, $classNameObject, $ctorarfg);
+        switch (func_num_args()) {
+            case 1:
+                return $this->statement->setFetchMode($mode);
+            case 2:
+                return $this->statement->setFetchMode($mode, $classNameObject);
+            case 3:
+                return $this->statement->setFetchMode($mode, $classNameObject, $ctorarfg);
+            default:
+                return call_user_func_array([$this->statement, 'setFetchMode'], func_get_args());
+        }
     }
 
     /**

--- a/tests/Propel/Tests/Runtime/Connection/PropelPDOTest.php
+++ b/tests/Propel/Tests/Runtime/Connection/PropelPDOTest.php
@@ -106,6 +106,11 @@ class PropelPDOTest extends BookstoreTestBase
         $stmt = $con->prepare('SELECT author.FIRST_NAME, author.LAST_NAME FROM author');
         $stmt->execute();
         $stmt->fetchAll(); // should not throw exception
+
+        $stmt = $con->prepare('SELECT author.FIRST_NAME, author.LAST_NAME FROM author');
+        $stmt->execute();
+        $stmt->setFetchMode(PDO::FETCH_ASSOC); // should not throw exception
+        $stmt->fetchAll();
     }
 
     /**


### PR DESCRIPTION
# Reasons
#1611 introduced [faulty handling of `StatementWrapper::setFetchMode()`](https://travis-ci.org/github/prgTW/Propel2/jobs/742558255#L638-L642)

## Test

```php
<?php

$pdo = new PDO('sqlite::memory:');

$pdo->query('CREATE TABLE dummy(id int)');

$stmt = $pdo->prepare('SELECT * FROM dummy');
$stmt->setFetchMode(PDO::FETCH_ASSOC, null, array()); // shouldn't render any errors
// fix
// $stmt->setFetchMode(PDO::FETCH_ASSOC); // only 1 argument passed
```
ref: https://3v4l.org/fniRF

### Expected behavior

no warning or exception

### Actual behavior

PHP >=8.0:
> Fatal error: Uncaught PDOException: SQLSTATE[HY000]: General error: fetch mode doesn't allow any extra arguments

PHP <8.0:
> Warning: PDOStatement::setFetchMode(): SQLSTATE[HY000]: General error: fetch mode doesn't allow any extra arguments

# Changes
- `PdoStatement::setFetchMode()` passes the same number of arguments that it received back when it extended `PDOStatement` and `setFetchMode` wasn't overriden in this class

## Tests

### Reconstruction
https://travis-ci.org/github/prgTW/Propel2/jobs/742558255#L638-L642

### Fix
https://travis-ci.org/github/prgTW/Propel2/builds/742574602
