### PR TITLE
Added functionality to use foreignSchema attribute of foreign-key tag…

### DIFF
--- a/src/Propel/Generator/Model/Database.php
+++ b/src/Propel/Generator/Model/Database.php
@@ -484,6 +484,18 @@ class Database extends ScopedMappingModel
             && strpos($name, $this->getPlatform()->getSchemaDelimiter()) === false
         ) {
             $name = $this->getSchema() . $this->getPlatform()->getSchemaDelimiter() . $name;
+        } else if (strpos($name, '.') !== false){
+            /*
+            For pgSql and other dbs which support schemas, getSchema will work exactly as expected.
+            For other dbs, the <foreign-key foreignSchema="" > attribute can be used to link to databases within the same propel projec
+             */
+            $db = explode(".", $name)[0];
+            $name = explode(".", $name)[1];
+            
+            $sc = $this->getParentSchema();
+            $db = $sc->getDatabase($db, false);
+            
+            return $db->getTable($name);
         }
 
         if (!$this->hasTable($name, $caseInsensitive)) {


### PR DESCRIPTION
Reference: 
https://github.com/propelorm/Propel/issues/191

The foreignSchema attribute of the foreign-key tag can be used on MySQL to link to other databases
According to the documentation provided at:
http://propelorm.org/documentation/cookbook/using-sql-schemas.html

In databases which support schemas (MySQL), there is no way to add foreign keys across databases.

This PR enables the foreign key relationships by using the database name as the schema name in these cases.

Tested with MySQL