### PR TITLE
Wrong behavior when inserting rows into crossRef table with auto increment primary key column.

### DIFF
--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -6609,16 +6609,18 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
         } catch (Exception \$e) {
             throw new PropelException('Unable to get autoincrement id.', 0, \$e);
         }";
-            $column = $table->getFirstPrimaryKeyColumn();
-            if ($column) {
+            foreach ($table->getPrimaryKey() as $col) {
+                if (!$col->isAutoIncrement()) {
+                    continue;
+                }
                 if ($table->isAllowPkInsert()) {
                     $script .= "
         if (\$pk !== null) {
-            \$this->set" . $column->getPhpName() . "(\$pk);
+            \$this->set" . $col->getPhpName() . "(\$pk);
         }";
                 } else {
                     $script .= "
-        \$this->set" . $column->getPhpName() . '($pk);';
+        \$this->set" . $col->getPhpName() . '($pk);';
                 }
             }
             $script .= "


### PR DESCRIPTION
When inserting rows into crossRef table with auto increment primary key column defined at other than first position in table schema, then auto increment value is set to first defined primary key column instead of the correct one.