### PR TITLE
Update psalm-baseline.xml

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="3.14.2@3538fe1955d47f6ee926c0769d71af6db08aa488">
+<files psalm-version="4.1.1@16bfbd9224698bd738c665f33039fade2a1a3977">
   <file src="src/Propel/Common/Config/PropelConfiguration.php">
     <TooFewArguments occurrences="1">
       <code>new TreeBuilder()</code>
@@ -7,10 +7,10 @@
   </file>
   <file src="src/Propel/Generator/Behavior/AggregateColumn/templates/objectCompute.php">
     <UndefinedGlobalVariable occurrences="4">
+      <code>$bindings</code>
       <code>$column</code>
       <code>$column</code>
       <code>$sql</code>
-      <code>$bindings</code>
     </UndefinedGlobalVariable>
   </file>
   <file src="src/Propel/Generator/Behavior/AggregateColumn/templates/objectUpdate.php">
@@ -23,40 +23,40 @@
   </file>
   <file src="src/Propel/Generator/Behavior/AggregateColumn/templates/objectUpdateRelated.php">
     <UndefinedGlobalVariable occurrences="14">
-      <code>$relationName</code>
-      <code>$relationName</code>
       <code>$aggregateName</code>
-      <code>$variableName</code>
+      <code>$aggregateName</code>
+      <code>$aggregateName</code>
+      <code>$aggregateName</code>
       <code>$relationName</code>
-      <code>$variableName</code>
+      <code>$relationName</code>
+      <code>$relationName</code>
+      <code>$relationName</code>
+      <code>$relationName</code>
+      <code>$relationName</code>
       <code>$updateMethodName</code>
-      <code>$relationName</code>
-      <code>$aggregateName</code>
-      <code>$relationName</code>
-      <code>$aggregateName</code>
       <code>$updateMethodName</code>
-      <code>$relationName</code>
-      <code>$aggregateName</code>
+      <code>$variableName</code>
+      <code>$variableName</code>
     </UndefinedGlobalVariable>
   </file>
   <file src="src/Propel/Generator/Behavior/AggregateColumn/templates/queryFindRelated.php">
     <UndefinedGlobalVariable occurrences="6">
-      <code>$foreignTable</code>
-      <code>$relationName</code>
       <code>$aggregateName</code>
-      <code>$variableName</code>
       <code>$foreignQueryName</code>
+      <code>$foreignTable</code>
       <code>$refRelationName</code>
+      <code>$relationName</code>
+      <code>$variableName</code>
     </UndefinedGlobalVariable>
   </file>
   <file src="src/Propel/Generator/Behavior/AggregateColumn/templates/queryUpdateRelated.php">
     <UndefinedGlobalVariable occurrences="7">
-      <code>$relationName</code>
       <code>$aggregateName</code>
-      <code>$variableName</code>
-      <code>$variableName</code>
-      <code>$variableName</code>
+      <code>$relationName</code>
       <code>$updateMethodName</code>
+      <code>$variableName</code>
+      <code>$variableName</code>
+      <code>$variableName</code>
       <code>$variableName</code>
     </UndefinedGlobalVariable>
   </file>
@@ -68,9 +68,9 @@
   <file src="src/Propel/Generator/Behavior/Archivable/templates/objectArchive.php">
     <UndefinedGlobalVariable occurrences="4">
       <code>$archiveTablePhpName</code>
-      <code>$hasArchiveClass</code>
       <code>$archiveTablePhpName</code>
       <code>$archivedAtColumn</code>
+      <code>$hasArchiveClass</code>
     </UndefinedGlobalVariable>
   </file>
   <file src="src/Propel/Generator/Behavior/Archivable/templates/objectDeleteWithoutArchive.php">
@@ -87,10 +87,10 @@
   <file src="src/Propel/Generator/Behavior/Archivable/templates/objectPopulateFromArchive.php">
     <UndefinedGlobalVariable occurrences="5">
       <code>$archiveTablePhpName</code>
-      <code>$usesAutoIncrement</code>
+      <code>$columns</code>
+      <code>$columns</code>
       <code>$objectClassName</code>
-      <code>$columns</code>
-      <code>$columns</code>
+      <code>$usesAutoIncrement</code>
     </UndefinedGlobalVariable>
   </file>
   <file src="src/Propel/Generator/Behavior/Archivable/templates/objectPreDelete.php">
@@ -102,9 +102,9 @@
   </file>
   <file src="src/Propel/Generator/Behavior/Archivable/templates/objectSaveWithoutArchive.php">
     <UndefinedGlobalVariable occurrences="3">
-      <code>$objectClassName</code>
       <code>$isArchiveOnInsert</code>
       <code>$isArchiveOnUpdate</code>
+      <code>$objectClassName</code>
     </UndefinedGlobalVariable>
   </file>
   <file src="src/Propel/Generator/Behavior/Archivable/templates/queryArchive.php">
@@ -120,20 +120,20 @@
   </file>
   <file src="src/Propel/Generator/Behavior/Delegate/templates/queryMethodsTemplate.php">
     <UndefinedGlobalVariable occurrences="14">
-      <code>$fieldName</code>
-      <code>$phpName</code>
-      <code>$fieldName</code>
-      <code>$phpName</code>
-      <code>$fieldName</code>
-      <code>$phpName</code>
-      <code>$fieldName</code>
       <code>$childClassName</code>
+      <code>$fieldName</code>
+      <code>$fieldName</code>
+      <code>$fieldName</code>
+      <code>$fieldName</code>
+      <code>$phpName</code>
+      <code>$phpName</code>
+      <code>$phpName</code>
+      <code>$phpName</code>
+      <code>$phpName</code>
+      <code>$phpName</code>
       <code>$phpName</code>
       <code>$tablePhpName</code>
-      <code>$phpName</code>
-      <code>$phpName</code>
       <code>$tablePhpName</code>
-      <code>$phpName</code>
     </UndefinedGlobalVariable>
   </file>
   <file src="src/Propel/Generator/Behavior/I18n/I18nBehavior.php">
@@ -174,15 +174,15 @@
   </file>
   <file src="src/Propel/Generator/Behavior/I18n/templates/objectGetTranslation.php">
     <UndefinedGlobalVariable occurrences="9">
-      <code>$i18nTablePhpName</code>
       <code>$defaultLocale</code>
       <code>$i18nListVariable</code>
       <code>$i18nListVariable</code>
-      <code>$localeColumnName</code>
-      <code>$i18nTablePhpName</code>
-      <code>$localeColumnName</code>
       <code>$i18nQueryName</code>
       <code>$i18nSetterMethod</code>
+      <code>$i18nTablePhpName</code>
+      <code>$i18nTablePhpName</code>
+      <code>$localeColumnName</code>
+      <code>$localeColumnName</code>
     </UndefinedGlobalVariable>
   </file>
   <file src="src/Propel/Generator/Behavior/I18n/templates/objectPostDelete.php">
@@ -194,57 +194,57 @@
   <file src="src/Propel/Generator/Behavior/I18n/templates/objectRemoveTranslation.php">
     <UndefinedGlobalVariable occurrences="5">
       <code>$defaultLocale</code>
+      <code>$i18nCollection</code>
+      <code>$i18nCollection</code>
       <code>$i18nQueryName</code>
-      <code>$i18nCollection</code>
       <code>$localeColumnName</code>
-      <code>$i18nCollection</code>
     </UndefinedGlobalVariable>
   </file>
   <file src="src/Propel/Generator/Behavior/I18n/templates/objectSetLocale.php">
     <UndefinedGlobalVariable occurrences="2">
-      <code>$localeColumnName</code>
       <code>$defaultLocale</code>
+      <code>$localeColumnName</code>
     </UndefinedGlobalVariable>
   </file>
   <file src="src/Propel/Generator/Behavior/I18n/templates/objectSetLocaleAlias.php">
     <UndefinedGlobalVariable occurrences="4">
-      <code>$objectClassName</code>
       <code>$alias</code>
       <code>$defaultLocale</code>
       <code>$localeColumnName</code>
+      <code>$objectClassName</code>
     </UndefinedGlobalVariable>
   </file>
   <file src="src/Propel/Generator/Behavior/I18n/templates/objectSetTranslation.php">
     <UndefinedGlobalVariable occurrences="4">
-      <code>$i18nTablePhpName</code>
       <code>$defaultLocale</code>
-      <code>$localeColumnName</code>
       <code>$i18nTablePhpName</code>
+      <code>$i18nTablePhpName</code>
+      <code>$localeColumnName</code>
     </UndefinedGlobalVariable>
   </file>
   <file src="src/Propel/Generator/Behavior/I18n/templates/objectTranslatedColumnGetter.php">
     <UndefinedGlobalVariable occurrences="4">
+      <code>$columnPhpName</code>
       <code>$comment</code>
       <code>$functionStatement</code>
-      <code>$columnPhpName</code>
       <code>$params</code>
     </UndefinedGlobalVariable>
   </file>
   <file src="src/Propel/Generator/Behavior/I18n/templates/objectTranslatedColumnSetter.php">
     <UndefinedGlobalVariable occurrences="4">
+      <code>$columnPhpName</code>
       <code>$comment</code>
       <code>$functionStatement</code>
-      <code>$columnPhpName</code>
       <code>$params</code>
     </UndefinedGlobalVariable>
   </file>
   <file src="src/Propel/Generator/Behavior/I18n/templates/queryJoinI18n.php">
     <UndefinedGlobalVariable occurrences="5">
-      <code>$queryClass</code>
       <code>$defaultLocale</code>
       <code>$i18nRelationName</code>
       <code>$i18nRelationName</code>
       <code>$localeColumn</code>
+      <code>$queryClass</code>
     </UndefinedGlobalVariable>
   </file>
   <file src="src/Propel/Generator/Behavior/I18n/templates/queryJoinWithI18n.php">
@@ -256,10 +256,10 @@
   </file>
   <file src="src/Propel/Generator/Behavior/I18n/templates/queryUseI18nQuery.php">
     <UndefinedGlobalVariable occurrences="4">
-      <code>$queryClass</code>
       <code>$defaultLocale</code>
       <code>$i18nRelationName</code>
       <code>$namespacedQueryClass</code>
+      <code>$queryClass</code>
     </UndefinedGlobalVariable>
   </file>
   <file src="src/Propel/Generator/Behavior/I18n/templates/staticAttributes.php">
@@ -273,23 +273,23 @@
       <code>$objectClassName</code>
       <code>$objectClassName</code>
       <code>$objectClassName</code>
-      <code>$useScope</code>
       <code>$queryClassName</code>
+      <code>$useScope</code>
     </UndefinedGlobalVariable>
   </file>
   <file src="src/Propel/Generator/Behavior/NestedSet/templates/objectSetLeft.php">
     <UndefinedGlobalVariable occurrences="2">
-      <code>$objectClassName</code>
       <code>$leftColumn</code>
+      <code>$objectClassName</code>
     </UndefinedGlobalVariable>
   </file>
   <file src="src/Propel/Generator/Behavior/Sortable/templates/tableMapSortable.php">
     <UndefinedGlobalVariable occurrences="5">
-      <code>$tableName</code>
-      <code>$rankColumn</code>
-      <code>$useScope</code>
       <code>$multiScope</code>
+      <code>$rankColumn</code>
       <code>$scope</code>
+      <code>$tableName</code>
+      <code>$useScope</code>
     </UndefinedGlobalVariable>
   </file>
   <file src="src/Propel/Generator/Behavior/Validate/templates/objectLoadValidatorMetadata.php">
@@ -299,9 +299,9 @@
   </file>
   <file src="src/Propel/Generator/Behavior/Validate/templates/objectValidate.php">
     <UndefinedGlobalVariable occurrences="3">
-      <code>$hasForeignKeys</code>
       <code>$aVarNames</code>
       <code>$collVarNames</code>
+      <code>$hasForeignKeys</code>
     </UndefinedGlobalVariable>
   </file>
   <file src="src/Propel/Generator/Behavior/Versionable/VersionableBehavior.php">
@@ -316,51 +316,51 @@
   </file>
   <file src="src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php">
     <UndefinedMethod occurrences="25">
-      <code>addTemporalAccessor</code>
-      <code>addObjectAccessor</code>
+      <code>addAddArrayElement</code>
+      <code>addAddArrayElement</code>
       <code>addArrayAccessor</code>
+      <code>addArrayMutator</code>
+      <code>addBooleanAccessor</code>
+      <code>addBooleanMutator</code>
+      <code>addDefaultAccessor</code>
+      <code>addDefaultAccessor</code>
+      <code>addDefaultMutator</code>
+      <code>addEnumAccessor</code>
+      <code>addEnumMutator</code>
+      <code>addHasArrayElement</code>
       <code>addHasArrayElement</code>
       <code>addJsonAccessor</code>
-      <code>addEnumAccessor</code>
-      <code>addSetAccessor</code>
-      <code>addHasArrayElement</code>
-      <code>addDefaultAccessor</code>
-      <code>addBooleanAccessor</code>
-      <code>addDefaultAccessor</code>
-      <code>addLazyLoader</code>
-      <code>addObjectMutator</code>
-      <code>addLobMutator</code>
-      <code>addTemporalMutator</code>
-      <code>addArrayMutator</code>
-      <code>addAddArrayElement</code>
-      <code>addRemoveArrayElement</code>
       <code>addJsonMutator</code>
-      <code>addEnumMutator</code>
-      <code>addSetMutator</code>
-      <code>addAddArrayElement</code>
+      <code>addLazyLoader</code>
+      <code>addLobMutator</code>
+      <code>addObjectAccessor</code>
+      <code>addObjectMutator</code>
       <code>addRemoveArrayElement</code>
-      <code>addBooleanMutator</code>
-      <code>addDefaultMutator</code>
+      <code>addRemoveArrayElement</code>
+      <code>addSetAccessor</code>
+      <code>addSetMutator</code>
+      <code>addTemporalAccessor</code>
+      <code>addTemporalMutator</code>
     </UndefinedMethod>
   </file>
   <file src="src/Propel/Generator/Builder/Om/templates/baseObjectMethodHook.php">
     <UndefinedGlobalVariable occurrences="16">
-      <code>$preSave</code>
       <code>$hasBaseClass</code>
-      <code>$postSave</code>
       <code>$hasBaseClass</code>
-      <code>$preInsert</code>
       <code>$hasBaseClass</code>
-      <code>$postInsert</code>
       <code>$hasBaseClass</code>
-      <code>$preUpdate</code>
       <code>$hasBaseClass</code>
-      <code>$postUpdate</code>
       <code>$hasBaseClass</code>
-      <code>$preDelete</code>
+      <code>$hasBaseClass</code>
       <code>$hasBaseClass</code>
       <code>$postDelete</code>
-      <code>$hasBaseClass</code>
+      <code>$postInsert</code>
+      <code>$postSave</code>
+      <code>$postUpdate</code>
+      <code>$preDelete</code>
+      <code>$preInsert</code>
+      <code>$preSave</code>
+      <code>$preUpdate</code>
     </UndefinedGlobalVariable>
   </file>
   <file src="src/Propel/Generator/Builder/Om/templates/baseObjectMethodMagicCall.php">
@@ -377,56 +377,56 @@
   </file>
   <file src="src/Propel/Generator/Builder/Om/templates/tableMapClearRelatedInstancePool.php">
     <UndefinedGlobalVariable occurrences="2">
-      <code>$tableName</code>
       <code>$relatedClassNames</code>
+      <code>$tableName</code>
     </UndefinedGlobalVariable>
   </file>
   <file src="src/Propel/Generator/Builder/Om/templates/tableMapConstants.php">
     <UndefinedGlobalVariable occurrences="11">
       <code>$className</code>
+      <code>$classPath</code>
+      <code>$columns</code>
       <code>$dbName</code>
+      <code>$nbColumns</code>
+      <code>$nbHydrateColumns</code>
+      <code>$nbLazyLoadColumns</code>
+      <code>$stringFormat</code>
+      <code>$tableName</code>
       <code>$tableName</code>
       <code>$tablePhpName</code>
-      <code>$classPath</code>
-      <code>$nbColumns</code>
-      <code>$nbLazyLoadColumns</code>
-      <code>$nbHydrateColumns</code>
-      <code>$columns</code>
-      <code>$tableName</code>
-      <code>$stringFormat</code>
     </UndefinedGlobalVariable>
   </file>
   <file src="src/Propel/Generator/Builder/Om/templates/tableMapFields.php">
     <UndefinedGlobalVariable occurrences="10">
-      <code>$fieldNamesPhpName</code>
-      <code>$fieldNamesCamelCaseName</code>
-      <code>$fieldNamesColname</code>
-      <code>$fieldNamesFieldName</code>
-      <code>$fieldNamesNum</code>
-      <code>$fieldKeysPhpName</code>
       <code>$fieldKeysCamelCaseName</code>
       <code>$fieldKeysColname</code>
       <code>$fieldKeysFieldName</code>
       <code>$fieldKeysNum</code>
+      <code>$fieldKeysPhpName</code>
+      <code>$fieldNamesCamelCaseName</code>
+      <code>$fieldNamesColname</code>
+      <code>$fieldNamesFieldName</code>
+      <code>$fieldNamesNum</code>
+      <code>$fieldNamesPhpName</code>
     </UndefinedGlobalVariable>
   </file>
   <file src="src/Propel/Generator/Builder/Om/templates/tableMapInstancePool.php">
     <UndefinedGlobalVariable occurrences="9">
-      <code>$objectClassName</code>
-      <code>$objectClassName</code>
       <code>$addInstancePoolKeySnippet</code>
+      <code>$countPks</code>
+      <code>$objectClassName</code>
+      <code>$objectClassName</code>
+      <code>$objectClassName</code>
       <code>$objectClassName</code>
       <code>$objectClassName</code>
       <code>$removeInstancePoolKeySnippetObjects</code>
-      <code>$countPks</code>
       <code>$removeInstancePoolKeySnippetPks</code>
-      <code>$objectClassName</code>
     </UndefinedGlobalVariable>
   </file>
   <file src="src/Propel/Generator/Builder/Util/SchemaReader.php">
     <UndefinedFunction occurrences="2">
-      <code>'startElement'</code>
       <code>'endElement'</code>
+      <code>'startElement'</code>
     </UndefinedFunction>
   </file>
   <file src="src/Propel/Generator/Command/Console/Input/ArrayInput.php">
@@ -442,8 +442,8 @@
   </file>
   <file src="src/Propel/Generator/Command/Helper/ConsoleHelper3.php">
     <InvalidReturnType occurrences="2">
-      <code>writeSection</code>
       <code>writeBlock</code>
+      <code>writeSection</code>
     </InvalidReturnType>
   </file>
   <file src="src/Propel/Generator/Command/InitCommand.php">
@@ -462,108 +462,103 @@
   </file>
   <file src="src/Propel/Generator/Command/templates/propel.ini.dist.php">
     <UndefinedGlobalVariable occurrences="6">
-      <code>$schemaDir</code>
+      <code>$charset</code>
+      <code>$dsn</code>
       <code>$phpDir</code>
       <code>$rdbms</code>
-      <code>$dsn</code>
+      <code>$schemaDir</code>
       <code>$user</code>
-      <code>$charset</code>
     </UndefinedGlobalVariable>
   </file>
   <file src="src/Propel/Generator/Command/templates/propel.ini.php">
     <UndefinedGlobalVariable occurrences="5">
-      <code>$rdbms</code>
-      <code>$dsn</code>
-      <code>$user</code>
-      <code>$password</code>
       <code>$charset</code>
+      <code>$dsn</code>
+      <code>$password</code>
+      <code>$rdbms</code>
+      <code>$user</code>
     </UndefinedGlobalVariable>
   </file>
   <file src="src/Propel/Generator/Command/templates/propel.json.dist.php">
     <UndefinedGlobalVariable occurrences="2">
-      <code>$schemaDir</code>
       <code>$phpDir</code>
+      <code>$schemaDir</code>
     </UndefinedGlobalVariable>
   </file>
   <file src="src/Propel/Generator/Command/templates/propel.json.php">
     <UndefinedGlobalVariable occurrences="5">
-      <code>$rdbms</code>
-      <code>$dsn</code>
-      <code>$user</code>
-      <code>$password</code>
       <code>$charset</code>
+      <code>$dsn</code>
+      <code>$password</code>
+      <code>$rdbms</code>
+      <code>$user</code>
     </UndefinedGlobalVariable>
   </file>
   <file src="src/Propel/Generator/Command/templates/propel.php.dist.php">
     <UndefinedGlobalVariable occurrences="6">
-      <code>$schemaDir</code>
+      <code>$charset</code>
+      <code>$dsn</code>
       <code>$phpDir</code>
       <code>$rdbms</code>
-      <code>$dsn</code>
+      <code>$schemaDir</code>
       <code>$user</code>
-      <code>$charset</code>
     </UndefinedGlobalVariable>
   </file>
   <file src="src/Propel/Generator/Command/templates/propel.php.php">
     <UndefinedGlobalVariable occurrences="5">
-      <code>$rdbms</code>
-      <code>$dsn</code>
-      <code>$user</code>
-      <code>$password</code>
       <code>$charset</code>
+      <code>$dsn</code>
+      <code>$password</code>
+      <code>$rdbms</code>
+      <code>$user</code>
     </UndefinedGlobalVariable>
   </file>
   <file src="src/Propel/Generator/Command/templates/propel.xml.dist.php">
     <UndefinedGlobalVariable occurrences="6">
-      <code>$schemaDir</code>
+      <code>$charset</code>
+      <code>$dsn</code>
       <code>$phpDir</code>
       <code>$rdbms</code>
-      <code>$dsn</code>
+      <code>$schemaDir</code>
       <code>$user</code>
-      <code>$charset</code>
     </UndefinedGlobalVariable>
   </file>
   <file src="src/Propel/Generator/Command/templates/propel.xml.php">
     <UndefinedGlobalVariable occurrences="5">
-      <code>$rdbms</code>
-      <code>$dsn</code>
-      <code>$user</code>
-      <code>$password</code>
       <code>$charset</code>
+      <code>$dsn</code>
+      <code>$password</code>
+      <code>$rdbms</code>
+      <code>$user</code>
     </UndefinedGlobalVariable>
   </file>
   <file src="src/Propel/Generator/Command/templates/propel.yml.dist.php">
     <UndefinedGlobalVariable occurrences="6">
-      <code>$schemaDir</code>
+      <code>$charset</code>
+      <code>$dsn</code>
       <code>$phpDir</code>
       <code>$rdbms</code>
-      <code>$dsn</code>
+      <code>$schemaDir</code>
       <code>$user</code>
-      <code>$charset</code>
     </UndefinedGlobalVariable>
   </file>
   <file src="src/Propel/Generator/Command/templates/propel.yml.php">
     <UndefinedGlobalVariable occurrences="5">
-      <code>$rdbms</code>
-      <code>$dsn</code>
-      <code>$user</code>
-      <code>$password</code>
       <code>$charset</code>
+      <code>$dsn</code>
+      <code>$password</code>
+      <code>$rdbms</code>
+      <code>$user</code>
     </UndefinedGlobalVariable>
   </file>
   <file src="src/Propel/Generator/Command/templates/schema.xml.php">
     <UndefinedGlobalVariable occurrences="3">
-      <code>$rdbms</code>
       <code>$namespace</code>
+      <code>$rdbms</code>
       <code>$schemaDir</code>
     </UndefinedGlobalVariable>
   </file>
   <file src="src/Propel/Generator/Manager/AbstractManager.php">
-    <UndefinedClass occurrences="3">
-      <code>XsltProcessor</code>
-      <code>$xsl</code>
-      <code>$xsl</code>
-    </UndefinedClass>
     <UndefinedMethod occurrences="1">
       <code>getLocation</code>
     </UndefinedMethod>
@@ -629,8 +624,8 @@
   </file>
   <file src="src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php">
     <UndefinedMethod occurrences="2">
-      <code>static::getShortName($this-&gt;modelName)</code>
       <code>find</code>
+      <code>static::getShortName($this-&gt;modelName)</code>
     </UndefinedMethod>
   </file>
   <file src="src/Propel/Runtime/ActiveQuery/Criteria.php">
@@ -649,16 +644,16 @@
   </file>
   <file src="src/Propel/Runtime/ActiveQuery/ModelCriteria.php">
     <UndefinedClass occurrences="2">
-      <code>new $secondaryCriteriaClass()</code>
       <code>$tableMap::addSelectColumns($this, $this-&gt;useAliasInSQL ? $this-&gt;modelAlias : null)</code>
+      <code>new $secondaryCriteriaClass()</code>
     </UndefinedClass>
     <UndefinedMethod occurrences="10">
-      <code>getTableMap</code>
-      <code>getTableMap</code>
-      <code>getTableMap</code>
-      <code>getRelationMap</code>
-      <code>addSelfSelectColumns</code>
       <code>addSelectColumns</code>
+      <code>addSelfSelectColumns</code>
+      <code>getRelationMap</code>
+      <code>getTableMap</code>
+      <code>getTableMap</code>
+      <code>getTableMap</code>
       <code>getTableMap</code>
       <code>getTableMap</code>
       <code>getTableMap</code>
@@ -678,10 +673,10 @@
   <file src="src/Propel/Runtime/Adapter/Pdo/SqlsrvAdapter.php">
     <UndefinedConstant occurrences="5">
       <code>PDO::SQLSRV_ATTR_ENCODING</code>
-      <code>PDO::SQLSRV_ENCODING_UTF8</code>
       <code>PDO::SQLSRV_ATTR_ENCODING</code>
-      <code>PDO::SQLSRV_ENCODING_SYSTEM</code>
       <code>PDO::SQLSRV_ENCODING_BINARY</code>
+      <code>PDO::SQLSRV_ENCODING_SYSTEM</code>
+      <code>PDO::SQLSRV_ENCODING_UTF8</code>
     </UndefinedConstant>
   </file>
   <file src="src/Propel/Runtime/Collection/CollectionIterator.php">


### PR DESCRIPTION
Command and output:
```
$ vendor/bin/psalm.phar --update-baseline=psalm-baseline.xml
Scanning files...
Analyzing files...

░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░  60 / 342 (17%)
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 120 / 342 (35%)
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 180 / 342 (52%)
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 240 / 342 (70%)
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 300 / 342 (87%)
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
------------------------------
3 errors fixed

ERROR: UndefinedClass - src/Propel/Generator/Platform/SqlitePlatform.php:56:20 - Class or interface SQLite3 does not exist (see https://psalm.dev/019)
        $version = SQLite3::version();

------------------------------
1 errors found
------------------------------
1540 other issues found.
You can display them with --show-info=true
------------------------------
Psalm can automatically fix 76 of these issues.
Run Psalm again with
--alter --issues=InvalidNullableReturnType,InvalidReturnType,InvalidFalsableReturnType --dry-run
to see what it can fix.
------------------------------

Checks took 3.36 seconds and used 328.892MB of memory
Psalm was able to infer types for 93.0727% of the codebase
```

Note that the error about missing class SQLite3 is because I don't have
ext-sqlite3 installed. It's also missing from `composer.json`. The
`--update-baseline` command flag doesn't add any new errors, but only
removes/reorders. To add error-ignores, the `--set-baseline=<file>` flag
should be used.