### PR TITLE
Fixes docblock for transaction function

### DIFF
--- a/src/Propel/Runtime/Connection/ConnectionInterface.php
+++ b/src/Propel/Runtime/Connection/ConnectionInterface.php
@@ -136,7 +136,7 @@ interface ConnectionInterface
      *
      * @param callable $callable A callable to be wrapped in a transaction.
      *
-     * @throws \Exception Re-throws a possible <code>Exception</code> triggered by the callable.
+     * @throws \Throwable Re-throws a possible <code>Throwable</code> triggered by the callable.
      *
      * @return mixed Returns the result of the callable.
      */


### PR DESCRIPTION
After https://github.com/propelorm/Propel2/pull/1654 was introduced, docblocks in interface and implementation were not aligned with each other. 