### PR TITLE
Introduce PHP 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,15 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php-version: [ '7.2', '7.4' ]
+                php-version: [ '7.2', '7.4', '8.0' ]
                 db-type: [ sqlite, mysql, pgsql, agnostic ]
                 symfony-version: [ '3-min', '3-max', '4-min', '4-max', '5-min', '5-max' ]
+                exclude:
+                  - php-version: '8.0'
+                    symfony-version: '4-min'
         steps:
             - name: Install PostgreSQL latest
-              if: matrix.db-type == 'pgsql' && matrix.php-version == '7.4'
+              if: matrix.db-type == 'pgsql' && matrix.php-version != '7.2'
               uses: CasperWA/postgresql-action@v1.2
               with:
                   postgresql db: 'propel-tests'
@@ -36,7 +39,7 @@ jobs:
                   postgresql password: 'postgres'
 
             - name: Install MariaDb latest
-              if: matrix.db-type == 'mysql' && matrix.php-version == '7.4'
+              if: matrix.db-type == 'mysql' && matrix.php-version != '7.2'
               uses: getong/mariadb-action@v1.1
 
             - name: Install MariaDb min

--- a/composer.json
+++ b/composer.json
@@ -54,11 +54,19 @@
         "psalm": "vendor/bin/psalm.phar --show-info=false",
         "psalm-update-baseline": "vendor/bin/psalm.phar --update-baseline",
         "psalm-set-baseline": "vendor/bin/psalm.phar --set-baseline=psalm-baseline.xml",
-        "psalm-update-report": "vendor/bin/psalm.phar --report=psalm-report.xml"
+        "psalm-update-report": "vendor/bin/psalm.phar --report=psalm-report.xml",
+        "test": "phpunit --colors=always",
+        "test:agnostic": "@test -c tests/agnostic.phpunit.xml",
+        "test:mysql": "@test -c tests/mysql.phpunit.xml",
+        "test:sqlite": "@test -c tests/sqlite.phpunit.xml",
+        "test:pgsql": "@test -c tests/pgsql.phpunit.xml"
     },
     "extra": {
         "branch-alias": {
             "dev-master": "2.0-dev"
         }
+    },
+    "config": {
+        "process-timeout": 0
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -46,21 +46,6 @@ parameters:
 			path: src/Propel/Generator/Behavior/Sortable/SortableBehaviorObjectBuilderModifier.php
 
 		-
-			message: "#^Variable \\$paramsDoc might not be defined\\.$#"
-			count: 4
-			path: src/Propel/Generator/Behavior/Sortable/SortableBehaviorQueryBuilderModifier.php
-
-		-
-			message: "#^Variable \\$methodSignature might not be defined\\.$#"
-			count: 10
-			path: src/Propel/Generator/Behavior/Sortable/SortableBehaviorQueryBuilderModifier.php
-
-		-
-			message: "#^Variable \\$buildScope might not be defined\\.$#"
-			count: 1
-			path: src/Propel/Generator/Behavior/Sortable/SortableBehaviorQueryBuilderModifier.php
-
-		-
 			message: "#^Access to an undefined property Propel\\\\Generator\\\\Model\\\\Table\\:\\:\\$isVersionTable\\.$#"
 			count: 1
 			path: src/Propel/Generator/Behavior/Versionable/VersionableBehavior.php
@@ -556,16 +541,6 @@ parameters:
 			path: src/Propel/Runtime/Adapter/Pdo/MssqlAdapter.php
 
 		-
-			message: "#^Variable \\$dbMap might not be defined\\.$#"
-			count: 1
-			path: src/Propel/Runtime/Adapter/Pdo/PgsqlAdapter.php
-
-		-
-			message: "#^Variable \\$params might not be defined\\.$#"
-			count: 1
-			path: src/Propel/Runtime/Adapter/Pdo/PgsqlAdapter.php
-
-		-
 			message: "#^Call to an undefined method Propel\\\\Runtime\\\\Connection\\\\ConnectionInterface\\:\\:sqliteCreateFunction\\(\\)\\.$#"
 			count: 1
 			path: src/Propel/Runtime/Adapter/Pdo/SqliteAdapter.php
@@ -609,6 +584,16 @@ parameters:
 			message: "#^Call to an undefined method Propel\\\\Runtime\\\\ActiveRecord\\\\ActiveRecordInterface\\:\\:toArray\\(\\)\\.$#"
 			count: 1
 			path: src/Propel/Runtime/Collection/ArrayCollection.php
+
+		-
+			message: "#^Method ArrayIterator\\<mixed,mixed\\>\\:\\:asort\\(\\) invoked with 1 parameter, 0 required\\.$#"
+			count: 1
+			path: src/Propel/Runtime/Collection/CollectionIterator.php
+
+		-
+			message: "#^Method ArrayIterator\\<mixed,mixed\\>\\:\\:ksort\\(\\) invoked with 1 parameter, 0 required\\.$#"
+			count: 1
+			path: src/Propel/Runtime/Collection/CollectionIterator.php
 
 		-
 			message: "#^Call to an undefined method Propel\\\\Runtime\\\\ActiveRecord\\\\ActiveRecordInterface\\:\\:save\\(\\)\\.$#"

--- a/src/Propel/Runtime/Collection/CollectionIterator.php
+++ b/src/Propel/Runtime/Collection/CollectionIterator.php
@@ -235,7 +235,6 @@ class CollectionIterator extends ArrayIterator
      */
     public function asort($sort_flags = SORT_REGULAR)
     {
-        /* @phpstan-ignore-next-line */
         parent::asort($sort_flags);
         $this->refreshPositions();
     }
@@ -247,7 +246,6 @@ class CollectionIterator extends ArrayIterator
      */
     public function ksort($sort_flags = SORT_REGULAR)
     {
-        /* @phpstan-ignore-next-line */
         parent::ksort($sort_flags);
         $this->refreshPositions();
     }


### PR DESCRIPTION
Make Propel2 compatible with PHP 8 (well, it's already compatible: just few adjustments).

~~Test suite is green but the new version of PhpStan raises some esotheric (for me) errors: could you suggest me, please, how to fix them?~~

I added some composer scripts, if you don't like I can remove them, of course.