### PR TITLE
QuickBuilder refactor

### DIFF
--- a/src/Propel/Generator/Util/QuickBuilder.php
+++ b/src/Propel/Generator/Util/QuickBuilder.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types = 1);
 
 /**
  * MIT License. This file is part of the Propel package.
@@ -17,7 +17,10 @@ use Propel\Generator\Exception\BuildException;
 use Propel\Generator\Model\Database;
 use Propel\Generator\Model\Diff\DatabaseComparator;
 use Propel\Generator\Model\Table;
+use Propel\Generator\Platform\PlatformInterface;
 use Propel\Generator\Platform\SqlitePlatform;
+use Propel\Generator\Reverse\SchemaParserInterface;
+use Propel\Runtime\Adapter\AdapterInterface;
 use Propel\Runtime\Adapter\Pdo\SqliteAdapter;
 use Propel\Runtime\Connection\ConnectionInterface;
 use Propel\Runtime\Connection\ConnectionWrapper;
@@ -27,37 +30,39 @@ use Propel\Runtime\Propel;
 
 class QuickBuilder
 {
+    use VfsTrait;
+
     /**
      * The Xml.
      *
      * @var string
      */
-    protected $schema;
+    protected $schema = '';
 
     /**
      * The Database Schema.
      *
      * @var string
      */
-    protected $schemaName;
+    protected $schemaName = '';
 
     /**
-     * @var \Propel\Generator\Platform\PlatformInterface
+     * @var \Propel\Generator\Platform\PlatformInterface|null
      */
     protected $platform;
 
     /**
-     * @var \Propel\Generator\Config\GeneratorConfigInterface
+     * @var \Propel\Generator\Config\GeneratorConfigInterface|null
      */
     protected $config;
 
     /**
-     * @var \Propel\Generator\Model\Database
+     * @var \Propel\Generator\Model\Database|null
      */
     protected $database;
 
     /**
-     * @var \Propel\Generator\Reverse\SchemaParserInterface
+     * @var \Propel\Generator\Reverse\SchemaParserInterface|null
      */
     protected $parser;
 
@@ -74,11 +79,19 @@ class QuickBuilder
     protected $identifierQuoting = false;
 
     /**
+     * If use the virtual or physical filesystem.
+     * Default to virtual.
+     *
+     * @var bool
+     */
+    protected $vfs = true;
+
+    /**
      * @param string $schema
      *
      * @return void
      */
-    public function setSchema($schema)
+    public function setSchema(string $schema): void
     {
         $this->schema = $schema;
     }
@@ -86,7 +99,7 @@ class QuickBuilder
     /**
      * @return string
      */
-    public function getSchema()
+    public function getSchema(): string
     {
         return $this->schema;
     }
@@ -96,7 +109,7 @@ class QuickBuilder
      *
      * @return void
      */
-    public function setSchemaName($schemaName)
+    public function setSchemaName(string $schemaName): void
     {
         $this->schemaName = $schemaName;
     }
@@ -104,7 +117,7 @@ class QuickBuilder
     /**
      * @return string
      */
-    public function getSchemaName()
+    public function getSchemaName(): string
     {
         return $this->schemaName;
     }
@@ -114,15 +127,15 @@ class QuickBuilder
      *
      * @return void
      */
-    public function setParser($parser)
+    public function setParser(SchemaParserInterface $parser): void
     {
         $this->parser = $parser;
     }
 
     /**
-     * @return \Propel\Generator\Reverse\SchemaParserInterface
+     * @return \Propel\Generator\Reverse\SchemaParserInterface|null
      */
-    public function getParser()
+    public function getParser(): ?SchemaParserInterface
     {
         return $this->parser;
     }
@@ -134,7 +147,7 @@ class QuickBuilder
      *
      * @return void
      */
-    public function setPlatform($platform)
+    public function setPlatform(PlatformInterface $platform): void
     {
         $this->platform = $platform;
     }
@@ -144,7 +157,7 @@ class QuickBuilder
      *
      * @return \Propel\Generator\Platform\PlatformInterface
      */
-    public function getPlatform()
+    public function getPlatform(): PlatformInterface
     {
         if ($this->platform === null) {
             $this->platform = new SqlitePlatform();
@@ -162,7 +175,7 @@ class QuickBuilder
      *
      * @return void
      */
-    public function setConfig(GeneratorConfigInterface $config)
+    public function setConfig(GeneratorConfigInterface $config): void
     {
         $this->config = $config;
     }
@@ -182,18 +195,44 @@ class QuickBuilder
     }
 
     /**
+     * @return bool
+     */
+    public function isVfs(): bool
+    {
+        return $this->vfs;
+    }
+
+    /**
+     * @param bool $vfs
+     *
+     * @return void
+     */
+    public function setVfs(bool $vfs): void
+    {
+        $this->vfs = $vfs;
+    }
+
+    /**
      * @param string $schema
      * @param string|null $dsn
      * @param string|null $user
      * @param string|null $pass
      * @param \Propel\Runtime\Adapter\AdapterInterface|null $adapter
+     * @param bool $vfs
      *
      * @return \Propel\Runtime\Connection\ConnectionWrapper
      */
-    public static function buildSchema($schema, $dsn = null, $user = null, $pass = null, $adapter = null)
-    {
+    public static function buildSchema(
+        string $schema,
+        ?string $dsn = null,
+        ?string $user = null,
+        ?string $pass = null,
+        ?AdapterInterface $adapter = null,
+        bool $vfs = true
+    ): ConnectionWrapper {
         $builder = new self();
         $builder->setSchema($schema);
+        $builder->setVfs($vfs);
 
         return $builder->build($dsn, $user, $pass, $adapter);
     }
@@ -207,17 +246,17 @@ class QuickBuilder
      *
      * @return \Propel\Runtime\Connection\ConnectionWrapper
      */
-    public function build($dsn = null, $user = null, $pass = null, $adapter = null, ?array $classTargets = null)
-    {
-        if ($dsn === null) {
-            $dsn = 'sqlite::memory:';
-        }
-        if ($adapter === null) {
-            $adapter = new SqliteAdapter();
-        }
-        if ($classTargets === null) {
-            $classTargets = $this->classTargets;
-        }
+    public function build(
+        ?string $dsn = null,
+        ?string $user = null,
+        ?string $pass = null,
+        ?AdapterInterface $adapter = null,
+        ?array $classTargets = null
+    ): ConnectionWrapper {
+        $dsn = $dsn ?? 'sqlite::memory:';
+        $adapter = $adapter ?? new SqliteAdapter();
+        $classTargets = $classTargets ?? $this->classTargets;
+
         $pdo = new PdoConnection($dsn, $user, $pass);
         $con = new ConnectionWrapper($pdo);
         $con->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_WARNING);
@@ -235,7 +274,7 @@ class QuickBuilder
     /**
      * @return \Propel\Generator\Model\Database|null
      */
-    public function getDatabase()
+    public function getDatabase(): ?Database
     {
         if ($this->database === null) {
             $xtad = new SchemaReader($this->getPlatform());
@@ -252,9 +291,9 @@ class QuickBuilder
      *
      * @throws \Exception
      *
-     * @return int
+     * @return int the number of statements executed
      */
-    public function buildSQL(ConnectionInterface $con)
+    public function buildSQL(ConnectionInterface $con): int
     {
         $sql = $this->getSQL();
         $statements = SqlParser::parseString($sql);
@@ -284,7 +323,7 @@ class QuickBuilder
      *
      * @return \Propel\Generator\Model\Database|null
      */
-    public function updateDB(ConnectionInterface $con)
+    public function updateDB(ConnectionInterface $con): ?Database
     {
         $database = $this->readConnectedDatabase();
         $diff = DatabaseComparator::computeDiff($database, $this->database);
@@ -319,7 +358,7 @@ class QuickBuilder
     /**
      * @return \Propel\Generator\Model\Database
      */
-    public function readConnectedDatabase()
+    public function readConnectedDatabase(): Database
     {
         $this->getDatabase();
         $database = new Database();
@@ -334,7 +373,7 @@ class QuickBuilder
     /**
      * @return string
      */
-    public function getSQL()
+    public function getSQL(): string
     {
         /** @var \Propel\Generator\Platform\DefaultPlatform $platform */
         $platform = $this->getPlatform();
@@ -343,11 +382,11 @@ class QuickBuilder
     }
 
     /**
-     * @param string[]|null $classTargets
+     * @param array|null $classTargets
      *
      * @return string
      */
-    public function getBuildName($classTargets = null)
+    public function getBuildName(?array $classTargets = null): string
     {
         $tables = [];
         foreach ($this->getDatabase()->getTables() as $table) {
@@ -367,52 +406,24 @@ class QuickBuilder
     }
 
     /**
+     * Build the classes files and include them.
+     *
+     * When generated to virtual filesystem, the classes reside in a unique file. When they're are built to
+     * physical filesystem, which is supposed to be for debugging purpose, the classes reside on separate file,
+     * for easier debug.
+     *
      * @param string[]|null $classTargets array('tablemap', 'object', 'query', 'objectstub', 'querystub')
-     * @param bool $separate pass true to get for each class a own file. better for debugging.
      *
      * @return void
      */
-    public function buildClasses(?array $classTargets = null, $separate = false)
+    public function buildClasses(?array $classTargets = null): void
     {
-        $classes = $classTargets === null ? ['tablemap', 'object', 'query', 'objectstub', 'querystub'] : $classTargets;
+        $classes = $classTargets ?? ['tablemap', 'object', 'query', 'objectstub', 'querystub'];
 
-        $dirHash = substr(sha1(getcwd()), 0, 10);
-        $dir = sys_get_temp_dir() . '/propelQuickBuild-' . Propel::VERSION . "-$dirHash/";
+        $includes = $this->isVfs() ? $this->buildClassesToVirtual($classes, $this->getDatabase()->getTables())
+            : $this->buildClassesToPhysical($classes, $this->getDatabase()->getTables());
 
-        if (!is_dir($dir)) {
-            mkdir($dir);
-        }
-
-        $includes = [];
-        $allCode = '';
-        $allCodeName = [];
-        foreach ($this->getDatabase()->getTables() as $table) {
-            if (5 > count($allCodeName)) {
-                $allCodeName[] = $table->getPhpName();
-            }
-
-            if ($separate) {
-                foreach ($classes as $class) {
-                    $code = $this->getClassesForTable($table, [$class]);
-                        $tempFile = $dir
-                            . str_replace('\\', '-', $table->getPhpName())
-                            . "-$class"
-                            . '.php';
-                        file_put_contents($tempFile, "<?php\n" . $code);
-                        $includes[] = $tempFile;
-                }
-            } else {
-                $code = $this->getClassesForTable($table, $classes);
-                $allCode .= $code;
-            }
-        }
-        if ($separate) {
-            foreach ($includes as $tempFile) {
-                include($tempFile);
-            }
-        } else {
-            $tempFile = $dir . implode('_', $allCodeName) . '.php';
-            file_put_contents($tempFile, "<?php\n" . $allCode);
+        foreach ($includes as $tempFile) {
             include($tempFile);
         }
     }
@@ -422,7 +433,7 @@ class QuickBuilder
      *
      * @return string
      */
-    public function getClasses(?array $classTargets = null)
+    public function getClasses(?array $classTargets = null): string
     {
         $script = '';
         foreach ($this->getDatabase()->getTables() as $table) {
@@ -438,12 +449,9 @@ class QuickBuilder
      *
      * @return string
      */
-    public function getClassesForTable(Table $table, ?array $classTargets = null)
+    public function getClassesForTable(Table $table, ?array $classTargets = null): string
     {
-        if ($classTargets === null) {
-            $classTargets = $this->classTargets;
-        }
-
+        $classTargets = $classTargets ?? $this->classTargets;
         $script = '';
 
         foreach ($classTargets as $target) {
@@ -494,30 +502,13 @@ class QuickBuilder
     }
 
     /**
-     * @param string $schema
-     * @param string $tableName
-     *
-     * @return void
-     */
-    public static function debugClassesForTable($schema, $tableName)
-    {
-        $builder = new self();
-        $builder->setSchema($schema);
-        foreach ($builder->getDatabase()->getTables() as $table) {
-            if ($table->getName() == $tableName) {
-                echo $builder->getClassesForTable($table);
-            }
-        }
-    }
-
-    /**
      * @see https://github.com/symfony/symfony/blob/master/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
      *
      * @param string $source
      *
      * @return string
      */
-    public function fixNamespaceDeclarations($source)
+    public function fixNamespaceDeclarations(string $source): string
     {
         $cooperativeLexems = [T_WHITESPACE, T_NS_SEPARATOR, T_STRING];
 
@@ -578,7 +569,7 @@ class QuickBuilder
      *
      * @return string
      */
-    protected function forceNamespace($code)
+    protected function forceNamespace(string $code): string
     {
         if (preg_match('/\nnamespace/', $code) === 0) {
             $use = array_filter(explode(PHP_EOL, $code), function ($string) {
@@ -596,7 +587,7 @@ class QuickBuilder
     /**
      * @return bool
      */
-    public function isIdentifierQuotingEnabled()
+    public function isIdentifierQuotingEnabled(): bool
     {
         return $this->identifierQuoting;
     }
@@ -606,8 +597,64 @@ class QuickBuilder
      *
      * @return void
      */
-    public function setIdentifierQuoting($identifierQuoting)
+    public function setIdentifierQuoting(bool $identifierQuoting): void
     {
         $this->identifierQuoting = $identifierQuoting;
+    }
+
+    /**
+     * Create separate classes to write to physical filesystem.
+     *
+     * @param string[] $classes
+     * @param \Propel\Generator\Model\Table[] $tables Array of Table objects
+     *
+     * @return string[] The files to include
+     */
+    private function buildClassesToPhysical(array $classes, array $tables): array
+    {
+        $includes = [];
+        $dirName = sys_get_temp_dir()
+            . '/propelQuickBuild-' . Propel::VERSION . '-' . substr(sha1(getcwd()), 0, 10) . '/';
+        if (!is_dir($dirName)) {
+            mkdir($dirName);
+        }
+        foreach ($tables as $table) {
+            foreach ($classes as $class) {
+                $code = $this->getClassesForTable($table, [$class]);
+                $tempFile = $dirName . str_replace('\\', '-', $table->getPhpName()) . "-$class.php";
+                file_put_contents($tempFile, "<?php\n" . $code);
+                $includes[] = $tempFile;
+            }
+        }
+
+        return $includes;
+    }
+
+    /**
+     * Create an all-classes file to write to virtual filesystem.
+     *
+     * @param string[] $classes
+     * @param \Propel\Generator\Model\Table[] $tables Array of Table objects
+     *
+     * @return string[] The one element array, containing the file to include
+     */
+    private function buildClassesToVirtual(array $classes, array $tables): array
+    {
+        $allCode = '';
+        $allCodeName = [];
+        $includes = [];
+
+        foreach ($tables as $table) {
+            if (5 > count($allCodeName)) {
+                $allCodeName[] = $table->getPhpName();
+            }
+            $allCode .= $this->getClassesForTable($table, $classes);
+        }
+
+        $tempFile = $this->newFile('propelQuickBuild/' . implode('_', $allCodeName) . '.php');
+        file_put_contents($tempFile->url(), "<?php\n" . $allCode);
+        $includes[] = $tempFile->url();
+
+        return $includes;
     }
 }

--- a/src/Propel/Generator/Util/VfsTrait.php
+++ b/src/Propel/Generator/Util/VfsTrait.php
@@ -1,13 +1,12 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
+
 /**
- * This file is part of the Propel package.
+ * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * @license MIT License
  */
 
-namespace Propel\Tests;
+namespace Propel\Generator\Util;
 
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
@@ -20,15 +19,17 @@ use org\bovigo\vfs\vfsStreamFile;
  */
 trait VfsTrait
 {
-    /** @var vfsStreamDirectory */
+    /**
+     * @var \org\bovigo\vfs\vfsStreamDirectory
+     */
     private $root;
 
     /**
-     * @return vfsStreamDirectory
+     * @return \org\bovigo\vfs\vfsStreamDirectory
      */
     public function getRoot(): vfsStreamDirectory
     {
-        if (null === $this->root) {
+        if ($this->root === null) {
             $this->root = vfsStream::setup();
         }
 
@@ -43,14 +44,14 @@ trait VfsTrait
      * @param string $filename
      * @param string $content
      *
-     * @return vfsStreamFile
+     * @return \org\bovigo\vfs\vfsStreamFile
      */
     public function newFile(string $filename, string $content = ''): vfsStreamFile
     {
         $path = pathinfo($filename);
         $dir = $this->getDir($path['dirname']);
 
-        return vfsStream::newFile($filename)->at($dir)->setContent($content);
+        return vfsStream::newFile($path['basename'])->at($dir)->setContent($content);
     }
 
     /**
@@ -60,7 +61,7 @@ trait VfsTrait
      *
      * @param string $dirname
      *
-     * @return vfsStreamDirectory
+     * @return \org\bovigo\vfs\vfsStreamDirectory
      */
     private function getDir(string $dirname): vfsStreamDirectory
     {

--- a/tests/Propel/Tests/Common/Config/ConfigurationManagerTest.php
+++ b/tests/Propel/Tests/Common/Config/ConfigurationManagerTest.php
@@ -12,7 +12,7 @@ use org\bovigo\vfs\vfsStream;
 use Propel\Common\Config\ConfigurationManager;
 use Propel\Common\Config\Exception\InvalidArgumentException;
 use Propel\Tests\TestCase;
-use Propel\Tests\VfsTrait;
+use Propel\Generator\Util\VfsTrait;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 class ConfigurationManagerTest extends TestCase

--- a/tests/Propel/Tests/Common/Config/Loader/IniFileLoaderTest.php
+++ b/tests/Propel/Tests/Common/Config/Loader/IniFileLoaderTest.php
@@ -14,7 +14,7 @@ use Propel\Common\Config\Exception\InvalidArgumentException;
 use Propel\Common\Config\Loader\IniFileLoader;
 use Propel\Common\Config\FileLocator;
 use Propel\Tests\TestCase;
-use Propel\Tests\VfsTrait;
+use Propel\Generator\Util\VfsTrait;
 use Symfony\Component\Config\Exception\FileLocatorFileNotFoundException;
 
 class IniFileLoaderTest extends TestCase

--- a/tests/Propel/Tests/Common/Config/Loader/JsonFileLoaderTest.php
+++ b/tests/Propel/Tests/Common/Config/Loader/JsonFileLoaderTest.php
@@ -14,7 +14,7 @@ use Propel\Common\Config\Exception\JsonParseException;
 use Propel\Common\Config\FileLocator;
 use Propel\Common\Config\Loader\JsonFileLoader;
 use Propel\Tests\TestCase;
-use Propel\Tests\VfsTrait;
+use Propel\Generator\Util\VfsTrait;
 
 class JsonFileLoaderTest extends TestCase
 {

--- a/tests/Propel/Tests/Common/Config/Loader/PhpFileLoaderTest.php
+++ b/tests/Propel/Tests/Common/Config/Loader/PhpFileLoaderTest.php
@@ -14,7 +14,7 @@ use Propel\Common\Config\Exception\InvalidArgumentException as PropelInvalidArgu
 use Propel\Common\Config\FileLocator;
 use Propel\Common\Config\Loader\PhpFileLoader;
 use Propel\Tests\TestCase;
-use Propel\Tests\VfsTrait;
+use Propel\Generator\Util\VfsTrait;
 
 class PhpFileLoaderTest extends TestCase
 {

--- a/tests/Propel/Tests/Common/Config/Loader/XmlFileLoaderTest.php
+++ b/tests/Propel/Tests/Common/Config/Loader/XmlFileLoaderTest.php
@@ -14,7 +14,7 @@ use Propel\Common\Config\Exception\InvalidArgumentException as PropelInvalidArgu
 use Propel\Common\Config\FileLocator;
 use Propel\Common\Config\Loader\XmlFileLoader;
 use Propel\Tests\TestCase;
-use Propel\Tests\VfsTrait;
+use Propel\Generator\Util\VfsTrait;
 
 class XmlFileLoaderTest extends TestCase
 {

--- a/tests/Propel/Tests/Common/Config/Loader/YamlFileLoaderTest.php
+++ b/tests/Propel/Tests/Common/Config/Loader/YamlFileLoaderTest.php
@@ -13,7 +13,7 @@ use Propel\Common\Config\Exception\InputOutputException;
 use Propel\Common\Config\FileLocator;
 use Propel\Common\Config\Loader\YamlFileLoader;
 use Propel\Tests\TestCase;
-use Propel\Tests\VfsTrait;
+use Propel\Generator\Util\VfsTrait;
 use Symfony\Component\Yaml\Exception\ParseException;
 
 class YamlFileLoaderTest extends TestCase

--- a/tests/Propel/Tests/Common/Config/XmlToArrayConverterTest.php
+++ b/tests/Propel/Tests/Common/Config/XmlToArrayConverterTest.php
@@ -13,7 +13,7 @@ use Propel\Common\Config\Exception\InvalidArgumentException;
 use Propel\Common\Config\Exception\XmlParseException;
 use Propel\Common\Config\XmlToArrayConverter;
 use Propel\Tests\TestCase;
-use Propel\Tests\VfsTrait;
+use Propel\Generator\Util\VfsTrait;
 
 class XmlToArrayConverterTest extends TestCase
 {

--- a/tests/Propel/Tests/Generator/Config/GeneratorConfigTest.php
+++ b/tests/Propel/Tests/Generator/Config/GeneratorConfigTest.php
@@ -14,7 +14,7 @@ use Propel\Generator\Exception\ClassNotFoundException;
 use Propel\Generator\Exception\InvalidArgumentException;
 use Propel\Tests\Common\Config\ConfigTestCase;
 use Propel\Tests\TestCase;
-use Propel\Tests\VfsTrait;
+use Propel\Generator\Util\VfsTrait;
 use ReflectionClass;
 
 /**

--- a/tests/Propel/Tests/Generator/Model/DatabaseTest.php
+++ b/tests/Propel/Tests/Generator/Model/DatabaseTest.php
@@ -17,7 +17,7 @@ use Propel\Generator\Model\Schema;
 use Propel\Generator\Model\Table;
 use Propel\Generator\Platform\MysqlPlatform;
 use Propel\Generator\Platform\PgsqlPlatform;
-use Propel\Tests\VfsTrait;
+use Propel\Generator\Util\VfsTrait;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**

--- a/tests/Propel/Tests/Generator/Platform/MysqlPlatformMigrationMyISAMTest.php
+++ b/tests/Propel/Tests/Generator/Platform/MysqlPlatformMigrationMyISAMTest.php
@@ -10,7 +10,7 @@ namespace Propel\Tests\Generator\Platform;
 
 use Propel\Generator\Config\GeneratorConfig;
 use Propel\Generator\Platform\MysqlPlatform;
-use Propel\Tests\VfsTrait;
+use Propel\Generator\Util\VfsTrait;
 
 class MysqlPlatformMigrationMyISAMTest extends PlatformMigrationTestProvider
 {

--- a/tests/Propel/Tests/Generator/Platform/MysqlPlatformMigrationTest.php
+++ b/tests/Propel/Tests/Generator/Platform/MysqlPlatformMigrationTest.php
@@ -11,7 +11,7 @@ namespace Propel\Tests\Generator\Platform;
 use Propel\Generator\Config\GeneratorConfig;
 use Propel\Generator\Model\Diff\DatabaseComparator;
 use Propel\Generator\Platform\MysqlPlatform;
-use Propel\Tests\VfsTrait;
+use Propel\Generator\Util\VfsTrait;
 
 class MysqlPlatformMigrationTest extends MysqlPlatformMigrationTestProvider
 {

--- a/tests/Propel/Tests/Generator/Util/QuickBuilderTest.php
+++ b/tests/Propel/Tests/Generator/Util/QuickBuilderTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * MIT License. This file is part of the Propel package.
@@ -12,10 +12,13 @@ use MyNameSpace\Map\QuickBuildFoo1TableMap;
 use MyNameSpace\QuickBuildFoo1;
 use MyNameSpace2\QuickBuildFoo2;
 use MyNameSpace2\QuickBuildFoo2Query;
+use MyNameSpace3\QuickBuildFoo3;
+use MyNameSpace3\QuickBuildFoo3Query;
 use Propel\Generator\Platform\MysqlPlatform;
 use Propel\Generator\Platform\SqlitePlatform;
 use Propel\Generator\Util\QuickBuilder;
 use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
+use Propel\Runtime\Propel;
 use Propel\Tests\TestCase;
 
 class QuickBuilderTest extends TestCase
@@ -23,7 +26,7 @@ class QuickBuilderTest extends TestCase
     /**
      * @return void
      */
-    public function testGetPlatform()
+    public function testGetPlatform(): void
     {
         $builder = new QuickBuilder();
         $builder->setPlatform(new MysqlPlatform());
@@ -32,7 +35,7 @@ class QuickBuilderTest extends TestCase
         $this->assertTrue($builder->getPlatform() instanceof SqlitePlatform);
     }
 
-    public function simpleSchemaProvider()
+    public function simpleSchemaProvider(): array
     {
         $xmlSchema = <<<EOF
 <database name="test_quick_build_2" namespace="MyNameSpace">
@@ -53,7 +56,7 @@ EOF;
      *
      * @return void
      */
-    public function testGetDatabase($builder)
+    public function testGetDatabase($builder): void
     {
         $database = $builder->getDatabase();
         $this->assertEquals('test_quick_build_2', $database->getName());
@@ -66,7 +69,7 @@ EOF;
      *
      * @return void
      */
-    public function testGetSQL($builder)
+    public function testGetSQL($builder): void
     {
         $expected = <<<EOF
 
@@ -92,7 +95,7 @@ EOF;
      *
      * @return void
      */
-    public function testGetClasses($builder)
+    public function testGetClasses($builder): void
     {
         $script = $builder->getClasses();
         $this->assertStringContainsString('class QuickBuildFoo1 extends BaseQuickBuildFoo1', $script);
@@ -106,7 +109,7 @@ EOF;
      *
      * @return void
      */
-    public function testGetClassesLimitedClassTargets($builder)
+    public function testGetClassesLimitedClassTargets($builder): void
     {
         $script = $builder->getClasses(['tablemap', 'object', 'query']);
         $this->assertStringNotContainsString('class QuickBuildFoo1 extends BaseQuickBuildFoo1', $script);
@@ -120,7 +123,7 @@ EOF;
      *
      * @return void
      */
-    public function testBuildClasses($builder)
+    public function testBuildClasses($builder): void
     {
         $builder->buildClasses();
         $foo = new QuickBuildFoo1();
@@ -131,7 +134,7 @@ EOF;
     /**
      * @return void
      */
-    public function testBuild()
+    public function testBuild(): void
     {
         $xmlSchema = <<<EOF
 <database name="test_quick_build_2" namespace="MyNameSpace2">
@@ -150,5 +153,30 @@ EOF;
         $foo->save();
         $this->assertEquals(1, QuickBuildFoo2Query::create()->count());
         $this->assertEquals($foo, QuickBuildFoo2Query::create()->findOne());
+    }
+
+    public function testBuildOnPhysicalFilesystem(): void
+    {
+        $xmlSchema = <<<EOF
+<database name="test_quick_build_3" namespace="MyNameSpace3">
+    <table name="quick_build_foo_3">
+        <column name="id" primaryKey="true" type="INTEGER" autoIncrement="true"/>
+        <column name="bar" type="INTEGER"/>
+    </table>
+</database>
+EOF;
+        $builder = new QuickBuilder();
+        $builder->setSchema($xmlSchema);
+        $builder->setVfs(false);
+        $builder->build();
+        $this->assertEquals(0, QuickBuildFoo3Query::create()->count());
+        $foo = new QuickBuildFoo3();
+        $foo->setBar(3);
+        $foo->save();
+        $this->assertEquals(1, QuickBuildFoo3Query::create()->count());
+        $this->assertEquals($foo, QuickBuildFoo3Query::create()->findOne());
+
+        $this->assertDirectoryExists(
+            sys_get_temp_dir() . '/propelQuickBuild-' . Propel::VERSION . '-' . substr(sha1(getcwd()), 0, 10));
     }
 }

--- a/tests/Propel/Tests/Runtime/Parser/AbstractParserTest.php
+++ b/tests/Propel/Tests/Runtime/Parser/AbstractParserTest.php
@@ -12,7 +12,7 @@ use Propel\Runtime\Exception\FileNotFoundException;
 use Propel\Runtime\Parser\AbstractParser;
 use Propel\Runtime\Parser\XmlParser;
 use Propel\Tests\TestCase;
-use Propel\Tests\VfsTrait;
+use Propel\Generator\Util\VfsTrait;
 
 /**
  * Test for JsonParser class


### PR DESCRIPTION
Refactor`QuickBuilder` to build classes on virtual filesystem.
This commit introduces the following differences:

-  The built classes are grouped in a single file and written on virtual filesystem, by default. Optionally, it's possible to write them on physical filesystem, for debugging purpose. When we use the physical filesystem, the classes are written in separated files, to make the debug easier. E.g.:
```php
<?php
use Propel\Generator\Util\QuickBuilder;

$schema = '<database>.............</database>';

//---The following builds on virtual filesystem
$builder = new QuickBuilder();
$builder->build($schema);
     // or alternatively
QuickBuilder::buildSchema($schema);


//---The following builds on physical filesystem
$builder = new QuickBuilder();
$builder->setVfs(false);
$builder->build($schema);
     // or alternatively
QuickBuilder::buildSchema($schema, null, null, null, null, false);
```
-  I moved `VfsTrait` from __Tests__  to __Propel\Generator\Util__ namespace, because otherwise PhpStan can't autoload it, rising an error (the more I use PhpStan the more I hate it :smile: ).
-   The refactored code and relative tests are strict typed.