### PR TITLE
Add parameter-dependent psalm return type hint to temporal accessors

### DIFF
--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -894,6 +894,8 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * @return string|{$dateTimeClass}{$orNull} Formatted date/time value as string or $dateTimeClass object (if format is NULL), NULL if column is NULL" . ($handleMysqlDate ? ', and 0 if column value is ' . $mysqlInvalidDateString : '') . "
      *
      * @throws PropelException - if unable to parse/validate the date/time value.
+     *
+     * @psalm-return (\$format is null ? {$dateTimeClass}{$orNull} : string{$orNull})
      */";
     }
 


### PR DESCRIPTION
Please refer to the Psalm documentation for conditional types[^0] for
more information. Although the docs specify that template parameters are
required, the reference-a-variable shorthand for templates also work,
see the [example].

Usually this project seems to prefer `@phpstan-`-prefixes, but this
construct is currently not available to PHPstan[^1].

[^0]: https://psalm.dev/docs/annotating_code/type_syntax/conditional_types/
[^1]: https://github.com/phpstan/phpstan/issues/3853
[example]: https://psalm.dev/r/11cdedd7b3