### PR TITLE
Fix up interface method signature for PHP8+. Fix variable naming.

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -582,8 +582,8 @@
   </file>
   <file src="src/Propel/Runtime/Collection/CollectionIterator.php">
     <InvalidArgument occurrences="2">
-      <code>$cmp_function</code>
-      <code>$cmp_function</code>
+      <code>$callback</code>
+      <code>$callback</code>
     </InvalidArgument>
   </file>
   <file src="src/Propel/Runtime/Connection/StatementWrapper.php">

--- a/src/Propel/Common/Config/Loader/FileLoader.php
+++ b/src/Propel/Common/Config/Loader/FileLoader.php
@@ -82,7 +82,7 @@ abstract class FileLoader extends BaseFileLoader
     }
 
     /**
-     * Get the pathof a given resource
+     * Get the path of a given resource
      *
      * @param string $file The resource
      *
@@ -268,20 +268,20 @@ abstract class FileLoader extends BaseFileLoader
     /**
      * Return the value correspondent to a given key.
      *
-     * @param mixed $property_key The key, in the configuration values array, to return the respective value
+     * @param mixed $propertyKey The key, in the configuration values array, to return the respective value
      *
      * @throws \Propel\Common\Config\Exception\InvalidArgumentException when non-existent key in configuration array
      *
      * @return mixed
      */
-    private function get($property_key)
+    private function get($propertyKey)
     {
         $found = false;
 
-        $ret = $this->getValue($property_key, null, $found);
+        $ret = $this->getValue($propertyKey, null, $found);
 
         if ($found === false) {
-            throw new InvalidArgumentException("Parameter '$property_key' not found in configuration file.");
+            throw new InvalidArgumentException("Parameter '$propertyKey' not found in configuration file.");
         }
 
         return $ret;
@@ -290,26 +290,26 @@ abstract class FileLoader extends BaseFileLoader
     /**
      * Scan recursively an array to find a value of a given key.
      *
-     * @param string $property_key The array key
+     * @param string $propertyKey The array key
      * @param array|null $config The array to scan
      * @param bool $found if the key was found
      *
      * @return mixed The value or null if not found
      */
-    private function getValue($property_key, $config, &$found)
+    private function getValue($propertyKey, $config, &$found)
     {
         if ($config === null) {
             $config = $this->config;
         }
 
         foreach ($config as $key => $value) {
-            if ($key === $property_key) {
+            if ($key === $propertyKey) {
                 $found = true;
 
                 return $value;
             }
             if (is_array($value)) {
-                $ret = $this->getValue($property_key, $value, $found);
+                $ret = $this->getValue($propertyKey, $value, $found);
 
                 if ($ret !== null) {
                     return $ret;

--- a/src/Propel/Generator/Behavior/Delegate/DelegateBehavior.php
+++ b/src/Propel/Generator/Behavior/Delegate/DelegateBehavior.php
@@ -185,7 +185,7 @@ if (method_exists({$ARFQCN}::class, \$name)) {
         $matches = [];
         preg_match('/(\$result = array\(([^;]+)\);)/U', $text, $matches);
         $values = rtrim($matches[2]) . "\n";
-        $new_result = '';
+        $newResult = '';
         $indent = '        ';
 
         foreach ($this->delegates as $key => $value) {
@@ -193,7 +193,7 @@ if (method_exists({$ARFQCN}::class, \$name)) {
 
             $tn = ($delegateTable->getSchema() ? $delegateTable->getSchema() . NameGeneratorInterface::STD_SEPARATOR_CHAR : '') . $delegateTable->getCommonName();
             $ns = $delegateTable->getNamespace() ? '\\' . $delegateTable->getNamespace() : '';
-            $new_result .= "{$indent}\$keys_{$tn} = {$ns}\\Map\\{$delegateTable->getPhpName()}TableMap::getFieldNames(\$keyType);\n";
+            $newResult .= "{$indent}\$keys_{$tn} = {$ns}\\Map\\{$delegateTable->getPhpName()}TableMap::getFieldNames(\$keyType);\n";
             $i = 0;
             foreach ($delegateTable->getColumns() as $column) {
                 if (!$this->isColumnForeignKeyOrDuplicated($column)) {
@@ -203,8 +203,8 @@ if (method_exists({$ARFQCN}::class, \$name)) {
             }
         }
 
-        $new_result .= "{$indent}\$result = array({$values}\n{$indent});";
-        $text = str_replace($matches[1], ltrim($new_result), $text);
+        $newResult .= "{$indent}\$result = array({$values}\n{$indent});";
+        $text = str_replace($matches[1], ltrim($newResult), $text);
         $p->replaceMethod('toArray', $text);
         $script = $p->getCode();
     }

--- a/src/Propel/Generator/Behavior/Sluggable/SluggableBehavior.php
+++ b/src/Propel/Generator/Behavior/Sluggable/SluggableBehavior.php
@@ -376,9 +376,9 @@ protected function makeSlugUnique(\$slug, \$separator = '" . $this->getParameter
         ->prune(\$this)";
 
         if ($this->getParameter('scope_column')) {
-            $scope_column = $this->getColumnForParameter('scope_column')->getPhpName();
+            $scopeColumn = $this->getColumnForParameter('scope_column')->getPhpName();
             $script .= "
-            ->filterBy('{$scope_column}', \$this->get{$scope_column}())";
+            ->filterBy('{$scopeColumn}', \$this->get{$scopeColumn}())";
         }
         // watch out: some of the columns may be hidden by the soft_delete behavior
         if ($this->table->hasBehavior('soft_delete')) {

--- a/src/Propel/Generator/Builder/Util/SchemaReader.php
+++ b/src/Propel/Generator/Builder/Util/SchemaReader.php
@@ -393,13 +393,13 @@ class SchemaReader
 
     /**
      * @param resource $parser
-     * @param string $tag_name
+     * @param string $tagName
      *
      * @throws \Propel\Generator\Exception\SchemaException
      *
      * @return void
      */
-    protected function _throwInvalidTagException($parser, $tag_name)
+    protected function _throwInvalidTagException($parser, $tagName)
     {
         $location = '';
         if ($this->currentXmlFile !== null) {
@@ -411,7 +411,7 @@ class SchemaReader
             $location .= sprintf(', column %d', $col);
         }
 
-        throw new SchemaException(sprintf('Unexpected tag <%s> in %s', $tag_name, $location));
+        throw new SchemaException(sprintf('Unexpected tag <%s> in %s', $tagName, $location));
     }
 
     /**

--- a/src/Propel/Generator/Model/Diff/DatabaseComparator.php
+++ b/src/Propel/Generator/Model/Diff/DatabaseComparator.php
@@ -300,13 +300,13 @@ class DatabaseComparator
      */
     protected function isTableExcluded(Table $table)
     {
-        $tablename = $table->getName();
-        if (in_array($tablename, $this->excludedTables)) {
+        $tableName = $table->getName();
+        if (in_array($tableName, $this->excludedTables)) {
             return true;
         }
 
-        foreach ($this->excludedTables as $exclude_tablename) {
-            if (preg_match('/^' . str_replace('*', '.*', $exclude_tablename) . '$/', $tablename)) {
+        foreach ($this->excludedTables as $excludedTableName) {
+            if (preg_match('/^' . str_replace('*', '.*', $excludedTableName) . '$/', $tableName)) {
                 return true;
             }
         }

--- a/src/Propel/Runtime/Adapter/Pdo/PdoAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/PdoAdapter.php
@@ -51,7 +51,7 @@ abstract class PdoAdapter
 
         // load any driver options from the config file
         // driver options are those PDO settings that have to be passed during the connection construction
-        $driver_options = [];
+        $driverOptions = [];
         if (isset($conparams['options']) && is_array($conparams['options'])) {
             foreach ($conparams['options'] as $option => $optiondata) {
                 $value = $optiondata;
@@ -61,12 +61,12 @@ abstract class PdoAdapter
                     }
                     $value = constant($value);
                 }
-                $driver_options[$option] = $value;
+                $driverOptions[$option] = $value;
             }
         }
 
         try {
-            $con = new PdoConnection($dsn, $user, $password, $driver_options);
+            $con = new PdoConnection($dsn, $user, $password, $driverOptions);
             $this->initConnection($con, isset($conparams['settings']) && is_array($conparams['settings']) ? $conparams['settings'] : []);
         } catch (PDOException $e) {
             throw new AdapterException('Unable to open PDO connection', 0, $e);

--- a/src/Propel/Runtime/Collection/Collection.php
+++ b/src/Propel/Runtime/Collection/Collection.php
@@ -628,7 +628,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
     }
 
     /**
-     * @return \Propel\Common\Pluralizer\PluralizerInterface|null
+     * @return \Propel\Common\Pluralizer\PluralizerInterface
      */
     protected function getPluralizer()
     {

--- a/src/Propel/Runtime/Collection/CollectionIterator.php
+++ b/src/Propel/Runtime/Collection/CollectionIterator.php
@@ -193,14 +193,14 @@ class CollectionIterator extends ArrayIterator
 
     /**
      * @param string $index
-     * @param string $newval
+     * @param string $value
      *
      * @return void
      */
-    public function offsetSet($index, $newval)
+    public function offsetSet($index, $value)
     {
-        $this->collection->offsetSet($index, $newval);
-        parent::offsetSet($index, $newval);
+        $this->collection->offsetSet($index, $value);
+        parent::offsetSet($index, $value);
         $this->refreshPositions();
     }
 
@@ -229,46 +229,46 @@ class CollectionIterator extends ArrayIterator
     }
 
     /**
-     * @param int $sort_flags
+     * @param int $flags
      *
      * @return void
      */
-    public function asort($sort_flags = SORT_REGULAR)
+    public function asort($flags = SORT_REGULAR)
     {
-        parent::asort($sort_flags);
+        parent::asort($flags);
         $this->refreshPositions();
     }
 
     /**
-     * @param int $sort_flags
+     * @param int $flags
      *
      * @return void
      */
-    public function ksort($sort_flags = SORT_REGULAR)
+    public function ksort($flags = SORT_REGULAR)
     {
-        parent::ksort($sort_flags);
+        parent::ksort($flags);
         $this->refreshPositions();
     }
 
     /**
-     * @param string $cmp_function
+     * @param string $callback
      *
      * @return void
      */
-    public function uasort($cmp_function)
+    public function uasort($callback)
     {
-        parent::uasort($cmp_function);
+        parent::uasort($callback);
         $this->refreshPositions();
     }
 
     /**
-     * @param string $cmp_function
+     * @param string $callback
      *
      * @return void
      */
-    public function uksort($cmp_function)
+    public function uksort($callback)
     {
-        parent::uksort($cmp_function);
+        parent::uksort($callback);
         $this->refreshPositions();
     }
 

--- a/src/Propel/Runtime/Connection/StatementInterface.php
+++ b/src/Propel/Runtime/Connection/StatementInterface.php
@@ -87,11 +87,11 @@ interface StatementInterface
     /**
      * Returns a single column from the next row of a result set.
      *
-     * @param int $column_number 0-indexed number of the column you wish to retrieve from the row.
+     * @param int $columnNumber 0-indexed number of the column you wish to retrieve from the row.
      *
      * @return string|null Returns a single column from the next row of a result set or FALSE if there are no more rows.
      */
-    public function fetchColumn($column_number = 0);
+    public function fetchColumn($columnNumber = 0);
 
     /**
      * Returns an array containing all of the result set rows.


### PR DESCRIPTION
With PHP8 and potential use of named arguments, we need to more closely follow core naming of method variables, especially when overriding or extending core classes or interfaces.

I also fixed up some variable naming to proper casing.