### PR TITLE
Bugfix: table alias and regular column name leads to cross join

### DIFF
--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -255,7 +255,7 @@ class Criteria
     /**
      * Default operator for combination of criterions
      *
-     * @see addUsingOperator
+     * @see addUsingOperator()
      * @var string Criteria::LOGICAL_AND or Criteria::LOGICAL_OR
      */
     protected $defaultCombineOperator = Criteria::LOGICAL_AND;

--- a/src/Propel/Runtime/Map/TableMap.php
+++ b/src/Propel/Runtime/Map/TableMap.php
@@ -555,6 +555,28 @@ class TableMap
     }
 
     /**
+     * Tries to find a column by name.
+     *
+     * @param string $name
+     *
+     * @return \Propel\Runtime\Map\ColumnMap|null
+     */
+    public function findColumnByName(string $name): ?ColumnMap
+    {
+        if (isset($this->columnsByPhpName[$name])) {
+            return $this->getColumnByPhpName($name);
+        }
+        if ($this->hasColumn($name, false)) {
+            return $this->getColumn($name, false);
+        }
+        if ($this->hasColumn($name, true)) {
+            return $this->getColumn($name, true);
+        }
+
+        return null;
+    }
+
+    /**
      * Get a ColumnMap[] of the columns in this table.
      *
      * @return \Propel\Runtime\Map\ColumnMap[]

--- a/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaTest.php
@@ -240,6 +240,26 @@ class ModelCriteriaTest extends BookstoreTestBase
         ];
         $this->assertCriteriaTranslation($c, $sql, $params, 'setModelAlias() allows the definition of a true SQL alias after construction');
     }
+    
+    /**
+     * @return void
+     */
+    public function testTrueTableAliasWithOriginalColumnName()
+    {
+        $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
+        $c->setModelAlias('b', true);
+        $c->where('b.title = ?', 'foo');
+        $c->join('b.Author a');
+        $c->where('a.first_name = ?', 'john');
+        
+        $sql = $this->getSql('SELECT  FROM book b INNER JOIN author a ON (b.author_id=a.id) WHERE b.title = :p1 AND a.first_name = :p2');
+        
+        $params = [
+            ['table' => 'book', 'column' => 'title', 'value' => 'foo'],
+            ['table' => 'author', 'column' => 'first_name', 'value' => 'john'],
+        ];
+        $this->assertCriteriaTranslation($c, $sql, $params, 'setModelAlias() allows the definition of a true SQL alias after construction');
+    }
 
     /**
      * @return void

--- a/tests/Propel/Tests/Runtime/Map/TableMapTest.php
+++ b/tests/Propel/Tests/Runtime/Map/TableMapTest.php
@@ -8,6 +8,7 @@
 
 namespace Propel\Tests\Runtime\Map;
 
+use Exception;
 use Propel\Runtime\Collection\ObjectCollection;
 use Propel\Runtime\Map\ColumnMap;
 use Propel\Runtime\Map\DatabaseMap;
@@ -136,6 +137,18 @@ class TableMapTest extends TestCase
         $column1 = $this->tmap->addColumn('BAR', 'Bar', 'INTEGER');
         $column2 = $this->tmap->addColumn('BAZ', 'Baz', 'INTEGER');
         $this->assertEquals(['BAR' => $column1, 'BAZ' => $column2], $this->tmap->getColumns(), 'getColumns returns the columns indexed by name');
+    }
+
+    /**
+     * @return void
+     */
+    public function testFindColumnsByName()
+    {
+        $this->assertNull($this->tmap->findColumnByName('LeName'), 'findColumnByName() should return null on empty map');
+        $column = $this->tmap->addColumn('BAR', 'Bar', 'INTEGER');
+        $this->assertEquals($column, $this->tmap->findColumnByName('BAR'), 'findColumnByName() should find column if regular name matches');
+        $this->assertEquals($column, $this->tmap->findColumnByName('Bar'), 'findColumnByName() should find column if phpName matches');
+        $this->assertEquals($column, $this->tmap->findColumnByName('table.bar'), 'findColumnByName() should try normalizing input name');
     }
 
     /**


### PR DESCRIPTION
Ok, so this drove me nuts for quite a while. When using aliases and regular column names (i.e. a.name instead of a.Name), queries broke horribly, as Propel inserted these columns with a cross join.

Example:

```php
$c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
$c->setModelAlias('b', true);
$c->where('b.title = ?', 'foo');    // note: using title, not Title
$c->join('b.Author a');
$c->where('a.first_name = ?', 'john'); // note: using first_name, not FirstName
```
led to query

```sql
SELECT  
FROM book b 
CROSS JOIN book     -- nooooooo
CROSS JOIN author   -- noooooooooooooo
INNER JOIN author a ON (b.author_id=a.id) 
WHERE b.title = :p1 AND a.first_name = :p2'
```

Same happened with regular query objects. 

Turns out, around line 2100 in ModelCriteria.php, where column literals are resolved, checking if the aliased table name should be used was only done with phpNames, not normal names. This lead to the table being added twice to the from clause, once aliased and once normally, the latter without a join condition, causing the cross join.

Test cases only checked for phpNames, so it wasn't detected.

I kept running into this for quite a while, so I am happy to squash that bugger. Please, please make it go away for good.