### PR TITLE
Feature: Add exists operator

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -431,11 +431,6 @@ parameters:
 			path: src/Propel/Generator/Util/QuickBuilder.php
 
 		-
-			message: "#^Access to an undefined property Propel\\\\Runtime\\\\ActiveQuery\\\\BaseModelCriteria\\:\\:\\$useAliasInSQL\\.$#"
-			count: 1
-			path: src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
-
-		-
 			message: "#^Call to an undefined method Propel\\\\Runtime\\\\ActiveQuery\\\\BaseModelCriteria\\:\\:find\\(\\)\\.$#"
 			count: 1
 			path: src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php

--- a/src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
@@ -29,6 +29,11 @@ class BaseModelCriteria extends Criteria implements IteratorAggregate
     protected $modelTableMapName;
 
     /**
+     * @var bool
+     */
+    protected $useAliasInSQL = false;
+
+    /**
      * @var string|null
      */
     protected $modelAlias;
@@ -258,6 +263,22 @@ class BaseModelCriteria extends Criteria implements IteratorAggregate
     public function getTableMap()
     {
         return $this->tableMap;
+    }
+
+    /**
+     * Returns the name of the table as used in the query.
+     *
+     * Either the SQL name or an alias.
+     *
+     * @return string
+     */
+    public function getTableNameInQuery()
+    {
+        if ($this->useAliasInSQL && $this->modelAlias) {
+            return $this->modelAlias;
+        }
+
+        return $this->getTableMap()->getName();
     }
 
     /**

--- a/src/Propel/Runtime/ActiveQuery/Criterion/ExistsCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/ExistsCriterion.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Runtime\ActiveQuery\Criterion;
+
+use Propel\Runtime\ActiveQuery\ModelJoin;
+use Propel\Runtime\Map\RelationMap;
+
+/**
+ * Specialized Criterion used for EXISTS
+ */
+class ExistsCriterion extends AbstractCriterion
+{
+    public const TYPE_EXISTS = 'EXISTS';
+
+    public const TYPE_NOT_EXISTS = 'NOT EXISTS';
+
+    /**
+     * The inner query of the exists
+     *
+     * @var \Propel\Runtime\ActiveQuery\ModelCriteria
+     */
+    private $existsQuery;
+
+    /**
+     * Build NOT EXISTS instead of EXISTS
+     *
+     * @var string $keyword Either ExistsCriterion::TYPE_EXISTS or ExistsCriterion::TYPE_NOT_EXISTS
+     *
+     * @phpstan-var ExistsCriterion::TYPE_*
+     */
+    private $typeOfExists = self::TYPE_EXISTS;
+
+    /**
+     * @phpstan-param ExistsCriterion::TYPE_*|null $typeOfExists
+     *
+     * @param \Propel\Runtime\ActiveQuery\ModelCriteria $outerQuery
+     * @param \Propel\Runtime\ActiveQuery\ModelCriteria $existsQuery
+     * @param string|null $typeOfExists Either ExistsCriterion::TYPE_EXISTS or ExistsCriterion::TYPE_NOT_EXISTS
+     * @param \Propel\Runtime\Map\RelationMap|null $relationMap where outer query is on the left side
+     */
+    public function __construct($outerQuery, $existsQuery, ?string $typeOfExists = null, ?RelationMap $relationMap = null)
+    {
+        parent::__construct($outerQuery, '', null, null);
+        $this->existsQuery = $existsQuery;
+        $this->typeOfExists = ($typeOfExists === self::TYPE_NOT_EXISTS) ? self::TYPE_NOT_EXISTS : self::TYPE_EXISTS;
+
+        if ($relationMap !== null) {
+            $joinCondition = $this->buildJoinCondition($outerQuery, $relationMap);
+            $this->existsQuery->addAnd($joinCondition);
+        }
+    }
+
+    /**
+     * @see \Propel\Runtime\ActiveQuery\Criterion\AbstractCriterion::appendPsForUniqueClauseTo()
+     *
+     * @param string $sb The string that will receive the Prepared Statement
+     * @param array $params A list to which Prepared Statement parameters will be appended
+     *
+     * @return void
+     */
+    protected function appendPsForUniqueClauseTo(&$sb, array &$params)
+    {
+        $existsQuery = $this->existsQuery
+            ->clearSelectColumns()
+            ->addAsColumn('existsFlag', '1')
+            ->createSelectSql($params);
+        $sb .= $this->typeOfExists . ' (' . $existsQuery . ')';
+    }
+
+    /**
+     * @param \Propel\Runtime\ActiveQuery\ModelCriteria $outerQuery
+     * @param \Propel\Runtime\Map\RelationMap $relationMap where outer query is on the left side
+     *
+     * @return \Propel\Runtime\ActiveQuery\Criterion\AbstractCriterion
+     */
+    protected function buildJoinCondition($outerQuery, RelationMap $relationMap)
+    {
+        $join = new ModelJoin();
+        $outerAlias = $outerQuery->getModelAlias();
+        $innerAlias = $this->existsQuery->getModelAlias();
+        $join->setRelationMap($relationMap, $outerAlias, $innerAlias);
+        $join->buildJoinCondition($outerQuery);
+
+        $joinCondition = $join->getJoinCondition();
+        $joinCondition->setTable($this->existsQuery->getTableNameInQuery());
+
+        return $joinCondition;
+    }
+}

--- a/tests/Propel/Tests/Generator/Builder/Om/QueryBuilderTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/QueryBuilderTest.php
@@ -40,6 +40,7 @@ use Propel\Tests\Bookstore\ReviewQuery;
 use Propel\Tests\Helpers\Bookstore\BookstoreDataPopulator;
 use Propel\Tests\Helpers\Bookstore\BookstoreTestBase;
 use ReflectionMethod;
+use Propel\Runtime\ActiveQuery\Criterion\ExistsCriterion;
 
 /**
  * Test class for QueryBuilder.
@@ -1286,7 +1287,59 @@ class QueryBuilderTest extends BookstoreTestBase
         $q2 = $con->getLastExecutedQuery();
         $this->assertEquals($q1, $q2, 'with() can be used after a call to useFkQuery() with no alias');
     }
-
+    
+    /**
+     * @return void
+     */
+    public function testUseRelationExistsQuery()
+    {
+        $expected = BookQuery::create()
+        ->useExistsQuery('Author')
+        ->filterByFirstName('Leo')
+        ->endUse();
+        $actual = BookQuery::create()
+        ->useAuthorExistsQuery()
+        ->filterByFirstName('Leo')
+        ->endUse();
+        
+        $this->assertEquals($expected, $actual, 'useExistsQuery() is available and calls correct parent method');
+    }
+    
+    /**
+     * @return void
+     */
+    public function testUseRelationNotExistsQuery()
+    {
+        $expected = BookQuery::create()
+        ->useExistsQuery('Author', null, null, ExistsCriterion::TYPE_NOT_EXISTS)
+        ->filterByFirstName('Leo')
+        ->endUse();
+        $actual = BookQuery::create()
+        ->useAuthorNotExistsQuery()
+        ->filterByFirstName('Leo')
+        ->endUse();
+        
+        $this->assertEquals($expected, $actual, 'useNotExistsQuery() is available and calls correct parent method');
+    }
+    
+    /**
+     * @return void
+     */
+    public function testUseRelationExistsQueryWithCustomQueryClass()
+    {
+        $query = BookQuery::create()->useAuthorExistsQuery(null, BookClubListQuery::class, false);
+        $this->assertInstanceOf(BookClubListQuery::class, $query, 'useExistsQuery() passes on given query class');
+    }
+    
+    /**
+     * @return void
+     */
+    public function testUseRelationNotExistsQueryWithCustomQueryClass()
+    {
+        $query = BookQuery::create()->useAuthorNotExistsQuery(null, BookClubListQuery::class);
+        $this->assertInstanceOf(BookClubListQuery::class, $query, 'useNotExistsQuery() passes on given query class');
+    }
+    
     /**
      * @return void
      */

--- a/tests/Propel/Tests/Runtime/ActiveQuery/Criterion/ExistsCriterionTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/Criterion/ExistsCriterionTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Tests\Runtime\ActiveQuery\Criterion;
+
+use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\ActiveQuery\Criterion\ExistsCriterion;
+use Propel\Tests\Bookstore\BookQuery;
+use Propel\Tests\TestCaseFixtures;
+use Propel\Tests\Bookstore\AuthorQuery;
+
+/**
+ * Test class for ExistsCriterion.
+ *
+ * @author Moritz Ringler
+ */
+class ExistsCriterionTest extends TestCaseFixtures
+{
+    /**
+     * @return void
+     */
+    public function testAppendPsToAppendsExistsClause()
+    {
+        $query = BookQuery::create();
+        $exists = new ExistsCriterion(new Criteria(), $query);
+
+        $params = [];
+        $ps = '';
+        $exists->appendPsTo($ps, $params);
+
+        $params2 = [];
+        $innerQueryStatement = $query->createSelectSql($params2);
+
+        $this->assertEquals("EXISTS ($innerQueryStatement)", $ps);
+        $this->assertEquals([], $params);
+    }
+
+    /**
+     * @return void
+     */
+    public function testAppendPsToAppendsNotExistsClause()
+    {
+        $query = BookQuery::create();
+        $exists = new ExistsCriterion(new Criteria(), $query, ExistsCriterion::TYPE_NOT_EXISTS);
+
+        $params = [];
+        $ps = '';
+        $exists->appendPsTo($ps, $params);
+
+        $params2 = [];
+        $innerQueryStatement = $query->createSelectSql($params2);
+
+        $this->assertEquals("NOT EXISTS ($innerQueryStatement)", $ps);
+        $this->assertEquals([], $params);
+    }
+
+    /**
+     * @return void
+     */
+    public function testBuildsRelationConditionDuringInit()
+    {
+        $authorQuery = AuthorQuery::create();
+        $bookQuery = BookQuery::create();
+        $bookRelationMap = $authorQuery->getTableMap()->getRelation('Book');
+        new ExistsCriterion($authorQuery, $bookQuery, ExistsCriterion::TYPE_EXISTS, $bookRelationMap);
+        $params = [];
+        $bookSql = $bookQuery->createSelectSql($params);
+
+        $this->assertEquals('SELECT  FROM book WHERE author.id=book.author_id', $bookSql);
+    }
+
+    /**
+     * @return void
+     */
+    public function testSetsSelectOnInsertQuery()
+    {
+        $authorQuery = AuthorQuery::create();
+        $bookQuery = BookQuery::create();
+        $bookRelationMap = $authorQuery->getTableMap()->getRelation('Book');
+        $exists = new ExistsCriterion($authorQuery, $bookQuery, ExistsCriterion::TYPE_EXISTS, $bookRelationMap);
+
+        $params = [];
+        $ps = '';
+        $exists->appendPsTo($ps, $params);
+        $bookSql = $bookQuery->createSelectSql($params);
+
+        $this->assertEquals('SELECT 1 AS existsFlag FROM book WHERE author.id=book.author_id', $bookSql);
+    }
+}

--- a/tests/Propel/Tests/Runtime/ActiveQuery/ExistsTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/ExistsTest.php
@@ -1,0 +1,277 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Tests\Runtime\ActiveQuery;
+
+use Exception;
+use Propel\Tests\Bookstore\Author;
+use Propel\Tests\Bookstore\AuthorQuery;
+use Propel\Tests\Bookstore\Book;
+use Propel\Tests\Bookstore\BookQuery;
+use Propel\Tests\Bookstore\Essay;
+use Propel\Tests\Bookstore\Publisher;
+use Propel\Tests\Bookstore\PublisherQuery;
+use Propel\Tests\Helpers\Bookstore\BookstoreTestBase;
+
+/**
+ * Test class for Exists.
+ *
+ * @author Moritz Ringler
+ *
+ * @group database
+ */
+class ExistsTest extends BookstoreTestBase
+{
+    /**
+     * @return void
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        require_once __DIR__ . DIRECTORY_SEPARATOR . 'ExistsTestClasses.php';
+    }
+
+    /**
+     * @return void
+     */
+    public function testWhereExists()
+    {
+        [$author1, $author2, $author3] = $this->createTestData();
+        // all authors with at least one good book
+        $existsQueryCriteria = BookQuery::create()->filterByTitle('good')->where('Book.AuthorId = Author.Id');
+        $authors = AuthorQuery::create()->whereExists($existsQueryCriteria)->find($this->con)->getData();
+
+        $this->assertEquals([$author1, $author3], $authors);
+    }
+
+    /**
+     * @return void
+     */
+    public function testWhereNotExists()
+    {
+        [$author1, $author2, $author3, $author4] = $this->createTestData();
+        // all authors with no bad book
+        $existsQueryCriteria = BookQuery::create()->filterByTitle('bad')->where('Book.AuthorId = Author.Id');
+        $authors = AuthorQuery::create()->whereNotExists($existsQueryCriteria)->find($this->con)->getData();
+
+        $this->assertEquals([$author3, $author4], $authors);
+    }
+
+    /**
+     * @return void
+     */
+    public function testCustomExistsOnNonrelatedTables()
+    {
+        [$author1] = $this->createTestData();
+        PublisherQuery::create()->deleteAll($this->con);
+        $publisher = new Publisher();
+        $publisher->setName($author1->getLastName())->save($this->con);
+        (new Publisher())->setName('Random Horse')->save($this->con);
+        // all publishers with name of an author
+        $existsQueryCriteria = AuthorQuery::create()->where('Author.LastName = Publisher.Name');
+        $publishers = PublisherQuery::create()->whereExists($existsQueryCriteria)->find($this->con)->getData();
+
+        $this->assertEquals([$publisher], $publishers);
+    }
+
+    /**
+     * @return void
+     */
+    public function testUseExistsQueryReturnsSecondaryQuery()
+    {
+        $query = AuthorQuery::create()->useExistsQuery('Book');
+        $this->assertInstanceOf(BookQuery::class, $query);
+    }
+    
+    /**
+     * @return void
+     */
+    public function testUseExistsQueryWithSpecificClassReturnsCorrectClass()
+    {
+        new GoodBookQuery();
+        $query = AuthorQuery::create()->useExistsQuery('Book', null, GoodBookQuery::class);
+        $this->assertInstanceOf(GoodBookQuery::class, $query);
+    }
+
+    /**
+     * @return void
+     */
+    public function testUseExistsQuery()
+    {
+        [$author1, $author2, $author3] = $this->createTestData();
+        // all authors with at least one good book
+        $authors = AuthorQuery::create()
+        ->useExistsQuery('Book')
+        ->filterByTitle('good')
+        ->endUse()
+        ->find($this->con)
+        ->getData();
+
+        $this->assertEquals([$author1, $author3], $authors);
+    }
+
+    /**
+     * @return void
+     */
+    public function testUseNotExistsQuery()
+    {
+        [$author1, $author2, $author3, $author4] = $this->createTestData();
+        // all authors with no bad book
+        $authors = AuthorQuery::create()
+        ->useNotExistsQuery('Book')
+        ->filterByTitle('bad')
+        ->endUse()
+        ->find($this->con)
+        ->getData();
+
+        $this->assertEquals([$author3, $author4], $authors);
+    }
+
+    /**
+     * @return void
+     */
+    public function testUseExistsQueryWithAlias()
+    {
+        [$author1, $author2] = $this->createTestData();
+        // books of authors who have written more than one books (dummy query)
+        $books = BookQuery::create('outerBook')
+        ->useAuthorQuery()
+        ->useExistsQuery('Book', 'innerBook')
+        ->where('outerBook.id != innerBook.Id')
+        ->endUse()
+        ->endUse()
+        ->find($this->con)
+        ->getData();
+        $this->assertCount($author1->countBooks(null, false, $this->con) + $author2->countBooks(null, false, $this->con), $books);
+    }
+
+    /**
+     * @return void
+     */
+    public function testUseExistsAndWithQuery()
+    {
+        $this->createTestData();
+        // all books of authors with at least one good book
+        $query = BookQuery::create()
+        ->joinWithAuthor()
+        ->useAuthorQuery()
+        ->useExistsQuery('Book')
+        ->filterByTitle('good')
+        ->endUse()
+        ->endUse();
+
+        $expectedSql =
+        'SELECT book.id, book.title, book.isbn, book.price, book.publisher_id, book.author_id, author.id, author.first_name, author.last_name, author.email, author.age '
+            . 'FROM book LEFT JOIN author ON (book.author_id=author.id) '
+                . 'WHERE EXISTS (SELECT 1 AS existsFlag FROM book WHERE author.id=book.author_id AND book.title=:p1)';
+                $params = [];
+                $this->assertEquals($expectedSql, $query->createSelectSql($params));
+
+                $books = $query->find($this->con)->getData();
+                $this->assertCount(4, $books);
+    }
+
+    /**
+     * @return void
+     */
+    public function testUseExistsQueryWithSpecificClass()
+    {
+        [$author1, $author2, $author3] = $this->createTestData();
+     // all authors with at least one good book according to GoodBookQuery
+        $authors = AuthorQuery::create()
+        ->useExistsQuery('Book', null, GoodBookQuery::class)
+        ->filterByIsGood()
+        ->endUse()
+        ->find($this->con)
+        ->getData();
+
+        $this->assertEquals([$author1, $author3], $authors);
+    }
+
+    /**
+     * @return void
+     */
+    public function testUseExistsQueryCanNestUseQuery()
+    {
+        [$author1, $author2, $author3] = $this->createTestData();
+        (new Essay())->setFirstAuthor($author1)->setTitle('leEssay')->save($this->con);
+        (new Essay())->setFirstAuthor($author1)->setTitle('leEssay')->save($this->con);
+        (new Essay())->setFirstAuthor($author3)->setTitle('leEssay')->save($this->con);
+
+        // all books of authors who are first author of an essay called 'leEssay'
+        $books = BookQuery::create()
+        ->useExistsQuery('Author')
+        ->useEssayRelatedByFirstAuthorIdQuery()
+        ->filterByTitle('leEssay')
+        ->endUse()
+        ->endUse()
+        ->find($this->con)
+        ->getData();
+
+        $this->assertCount($author1->countBooks(null, false, $this->con) + $author3->countBooks(null, false, $this->con), $books);
+    }
+
+    /**
+     * @return void
+     */
+    public function testUseExistsQueryDoesNotMergeWithOuterQuery()
+    {
+        $sawException = false;
+        $innerBookQuery = ExceptionOnMergeAuthorQuery::create()->useExistsQuery('Book');
+        try {
+            $innerBookQuery->endUse();
+        } catch (Exception $e) {
+            $sawException = true;
+        }
+        $this->assertFalse($sawException, 'endUse() should not call mergeWidth');
+    }
+
+    /**
+     * Creates and returns four authors, one and three have a good book, one and two have a bad book, four has no book
+     *
+     * @return \Propel\Tests\Bookstore\Author[]
+     */
+    private function createTestData()
+    {
+        BookQuery::create()->deleteAll($this->con);
+        AuthorQuery::create()->deleteAll($this->con);
+
+        $author1 = $this->createAuthor('LeAuthor1');
+        $this->createBook($author1);
+        $this->createBook($author1, 1);
+        $this->createBook($author1, 1);
+
+        $author2 = $this->createAuthor('LeAuthor2');
+        $this->createBook($author2);
+        $this->createBook($author2);
+
+        $author3 = $this->createAuthor('LeAuthor3');
+        $this->createBook($author3, 1);
+
+        $author4 = $this->createAuthor('LeAuthor4');
+
+        return [$author1, $author2, $author3, $author4];
+    }
+
+    private function createAuthor(string $lastName, string $firstname = 'LeDefaultFirstname')
+    {
+        $author = new Author();
+        $author->setLastName($lastName)->setFirstName($firstname)->save($this->con);
+
+        return $author;
+    }
+
+    private function createBook(Author $author, $isGood = false)
+    {
+        $title = ($isGood) ? 'good' : 'bad';
+        $book = new Book();
+        $book->setTitle($title)->setAuthor($author)->setISBN('123')->save($this->con);
+
+        return $book;
+    }
+}

--- a/tests/Propel/Tests/Runtime/ActiveQuery/ExistsTestClasses.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/ExistsTestClasses.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Tests\Runtime\ActiveQuery;
+
+use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Tests\Bookstore\AuthorQuery;
+use Propel\Tests\Bookstore\BookQuery;
+
+class GoodBookQuery extends BookQuery
+{
+    public function filterByIsGood(): GoodBookQuery
+    {
+        return $this->filterByTitle('good');
+    }
+}
+
+class ExceptionOnMergeAuthorQuery extends AuthorQuery
+{
+    public function mergeWith(Criteria $criteria, $operator = null)
+    {
+        throw new \Exception('nodontmerge');
+    }
+}

--- a/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaTest.php
@@ -85,6 +85,18 @@ class ModelCriteriaTest extends BookstoreTestBase
     /**
      * @return void
      */
+    public function testGetTableNameInQuery()
+    {
+        $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
+        $this->assertEquals('book', $c->getTableNameInQuery());
+
+        $c->setModelAlias('b', true);
+        $this->assertEquals('b', $c->getTableNameInQuery());
+    }
+
+    /**
+     * @return void
+     */
     public function testFormatter()
     {
         $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
@@ -2933,7 +2945,9 @@ class ModelCriteriaTest extends BookstoreTestBase
         $c1->leftJoinWith('b.Author a');
         $c2 = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Author');
         $c1->mergeWith($c2);
-        $this->assertCount(1, array_filter($c1->getSelectColumns(), function($v) { return BookTableMap::COL_ID == $v; }), '$c1 criteria has selected Book columns twice');
+        $this->assertCount(1, array_filter($c1->getSelectColumns(), function ($v) {
+            return BookTableMap::COL_ID == $v;
+        }), '$c1 criteria has selected Book columns twice');
         $with = $c1->getWith();
         $this->assertEquals(1, count($with), 'mergeWith() does not remove an existing join');
         $this->assertEquals('modelName: Propel\Tests\Bookstore\Author, relationName: Author, relationMethod: setAuthor, leftPhpName: , rightPhpName: a', $with['a']->__toString(), 'mergeWith() does not remove an existing join');
@@ -2942,7 +2956,9 @@ class ModelCriteriaTest extends BookstoreTestBase
         $c1->leftJoinWith('b.Author a');
         $c2 = new ModelCriteria('bookstore', '\Propel\Tests\Bookstore\Author');
         $c1->mergeWith($c2);
-        $this->assertCount(1, array_filter($c1->getSelectColumns(), function($v) { return BookTableMap::COL_ID == $v; }), '$c1 criteria has selected Book columns twice');
+        $this->assertCount(1, array_filter($c1->getSelectColumns(), function ($v) {
+            return BookTableMap::COL_ID == $v;
+        }), '$c1 criteria has selected Book columns twice');
         $with = $c1->getWith();
         $this->assertEquals(1, count($with), 'mergeWith() does not remove an existing join');
         $this->assertEquals('modelName: Propel\Tests\Bookstore\Author, relationName: Author, relationMethod: setAuthor, leftPhpName: , rightPhpName: a', $with['a']->__toString(), 'mergeWith() does not remove an existing join');
@@ -2951,7 +2967,9 @@ class ModelCriteriaTest extends BookstoreTestBase
         $c2 = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book', 'b');
         $c2->leftJoinWith('b.Author a');
         $c1->mergeWith($c2);
-        $this->assertCount(1, array_filter($c1->getSelectColumns(), function($v) { return BookTableMap::COL_ID == $v; }), '$c1 criteria has selected Book columns twice');
+        $this->assertCount(1, array_filter($c1->getSelectColumns(), function ($v) {
+            return BookTableMap::COL_ID == $v;
+        }), '$c1 criteria has selected Book columns twice');
         $with = $c1->getWith();
         $this->assertEquals(1, count($with), 'mergeWith() merge joins to an empty join');
         $this->assertEquals('modelName: Propel\Tests\Bookstore\Author, relationName: Author, relationMethod: setAuthor, leftPhpName: , rightPhpName: a', $with['a']->__toString(), 'mergeWith() merge joins to an empty join');
@@ -2961,7 +2979,9 @@ class ModelCriteriaTest extends BookstoreTestBase
         $c2 = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book', 'b');
         $c2->innerJoinWith('b.Publisher p');
         $c1->mergeWith($c2);
-        $this->assertCount(1, array_filter($c1->getSelectColumns(), function($v) { return BookTableMap::COL_ID == $v; }), '$c1 criteria has selected Book columns twice');
+        $this->assertCount(1, array_filter($c1->getSelectColumns(), function ($v) {
+            return BookTableMap::COL_ID == $v;
+        }), '$c1 criteria has selected Book columns twice');
         $with = $c1->getWith();
         $this->assertEquals(2, count($with), 'mergeWith() merge joins to an existing join');
         $this->assertEquals('modelName: Propel\Tests\Bookstore\Author, relationName: Author, relationMethod: setAuthor, leftPhpName: , rightPhpName: a', $with['a']->__toString(), 'mergeWith() merge joins to an empty join');


### PR DESCRIPTION
Did you realize, there is no possibility to do EXISTS in Propel, except through `->where('EXISTS (...))`, which has its own caveats (buggy, no query logic). So I had a look at how this probably should work, and it actually went ahead pretty quickly.
These changes allow to create exist queries in two ways:

First one is through regular useQuery logic, same as with the other high-level Propel statements. The relation condition is added to the inner query (in the example author.Id = book.author_id):  
```php
BookQuery::create()
->useAuthorExistsQuery()    // or ->useExistsQuery('Author')
  ->filterBy...
->endUse()
```

Second one is more basic, where a nested query is set as exists query. Here, any table can be used, but the filter in the exists-query must be added manually:
```php
$existsQuery = BookQuery::create()
->filterBy...
->where('Book.AuthorId = Author.Id'); // own join condition in where

AuthorQuery::create()
->whereExists($existsQuery)
```
As exists is such a basic part of SQL, I feel like there are lots of ways to use it which will not work with this implementation (yet). So it might need more refinement over time. Tests run through fine, but if you find anything, please let me know. Same goes for any feedback, of course.