### PR TITLE
Bugfix: reset partial flag when populating a relation

### DIFF
--- a/src/Propel/Runtime/Collection/ObjectCollection.php
+++ b/src/Propel/Runtime/Collection/ObjectCollection.php
@@ -379,8 +379,10 @@ class ObjectCollection extends Collection
         if ($relationMap->getType() === RelationMap::ONE_TO_MANY) {
             // initialize the embedded collections of the main objects
             $relationName = $relationMap->getName();
+            $resetPartialStatusMethod = 'resetPartial' . $relationMap->getPluralName();
             foreach ($this as $mainObj) {
                 $mainObj->initRelation($relationName);
+                $mainObj->$resetPartialStatusMethod(false);
             }
             // associate the related objects to the main objects
             $getMethod = 'get' . $symRelationMap->getName();


### PR DESCRIPTION
Another day, another merge request. Hope this isn't unwelcome.

This is a small one: Calling `ObjectCollection->populateRelation()` does not reset the partial flag, which leads to consecutive queries on an already initialized relation. So if a data object with a partially loaded relation is retrieved from instance pooling, `populateRelation()` loads the relation data, but when accessing the data, another reload is triggered.

Simple example:
```php
$book = BookQuery::create()
->leftJoinWithAuthor() // will create a partially loaded book relation on autor object
->findOne();

$authors = AuthorQuery::create()->find(); // already loaded author object will be retrieved from cache 
$authors->populateRelation('Book'); // loads all books

$book->getAuthor()->getBooks(); // loads books again when relation is still marked as partial
```

**Why this matters:** Apart from being inconsistent, this significantly reduces performance in some scenarios, where the bug can easily cause 100+ unexpected queries.
For example, in my project, I have patients and their relatives. You can search in both groups at the same time. The generated view lists for each patient (among other data) the name of the patient's relatives, and relatives do the same with patient names. So I do something like this:
```php
$patients = PatientQuery::create()->findBy($searchTerm);
$patients->populateRelation('Relatives');     // Prefetch associated relatives, they are initialized with a partial "Patient" relation 

$relatives = RelativesQuery::create()->findBy($searchTerm); // Some of them are already cached and won't be re-initialized
$relatives->populateRelation('Patients');     // All patients are loaded, but "partial" flag is not updated
...
foreach($relatives as $relative) {
    $relative->getPatients(); // Causes an additional query for each relative where "Patient" relation is marked partial, despite populateRelation
}
```
In my case, this causes literally hundreds of unnecessary queries, even though I specifically use `populateRelation` to avoid a n+1 scenario.