### PR TITLE
Tests cleanup

### DIFF
--- a/tests/Propel/Tests/Generator/Behavior/NestedSet/NestedSetBehaviorQueryBuilderModifierWithScopeTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/NestedSet/NestedSetBehaviorQueryBuilderModifierWithScopeTest.php
@@ -194,6 +194,7 @@ class NestedSetBehaviorQueryBuilderModifierWithScopeTest extends TestCase
      */
     public function testAncestorsOf()
     {
+        $this->markTestIncomplete();
         [$t1, $t2, $t3, $t4, $t5, $t6, $t7, $t8, $t9, $t10] = $this->initTreeWithScope();
         /* Tree used for tests
          Scope 1
@@ -233,6 +234,7 @@ class NestedSetBehaviorQueryBuilderModifierWithScopeTest extends TestCase
      */
     public function testRootsOf()
     {
+        $this->markTestIncomplete();
         [$t1, $t2, $t3, $t4, $t5, $t6, $t7, $t8, $t9, $t10] = $this->initTreeWithScope();
         /* Tree used for tests
          Scope 1

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectWithFixturesTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectWithFixturesTest.php
@@ -186,6 +186,8 @@ class GeneratedObjectWithFixturesTest extends BookstoreEmptyTestBase
      * This is a test for expected exceptions when saving UNIQUE.
      * See http://propel.phpdb.org/trac/ticket/2
      *
+     * @doesNotPerformAssertions
+     *
      * @return void
      */
     public function testSaveUnique()

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedQueryDoDeleteTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedQueryDoDeleteTest.php
@@ -8,6 +8,7 @@
 
 namespace Propel\Tests\Generator\Builder\Om;
 
+use Exception;
 use Propel\Runtime\ActiveQuery\Criteria;
 use Propel\Runtime\Propel;
 use Propel\Tests\Bookstore\AuthorQuery;
@@ -451,6 +452,8 @@ class GeneratedQueryDoDeleteTest extends BookstoreEmptyTestBase
 
     /**
      * Test passing null values to removeInstanceFromPool().
+     *
+     * @doesNotPerformAssertions
      *
      * @return void
      */

--- a/tests/Propel/Tests/Generator/Builder/Om/QueryBuilderInheritanceTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/QueryBuilderInheritanceTest.php
@@ -185,6 +185,8 @@ class QueryBuilderInheritanceTest extends BookstoreTestBase
     /**
      * This test prove failure with propel.emulateForeignKeyConstraints = true
      *
+     * @doesNotPerformAssertions
+     *
      * @return void
      */
     public function testDeleteCascadeWithAbstractSingleTableInheritance()

--- a/tests/Propel/Tests/Generator/Migration/BaseTest.php
+++ b/tests/Propel/Tests/Generator/Migration/BaseTest.php
@@ -231,7 +231,7 @@ class BaseTest extends MigrationTestCase
     <table name="migration_test_3">
         <column name="field1" type="CHAR" size="5"/>
 
-        <column name="field2" type="INTEGER" size="6"/>
+        <column name="field2" type="VARCHAR" size="6"/>
         <column name="field3" type="BIGINT"/>
         <column name="field4" type="REAL"/>
         <column name="field5" type="FLOAT"/>
@@ -256,7 +256,7 @@ class BaseTest extends MigrationTestCase
     <table name="migration_test_3">
         <column name="field1" type="CHAR" size="5"/>
 
-        <column name="field2" type="INTEGER" size="12"/>
+        <column name="field2" type="VARCHAR" size="12"/>
         <column name="field3" type="REAL"/>
         <column name="field4" type="FLOAT"/>
         <column name="field5" type="DOUBLE"/>

--- a/tests/Propel/Tests/Issues/Issue829Test.php
+++ b/tests/Propel/Tests/Issues/Issue829Test.php
@@ -45,6 +45,8 @@ class Issue829Test extends TestCase
      * that can be serialized but cannot be casted to a string (f.in. \DateTime)
      */
     /**
+     * @doesNotPerformAssertions
+     *
      * @return void
      */
     public function testAddingToInstancePool()

--- a/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaTest.php
@@ -2774,9 +2774,13 @@ class ModelCriteriaTest extends BookstoreTestBase
     public function testMagicGroupBy()
     {
         $con = Propel::getServiceContainer()->getConnection(BookTableMap::DATABASE_NAME);
+        if( $this->runningOnMySQL())
+        {
+            $con->exec('SET SESSION sql_mode = "TRADITIONAL"');
+        }
 
         $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
-        $books = $c->groupByTitle()->find($con);
+        $c->groupByTitle()->find($con);
 
         if ($this->isDb('pgsql')) {
             $expectedSQL = 'SELECT book.id, book.title, book.isbn, book.price, book.publisher_id, book.author_id FROM book GROUP BY book.title,book.id,book.isbn,book.price,book.publisher_id,book.author_id';
@@ -3261,6 +3265,8 @@ class ModelCriteriaTest extends BookstoreTestBase
     }
 
     /**
+     * @doesNotPerformAssertions
+     *
      * @return void
      */
     public function testJoinSelectColumn()

--- a/tests/Propel/Tests/Runtime/ActiveQuery/QuotingTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/QuotingTest.php
@@ -143,6 +143,7 @@ class QuotingTest extends TestCaseFixturesDatabase
         if ($this->runningOnPostgreSQL()) {
             $expected = $this->getSql('SELECT g.id, g.name, g.type_id FROM quoting_author g GROUP BY g.id,g.name,g.type_id HAVING g.id > 0');
         } else {
+            // note that this only works with MySQL because the query return no data, otherwise an "Expression of SELECT list is not in GROUP BY" error would be thrown
             $expected = $this->getSql('SELECT g.id, g.name, g.type_id FROM quoting_author g GROUP BY g.id HAVING g.id > 0');
         }
         $this->assertEquals($expected, $this->getLastQuery());
@@ -167,10 +168,15 @@ class QuotingTest extends TestCaseFixturesDatabase
      */
     public function testHaving()
     {
+        $con = Propel::getServiceContainer()->getConnection(GroupTableMap::DATABASE_NAME);
+        if( $this->runningOnMySQL())
+        {
+            $con->exec('SET SESSION sql_mode = "TRADITIONAL"');
+        }
         GroupQuery::create()
         ->groupBy('group.As')
         ->having('group.As > 0')
-        ->find();
+        ->find($con);
 
         if ($this->runningOnPostgreSQL()) {
             $expected = $this->getSql('SELECT `group`.`id`, `group`.`title`, `group`.`by`, `group`.`as`, `group`.`author_id` FROM `group` GROUP BY `group`.`as`,`group`.`id`,`group`.`title`,`group`.`by`,`group`.`author_id` HAVING `group`.`as` > 0');

--- a/tests/Propel/Tests/Runtime/Connection/PropelPDOTest.php
+++ b/tests/Propel/Tests/Runtime/Connection/PropelPDOTest.php
@@ -16,7 +16,6 @@ use PDOException;
 use Propel\Runtime\ActiveQuery\Criteria;
 use Propel\Runtime\Connection\Exception\RollbackException;
 use Propel\Runtime\Connection\PropelPDO;
-use Propel\Runtime\Propel;
 use Propel\Tests\Bookstore\Author;
 use Propel\Tests\Bookstore\AuthorQuery;
 use Propel\Tests\Bookstore\BookQuery;
@@ -36,14 +35,8 @@ class PropelPDOTest extends BookstoreTestBase
      */
     protected function setUp(): void
     {
-        $this->con = Propel::getServiceContainer()->getConnection(BookTableMap::DATABASE_NAME);
-    }
-
-    /**
-     * @return void
-     */
-    protected function tearDown(): void
-    {
+        parent::setUp();
+        $this->con->commit(); // parent setup starts a transaction, but we want to start our own
     }
 
     /**
@@ -51,7 +44,7 @@ class PropelPDOTest extends BookstoreTestBase
      */
     public function testSetAttribute()
     {
-        $con = Propel::getServiceContainer()->getConnection(BookTableMap::DATABASE_NAME);
+        $con = $this->con;
         $this->assertFalse($con->getAttribute(PropelPDO::PROPEL_ATTR_CACHE_PREPARES));
         $con->setAttribute(PropelPDO::PROPEL_ATTR_CACHE_PREPARES, true);
         $this->assertTrue($con->getAttribute(PropelPDO::PROPEL_ATTR_CACHE_PREPARES));
@@ -65,7 +58,7 @@ class PropelPDOTest extends BookstoreTestBase
      */
     public function testCommitBeforeFetch()
     {
-        $con = Propel::getServiceContainer()->getConnection(BookTableMap::DATABASE_NAME);
+        $con = $this->con;
         AuthorTableMap::doDeleteAll($con);
         $a = new Author();
         $a->setFirstName('Test');
@@ -79,7 +72,6 @@ class PropelPDOTest extends BookstoreTestBase
         $con->commit();
         $authorArr = [0 => 'Test', 1 => 'User'];
 
-        $i = 0;
         try {
             $row = $stmt->fetch(PDO::FETCH_NUM);
             $stmt->closeCursor();
@@ -90,11 +82,13 @@ class PropelPDOTest extends BookstoreTestBase
     }
 
     /**
+     * @doesNotPerformAssertions
+     *
      * @return void
      */
     public function testPdoSignature()
     {
-        $con = Propel::getServiceContainer()->getConnection(BookTableMap::DATABASE_NAME);
+        $con = $this->con;
         $stmt = $con->prepare('SELECT author.FIRST_NAME, author.LAST_NAME FROM author');
         $stmt->execute();
         $stmt->fetchAll(PDO::FETCH_COLUMN, 0); // should not throw exception: Third parameter not allowed for PDO::FETCH_COLUMN
@@ -118,7 +112,7 @@ class PropelPDOTest extends BookstoreTestBase
      */
     public function testCommitAfterFetch()
     {
-        $con = Propel::getServiceContainer()->getConnection(BookTableMap::DATABASE_NAME);
+        $con = $this->con;
         AuthorTableMap::doDeleteAll($con);
         $a = new Author();
         $a->setFirstName('Test');
@@ -131,7 +125,6 @@ class PropelPDOTest extends BookstoreTestBase
         $stmt->execute();
         $authorArr = [0 => 'Test', 1 => 'User'];
 
-        $i = 0;
         $row = $stmt->fetch(PDO::FETCH_NUM);
         $stmt->closeCursor();
         $con->commit();
@@ -143,8 +136,7 @@ class PropelPDOTest extends BookstoreTestBase
      */
     public function testNestedTransactionCommit()
     {
-        $con = Propel::getServiceContainer()->getConnection(BookTableMap::DATABASE_NAME);
-        $driver = $con->getAttribute(PDO::ATTR_DRIVER_NAME);
+        $con = $this->con;
 
         $this->assertEquals(0, $con->getNestedTransactionCount(), 'nested transaction is equal to 0 before transaction');
         $this->assertFalse($con->isInTransaction(), 'PropelPDO is not in transaction by default');
@@ -209,8 +201,7 @@ class PropelPDOTest extends BookstoreTestBase
      */
     public function testNestedTransactionRollBackRethrow()
     {
-        $con = Propel::getServiceContainer()->getConnection(BookTableMap::DATABASE_NAME);
-        $driver = $con->getAttribute(PDO::ATTR_DRIVER_NAME);
+        $con = $this->con;
 
         $con->beginTransaction();
         try {
@@ -263,8 +254,7 @@ class PropelPDOTest extends BookstoreTestBase
      */
     public function testNestedTransactionRollBackSwallow()
     {
-        $con = Propel::getServiceContainer()->getConnection(BookTableMap::DATABASE_NAME);
-        $driver = $con->getAttribute(PDO::ATTR_DRIVER_NAME);
+        $con = $this->con;
 
         $con->beginTransaction();
         try {
@@ -321,8 +311,7 @@ class PropelPDOTest extends BookstoreTestBase
      */
     public function testNestedTransactionForceRollBack()
     {
-        $con = Propel::getServiceContainer()->getConnection(BookTableMap::DATABASE_NAME);
-        $driver = $con->getAttribute(PDO::ATTR_DRIVER_NAME);
+        $con = $this->con;
 
         // main transaction
         $con->beginTransaction();
@@ -360,7 +349,7 @@ class PropelPDOTest extends BookstoreTestBase
      */
     public function testLatestQuery()
     {
-        $con = Propel::getServiceContainer()->getConnection(BookTableMap::DATABASE_NAME);
+        $con = $this->con;
         $con->setLastExecutedQuery(123);
         $this->assertEquals(123, $con->getLastExecutedQuery(), 'PropelPDO has getter and setter for last executed query');
     }
@@ -370,10 +359,10 @@ class PropelPDOTest extends BookstoreTestBase
      */
     public function testLatestQueryMoreThanTenArgs()
     {
-        $con = Propel::getServiceContainer()->getConnection(BookTableMap::DATABASE_NAME);
+        $con = $this->con;
         $c = new Criteria();
         $c->add(BookTableMap::COL_ID, [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1], Criteria::IN);
-        $books = BookQuery::create(null, $c)->find($con);
+        BookQuery::create(null, $c)->find($con);
         $expected = $this->getSql('SELECT book.id, book.title, book.isbn, book.price, book.publisher_id, book.author_id FROM book WHERE book.id IN (1,1,1,1,1,1,1,1,1,1,1,1)');
         $this->assertEquals($expected, $con->getLastExecutedQuery(), 'PropelPDO correctly replaces arguments in queries');
     }
@@ -383,7 +372,7 @@ class PropelPDOTest extends BookstoreTestBase
      */
     public function testQueryCount()
     {
-        $con = Propel::getServiceContainer()->getConnection(BookTableMap::DATABASE_NAME);
+        $con = $this->con;
         $count = $con->getQueryCount();
         $con->incrementQueryCount();
         $this->assertEquals($count + 1, $con->getQueryCount(), 'PropelPDO has getter and incrementer for query count');
@@ -394,7 +383,7 @@ class PropelPDOTest extends BookstoreTestBase
      */
     public function testUseDebug()
     {
-        $con = Propel::getServiceContainer()->getConnection(BookTableMap::DATABASE_NAME);
+        $con = $this->con;
         $con->useDebug(false);
         $stmtClass = $con->getAttribute(PDO::ATTR_STATEMENT_CLASS);
         $expectedClass = defined('HHVM_VERSION') ? '\PdoStatement' : 'PDOStatement';
@@ -410,18 +399,18 @@ class PropelPDOTest extends BookstoreTestBase
      */
     public function testDebugLatestQuery()
     {
-        $con = Propel::getServiceContainer()->getConnection(BookTableMap::DATABASE_NAME);
+        $con = $this->con;
         $c = new Criteria();
         $c->add(BookTableMap::COL_TITLE, 'Harry%s', Criteria::LIKE);
 
         $con->useDebug(false);
         $this->assertEquals('', $con->getLastExecutedQuery(), 'PropelPDO reinitializes the latest query when debug is set to false');
 
-        $books = BookQuery::create(null, $c)->find($con);
+        BookQuery::create(null, $c)->find($con);
         $this->assertEquals('', $con->getLastExecutedQuery(), 'PropelPDO does not update the last executed query when useLogging is false');
 
         $con->useDebug(true);
-        $books = BookQuery::create(null, $c)->find($con);
+        BookQuery::create(null, $c)->find($con);
         $latestExecutedQuery = $this->getSql("SELECT book.id, book.title, book.isbn, book.price, book.publisher_id, book.author_id FROM book WHERE book.title LIKE 'Harry%s'");
         $this->assertEquals($latestExecutedQuery, $con->getLastExecutedQuery(), 'PropelPDO updates the last executed query when useLogging is true');
 
@@ -453,18 +442,18 @@ class PropelPDOTest extends BookstoreTestBase
      */
     public function testDebugQueryCount()
     {
-        $con = Propel::getServiceContainer()->getConnection(BookTableMap::DATABASE_NAME);
+        $con = $this->con;
         $c = new Criteria();
         $c->add(BookTableMap::COL_TITLE, 'Harry%s', Criteria::LIKE);
 
         $con->useDebug(false);
         $this->assertEquals(0, $con->getQueryCount(), 'PropelPDO does not update the query count when useLogging is false');
 
-        $books = BookQuery::create(null, $c)->find($con);
+        BookQuery::create(null, $c)->find($con);
         $this->assertEquals(0, $con->getQueryCount(), 'PropelPDO does not update the query count when useLogging is false');
 
         $con->useDebug(true);
-        $books = BookQuery::create(null, $c)->find($con);
+        BookQuery::create(null, $c)->find($con);
         $this->assertEquals(1, $con->getQueryCount(), 'PropelPDO updates the query count when useLogging is true');
 
         BookTableMap::doDeleteAll($con);
@@ -494,7 +483,7 @@ class PropelPDOTest extends BookstoreTestBase
      */
     public function testDebugLog()
     {
-        $con = Propel::getServiceContainer()->getConnection(BookTableMap::DATABASE_NAME);
+        $con = $this->con;
 
         // save data to return to normal state after test
         $logger = $con->getLogger();
@@ -542,7 +531,7 @@ class PropelPDOTest extends BookstoreTestBase
         $c = new Criteria();
         $c->add(BookTableMap::COL_TITLE, 'Harry%s', Criteria::LIKE);
 
-        $books = BookQuery::create(null, $c)->find($con);
+        BookQuery::create(null, $c)->find($con);
         $latestExecutedQuery = $this->getSql("SELECT book.id, book.title, book.isbn, book.price, book.publisher_id, book.author_id FROM book WHERE book.title LIKE 'Harry%s'");
         $this->assertEquals($latestExecutedQuery, $handler->latestMessage, 'PropelPDO logs queries and populates bound parameters in debug mode');
 

--- a/tests/Propel/Tests/Runtime/Util/TableMapTest.php
+++ b/tests/Propel/Tests/Runtime/Util/TableMapTest.php
@@ -45,7 +45,7 @@ class TableMapTest extends BookstoreTestBase
             $c = new Criteria();
             $c->setDistinct();
             if ($db instanceof PgsqlAdapter) {
-                $c->addSelectColumn('substring(' . BookTableMap::TITLE . " from position('Potter' in " . BookTableMap::TITLE . ')) AS col');
+                $c->addSelectColumn('substring(' . BookTableMap::COL_TITLE . " from position('Potter' in " . BookTableMap::COL_TITLE . ')) AS col');
             } else {
                 $this->markTestSkipped('Configured database vendor is not PostgreSQL');
             }

--- a/tests/Propel/Tests/Runtime/Util/TableMapTest.php
+++ b/tests/Propel/Tests/Runtime/Util/TableMapTest.php
@@ -8,7 +8,10 @@
 
 namespace Propel\Tests\Runtime\Util;
 
+use Exception;
 use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\Adapter\Pdo\MssqlAdapter;
+use Propel\Runtime\Adapter\Pdo\PgsqlAdapter;
 use Propel\Runtime\Exception\PropelException;
 use Propel\Runtime\Propel;
 use Propel\Tests\Bookstore\BookQuery;
@@ -17,6 +20,7 @@ use Propel\Tests\Bookstore\BookstoreQuery;
 use Propel\Tests\Bookstore\Map\AuthorTableMap;
 use Propel\Tests\Bookstore\Map\BookstoreTableMap;
 use Propel\Tests\Bookstore\Map\BookTableMap;
+use Propel\Tests\Bookstore\Map\PublisherTableMap;
 use Propel\Tests\Helpers\Bookstore\BookstoreTestBase;
 
 /**
@@ -75,6 +79,8 @@ class TableMapTest extends BookstoreTestBase
     }
 
     /**
+     * @doesNotPerformAssertions
+     *
      * @return void
      */
     public function testDoCountDuplicateColumnName()
@@ -86,7 +92,7 @@ class TableMapTest extends BookstoreTestBase
         $c->addSelectColumn(AuthorTableMap::COL_ID);
         $c->setLimit(3);
         try {
-            $count = $c->doCount($con);
+            $c->doCount($con);
         } catch (Exception $e) {
             $this->fail('doCount() cannot deal with a criteria selecting duplicate column names ');
         }


### PR DESCRIPTION
Some of the tests were "risky" when they did not perform any assertions, and phpunit cluttered the output with warning. Most of them check there is no exception, so I marked them with `@doesNotPerformAssertions`. Two tests were not finished, so I added `$this->markTestIncomplete();`.

One test failed with MySQL because it did not account for MySQL 8, which removed display size for int (as in INT(4), see https://stackoverflow.com/questions/60892749/mysql-8-ignoring-integer-lengths). Simple fix is to use VARCHAR instead.

Two tests failed with MySQL (and probably with Oracle, too) because of `Expression of SELECT list is not in GROUP BY clause`. I think this is a bug in Propel, which should not force users to change server mode, but since these tests are about something else, I only change the server mode locally in those tests. 

I did not change the test themselves, except for `PropelPDOTest.php`, where connection initialization unnecessarily deviated from how it is done in parent class.

One test is still printed as risky, as the test is skipped as part of an unresolved problem (according to the comment there).

Wish I (or someone else) had done this earlier, working with dirty tests is not good.