### PR TITLE
Bugfix: wrap nonaggregated columns in MySQL

### DIFF
--- a/src/Propel/Runtime/Adapter/Pdo/PdoAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/PdoAdapter.php
@@ -446,7 +446,7 @@ abstract class PdoAdapter
                 // it could be a function:  e.g. MAX(books.price)
                 $tableName = null;
 
-                $selectClause[] = $columnName; // the full column name: e.g. MAX(books.price)
+                $selectClause[] = $this->adjustSimpleColumnSelectionLiteral($criteria, $columnName);
 
                 $parenPos = strrpos($columnName, '(');
                 $dotPos = strrpos($columnName, '.', ($parenPos !== false ? $parenPos : 0));
@@ -515,6 +515,22 @@ abstract class PdoAdapter
         }
 
         return $selected;
+    }
+
+    /**
+     * Performs vendor-specific adjustments to a given select column statement.
+     *
+     * Overridden by adapters that need specific adjustment, like MysqlAdapter, which needs to wrap nonaggregated
+     * columns in GROUP BY queries.
+     *
+     * @param \Propel\Runtime\ActiveQuery\Criteria $queryBuilder
+     * @param string $columnSelectionLiteral
+     *
+     * @return string
+     */
+    protected function adjustSimpleColumnSelectionLiteral(Criteria $queryBuilder, string $columnSelectionLiteral): string
+    {
+        return $columnSelectionLiteral;
     }
 
     /**

--- a/tests/Propel/Tests/Helpers/Bookstore/BookstoreTestBase.php
+++ b/tests/Propel/Tests/Helpers/Bookstore/BookstoreTestBase.php
@@ -40,7 +40,7 @@ abstract class BookstoreTestBase extends TestCaseFixturesDatabase
             if (!file_exists($file)) {
                 return;
             }
-            Propel::init($file);
+            include $file;
             self::$isInitialized = true;
         }
         $this->con = Propel::getServiceContainer()->getConnection(BookTableMap::DATABASE_NAME);

--- a/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaTest.php
@@ -1440,6 +1440,8 @@ class CriteriaTest extends BookstoreTestBase
 
         if ($this->runningOnPostgreSQL()) {
             $sql = 'SELECT book.id, book.title, book.isbn, book.price, book.publisher_id, book.author_id, COUNT(review.id) AS Count FROM book LEFT JOIN review ON (book.id=review.book_id) GROUP BY book.id,book.title,book.isbn,book.price,book.publisher_id,book.author_id';
+        }  else if ($this->runningOnMySQL()) {
+            $sql = 'SELECT book.id, ANY_VALUE(book.title) AS \'title\', ANY_VALUE(book.isbn) AS \'isbn\', ANY_VALUE(book.price) AS \'price\', ANY_VALUE(book.publisher_id) AS \'publisher_id\', ANY_VALUE(book.author_id) AS \'author_id\', COUNT(review.id) AS Count FROM book LEFT JOIN review ON (book.id=review.book_id) GROUP BY book.id';
         } else {
             $sql = $this->getSql('SELECT book.id, book.title, book.isbn, book.price, book.publisher_id, book.author_id, COUNT(review.id) AS Count FROM book LEFT JOIN review ON (book.id=review.book_id) GROUP BY book.id');
         }

--- a/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaTest.php
@@ -2778,8 +2778,11 @@ class ModelCriteriaTest extends BookstoreTestBase
         $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
         $books = $c->groupByTitle()->find($con);
 
-        if ($this->isDb('pgsql')) {
+        if ($this->runningOnPostgreSQL()) {
             $expectedSQL = 'SELECT book.id, book.title, book.isbn, book.price, book.publisher_id, book.author_id FROM book GROUP BY book.title,book.id,book.isbn,book.price,book.publisher_id,book.author_id';
+        } else if ($this->runningOnMySQL()) {
+            $expectedSQL = 'SELECT ANY_VALUE(book.id) AS \'id\', book.title, ANY_VALUE(book.isbn) AS \'isbn\', ANY_VALUE(book.price) AS \'price\', ANY_VALUE(book.publisher_id) AS \'publisher_id\', ANY_VALUE(book.author_id) AS \'author_id\' '
+                . 'FROM book GROUP BY book.title';
         } else {
             $expectedSQL = $this->getSql('SELECT book.id, book.title, book.isbn, book.price, book.publisher_id, book.author_id FROM book GROUP BY book.title');
         }

--- a/tests/Propel/Tests/Runtime/ActiveQuery/QuotingTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/QuotingTest.php
@@ -86,9 +86,7 @@ class QuotingTest extends TestCaseFixturesDatabase
      */
     public function testJoinWithNonQuotingQuery()
     {
-        $groupQuery = GroupQuery::create();
-
-        $groupQuery
+        GroupQuery::create()
         ->joinAuthor()
         ->useAuthorQuery()
         ->filterByName('Author filter')
@@ -142,6 +140,8 @@ class QuotingTest extends TestCaseFixturesDatabase
 
         if ($this->runningOnPostgreSQL()) {
             $expected = $this->getSql('SELECT g.id, g.name, g.type_id FROM quoting_author g GROUP BY g.id,g.name,g.type_id HAVING g.id > 0');
+        } else if ($this->runningOnMySQL()) {
+            $expected = $this->getSql('SELECT g.id, ANY_VALUE(g.name) AS \'name\', ANY_VALUE(g.type_id) AS \'type_id\' FROM quoting_author g GROUP BY g.id HAVING g.id > 0');
         } else {
             $expected = $this->getSql('SELECT g.id, g.name, g.type_id FROM quoting_author g GROUP BY g.id HAVING g.id > 0');
         }
@@ -174,6 +174,8 @@ class QuotingTest extends TestCaseFixturesDatabase
 
         if ($this->runningOnPostgreSQL()) {
             $expected = $this->getSql('SELECT `group`.`id`, `group`.`title`, `group`.`by`, `group`.`as`, `group`.`author_id` FROM `group` GROUP BY `group`.`as`,`group`.`id`,`group`.`title`,`group`.`by`,`group`.`author_id` HAVING `group`.`as` > 0');
+        } else if ($this->runningOnMySQL()) {
+            $expected = $this->getSql('SELECT ANY_VALUE(`group`.`id`) AS \'id\', ANY_VALUE(`group`.`title`) AS \'title\', ANY_VALUE(`group`.`by`) AS \'by\', `group`.`as`, ANY_VALUE(`group`.`author_id`) AS \'author_id\' FROM `group` GROUP BY `group`.`as` HAVING `group`.`as` > 0');
         } else {
             $expected = $this->getSql('SELECT `group`.`id`, `group`.`title`, `group`.`by`, `group`.`as`, `group`.`author_id` FROM `group` GROUP BY `group`.`as` HAVING `group`.`as` > 0');
         }


### PR DESCRIPTION
Currently, Propel assumes that databases can handle nonaggregated columns in a GROUP BY query (except for Postgres), as in:
```SQL
SELECT id, name, COUNT(*)
FROM leTable
GROUP BY id
```
However, the default for MySQL is to reject such statements:

> PDOException: SQLSTATE[42000]: Syntax error or access violation: 1055 Expression #2 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'test.leTable.name' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by

In general, this can be seen as a YP, as users should write correct columns. However, there are scenarios where the columns are added automatically, without the user being able to change it. Those queries currently do not run on MySQL, or need adjustment to the sql mode, which is quite invasive. An example for such a query can be found in the [documentation](http://propelorm.org/documentation/reference/model-criteria.html#sub-selects):
```php
$latestBooks = BookQuery::create()
  ->withColumn('MAX(Book.CreatedAt)')
  ->groupBy('Book.AuthorId');
$latestCheapBooks = BookQuery::create()
  ->addSelectQuery($latestBooks, 'lastBook') // always adds all columns from the parent table
  ->where('lastBook.Price < ?', 20)
  ->find();
```
Some of the test also fail when running on an unchanged MySQL installation. (Do the github tests run on a pre-configured database?)

There are four approaches to fix this:

1. Remove all nonaggregated columns from select
2. Add all nonaggregated columns to the group by
3. Wrap nonaggregated columns in an [ANY_VALUE()](https://dev.mysql.com/doc/refman/8.0/en/miscellaneous-functions.html#function_any-value) clause (MySQL only)
4. Change the sql mode on a per-query basis (MySQL only)

I consider option 4 still as too invasive. PostgresAdapter does 2. I would always prefer 1 because we want to remove those automatically added columns, instead of grouping by them. But in case there is a madman out there who depends on the current behavior, I went with the 3rd approach.

Alas, no more errors in tests (unless you run them on Oracle, which probably has the same problem).