### PR TITLE
make primary table always available in query

### DIFF
--- a/src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
@@ -158,23 +158,28 @@ class BaseModelCriteria extends Criteria implements IteratorAggregate
      * Sets the model name.
      * This also sets `this->modelTableMapName` and `this->tableMap`.
      *
-     * @param string $modelName
+     * @param string|null $modelName
      *
      * @return $this The current object, for fluid interface
      */
     public function setModelName($modelName)
     {
-        if (strpos($modelName, '\\') === 0) {
-            $this->modelName = substr($modelName, 1);
-        } else {
-            $this->modelName = $modelName;
+        if (empty($modelName)) {
+            $this->modelName = null;
+
+            return $this;
         }
-        if ($this->modelName && !$this->modelTableMapName) {
+        if (strpos($modelName, '\\') === 0) {
+            $modelName = substr($modelName, 1);
+        }
+
+        $this->modelName = $modelName;
+        if (!$this->modelTableMapName) {
             $this->modelTableMapName = constant($this->modelName . '::TABLE_MAP');
         }
-        if ($this->modelName) {
-            $this->tableMap = Propel::getServiceContainer()->getDatabaseMap($this->getDbName())->getTableByPhpName($this->modelName);
-        }
+        $dbName = $this->getDbName();
+        $this->tableMap = Propel::getServiceContainer()->getDatabaseMap($dbName)->getTableByPhpName($modelName);
+        $this->setPrimaryTableName(constant($this->modelTableMapName . '::TABLE_NAME'));
 
         return $this;
     }

--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -2169,20 +2169,16 @@ class Criteria
             }
         }
 
-        if (empty($fromClause) && $this->getPrimaryTableName()) {
-            $fromClause[] = $this->getPrimaryTableName();
-        }
-
         // tables should not exist as alias of subQuery
         if ($this->hasSelectQueries()) {
-            foreach ($fromClause as $key => $ftable) {
+            foreach ($fromClause as $index => $ftable) {
                 if (strpos($ftable, ' ') !== false) {
                     [, $tableName] = explode(' ', $ftable);
                 } else {
                     $tableName = $ftable;
                 }
                 if ($this->hasSelectQuery($tableName)) {
-                    unset($fromClause[$key]);
+                    unset($fromClause[$index]);
                 }
             }
         }
@@ -2194,6 +2190,10 @@ class Criteria
         // add subQuery to From after adding quotes
         foreach ($this->getSelectQueries() as $subQueryAlias => $subQueryCriteria) {
             $fromClause[] = '(' . $subQueryCriteria->createSelectSql($params) . ') AS ' . $subQueryAlias;
+        }
+
+        if (empty($fromClause) && $this->getPrimaryTableName()) {
+            $fromClause[] = $this->getPrimaryTableName();
         }
 
         // build from-clause

--- a/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
@@ -1496,11 +1496,6 @@ class ModelCriteria extends BaseModelCriteria
         $criteria->setDbName($this->getDbName()); // Set the correct dbName
         $criteria->clearOrderByColumns(); // ORDER BY won't ever affect the count
 
-        // We need to set the primary table name, since in the case that there are no WHERE columns
-        // it will be impossible for the createSelectSql() method to determine which
-        // tables go into the FROM clause.
-        $criteria->setPrimaryTableName(constant($this->modelTableMapName . '::TABLE_NAME'));
-
         $dataFetcher = $criteria->doCount($con);
         $row = $dataFetcher->fetch();
         if ($row) {
@@ -1550,11 +1545,6 @@ class ModelCriteria extends BaseModelCriteria
         $criteria->clearSelectColumns(); // We are not retrieving data
         $criteria->addSelectColumn('1');
         $criteria->limit(1);
-
-        // We need to set the primary table name, since in the case that there are no WHERE columns
-        // it will be impossible for the createSelectSql() method to determine which
-        // tables go into the FROM clause.
-        $criteria->setPrimaryTableName(constant($this->modelTableMapName . '::TABLE_NAME'));
 
         $dataFetcher = $criteria->doSelect($con);
         $exists = (bool)$dataFetcher->fetchColumn(0);
@@ -1720,7 +1710,6 @@ class ModelCriteria extends BaseModelCriteria
             throw new RuntimeException('Delete does not support join');
         }
 
-        $this->setPrimaryTableName(constant($this->modelTableMapName . '::TABLE_NAME'));
         $tableName = $this->getPrimaryTableName();
 
         $affectedRows = 0; // initialize this in case the next loop has no iterations.
@@ -1822,9 +1811,6 @@ class ModelCriteria extends BaseModelCriteria
         }
 
         $criteria = $this->isKeepQuery() ? clone $this : $this;
-        if ($this->modelTableMapName) {
-            $criteria->setPrimaryTableName(constant($this->modelTableMapName . '::TABLE_NAME'));
-        }
 
         return $con->transaction(function () use ($con, $values, $criteria, $forceIndividualSaves) {
             $affectedRows = $criteria->basePreUpdate($values, $con, $forceIndividualSaves);
@@ -2166,13 +2152,6 @@ class ModelCriteria extends BaseModelCriteria
 
         // clear only the selectColumns, clearSelectColumns() clears asColumns too
         $this->selectColumns = [];
-
-        // We need to set the primary table name, since in the case that there are no WHERE columns
-        // it will be impossible for the createSelectSql() method to determine which
-        // tables go into the FROM clause.
-        if (!$this->selectQueries) {
-            $this->setPrimaryTableName(constant($this->modelTableMapName . '::TABLE_NAME'));
-        }
 
         // Add requested columns which are not withColumns
         $columnNames = is_array($this->select) ? $this->select : [$this->select];

--- a/tests/Propel/Tests/Issues/Issue1463Test.php
+++ b/tests/Propel/Tests/Issues/Issue1463Test.php
@@ -73,34 +73,34 @@ END;
 
             'Zero' => [
                 'limit' => 0,
-                'expectedSql' => 'SELECT  FROM  LIMIT 0',
+                'expectedSql' => 'SELECT  FROM issue_1463_item LIMIT 0',
             ],
 
             'Small integer' => [
                 'limit' => 38427,
-                'expectedSql' => 'SELECT  FROM  LIMIT 38427',
+                'expectedSql' => 'SELECT  FROM issue_1463_item LIMIT 38427',
             ],
             'Small integer as a string' => [
                 'limit' => '38427',
-                'expectedSql' => 'SELECT  FROM  LIMIT 38427',
+                'expectedSql' => 'SELECT  FROM issue_1463_item LIMIT 38427',
             ],
 
             'Large integer' => [
                 'limit' => 9223372036854775807,
-                'expectedSql' => 'SELECT  FROM  LIMIT 9223372036854775807',
+                'expectedSql' => 'SELECT  FROM issue_1463_item LIMIT 9223372036854775807',
             ],
             'Large integer as a string' => [
                 'limit' => '9223372036854775807',
-                'expectedSql' => 'SELECT  FROM  LIMIT 9223372036854775807',
+                'expectedSql' => 'SELECT  FROM issue_1463_item LIMIT 9223372036854775807',
             ],
 
             'Decimal value' => [
                 'limit' => 123.9,
-                'expectedSql' => 'SELECT  FROM  LIMIT 123',
+                'expectedSql' => 'SELECT  FROM issue_1463_item LIMIT 123',
             ],
             'Decimal value as a string' => [
                 'limit' => '123.9',
-                'expectedSql' => 'SELECT  FROM  LIMIT 123',
+                'expectedSql' => 'SELECT  FROM issue_1463_item LIMIT 123',
             ],
 
             /*
@@ -109,15 +109,15 @@ END;
 
             'Negative value' => [
                 'limit' => -1,
-                'expectedSql' => 'SELECT  FROM ',
+                'expectedSql' => 'SELECT  FROM issue_1463_item',
             ],
             'Non-numeric string' => [
                 'limit' => 'foo',
-                'expectedSql' => 'SELECT  FROM  LIMIT 0',
+                'expectedSql' => 'SELECT  FROM issue_1463_item LIMIT 0',
             ],
             'Injected SQL' => [
                 'limit' => '3;DROP TABLE abc',
-                'expectedSql' => 'SELECT  FROM  LIMIT 3',
+                'expectedSql' => 'SELECT  FROM issue_1463_item LIMIT 3',
             ],
         ];
     }
@@ -149,34 +149,34 @@ END;
 
             'Zero' => [
                 'offset' => 0,
-                'expectedSql' => 'SELECT  FROM ',
+                'expectedSql' => 'SELECT  FROM issue_1463_item',
             ],
 
             'Small integer' => [
                 'offset' => 38427,
-                'expectedSql' => 'SELECT  FROM  LIMIT 38427, 18446744073709551615',
+                'expectedSql' => 'SELECT  FROM issue_1463_item LIMIT 38427, 18446744073709551615',
             ],
             'Small integer as a string' => [
                 'offset' => '38427',
-                'expectedSql' => 'SELECT  FROM  LIMIT 38427, 18446744073709551615',
+                'expectedSql' => 'SELECT  FROM issue_1463_item LIMIT 38427, 18446744073709551615',
             ],
 
             'Large integer' => [
                 'offset' => 9223372036854775807,
-                'expectedSql' => 'SELECT  FROM  LIMIT 9223372036854775807, 18446744073709551615',
+                'expectedSql' => 'SELECT  FROM issue_1463_item LIMIT 9223372036854775807, 18446744073709551615',
             ],
             'Large integer as a string' => [
                 'offset' => '9223372036854775807',
-                'expectedSql' => 'SELECT  FROM  LIMIT 9223372036854775807, 18446744073709551615',
+                'expectedSql' => 'SELECT  FROM issue_1463_item LIMIT 9223372036854775807, 18446744073709551615',
             ],
 
             'Decimal value' => [
                 'offset' => 123.9,
-                'expectedSql' => 'SELECT  FROM  LIMIT 123, 18446744073709551615',
+                'expectedSql' => 'SELECT  FROM issue_1463_item LIMIT 123, 18446744073709551615',
             ],
             'Decimal value as a string' => [
                 'offset' => '123.9',
-                'expectedSql' => 'SELECT  FROM  LIMIT 123, 18446744073709551615',
+                'expectedSql' => 'SELECT  FROM issue_1463_item LIMIT 123, 18446744073709551615',
             ],
 
             /*
@@ -185,15 +185,15 @@ END;
 
             'Negative value' => [
                 'offset' => -1,
-                'expectedSql' => 'SELECT  FROM ',
+                'expectedSql' => 'SELECT  FROM issue_1463_item',
             ],
             'Non-numeric string' => [
                 'offset' => 'foo',
-                'expectedSql' => 'SELECT  FROM ',
+                'expectedSql' => 'SELECT  FROM issue_1463_item',
             ],
             'Injected SQL' => [
                 'offset' => '3;DROP TABLE abc',
-                'expectedSql' => 'SELECT  FROM  LIMIT 3, 18446744073709551615',
+                'expectedSql' => 'SELECT  FROM issue_1463_item LIMIT 3, 18446744073709551615',
             ],
         ];
     }
@@ -225,34 +225,34 @@ END;
 
             'Zero' => [
                 'offset' => 0,
-                'expectedSql' => 'SELECT  FROM  LIMIT 999',
+                'expectedSql' => 'SELECT  FROM issue_1463_item LIMIT 999',
             ],
 
             'Small integer' => [
                 'offset' => 38427,
-                'expectedSql' => 'SELECT  FROM  LIMIT 38427, 999',
+                'expectedSql' => 'SELECT  FROM issue_1463_item LIMIT 38427, 999',
             ],
             'Small integer as a string' => [
                 'offset' => '38427',
-                'expectedSql' => 'SELECT  FROM  LIMIT 38427, 999',
+                'expectedSql' => 'SELECT  FROM issue_1463_item LIMIT 38427, 999',
             ],
 
             'Large integer' => [
                 'offset' => 9223372036854775807,
-                'expectedSql' => 'SELECT  FROM  LIMIT 9223372036854775807, 999',
+                'expectedSql' => 'SELECT  FROM issue_1463_item LIMIT 9223372036854775807, 999',
             ],
             'Large integer as a string' => [
                 'offset' => '9223372036854775807',
-                'expectedSql' => 'SELECT  FROM  LIMIT 9223372036854775807, 999',
+                'expectedSql' => 'SELECT  FROM issue_1463_item LIMIT 9223372036854775807, 999',
             ],
 
             'Decimal value' => [
                 'offset' => 123.9,
-                'expectedSql' => 'SELECT  FROM  LIMIT 123, 999',
+                'expectedSql' => 'SELECT  FROM issue_1463_item LIMIT 123, 999',
             ],
             'Decimal value as a string' => [
                 'offset' => '123.9',
-                'expectedSql' => 'SELECT  FROM  LIMIT 123, 999',
+                'expectedSql' => 'SELECT  FROM issue_1463_item LIMIT 123, 999',
             ],
 
             /*
@@ -261,15 +261,15 @@ END;
 
             'Negative value' => [
                 'offset' => -1,
-                'expectedSql' => 'SELECT  FROM  LIMIT 999',
+                'expectedSql' => 'SELECT  FROM issue_1463_item LIMIT 999',
             ],
             'Non-numeric string' => [
                 'offset' => 'foo',
-                'expectedSql' => 'SELECT  FROM  LIMIT 999',
+                'expectedSql' => 'SELECT  FROM issue_1463_item LIMIT 999',
             ],
             'Injected SQL' => [
                 'offset' => '3;DROP TABLE abc',
-                'expectedSql' => 'SELECT  FROM  LIMIT 3, 999',
+                'expectedSql' => 'SELECT  FROM issue_1463_item LIMIT 3, 999',
             ],
         ];
     }

--- a/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaTest.php
@@ -586,7 +586,7 @@ class ModelCriteriaTest extends BookstoreTestBase
         $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
         $c->having('Propel\Tests\Bookstore\Book.Title <> ?', 'foo');
 
-        $sql = 'SELECT  FROM  HAVING book.title <> :p1';
+        $sql = 'SELECT  FROM book HAVING book.title <> :p1';
         $params = [
             ['table' => 'book', 'column' => 'title', 'value' => 'foo'],
         ];
@@ -603,7 +603,7 @@ class ModelCriteriaTest extends BookstoreTestBase
         $c->condition('cond2', 'Propel\Tests\Bookstore\Book.Title like ?', '%bar%');
         $c->having(['cond1', 'cond2']);
 
-        $sql = 'SELECT  FROM  HAVING (book.title <> :p1 AND book.title like :p2)';
+        $sql = 'SELECT  FROM book HAVING (book.title <> :p1 AND book.title like :p2)';
         $params = [
             ['table' => 'book', 'column' => 'title', 'value' => 'foo'],
             ['table' => 'book', 'column' => 'title', 'value' => '%bar%'],
@@ -615,7 +615,7 @@ class ModelCriteriaTest extends BookstoreTestBase
         $c->condition('cond2', 'Propel\Tests\Bookstore\Book.Title like ?', '%bar%');
         $c->having(['cond1', 'cond2'], Criteria::LOGICAL_OR);
 
-        $sql = 'SELECT  FROM  HAVING (book.title <> :p1 OR book.title like :p2)';
+        $sql = 'SELECT  FROM book HAVING (book.title <> :p1 OR book.title like :p2)';
         $this->assertCriteriaTranslation($c, $sql, $params, 'having() accepts an array of named conditions with an operator');
     }
 
@@ -651,14 +651,14 @@ class ModelCriteriaTest extends BookstoreTestBase
         $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
         $c->orderBy('Propel\Tests\Bookstore\Book.Title');
 
-        $sql = 'SELECT  FROM  ORDER BY book.title ASC';
+        $sql = 'SELECT  FROM book ORDER BY book.title ASC';
         $params = [];
         $this->assertCriteriaTranslation($c, $sql, $params, 'orderBy() accepts a column name and adds an ORDER BY clause');
 
         $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
         $c->orderBy('Propel\Tests\Bookstore\Book.Title', 'desc');
 
-        $sql = 'SELECT  FROM  ORDER BY book.title DESC';
+        $sql = 'SELECT  FROM book ORDER BY book.title DESC';
         $this->assertCriteriaTranslation($c, $sql, $params, 'orderBy() accepts an order parameter');
 
         $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
@@ -685,7 +685,7 @@ class ModelCriteriaTest extends BookstoreTestBase
         $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
         $c->orderBy('Title');
 
-        $sql = 'SELECT  FROM  ORDER BY book.title ASC';
+        $sql = 'SELECT  FROM book ORDER BY book.title ASC';
         $params = [];
         $this->assertCriteriaTranslation($c, $sql, $params, 'orderBy() accepts a simple column name and adds an ORDER BY clause');
     }
@@ -699,7 +699,7 @@ class ModelCriteriaTest extends BookstoreTestBase
         $c->addAsColumn('t', BookTableMap::COL_TITLE);
         $c->orderBy('t');
 
-        $sql = 'SELECT book.title AS t FROM  ORDER BY t ASC';
+        $sql = 'SELECT book.title AS t FROM book ORDER BY t ASC';
         $params = [];
         $this->assertCriteriaTranslation($c, $sql, $params, 'orderBy() accepts a column alias and adds an ORDER BY clause');
     }
@@ -712,7 +712,7 @@ class ModelCriteriaTest extends BookstoreTestBase
         $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
         $c->groupBy('Propel\Tests\Bookstore\Book.AuthorId');
 
-        $sql = 'SELECT  FROM  GROUP BY book.author_id';
+        $sql = 'SELECT  FROM book GROUP BY book.author_id';
         $params = [];
         $this->assertCriteriaTranslation($c, $sql, $params, 'groupBy() accepts a column name and adds a GROUP BY clause');
 
@@ -733,7 +733,7 @@ class ModelCriteriaTest extends BookstoreTestBase
         $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
         $c->groupBy('AuthorId');
 
-        $sql = 'SELECT  FROM  GROUP BY book.author_id';
+        $sql = 'SELECT  FROM book GROUP BY book.author_id';
         $params = [];
         $this->assertCriteriaTranslation($c, $sql, $params, 'groupBy() accepts a simple column name and adds a GROUP BY clause');
     }
@@ -747,7 +747,7 @@ class ModelCriteriaTest extends BookstoreTestBase
         $c->addAsColumn('t', BookTableMap::COL_TITLE);
         $c->groupBy('t');
 
-        $sql = 'SELECT book.title AS t FROM  GROUP BY t';
+        $sql = 'SELECT book.title AS t FROM book GROUP BY t';
         $params = [];
         $this->assertCriteriaTranslation($c, $sql, $params, 'groupBy() accepts a column alias and adds a GROUP BY clause');
     }
@@ -771,7 +771,7 @@ class ModelCriteriaTest extends BookstoreTestBase
         $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
         $c->groupByClass('Propel\Tests\Bookstore\Book');
 
-        $sql = 'SELECT  FROM  GROUP BY book.id,book.title,book.isbn,book.price,book.publisher_id,book.author_id';
+        $sql = 'SELECT  FROM book GROUP BY book.id,book.title,book.isbn,book.price,book.publisher_id,book.author_id';
         $params = [];
         $this->assertCriteriaTranslation($c, $sql, $params, 'groupByClass() accepts a class name and adds a GROUP BY clause for all columns of the class');
     }
@@ -784,7 +784,7 @@ class ModelCriteriaTest extends BookstoreTestBase
         $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book', 'b');
         $c->groupByClass('b');
 
-        $sql = 'SELECT  FROM  GROUP BY book.id,book.title,book.isbn,book.price,book.publisher_id,book.author_id';
+        $sql = 'SELECT  FROM book GROUP BY book.id,book.title,book.isbn,book.price,book.publisher_id,book.author_id';
         $params = [];
         $this->assertCriteriaTranslation($c, $sql, $params, 'groupByClass() accepts a class alias and adds a GROUP BY clause for all columns of the class');
     }
@@ -798,7 +798,7 @@ class ModelCriteriaTest extends BookstoreTestBase
         $c->setModelAlias('b', true);
         $c->groupByClass('b');
 
-        $sql = 'SELECT  FROM  GROUP BY b.id,b.title,b.isbn,b.price,b.publisher_id,b.author_id';
+        $sql = 'SELECT  FROM book GROUP BY b.id,b.title,b.isbn,b.price,b.publisher_id,b.author_id';
         $params = [];
         $this->assertCriteriaTranslation($c, $sql, $params, 'groupByClass() accepts a true class alias and adds a GROUP BY clause for all columns of the class');
     }
@@ -838,7 +838,7 @@ class ModelCriteriaTest extends BookstoreTestBase
     {
         $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
         $c->distinct();
-        $sql = 'SELECT DISTINCT  FROM ';
+        $sql = 'SELECT DISTINCT  FROM book';
         $params = [];
         $this->assertCriteriaTranslation($c, $sql, $params, 'distinct() adds a DISTINCT clause');
     }
@@ -850,12 +850,12 @@ class ModelCriteriaTest extends BookstoreTestBase
     {
         $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\Book');
         $c->limit(10);
-        $sql = 'SELECT  FROM  LIMIT 10';
+        $sql = 'SELECT  FROM book LIMIT 10';
         $params = [];
         $this->assertCriteriaTranslation($c, $sql, $params, 'limit() adds a LIMIT clause');
         //test that limit 0 also works
         $c->limit(0);
-        $sql = 'SELECT  FROM  LIMIT 0';
+        $sql = 'SELECT  FROM book LIMIT 0';
         $params = [];
         $this->assertCriteriaTranslation($c, $sql, $params, 'limit() adds a LIMIT clause');
     }
@@ -869,9 +869,9 @@ class ModelCriteriaTest extends BookstoreTestBase
         $c->limit(50);
         $c->offset(10);
         if ($this->isDb('mysql')) {
-            $sql = 'SELECT  FROM  LIMIT 10, 50';
+            $sql = 'SELECT  FROM book LIMIT 10, 50';
         } else {
-            $sql = 'SELECT  FROM  LIMIT 50 OFFSET 10';
+            $sql = 'SELECT  FROM book LIMIT 50 OFFSET 10';
         }
         $params = [];
         $this->assertCriteriaTranslation($c, $sql, $params, 'offset() adds an OFFSET clause');
@@ -953,7 +953,7 @@ class ModelCriteriaTest extends BookstoreTestBase
     {
         $c = new ModelCriteria('bookstore', 'Propel\Tests\Bookstore\BookstoreEmployee');
         $c->join('Propel\Tests\Bookstore\BookstoreEmployee.Supervisor');
-        $sql = $this->getSql('SELECT  FROM  INNER JOIN bookstore_employee ON (bookstore_employee.supervisor_id=bookstore_employee.id)');
+        $sql = $this->getSql('SELECT  FROM bookstore_employee INNER JOIN bookstore_employee ON (bookstore_employee.supervisor_id=bookstore_employee.id)');
         $params = [];
         $this->assertCriteriaTranslation($c, $sql, $params, 'join() uses relation names as defined in schema.xml');
     }


### PR DESCRIPTION
So, I am trying to get the `ModelCriteria::addSelectQuery()` to work, but there are several issues. Guess my sabbatical starts to bore me. Time to do this for money again soon.

So far, the issues I have found with `ModelCriteria::addSelectQuery()`:

- primary table is not set, leading to queries without `FROM`
- columns from `ModelCriteria::select()` are not resolved`, so selection does not work, causing "nonaggregated columns" error in nested group by
- using `ModelCriteria::select()` to join with a subquery is quirky (a statement like `A.id = B.id` will resolve all columns by table A, so if table A is the subquery, the nested table is used even though it is not available, and if table B is the suquery, its columns are resolved by the outer table, causing naming collisions)

This addresses the first issue, when queries are generated without a `FROM` clause:
Looking at the code, the same problems occurs at several positions, when no `WHERE` clause was given, and was fixed locally, instead of going to the root. Quick fix would have been to add the same workaround to nested queries, but the simple solution is to set the primary table during initialization of `BaseModelCriteria`, which has the benefit of making the other workarounds obsolete.
Only a few lines of code need to be changed, thought a lot of tests required adjustment, when suddenly (more) correct queries were returned.