### PR TITLE
Make fromArray() chainable (aka return $this)

### DIFF
--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -3404,7 +3404,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @param      array  \$arr     An array to populate the object from.
      * @param      string \$keyType The type of keys the array uses.
-     * @return void
+     * @return     \$this|" . $this->getObjectClassName(true) . "
      */
     public function fromArray(\$arr, \$keyType = TableMap::$defaultKeyType)
     {
@@ -3418,6 +3418,8 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
         }";
         } /* foreach */
         $script .= "
+
+        return \$this;
     }
 ";
     }

--- a/tests/Propel/Tests/FieldnameRelatedTest.php
+++ b/tests/Propel/Tests/FieldnameRelatedTest.php
@@ -334,7 +334,8 @@ class FieldnameRelatedTest extends TestCaseFixtures
 
         foreach ($types as $type) {
             $expected = $expecteds[$type];
-            $book->fromArray($expected, $type);
+            $returnedBook = $book->fromArray($expected, $type);
+            $this->assertEquals($book, $returnedBook);
             $result = [];
             foreach (array_keys($expected) as $key) {
                 $result[$key] = $book->getByName($key, $type);


### PR DESCRIPTION
Just when I thought I was done with Propel.

In general, methods of ActiveRecods are chainable, but `->fromArray()` isn't, meaning you have to write:
```php
$book = BookQuery::create()->findPk($id); // get the object reference
$book->fromArray($data);            // call void method
$book->setChanger($userId)->save();           // finish
```
when you could just do:
```php
BookQuery::create()
  ->findPk($id)
  ->fromArray($data)
  ->setChanger($userId)
  ->save();
```

Some people prefer the former, which is fine, and they can still use it, but lots of folks prefer the latter, lean version, and it is consistent with the other setters.
There really is no reason why the first one should be disallowed.