### PR TITLE
Bugfix: remove undefined index notice from profiler

### DIFF
--- a/src/Propel/Runtime/Connection/ConnectionWrapper.php
+++ b/src/Propel/Runtime/Connection/ConnectionWrapper.php
@@ -123,9 +123,6 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
     public function __construct(ConnectionInterface $connection)
     {
         $this->connection = $connection;
-        if ($this->useDebug) {
-            $this->log('Opening connection');
-        }
     }
 
     /**
@@ -688,18 +685,5 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
     public function __call($method, $args)
     {
         return call_user_func_array([$this->connection, $method], $args);
-    }
-
-    /**
-     * If so configured, makes an entry to the log of the state of this object just prior to its destruction.
-     *
-     * @see self::log()
-     */
-    public function __destruct()
-    {
-        if ($this->useDebug) {
-            $this->log('Closing connection');
-        }
-        $this->connection = null;
     }
 }

--- a/src/Propel/Runtime/Util/Profiler.php
+++ b/src/Propel/Runtime/Util/Profiler.php
@@ -31,9 +31,9 @@ class Profiler
     protected $outerGlue;
 
     /**
-     * @var array
+     * @var array|null
      */
-    protected $snapshot = [];
+    protected $snapshot;
 
     /**
      * @var array
@@ -213,7 +213,11 @@ class Profiler
      */
     public function getProfile()
     {
-        return $this->getProfileBetween($this->snapshot, self::getSnapshot());
+        $endSnapshot = self::getSnapshot();
+        $startSnapshot = ($this->snapshot === null) ? $endSnapshot : $this->snapshot;
+        $this->snapshot = null;
+
+        return $this->getProfileBetween($startSnapshot, $endSnapshot);
     }
 
     /**

--- a/tests/Propel/Tests/Runtime/Util/ProfilerTest.php
+++ b/tests/Propel/Tests/Runtime/Util/ProfilerTest.php
@@ -278,4 +278,39 @@ class ProfilerTest extends BaseTestCase
     {
         $this->assertSame(Profiler::toPrecision(123.456789, $input), $output);
     }
+
+    /**
+     * @doesNotPerformAssertions
+     *
+     * @return void
+     */
+    public function testGetProfilerWithoutStartValuesUsesEndValues()
+    {
+        $profiler = new Profiler();
+        $profile = $profiler->getProfile();
+        $expectedProfilePattern = '/^\s+Time:\s+0ms \| Memory:\s+[0-9.kMGTPEZY]+B \| Memory Delta:\s+0B \| Memory Peak:\s+[0-9.kMGTPEZY]+B \| $/';
+
+        // $this->assertMatchesRegularExpression is currently not available in github testsuite
+        if (preg_match($expectedProfilePattern, $profile) !== 1) {
+            $this->fail("Getting profile without start values should return empty values\nExpected Pattern: $expectedProfilePattern\nReceived Profile: '$profile'");
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetProfilerClearsStartValues()
+    {
+        $profiler = new class () extends Profiler{
+            public function getStartSnapshot(): ?array
+            {
+                return $this->snapshot;
+            }
+        };
+        $profiler->start();
+        $this->assertNotNull($profiler->getStartSnapshot(), 'Snapshot from start should be set');
+        $profiler->getProfile();
+
+        $this->assertNull($profiler->getStartSnapshot(), 'Snapshot from start should be unset');
+    }
 }


### PR DESCRIPTION
When using the Profiler to check time and memory usage, php shows three notices:

> **Notice**: Undefined index: microtime in **vendor/propel/propel/src/Propel/Runtime/Util/Profiler.php** on line **242**
> **Notice**: Undefined index: microtime in **vendor/propel/propel/src/Propel/Runtime/Util/Profiler.php** on line  **253**
> **Notice**: Undefined index: memoryUsage in **vendor/propel/propel/src/Propel/Runtime/Util/Profiler.php** on line  **261** 

The problem is outlined [here](https://github.com/propelorm/Propel2/pull/1647#issuecomment-801380568).

If merged, this replaces #1647