### PR TITLE
Feature: use heredoc in migration file

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -246,6 +246,46 @@ parameters:
 			path: src/Propel/Generator/Manager/ReverseManager.php
 
 		-
+			message: "#^Variable \\$timestamp might not be defined\\.$#"
+			count: 1
+			path: src/Propel/Generator/Manager/templates/migration_template.php
+
+		-
+			message: "#^Variable \\$migrationAuthor might not be defined\\.$#"
+			count: 1
+			path: src/Propel/Generator/Manager/templates/migration_template.php
+
+		-
+			message: "#^Variable \\$timeInWords might not be defined\\.$#"
+			count: 1
+			path: src/Propel/Generator/Manager/templates/migration_template.php
+
+		-
+			message: "#^Variable \\$migrationClassName might not be defined\\.$#"
+			count: 1
+			path: src/Propel/Generator/Manager/templates/migration_template.php
+
+		-
+			message: "#^Variable \\$commentString might not be defined\\.$#"
+			count: 1
+			path: src/Propel/Generator/Manager/templates/migration_template.php
+
+		-
+			message: "#^Variable \\$migrationsUp might not be defined\\.$#"
+			count: 1
+			path: src/Propel/Generator/Manager/templates/migration_template.php
+
+		-
+			message: "#^Variable \\$connectionToVariableName might not be defined\\.$#"
+			count: 2
+			path: src/Propel/Generator/Manager/templates/migration_template.php
+
+		-
+			message: "#^Variable \\$migrationsDown might not be defined\\.$#"
+			count: 1
+			path: src/Propel/Generator/Manager/templates/migration_template.php
+
+		-
 			message: "#^Strict comparison using \\=\\=\\= between string and null will always evaluate to false\\.$#"
 			count: 1
 			path: src/Propel/Generator/Model/Column.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -489,6 +489,21 @@
       <code>int[]</code>
     </InvalidReturnType>
   </file>
+  <file src="src/Propel/Generator/Manager/templates/migration_template.php">
+    <UndefinedGlobalVariable occurrences="11">
+      <code>$commentString</code>
+      <code>$connectionToVariableName</code>
+      <code>$connectionToVariableName</code>
+      <code>$connectionToVariableName</code>
+      <code>$connectionToVariableName</code>
+      <code>$migrationAuthor</code>
+      <code>$migrationClassName</code>
+      <code>$migrationsDown</code>
+      <code>$migrationsUp</code>
+      <code>$timeInWords</code>
+      <code>$timestamp</code>
+    </UndefinedGlobalVariable>
+  </file>
   <file src="src/Propel/Generator/Model/Column.php">
     <InvalidArgument occurrences="1">
       <code>[ $name, $phpNamingMethod, $namePrefix ]</code>

--- a/src/Propel/Generator/Manager/templates/migration_template.php
+++ b/src/Propel/Generator/Manager/templates/migration_template.php
@@ -1,0 +1,76 @@
+<?= '<?php' ?>
+
+use Propel\Generator\Manager\MigrationManager;
+
+/**
+ * Data object containing the SQL and PHP code to migrate the database
+ * up to version <?= $timestamp ?>.
+ * Generated on <?= $timeInWords ?> <?= $migrationAuthor ?> 
+ */
+class <?= $migrationClassName ?> 
+{
+    public $comment = '<?= $commentString ?>';
+
+    public function preUp(MigrationManager $manager)
+    {
+        // add the pre-migration code here
+    }
+
+    public function postUp(MigrationManager $manager)
+    {
+        // add the post-migration code here
+    }
+
+    public function preDown(MigrationManager $manager)
+    {
+        // add the pre-migration code here
+    }
+
+    public function postDown(MigrationManager $manager)
+    {
+        // add the post-migration code here
+    }
+
+    /**
+     * Get the SQL statements for the Up migration
+     *
+     * @return array list of the SQL strings to execute for the Up migration
+     *               the keys being the datasources
+     */
+    public function getUpSQL()
+    {
+<?php foreach($migrationsUp as $connectionName => $sql): ?>
+        <?= $connectionToVariableName[$connectionName] ?> = <<< 'EOT'
+<?= $sql ?>
+EOT;
+
+<?php endforeach;?>
+        return array(
+<?php foreach($connectionToVariableName as $connectionName => $variableName): ?>
+            '<?= $connectionName ?>' => <?= $variableName ?>,
+<?php endforeach;?>
+        );
+    }
+
+    /**
+     * Get the SQL statements for the Down migration
+     *
+     * @return array list of the SQL strings to execute for the Down migration
+     *               the keys being the datasources
+     */
+    public function getDownSQL()
+    {
+<?php foreach($migrationsDown as $connectionName => $sql): ?>
+        <?= $connectionToVariableName[$connectionName] ?> = <<< 'EOT'
+<?= $sql ?>
+EOT;
+
+<?php endforeach;?>
+        return array(
+<?php foreach($connectionToVariableName as $connectionName => $variableName): ?>
+            '<?= $connectionName ?>' => <?= $variableName ?>,
+<?php endforeach;?>
+        );
+    }
+
+}

--- a/tests/Propel/Tests/Generator/Manager/MigrationManagerTest.php
+++ b/tests/Propel/Tests/Generator/Manager/MigrationManagerTest.php
@@ -9,6 +9,7 @@
 namespace Propel\Tests\Generator\Manager;
 
 use Propel\Generator\Config\GeneratorConfig;
+use Propel\Generator\Manager\MigrationManager;
 use Propel\Tests\TestCase;
 
 /**
@@ -25,7 +26,7 @@ class MigrationManagerTest extends TestCase
 
         $connections = $generatorConfig->getBuildConnections();
 
-        $migrationManager = $this->getMockBuilder('Propel\Generator\Manager\MigrationManager')
+        $migrationManager = $this->getMockBuilder(MigrationManager::class)
             ->setMethods(['getMigrationTimestamps'])
             ->getMock();
         $migrationManager->setGeneratorConfig($generatorConfig);
@@ -195,8 +196,36 @@ class MigrationManagerTest extends TestCase
     {
         $migrationManager = $this->createMigrationManager([1, 2, 3]);
 
-        $body = $migrationManager->getMigrationClassBody('foo', 'bar', 4, 'migration comment');
+        $body = $migrationManager->getMigrationClassBody(['foo' => ''], ['foo' => ''], 4, 'migration comment');
 
         $this->assertStringContainsString('public $comment = \'migration comment\';', $body);
+    }
+
+    /**
+     * @return void
+     */
+    public function testBuildVariableNamesFromConnectionNames()
+    {
+        $manager = new class() extends MigrationManager{
+            public function build(array $migrationsUp, array $migrationsDown): array
+            {
+                return static::buildConnectionToVariableNameMap($migrationsUp, $migrationsDown);
+            }
+        };
+        
+        $migrationsUp = array_fill_keys(['default', 'with space', '\/', '123'], '');
+        $migrationsDown = array_fill_keys(['default', 'connection$', 'connection&', 'connection%'], '');
+        
+        $expectedResult = [
+            'default' => '$connection_default',
+            'with space' => '$connection_withspace',
+            '\/' => '$connection_2',
+            '123' => '$connection_123',
+            'connection$' => '$connection_connection',
+            'connection&' => '$connection_connectionI',
+            'connection%' => '$connection_connectionII',
+        ];
+        $result = $manager->build($migrationsUp, $migrationsDown);
+        $this->assertEquals($expectedResult, $result);
     }
 }


### PR DESCRIPTION
Found some stuff while cleaning up my project, that other might find useful.

This changes the migration files to use heredoc instead of string literals. The advantage is that you can copy lines from and to a database editor, without having to quote/unquote strings, which I had to do a lot for more complex migrations.

I also moved the migration template from the generating code into its own file, similar to other Propel templates.

With this change, migrations look like this:
```php
    public function getUpSQL()
    {
        $connection_default = <<< 'EOT'
ALTER TABLE `payment`

  CHANGE `status` `status` set('granted','denied','in_submission', 'deleted') NOT NULL;
EOT;

        return array(
            'default' => $connection_default,
        );
    }
```

instead of:
```php
    public function getUpSQL()
    {
        return array (
  'default' => '
ALTER TABLE `payment`

  CHANGE `status` `status` set(\'granted\',\'denied\',\'in_submission\', \'deleted\') NOT NULL;
',
);
    }
```