### PR TITLE
fix stan

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -396,11 +396,6 @@ parameters:
 			path: src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
 
 		-
-			message: "#^Call to an undefined static method Propel\\\\Runtime\\\\ActiveQuery\\\\BaseModelCriteria\\:\\:getShortName\\(\\)\\.$#"
-			count: 1
-			path: src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
-
-		-
 			message: "#^Call to an undefined method Propel\\\\Runtime\\\\ActiveQuery\\\\BaseModelCriteria\\:\\:find\\(\\)\\.$#"
 			count: 1
 			path: src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
@@ -438,16 +433,6 @@ parameters:
 		-
 			message: "#^Call to an undefined method Propel\\\\Runtime\\\\Adapter\\\\AdapterInterface\\:\\:bindValues\\(\\)\\.$#"
 			count: 3
-			path: src/Propel/Runtime/ActiveQuery/Criteria.php
-
-		-
-			message: "#^Variable \\$sql might not be defined\\.$#"
-			count: 3
-			path: src/Propel/Runtime/ActiveQuery/Criteria.php
-
-		-
-			message: "#^Strict comparison using \\!\\=\\= between null and null will always evaluate to false\\.$#"
-			count: 1
 			path: src/Propel/Runtime/ActiveQuery/Criteria.php
 
 		-
@@ -507,11 +492,6 @@ parameters:
 
 		-
 			message: "#^Call to an undefined method Propel\\\\Runtime\\\\Map\\\\TableMap\\:\\:addSelectColumns\\(\\)\\.$#"
-			count: 1
-			path: src/Propel/Runtime/ActiveQuery/ModelCriteria.php
-
-		-
-			message: "#^Variable \\$sql might not be defined\\.$#"
 			count: 1
 			path: src/Propel/Runtime/ActiveQuery/ModelCriteria.php
 

--- a/src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
@@ -238,6 +238,20 @@ class BaseModelCriteria extends Criteria implements IteratorAggregate
     }
 
     /**
+     * Return the short ClassName for class with namespace
+     *
+     * @param string $fullyQualifiedClassName The fully qualified class name
+     *
+     * @return string The short class name
+     */
+    public static function getShortName($fullyQualifiedClassName)
+    {
+        $namespaceParts = explode('\\', $fullyQualifiedClassName);
+
+        return array_pop($namespaceParts);
+    }
+
+    /**
      * Returns the TableMap object for this Criteria
      *
      * @return \Propel\Runtime\Map\TableMap

--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -2449,6 +2449,7 @@ class Criteria
             $this->add($pk->getFullyQualifiedName(), $id);
         }
 
+        $sql = null;
         try {
             $qualifiedCols = $this->keys(); // we need table.column cols when populating values
             $columns = []; // but just 'column' cols for the SQL
@@ -2577,6 +2578,8 @@ class Criteria
             $whereClause = [];
             $params = [];
             $stmt = null;
+            $sql = null;
+
             try {
                 $sql = 'UPDATE ';
                 $queryComment = $this->getComment();
@@ -2655,9 +2658,7 @@ class Criteria
 
                 $stmt = null; // close
             } catch (Exception $e) {
-                if ($stmt !== null) {
-                    $stmt = null; // close
-                }
+                $stmt = null; // close
                 Propel::log($e->getMessage(), Propel::LOG_ERR);
 
                 throw new PropelException(sprintf('Unable to execute UPDATE statement [%s]', $sql), 0, $e);
@@ -2808,6 +2809,7 @@ class Criteria
             $whereClause = [];
             $params = [];
             $stmt = null;
+            $sql = null;
             try {
                 $sql = $adapter->getDeleteFromClause($this, $tableName);
 

--- a/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
@@ -525,7 +525,7 @@ class ModelCriteria extends BaseModelCriteria
             $tableMap = $this->getTableMap();
         } else {
             [$leftName, $relationName] = explode('.', $fullName);
-            $shortLeftName = self::getShortName($leftName);
+            $shortLeftName = static::getShortName($leftName);
             // find the TableMap for the left table using the $leftName
             if ($leftName === $this->getModelAliasOrName() || $leftName === $this->getModelShortName()) {
                 $previousJoin = $this->getPreviousJoin();
@@ -1725,9 +1725,10 @@ class ModelCriteria extends BaseModelCriteria
 
         $affectedRows = 0; // initialize this in case the next loop has no iterations.
 
+        $tableName = $this->quoteIdentifierTable($tableName);
+        $sql = 'DELETE FROM ' . $tableName;
+
         try {
-            $tableName = $this->quoteIdentifierTable($tableName);
-            $sql = 'DELETE FROM ' . $tableName;
             $stmt = $con->prepare($sql);
 
             $stmt->execute();
@@ -2061,7 +2062,7 @@ class ModelCriteria extends BaseModelCriteria
             [$prefix, $phpName] = explode('.', $phpName);
         }
 
-        $shortClass = self::getShortName($prefix);
+        $shortClass = static::getShortName($prefix);
 
         if ($prefix === $this->getModelAliasOrName()) {
             // column of the Criteria's model
@@ -2262,20 +2263,6 @@ class ModelCriteria extends BaseModelCriteria
         }
 
         return $colName;
-    }
-
-    /**
-     * Return the short ClassName for class with namespace
-     *
-     * @param string $fullyQualifiedClassName The fully qualified class name
-     *
-     * @return string The short class name
-     */
-    public static function getShortName($fullyQualifiedClassName)
-    {
-        $namespaceParts = explode('\\', $fullyQualifiedClassName);
-
-        return array_pop($namespaceParts);
     }
 
     /**


### PR DESCRIPTION
Not sure why, but phpstan fails during #1719 and #1720:
```
 Error: ] Found 5 errors                                                         

Error: Ignored error pattern #^Call to an undefined static method Propel\\Runtime\\ActiveQuery\\BaseModelCriteria\:\:getShortName\(\)\.$# in path /home/runner/work/Propel2/Propel2/src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php was not matched in reported errors.
Error: Call to an undefined static method static(Propel\Runtime\ActiveQuery\BaseModelCriteria)::getShortName().
Error: Ignored error pattern #^Strict comparison using \!\=\= between null and null will always evaluate to false\.$# in path /home/runner/work/Propel2/Propel2/src/Propel/Runtime/ActiveQuery/Criteria.php was not matched in reported errors.
Error: Ignored error pattern #^Variable \$sql might not be defined\.$# in path /home/runner/work/Propel2/Propel2/src/Propel/Runtime/ActiveQuery/Criteria.php was not matched in reported errors.
Error: Ignored error pattern #^Variable \$sql might not be defined\.$# in path /home/runner/work/Propel2/Propel2/src/Propel/Runtime/ActiveQuery/ModelCriteria.php was not matched in reported errors.
Script vendor/bin/phpstan analyze handling the stan event returned with error code 1
Error: Process completed with exit code 1.
```

- Offending classes (BaseModelCriteria, ModelCriteria and Criteria) have nothing to do with the PRs and have not been changed since January.
- The phpstan.neon and phpstan-baseline.neon have not been changed since February and December respectively, and I have run the suite successfully after that.
- Running `composer run-script stan` locally gives no errors

This PR fixes the offending errors (one access of a static child method in parent through `static` and several times access of a variable declared in a `try` in the `catch` block). So with the offending lines and the rules to ignore them gone, the errors might be gone, too.
The actual problem is something else though, since smelly code + ignore warning should have worked, too.
Any idea why this suddenly broke?