### PR TITLE
Tests & Fixes for #1660, #1713 - Bugfix: getCollectionClassName() should only return Collection classes

### DIFF
--- a/src/Propel/Runtime/Map/TableMap.php
+++ b/src/Propel/Runtime/Map/TableMap.php
@@ -9,6 +9,8 @@
 namespace Propel\Runtime\Map;
 
 use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\Collection\Collection;
+use Propel\Runtime\Collection\ObjectCollection;
 use Propel\Runtime\Map\Exception\ColumnNotFoundException;
 use Propel\Runtime\Map\Exception\RelationNotFoundException;
 use Propel\Runtime\Propel;
@@ -293,12 +295,12 @@ class TableMap
      */
     public function getCollectionClassName()
     {
-        $collectionClass = $this->getClassName() . 'Collection';
-        if (class_exists($collectionClass)) {
-            return $collectionClass;
+        $collectionClassName = $this->getClassName() . 'Collection';
+        if (class_exists($collectionClassName) && is_subclass_of($collectionClassName, Collection::class)) {
+            return $collectionClassName;
         }
 
-        return '\Propel\Runtime\Collection\ObjectCollection';
+        return ObjectCollection::class;
     }
 
     /**

--- a/tests/Propel/Tests/Runtime/Map/TableMapTest.php
+++ b/tests/Propel/Tests/Runtime/Map/TableMapTest.php
@@ -297,16 +297,37 @@ class TableMapTest extends TestCase
     /**
      * @return void
      */
-    public function testGetCollectionClassName()
+    public function testGetCollectionClassNameReturnsObjectCollection()
     {
-        $this->assertEquals('\Propel\Runtime\Collection\ObjectCollection', $this->tmap->getCollectionClassName());
-
-        $this->tmap->setClassName('Propel\Tests\Runtime\Map\Test');
-        $this->assertEquals('Propel\Tests\Runtime\Map\TestCollection', $this->tmap->getCollectionClassName());
+        $this->assertEquals(ObjectCollection::class, $this->tmap->getCollectionClassName());
+    }
+    
+    /**
+     * @return void
+     */
+    public function testGetCollectionClassNameReturnsCustomCollection()
+    {
+        $classWithCollection = __NAMESPACE__ . '\ExtendingTest';
+        $this->tmap->setClassName($classWithCollection);
+        $this->assertEquals(ExtendingTestCollection::class, $this->tmap->getCollectionClassName());
+    }
+        
+    /**
+     * @return void
+     */
+    public function testGetCollectionClassNameReturnsOnlyCollections()
+    {
+        $classWithUnrelatedCollection = __NAMESPACE__ . '\NonExtendingTest';
+        $this->tmap->setClassName($classWithUnrelatedCollection);
+        $this->assertEquals(ObjectCollection::class, $this->tmap->getCollectionClassName());
     }
 }
 
-class TestCollection extends ObjectCollection
+class ExtendingTestCollection extends ObjectCollection
+{
+}
+
+class NonExtendingTestCollection
 {
 }
 


### PR DESCRIPTION
Tests & fixes for #1660, #1713: Simply make sure that `getCollectionClassName()` returns a class extending `Collection`, otherwise bad things can happen.

If merged, this replaces #1660, #1713