### PR TITLE
Test fixes - update phpunit.xml.dist and MySQL 8 fixes

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     colors="true"
     convertErrorsToExceptions="true"
     convertNoticesToExceptions="true"
     convertWarningsToExceptions="true"
     bootstrap="tests/bootstrap.php"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
 >
 
     <testsuites>
@@ -26,14 +28,15 @@
         <env name="DB_PW" value=""/>
     </php>
 
-    <logging>
-        <log type="coverage-php" target="tests/clover.cov"/>
-    </logging>
+    <logging />
 
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>src/Propel/</directory>
-        </whitelist>
-    </filter>
+        </include>
+        <report>
+            <php outputFile="tests/clover.cov" />
+        </report>
+    </coverage>
 
 </phpunit>

--- a/tests/Propel/Tests/Generator/Migration/MigrationTestCase.php
+++ b/tests/Propel/Tests/Generator/Migration/MigrationTestCase.php
@@ -160,13 +160,13 @@ class MigrationTestCase extends TestCaseFixturesDatabase
         try {
             $this->applyXmlAndTest($originXml);
         } catch (BuildException $e) {
-            throw new BuildException('There was a exception in applying the first(origin) schema', 0, $e);
+            $this->fail("Failed to apply the first/original schema:\n\n" . $e->getMessage());
         }
 
         try {
             $this->applyXmlAndTest($targetXml, true);
         } catch (BuildException $e) {
-            throw new BuildException('There was a exception in applying the second(target) schema', 0, $e);
+            $this->fail("Failed to apply the second/target schema:\n\n" . $e->getMessage());
         }
     }
 

--- a/tests/Propel/Tests/Generator/Migration/PrimaryKeyAITest.php
+++ b/tests/Propel/Tests/Generator/Migration/PrimaryKeyAITest.php
@@ -8,6 +8,8 @@
 
 namespace Propel\Tests\Generator\Migration;
 
+use PDO;
+
 /**
  * @group database
  */
@@ -122,6 +124,10 @@ class PrimaryKeyAITest extends MigrationTestCase
      */
     public function testChangeSize()
     {
+        if ($this->con->getAttribute(PDO::ATTR_DRIVER_NAME) === 'mysql') {
+            $this->markTestSkipped('MySQL removed support of integer display width in version 8.0.19');
+        }
+
         $originXml = '
 <database>
     <table name="migration_test_9">


### PR DESCRIPTION
Played around with the tests a bit and fixed some things:

1. Updated the phpunit.xml.dist to get rid of the warning when starting phpunit:
```
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!
```
Basically, they changed how code coverage tool configuration is done. New version works (tested it with phpunit/php-code-coverage).

2. When running the test in the mysql group, a migration test failed because it uses the integer display with property (as in INTEGER(2)), which was removed in MySQL 8.0.19 (see [here](https://stackoverflow.com/questions/60892749/mysql-8-ignoring-integer-lengths/60892835#60892835)). The test is now skipped on MySQL
3. Updated a MySQL-only test, that used an incorrect query. The query used the table name to access a column in a subquery, instead of the subquery alias. Hard to say why this fails now/on MySQL 8, since it is a semantic problem unrelated to the DBMS. It might have worked before #1714 (even though the test did not fail there). Anyway, I changed the alias, now it works.