### PR TITLE
Show failed queries and SQL error in debug mode exception

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -466,11 +466,6 @@ parameters:
 			path: src/Propel/Runtime/ActiveQuery/Criteria.php
 
 		-
-			message: "#^Parameter \\#2 \\$code of class Propel\\\\Runtime\\\\Exception\\\\PropelException constructor expects int, null given\\.$#"
-			count: 1
-			path: src/Propel/Runtime/ActiveQuery/Criteria.php
-
-		-
 			message: "#^Result of && is always false\\.$#"
 			count: 1
 			path: src/Propel/Runtime/ActiveQuery/Criterion/AbstractCriterion.php

--- a/tests/Propel/Tests/Runtime/Util/TableMapExceptionsTest.php
+++ b/tests/Propel/Tests/Runtime/Util/TableMapExceptionsTest.php
@@ -9,10 +9,14 @@
 namespace Propel\Tests\Runtime\Util;
 
 use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\Connection\ConnectionInterface;
+use Propel\Runtime\Connection\ConnectionWrapper;
 use Propel\Runtime\Exception\PropelException;
 use Propel\Runtime\Propel;
 use Propel\Tests\Bookstore\Map\BookTableMap;
 use Propel\Tests\Helpers\Bookstore\BookstoreTestBase;
+use Exception;
+use Propel\Tests\Bookstore\BookQuery;
 
 /**
  * Tests the exceptions thrown by the TableMap classes.
@@ -25,94 +29,129 @@ use Propel\Tests\Helpers\Bookstore\BookstoreTestBase;
 class TableMapExceptionsTest extends BookstoreTestBase
 {
     /**
-     * @return void
+     * Get BookQuery child class through method, since the parent class is not always available on CI tool.
+     *
+     * @throws CorrectlyHandledException
+     * @return BookQuery class instance
      */
-    public function testDoSelect()
+    public static function createHandledBookQuery() : BookQuery
     {
-        try {
-            $c = new Criteria();
-            $c->add(BookTableMap::COL_ID, 12, ' BAD SQL');
-            BookTableMap::addSelectColumns($c);
-            $c->doSelect();
-            $this->fail('Missing expected exception on BAD SQL');
-        } catch (PropelException $e) {
-            $this->assertStringContainsString($this->getSql('[SELECT book.id, book.title, book.isbn, book.price, book.publisher_id, book.author_id FROM book WHERE book.id BAD SQL:p1]'), $e->getMessage(), 'SQL query is written in the exception message');
-        }
-    }
-
-    /**
-     * @return void
-     */
-    public function testDoCount()
-    {
-        try {
-            $c = new Criteria();
-            $c->add(BookTableMap::COL_ID, 12, ' BAD SQL');
-            BookTableMap::addSelectColumns($c);
-            $c->doCount();
-            $this->fail('Missing expected exception on BAD SQL');
-        } catch (PropelException $e) {
-            $this->assertStringContainsString($this->getSql('[SELECT COUNT(*) FROM book WHERE book.id BAD SQL:p1]'), $e->getMessage(), 'SQL query is written in the exception message');
-        }
-    }
-
-    /**
-     * @return void
-     */
-    public function testDoDelete()
-    {
-        try {
-            $c = new Criteria();
-            $c->setPrimaryTableName(BookTableMap::TABLE_NAME);
-            $c->add(BookTableMap::COL_ID, 12, ' BAD SQL');
-            $c->doDelete(Propel::getServiceContainer()->getWriteConnection(BookTableMap::DATABASE_NAME));
-            $this->fail('Missing expected exception on BAD SQL');
-        } catch (PropelException $e) {
-            $this->assertStringContainsString($this->getSql('[DELETE FROM book WHERE book.id BAD SQL:p1]'), $e->getMessage(), 'SQL query is written in the exception message');
-        }
-    }
-
-    /**
-     * @return void
-     */
-    public function testDoUpdate()
-    {
-        try {
-            $c1 = new Criteria();
-            $c1->setPrimaryTableName(BookTableMap::TABLE_NAME);
-            $c1->add(BookTableMap::COL_ID, 12, ' BAD SQL');
-            $c2 = new Criteria();
-            $c2->add(BookTableMap::COL_TITLE, 'Foo');
-
-            $c1->doUpdate($c2, Propel::getServiceContainer()->getWriteConnection(BookTableMap::DATABASE_NAME));
-            $this->fail('Missing expected exception on BAD SQL');
-        } catch (PropelException $e) {
-            $this->assertStringContainsString($this->getSql('[UPDATE book SET title=:p1 WHERE book.id BAD SQL:p2]'), $e->getMessage(), 'SQL query is written in the exception message');
-        }
-    }
-
-    /**
-     * @return void
-     */
-    public function testDoInsert()
-    {
-        $con = Propel::getServiceContainer()->getWriteConnection(BookTableMap::DATABASE_NAME);
-
-        try {
-            $c = new Criteria();
-            $c->setPrimaryTableName(BookTableMap::TABLE_NAME);
-            $c->add(BookTableMap::COL_AUTHOR_ID, 'lkhlkhj');
-
-            $db = Propel::getServiceContainer()->getAdapter($c->getDbName());
-
-            $c->doInsert($con);
-            $this->fail('Missing expected exception on BAD SQL');
-        } catch (PropelException $e) {
-            if ($db->isGetIdBeforeInsert()) {
-                $this->assertStringContainsString($this->getSql('[INSERT INTO book (author_id,id) VALUES (:p1,:p2)]'), $e->getMessage(), 'SQL query is written in the exception message');
-            } else {
-                $this->assertStringContainsString($this->getSql('[INSERT INTO book (author_id) VALUES (:p1)]'), $e->getMessage(), 'SQL query is written in the exception message');
+        return new class() extends BookQuery{
+            protected function handleStatementException(Exception $e, ?string $sql, ?ConnectionInterface $con = null, $stmt = null): void
+            {
+                throw new CorrectlyHandledException();
             }
+        };
+    }
+    
+    /**
+     * @return void
+     */
+    public function testDoSelectExceptionsAreHandledCorrectly()
+    {
+        $this->expectException(CorrectlyHandledException::class);
+        self::createHandledBookQuery()->where('oh this is no sql')->find();
+    }
+
+    /**
+     * @return void
+     */
+    public function testDoCountExceptionsAreHandledCorrectly()
+    {
+        $this->expectException(CorrectlyHandledException::class);
+        self::createHandledBookQuery()->where('oh this is no sql')->count();
+    }
+
+    /**
+     * @return void
+     */
+    public function testDoDeleteExceptionsAreHandledCorrectly()
+    {
+        $this->expectException(CorrectlyHandledException::class);
+        self::createHandledBookQuery()->where('oh this is no sql')->delete();
+    }
+
+    /**
+     * @return void
+     */
+    public function testDoUpdateExceptionsAreHandledCorrectly()
+    {
+        $c1 = new TableMapExceptionsTestCriteria();
+        $c1->setPrimaryTableName(BookTableMap::TABLE_NAME);
+        $c1->add(BookTableMap::COL_ID, 12, ' BAD SQL');
+        $c2 = new Criteria();
+        $c2->add(BookTableMap::COL_TITLE, 'Foo');
+
+        $this->expectException(CorrectlyHandledException::class);
+        $c1->doUpdate($c2, Propel::getServiceContainer()->getWriteConnection(BookTableMap::DATABASE_NAME));
+    }
+
+    /**
+     * @return void
+     */
+    public function testDoInsertExceptionsAreHandledCorrectly()
+    {
+
+        $c = new TableMapExceptionsTestCriteria();
+        $c->setPrimaryTableName(BookTableMap::TABLE_NAME);
+        $c->add(BookTableMap::COL_ID, 'lkhlkhj');
+        $c->add(BookTableMap::COL_AUTHOR_ID, 'lkhlkhj');
+
+        $this->expectException(CorrectlyHandledException::class);
+        $c->doInsert($this->con);
+    }
+
+    /**
+     * @return array
+     */
+    public function queryExceptionOutputFormatDataProvider()
+    {
+        // [$useDebug, $sqlStatement, $internalErrorMessage, $expectedPublicMessage]
+        return [
+            [false, '<SQL>', '<ERROR>', 'Unable to execute statement [<SQL>]'],
+            [true, '<SQL>', '<ERROR>', "Unable to execute statement [<SQL>]\nReason: [<ERROR>]"],
+        ];
+    }
+
+    /**
+     * @dataProvider queryExceptionOutputFormatDataProvider
+     *
+     * @param bool $useDebug
+     * @param string $sqlStatement
+     * @param string $internalErrorMessage
+     * @param string $expectedPublicMessage
+     *
+     * @return void
+     */
+    public function testQueryExceptionOutputFormat($useDebug, $sqlStatement, $internalErrorMessage, $expectedPublicMessage)
+    {
+        $c = new class () extends Criteria {
+            public function simulateException($msg, $sql, $con)
+            {
+                return $this->handleStatementException(new PropelException($msg), $sql, $con);
+            }
+        };
+
+        $con = new ConnectionWrapper($this->con->getWrappedConnection());
+        $con->useDebug($useDebug);
+
+        try {
+            $c->simulateException($internalErrorMessage, $sqlStatement, $con);
+            $this->fail('Cannot test without exception');
+        } catch (PropelException $e) {
+            $this->assertEquals($expectedPublicMessage, $e->getMessage());
         }
+    }
+}
+
+class CorrectlyHandledException extends Exception
+{
+}
+
+class TableMapExceptionsTestCriteria extends Criteria
+{
+    protected function handleStatementException(Exception $e, ?string $sql, ?ConnectionInterface $con = null, $stmt = null): void
+    {
+        throw new CorrectlyHandledException();
     }
 }


### PR DESCRIPTION
Failed queries are shown with placement variables in the Exception:
```
Unable to execute UPDATE statement [UPDATE payment SET receiver_id=:p1, date_changed=:p2 WHERE payment.id=:p3]
```
That makes it often hard to see what went wrong.

To see the database error, you have to check the log:
```
Error: SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'receiver_id' cannot be null
```
The query did not go to the log, but at least it is possible to puzzle together what went wrong.

However, there is a nice formatter available, which writes full queries to the log.

New Exception message looks like this:
```
Unable to execute statement [UPDATE payment SET receiver_id=NULL, date_changed='2021-04-28 22:15:55.450739' WHERE payment.id=1491]
Reason: [SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'receiver_id' cannot be null]
```
There is another PR #1728, which makes sure that failed queries are written to log, too.
