### PR TITLE
Bugfix: Failed queries should be written to log & Fix PdoConnection::exec()

### DIFF
--- a/src/Propel/Runtime/Connection/ConnectionInterface.php
+++ b/src/Propel/Runtime/Connection/ConnectionInterface.php
@@ -148,7 +148,7 @@ interface ConnectionInterface
      * @param string $statement The SQL statement to prepare and execute.
      *                          Data inside the query should be properly escaped.
      *
-     * @return \Propel\Runtime\DataFetcher\DataFetcherInterface The number of rows that were modified or deleted.
+     * @return int The number of rows that were modified or deleted.
      */
     public function exec($statement);
 

--- a/src/Propel/Runtime/Connection/PdoConnection.php
+++ b/src/Propel/Runtime/Connection/PdoConnection.php
@@ -137,13 +137,11 @@ class PdoConnection implements ConnectionInterface
     /**
      * @inheritDoc
      *
-     * @return \Propel\Runtime\DataFetcher\DataFetcherInterface
+     * @return int
      */
     public function exec($statement)
     {
-        $stmt = $this->pdo->exec($statement);
-
-        return $this->getDataFetcher($stmt);
+        return $this->pdo->exec($statement);
     }
 
     /**

--- a/tests/Propel/Tests/Runtime/Connection/ConnectionWrapperTest.php
+++ b/tests/Propel/Tests/Runtime/Connection/ConnectionWrapperTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Tests\Runtime\Connection;
+
+use Exception;
+use Propel\Runtime\Connection\ConnectionWrapper;
+use Propel\Tests\Helpers\Bookstore\BookstoreTestBase;
+
+/**
+ * @group database
+ */
+class ConnectionWrapperTest extends BookstoreTestBase
+{
+    /**
+     * Make sure logging is done after execution, otherwise Profiler will give wrong data.
+     *
+     * @return void
+     */
+    public function testQueriesAreLoggedAfterExecution()
+    {
+        $wrapper = new class ($this->con) extends ConnectionWrapper{
+            public $orderStack = [];
+
+            public function pushToOrderStack(string $op)
+            {
+                $this->orderStack[] = $op;
+            }
+
+            public function log($msg)
+            {
+                $this->pushToOrderStack('log');
+            }
+        };
+        $wrapper->callUserFunctionWithLogging([$wrapper, 'pushToOrderStack'], ['execute'], '');
+        $this->assertEquals(['execute', 'log'], $wrapper->orderStack, 'Execute should run before logging');
+    }
+
+    /**
+     * @return void
+     */
+    public function testQueryIsUnaffectedByDebugMode()
+    {
+        $con = new ConnectionWrapper($this->con->getWrappedConnection());
+
+        $query = 'SELECT * FROM book';
+
+        $con->useDebug(false);
+        $resultWithoutDebug = null;
+        try {
+            $resultWithoutDebug = $con->query($query)->fetch();
+        } catch (Exception $e) {
+            $this->fail('Could not execute query with debug mode DISABLED: ' . $e->getMessage());
+        }
+
+        $con->useDebug(true);
+        $resultWithDebug = null;
+        try {
+            $resultWithDebug = $con->query($query)->fetch();
+        } catch (Exception $e) {
+            $this->fail('Could not execute query with debug mode ENABLED: ' . $e->getMessage());
+        }
+
+        $this->assertEquals($resultWithoutDebug, $resultWithDebug);
+    }
+
+    /**
+     * @return void
+     */
+    public function testExecuteRunsInDebugMode()
+    {
+        $this->assertExecSimpleInsertWithGivenDebugModeWorks('ENABLED', true);
+    }
+
+    /**
+     * @return void
+     */
+    public function testExecuteRunsWithoutDebugMode()
+    {
+        $this->assertExecSimpleInsertWithGivenDebugModeWorks('DISABLED', false);
+    }
+
+    /**
+     * @return void
+     */
+    public function assertExecSimpleInsertWithGivenDebugModeWorks(string $description, bool $debugMode): void
+    {
+        $con = new ConnectionWrapper($this->con->getWrappedConnection());
+
+        $query = "INSERT INTO publisher(name) VALUES('Le Publisher')";
+
+        $con->useDebug($debugMode);
+        $affectedRows = -1;
+        try {
+            $affectedRows = $con->exec($query);
+        } catch (Exception $e) {
+            $this->fail("Could not execute query with debug mode $description: " . $e->getMessage());
+        }
+
+        $this->assertEquals(1, $affectedRows, "ConnectionWrapper::exec() should have inserted one rows with $description debug mode");
+    }
+}

--- a/tests/Propel/Tests/Runtime/Connection/StatementWrapperTest.php
+++ b/tests/Propel/Tests/Runtime/Connection/StatementWrapperTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Tests\Runtime\Connection;
+
+use Propel\Runtime\Connection\ConnectionWrapper;
+use Propel\Tests\Helpers\Bookstore\BookstoreTestBase;
+use Exception;
+
+/**
+ * @group database
+ */
+class StatementWrapperTest extends BookstoreTestBase
+{
+    /**
+     * @return void
+     */
+    public function testExecuteRunsInDebugMode()
+    {
+        $exitCode = $this->executeSimpleQueryWithGivenDebugMode('ENABLED', true);
+        $this->assertTrue($exitCode);
+    }
+
+    /**
+     * @return void
+     */
+    public function testExecuteRunsWithoutDebugMode()
+    {
+        $exitCode = $this->executeSimpleQueryWithGivenDebugMode('DISABLED', false);
+        $this->assertTrue($exitCode);
+    }
+
+    /**
+     *
+     * @return void
+     */
+    private function executeSimpleQueryWithGivenDebugMode(string $description, bool $debugMode): bool
+    {
+        $query = 'SELECT * FROM book';
+        $wrapper = new ConnectionWrapper($this->con->getWrappedConnection());
+        $wrapper->useDebug($debugMode);
+        
+        $stmt = $wrapper->prepare($query);
+        try{
+            return $stmt->execute();
+        } catch (Exception $e) {
+            $this->fail("Could not run query with debug mode $description: " . $e->getMessage());
+        }
+    }
+}


### PR DESCRIPTION
When a query fails during execution, only the exception message is written to log, not the query itself. That makes it hard to figure out what went wrong from the log.
With this fix, an exception is stored and then rethrown after logging. The query cannot be logged before execution, as this would give wrong execution time and memory usage in the Profiler.  

### ALSO

I fixed an error in `PdoConnection::exec()`. This is likey not a big deal, since it only fixes something that was broken, but you might want to check because of **backwards compatibility**, hence the double highlighting.

The `PdoConnection::exec()` method wraps `PDO::exec()`, which, according to the [manual](https://www.php.net/manual/en/pdo.exec.php) "does not return results from a SELECT statement". Instead, it returns the number of affected rows.
However, in `PdoConnection`, that returned int was wrapped into a `DataFetcher`, which only works with result sets. So now you can call `fetch()` on an int and admire the exception. I think you can call `DataFetcher::getDataObject()` to get the int back, but it is an ordeal, let alone confusing.
So I removed the DataFetcher and have `PdoConnection::exec()` return the int from `PDO::exec()` directly. If someone went the extra mile to get to the return value using `DataFetcher::getDataObject()`, that does not work anymore. 

I would like to have these two into own PRs, but the tests for query logging depend on the fix in PdoConnection (it's how I found the issue). They are different commits though.