### PR TITLE
fix doubly namespaces during database:reverse / write absolute namespaces to schema.xml

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -241,11 +241,6 @@ parameters:
 			path: src/Propel/Generator/Manager/AbstractManager.php
 
 		-
-			message: "#^Right side of && is always false\\.$#"
-			count: 1
-			path: src/Propel/Generator/Manager/ReverseManager.php
-
-		-
 			message: "#^Variable \\$timestamp might not be defined\\.$#"
 			count: 1
 			path: src/Propel/Generator/Manager/templates/migration_template.php

--- a/src/Propel/Generator/Builder/Om/AbstractOMBuilder.php
+++ b/src/Propel/Generator/Builder/Om/AbstractOMBuilder.php
@@ -361,21 +361,23 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      * check if the current $class need an alias or if the class could be used with a shortname without conflict
      *
      * @param string $class
-     * @param string $namespace
+     * @param string $classNamespace
      *
      * @return bool
      */
-    protected function needAliasForClassName($class, $namespace)
+    protected function needAliasForClassName($class, $classNamespace)
     {
-        if ($namespace == $this->getNamespace()) {
+        $builderNamespace = trim($this->getNamespace(), '\\');
+
+        if ($classNamespace == $builderNamespace) {
             return false;
         }
 
-        if (str_replace('\\Base', '', $namespace) == str_replace('\\Base', '', $this->getNamespace())) {
+        if (str_replace('\\Base', '', $classNamespace) == str_replace('\\Base', '', $builderNamespace)) {
             return true;
         }
 
-        if (empty($namespace) && $this->getNamespace() === 'Base') {
+        if (empty($classNamespace) && $builderNamespace === 'Base') {
             if (str_replace(['Query'], '', $class) == str_replace(['Query'], '', $this->getUnqualifiedClassName())) {
                 return true;
             }
@@ -385,14 +387,14 @@ abstract class AbstractOMBuilder extends DataModelBuilder
             }
 
             // force alias for model without namespace
-            if (array_search($class, $this->whiteListOfDeclaredClasses, true) === false) {
+            if (!in_array($class, $this->whiteListOfDeclaredClasses, true)) {
                 return true;
             }
         }
 
-        if ($namespace === 'Base' && $this->getNamespace() === '') {
+        if ($classNamespace === 'Base' && $builderNamespace === '') {
             // force alias for model without namespace
-            if (array_search($class, $this->whiteListOfDeclaredClasses, true) === false) {
+            if (!in_array($class, $this->whiteListOfDeclaredClasses, true)) {
                 return true;
             }
         }

--- a/src/Propel/Generator/Manager/ReverseManager.php
+++ b/src/Propel/Generator/Manager/ReverseManager.php
@@ -219,7 +219,9 @@ class ReverseManager extends AbstractManager
         $database->setPlatform($config->getConfiguredPlatform($connection));
         $database->setDefaultIdMethod(IdMethod::NATIVE);
 
-        $this->getNamespace() && $database->setNamespace($this->getNamespace());
+        if ($this->getNamespace()) {
+            $database->setNamespace($this->getNamespace());
+        }
 
         $buildConnection = $config->getBuildConnection($databaseName);
         $this->log(sprintf('Reading database structure of database `%s` using dsn `%s`', $this->getDatabaseName(), $buildConnection['dsn']));

--- a/src/Propel/Generator/Model/ScopedMappingModel.php
+++ b/src/Propel/Generator/Model/ScopedMappingModel.php
@@ -76,10 +76,16 @@ abstract class ScopedMappingModel extends MappingModel
     /**
      * Returns the namespace.
      *
-     * @return string
+     * @param bool $getAbsoluteNamespace
+     *
+     * @return string|null
      */
-    public function getNamespace()
+    public function getNamespace(bool $getAbsoluteNamespace = false): ?string
     {
+        if ($getAbsoluteNamespace) {
+            return $this->makeNamespaceAbsolute($this->namespace);
+        }
+
         return $this->namespace;
     }
 
@@ -116,7 +122,23 @@ abstract class ScopedMappingModel extends MappingModel
      */
     public function isAbsoluteNamespace($namespace)
     {
-        return strpos($namespace, '\\') === 0;
+        return ($namespace && substr($namespace, 0, 1) === '\\');
+    }
+
+    /**
+     * Prepends a backslash to a namespace if there is none.
+     *
+     * A namespace with a backslash is considered absolute.
+     *
+     * @param string|null $namespace
+     *
+     * @return string|null
+     */
+    protected function makeNamespaceAbsolute(?string $namespace): ?string
+    {
+        $prependBackslash = ($namespace && !$this->isAbsoluteNamespace($namespace));
+
+        return ($prependBackslash) ?  "\\$namespace" : $namespace;
     }
 
     /**

--- a/src/Propel/Generator/Model/Table.php
+++ b/src/Propel/Generator/Model/Table.php
@@ -545,7 +545,7 @@ class Table extends ScopedMappingModel implements IdMethod
     /**
      * Returns a delimiter-delimited string list of column names.
      *
-     * @see Platform::getColumnList() if quoting is required
+     * @see \Propel\Generator\Platform\PlatformInterface::getColumnListDDL() if quoting is required
      *
      * @param array $columns
      * @param string $delimiter
@@ -608,7 +608,7 @@ class Table extends ScopedMappingModel implements IdMethod
      */
     public function setBaseClass($class)
     {
-        $this->baseClass = $class;
+        $this->baseClass = $this->makeNamespaceAbsolute($class);
     }
 
     /**
@@ -620,7 +620,7 @@ class Table extends ScopedMappingModel implements IdMethod
      */
     public function setBaseQueryClass($class)
     {
-        $this->baseQueryClass = $class;
+        $this->baseQueryClass = $this->makeNamespaceAbsolute($class);
     }
 
     /**

--- a/src/Propel/Generator/Schema/Dumper/XmlDumper.php
+++ b/src/Propel/Generator/Schema/Dumper/XmlDumper.php
@@ -109,8 +109,9 @@ class XmlDumper implements DumperInterface
             $databaseNode->setAttribute('schema', $schema);
         }
 
-        if ($namespace = $database->getNamespace()) {
-            $databaseNode->setAttribute('namespace', $namespace);
+        $absoluteNamespace = $database->getNamespace(true);
+        if ($absoluteNamespace) {
+            $databaseNode->setAttribute('namespace', $absoluteNamespace);
         }
 
         if ($baseClass = $database->getBaseClass()) {
@@ -225,8 +226,9 @@ class XmlDumper implements DumperInterface
             $tableNode->setAttribute('package', $package);
         }
 
-        if ($namespace = $table->getNamespace()) {
-            $tableNode->setAttribute('namespace', $namespace);
+        $absoluteNamespace = $table->getNamespace(true);
+        if ($absoluteNamespace && $absoluteNamespace !== $database->getNamespace(true)) {
+            $tableNode->setAttribute('namespace', $absoluteNamespace);
         }
 
         if ($table->isSkipSql()) {

--- a/tests/Propel/Tests/Generator/Builder/Om/AbstractOMBuilderNamespaceTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/AbstractOMBuilderNamespaceTest.php
@@ -170,6 +170,41 @@ class AbstractOMBuilderNamespaceTest extends TestCase
         ];
         $this->assertEquals($expected, $builder->getDeclaredClasses());
     }
+
+    /**
+     * @return array
+     */
+    public function namespaceDataProvider(): array
+    {
+        //[<table namespace>, <class namespace>, <message>]]
+        return [
+            ['\\My\\Namespace', '\\My\\Namespace', 'slashed namespace should work'],
+            ['My\\Namespace', 'My\\Namespace', 'non-slashed namespace should work'],
+            ['My\\Namespace', '\\My\\Namespace', 'slashes are stripped from class namespace anyway'],
+            ['\\My\\Namespace', 'My\\Namespace', 'slashes are stripped from table namespace anyway'],
+        ];
+    }
+
+    /**
+     * @dataProvider namespaceDataProvider
+     * @doesNotPerformAssertions
+     *
+     * @return void
+     */
+    public function testDeclareClassNamespaceIgnoresLeadingSlashInNamespace(string $tableNamespace, string $classNamespace, string $message): void
+    {
+        $table = new Table('Table1');
+        $table->setNamespace($tableNamespace);
+
+        $builder = new TestableOMBuilder2($table);
+
+        $builder->declareClassNamespace('MyTable1Class', $classNamespace . '\\Base');
+        try{
+            $builder->declareClassNamespace('MyTable1Class', $classNamespace);
+        } catch(LogicException $e) {
+            $this->fail($message);
+        }
+    }
 }
 
 class TestableOMBuilder2 extends AbstractOMBuilder

--- a/tests/Propel/Tests/Generator/Model/DatabaseTest.php
+++ b/tests/Propel/Tests/Generator/Model/DatabaseTest.php
@@ -18,7 +18,6 @@ use Propel\Generator\Model\Table;
 use Propel\Generator\Platform\MysqlPlatform;
 use Propel\Generator\Platform\PgsqlPlatform;
 use Propel\Generator\Util\VfsTrait;
-use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * Unit test suite for Database model class.
@@ -459,25 +458,41 @@ class DatabaseTest extends ModelTestCase
     }
 
     /**
-     * @return void
+     * return array
      */
-    public function testSetBaseClasses()
+    public function baseClassDataProvider(): array
     {
-        $database = new Database();
-        $database->setBaseClass('CustomBaseObject');
-
-        $this->assertSame('CustomBaseObject', $database->getBaseClass());
+        return [
+            // [<Class name>, <Expected class name>, <message>]]
+            ['\CustomBaseQueryObject', '\CustomBaseQueryObject', 'Setter should set base query class'],
+            ['CustomBaseQueryObject', '\CustomBaseQueryObject', 'Setter should set absolute namespace of base query class'],
+        ];
     }
 
     /**
+     * @dataProvider baseClassDataProvider
+     *
      * @return void
      */
-    public function testSetBaseQueryClasses()
+    public function testSetBaseClass(string $className, string $expectedClassName, string $message)
     {
         $database = new Database();
-        $database->setBaseQueryClass('CustomBaseQueryObject');
+        $database->setBaseClass($className);
 
-        $this->assertSame('CustomBaseQueryObject', $database->getBaseQueryClass());
+        $this->assertSame($expectedClassName, $database->getBaseClass(), $message);
+    }
+
+    /**
+     * @dataProvider baseClassDataProvider
+     *
+     * @return void
+     */
+    public function testSetBaseQueryClass(string $className, string $expectedClassName, string $message)
+    {
+        $database = new Database();
+        $database->setBaseQueryClass($className);
+
+        $this->assertSame($expectedClassName, $database->getBaseQueryClass(), $message);
     }
 
     /**
@@ -554,5 +569,51 @@ EOF;
         $db->setSchema($schema);
 
         $this->assertEquals($schema, $db->getNamespace());
+    }
+
+    /**
+     * @return array
+     */
+    public function combinedNamespaceDataProvider(): array
+    {
+        // [<Database namespace>, <Table namespace>, <Combined namespace>, <Message>]
+        return [
+            [null, null, null, 'No namespaces should leave table namespace empty'],
+            ['Le\\Database', null, 'Le\\Database', 'No table namespace should use database namespace'],
+            [null, 'Il\\Table', 'Il\\Table', 'No database namespace should result in unchanged table namespace'],
+            ['Le\\Database', '\\Il\\Table', 'Il\\Table', 'Absolute table namespace should superseed database namespace'],
+            ['Le\\Database', 'Il\\Table', 'Le\\Database\\Il\\Table', 'Relative table namespace should be apended to database namespace'],
+            ['Le\\Database', 'Le\\Database', 'Le\\Database\\Le\\Database', 'Same relative namespace on database and table should be doubled'],
+            ['Le\\Database', '\\Le\\Database', 'Le\\Database', 'Same absolute namespace on database and table should be used only once (as all absolute namespaces)'],
+        ];
+    }
+
+    /**
+     * @dataProvider combinedNamespaceDataProvider
+     *
+     * @param string|null $databaseNamespace
+     * @param string|null $tableNamespace
+     * @param string|null $expectedNamespace
+     * @param string $message
+     *
+     * @return void
+     */
+    public function testCombineNamespace($databaseNamespace, $tableNamespace, $expectedNamespace, $message)
+    {
+        $database = new Database();
+
+        if ($databaseNamespace !== null) {
+            $database->setNamespace($databaseNamespace);
+        }
+
+        $table = new Table();
+        if ($tableNamespace !== null) {
+            $table->setNamespace($tableNamespace);
+        }
+
+        $database->addTable($table);
+        $combinedNamespace = $table->getNamespace();
+
+        $this->assertEquals($expectedNamespace, $combinedNamespace, $message);
     }
 }

--- a/tests/Propel/Tests/Generator/Model/TableTest.php
+++ b/tests/Propel/Tests/Generator/Model/TableTest.php
@@ -886,14 +886,41 @@ class TableTest extends ModelTestCase
     }
 
     /**
+     * return array
+     */
+    public function baseClassDataProvider(): array
+    {
+        return [
+            // [<Class name>, <Expected class name>, <message>]]
+            ['\CustomBaseQueryObject', '\CustomBaseQueryObject', 'Setter should set base query class'],
+            ['CustomBaseQueryObject', '\CustomBaseQueryObject', 'Setter should set absolute namespace of base query class'],
+        ];
+    }
+
+    /**
+     * @dataProvider baseClassDataProvider
+     *
      * @return void
      */
-    public function testSetBaseClasses()
+    public function testSetBaseClass(string $className, string $expectedClassName, string $message)
     {
         $table = new Table();
-        $table->setBaseClass('BaseObject');
+        $table->setBaseClass($className);
 
-        $this->assertSame('BaseObject', $table->getBaseClass());
+        $this->assertSame($expectedClassName, $table->getBaseClass(), $message);
+    }
+
+    /**
+     * @dataProvider baseClassDataProvider
+     *
+     * @return void
+     */
+    public function testSetBaseQueryClass(string $className, string $expectedClassName, string $message)
+    {
+        $table = new Table();
+        $table->setBaseQueryClass($className);
+
+        $this->assertSame($expectedClassName, $table->getBaseQueryClass(), $message);
     }
 
     /**

--- a/tests/Propel/Tests/Resources/blog-database.php
+++ b/tests/Propel/Tests/Resources/blog-database.php
@@ -75,6 +75,14 @@ $column64 = new Column('is_published', 'boolean');
 $column64->setNotNull();
 $column64->setDefaultValue('false');
 
+$column71 = new Column('id', 'integer');
+$column71->setNotNull();
+$column71->setPrimaryKey();
+
+$column81 = new Column('id', 'integer');
+$column81->setNotNull();
+$column81->setPrimaryKey();
+
 /* Foreign Keys */
 $fkAuthorPost = new ForeignKey('fk_post_has_author');
 $fkAuthorPost->addReference('author_id', 'id');
@@ -151,11 +159,12 @@ $table4->setPackage('Acme.Blog');
 $table4->addColumns([ $column41, $column42 ]);
 
 $table5 = new Table('blog_post_tag');
-$table5->setNamespace('Blog');
+$table5->setNamespace('\Acme\Model\Blog');
 $table5->setPackage('Acme.Blog');
 $table5->setCrossRef();
 $table5->addColumns([ $column51, $column52 ]);
 $table5->addForeignKeys([ $fkPostTag, $fkTagPost ]);
+$table5->setDescription('This table was given with an absolute namespace');
 
 $table6 = new Table('cms_page');
 $table6->setPhpName('Page');
@@ -166,6 +175,16 @@ $table6->addColumns([ $column61, $column62, $column63, $column64 ]);
 $table6->addIndex($pageContentFulltextIdx);
 $table6->addVendorInfo(new VendorInfo('mysql', ['Engine' => 'MyISAM']));
 
+$table7 = new Table('external_table');
+$table7->setNamespace('\\External');
+$table7->addColumns([ $column71 ]);
+$table7->setDescription('A table in the \\External namespace');
+
+$table8 = new Table('acme_base');
+$table8->setNamespace('\\Acme\\Model');
+$table8->addColumns([ $column81 ]);
+$table8->setDescription('A table in the \\Acme\\Model namespace should not have a namespace declaration');
+
 /* Database */
 $database = new Database('acme_blog', new MysqlPlatform());
 $database->setSchema('acme');
@@ -175,6 +194,6 @@ $database->setBaseClass('Acme\\Model\\ActiveRecord');
 $database->setPackage('Acme');
 $database->setHeavyIndexing();
 $database->addVendorInfo(new VendorInfo('mysql', [ 'Engine' => 'InnoDB', 'Charset' => 'utf8' ]));
-$database->addTables([ $table1, $table2, $table3, $table4, $table5, $table6 ]);
+$database->addTables([ $table1, $table2, $table3, $table4, $table5, $table6, $table7, $table8 ]);
 
 return $database;

--- a/tests/Propel/Tests/Resources/blog-database.xml
+++ b/tests/Propel/Tests/Resources/blog-database.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<database name="acme_blog" defaultIdMethod="native" package="Acme" schema="acme" namespace="Acme\Model" baseClass="Acme\Model\ActiveRecord" defaultPhpNamingMethod="underscore" heavyIndexing="true" tablePrefix="acme_">
+<database name="acme_blog" defaultIdMethod="native" package="Acme" schema="acme" namespace="\Acme\Model" baseClass="\Acme\Model\ActiveRecord" defaultPhpNamingMethod="underscore" heavyIndexing="true" tablePrefix="acme_">
   <vendor type="mysql">
     <parameter name="Engine" value="InnoDB"/>
     <parameter name="Charset" value="utf8"/>
   </vendor>
-  <table name="blog_post" phpName="BlogPost" package="Acme.Blog" namespace="Acme\Model\Blog" baseClass="Acme\Model\ActiveRecord" description="The list of posts">
+  <table name="blog_post" phpName="BlogPost" package="Acme.Blog" namespace="\Acme\Model\Blog" baseClass="\Acme\Model\ActiveRecord" description="The list of posts">
     <column name="id" phpName="Id" type="integer" size="7" primaryKey="true" autoIncrement="true" required="true"/>
     <column name="author_id" phpName="AuthorId" type="smallint" size="3" required="true"/>
     <column name="category_id" phpName="CategoryId" type="tinyint" size="2" required="true"/>
@@ -35,7 +35,7 @@
       <parameter name="unique_constraint" value="true"/>
     </behavior>
   </table>
-  <table name="blog_author" phpName="BlogAuthor" package="Acme.Blog" namespace="Acme\Model\Blog" baseClass="Acme\Model\ActiveRecord" description="The list of authors">
+  <table name="blog_author" phpName="BlogAuthor" package="Acme.Blog" namespace="\Acme\Model\Blog" baseClass="\Acme\Model\ActiveRecord" description="The list of authors">
     <column name="id" phpName="Id" type="smallint" size="3" primaryKey="true" autoIncrement="true" required="true"/>
     <column name="username" phpName="Username" type="varchar" size="15" required="true"/>
     <column name="password" phpName="Password" type="varchar" size="40" required="true"/>
@@ -43,15 +43,15 @@
       <unique-column name="username" size="8"/>
     </unique>
   </table>
-  <table name="blog_category" phpName="BlogCategory" package="Acme.Blog" namespace="Acme\Model\Blog" baseClass="Acme\Model\ActiveRecord" description="The list of categories">
+  <table name="blog_category" phpName="BlogCategory" package="Acme.Blog" namespace="\Acme\Model\Blog" baseClass="\Acme\Model\ActiveRecord" description="The list of categories">
     <column name="id" phpName="Id" type="tinyint" size="2" primaryKey="true" autoIncrement="true" required="true"/>
     <column name="name" phpName="Name" type="varchar" size="40" required="true"/>
   </table>
-  <table name="blog_tag" phpName="BlogTag" package="Acme.Blog" namespace="Acme\Model\Blog" baseClass="Acme\Model\ActiveRecord" description="The list of tags">
+  <table name="blog_tag" phpName="BlogTag" package="Acme.Blog" namespace="\Acme\Model\Blog" baseClass="\Acme\Model\ActiveRecord" description="The list of tags">
     <column name="id" phpName="Id" type="integer" size="7" primaryKey="true" autoIncrement="true" required="true"/>
     <column name="name" phpName="Name" type="varchar" size="40" required="true"/>
   </table>
-  <table name="blog_post_tag" phpName="BlogPostTag" package="Acme.Blog" namespace="Acme\Model\Blog" isCrossRef="true" baseClass="Acme\Model\ActiveRecord">
+  <table name="blog_post_tag" phpName="BlogPostTag" package="Acme.Blog" namespace="\Acme\Model\Blog" isCrossRef="true" baseClass="\Acme\Model\ActiveRecord" description="This table was given with an absolute namespace">
     <column name="post_id" phpName="PostId" type="integer" size="7" primaryKey="true" required="true"/>
     <column name="tag_id" phpName="TagId" type="integer" size="7" primaryKey="true" required="true"/>
     <foreign-key foreignTable="blog_post" name="fk_post_has_tags" phpName="Post" defaultJoin="Criteria::LEFT_JOIN" onDelete="CASCADE">
@@ -61,7 +61,7 @@
       <reference local="tag_id" foreign="id"/>
     </foreign-key>
   </table>
-  <table name="cms_page" phpName="Page" package="Acme.Cms" namespace="Acme\Model\Cms" baseClass="Acme\Model\PublicationActiveRecord">
+  <table name="cms_page" phpName="Page" package="Acme.Cms" namespace="\Acme\Model\Cms" baseClass="\Acme\Model\PublicationActiveRecord">
     <column name="id" phpName="Id" type="integer" size="5" primaryKey="true" autoIncrement="true" required="true"/>
     <column name="title" phpName="Title" type="varchar" size="150" required="true"/>
     <column name="content" phpName="Content" type="clob">
@@ -80,5 +80,11 @@
     <vendor type="mysql">
       <parameter name="Engine" value="MyISAM"/>
     </vendor>
+  </table>
+  <table name="external_table" phpName="ExternalTable" package="Acme" namespace="\External" baseClass="\Acme\Model\ActiveRecord" description="A table in the \External namespace">
+    <column name="id" phpName="Id" type="integer" primaryKey="true" required="true"/>
+  </table>
+  <table name="acme_base" phpName="AcmeBase" package="Acme" baseClass="\Acme\Model\ActiveRecord" description="A table in the \Acme\Model namespace should not have a namespace declaration">
+    <column name="id" phpName="Id" type="integer" primaryKey="true" required="true"/>
   </table>
 </database>

--- a/tests/Propel/Tests/Resources/blog-schema.xml
+++ b/tests/Propel/Tests/Resources/blog-schema.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <app-data>
-  <database name="acme_blog" defaultIdMethod="native" package="Acme" schema="acme" namespace="Acme\Model" baseClass="Acme\Model\ActiveRecord" defaultPhpNamingMethod="underscore" heavyIndexing="true" tablePrefix="acme_">
+  <database name="acme_blog" defaultIdMethod="native" package="Acme" schema="acme" namespace="\Acme\Model" baseClass="\Acme\Model\ActiveRecord" defaultPhpNamingMethod="underscore" heavyIndexing="true" tablePrefix="acme_">
     <vendor type="mysql">
       <parameter name="Engine" value="InnoDB"/>
       <parameter name="Charset" value="utf8"/>
     </vendor>
-    <table name="blog_post" phpName="BlogPost" package="Acme.Blog" namespace="Acme\Model\Blog" baseClass="Acme\Model\ActiveRecord" description="The list of posts">
+    <table name="blog_post" phpName="BlogPost" package="Acme.Blog" namespace="\Acme\Model\Blog" baseClass="\Acme\Model\ActiveRecord" description="The list of posts">
       <column name="id" phpName="Id" type="integer" size="7" primaryKey="true" autoIncrement="true" required="true"/>
       <column name="author_id" phpName="AuthorId" type="smallint" size="3" required="true"/>
       <column name="category_id" phpName="CategoryId" type="tinyint" size="2" required="true"/>
@@ -48,7 +48,7 @@
         <parameter name="unique_constraint" value="true"/>
       </behavior>
     </table>
-    <table name="blog_author" phpName="BlogAuthor" package="Acme.Blog" namespace="Acme\Model\Blog" baseClass="Acme\Model\ActiveRecord" description="The list of authors">
+    <table name="blog_author" phpName="BlogAuthor" package="Acme.Blog" namespace="\Acme\Model\Blog" baseClass="\Acme\Model\ActiveRecord" description="The list of authors">
       <column name="id" phpName="Id" type="smallint" size="3" primaryKey="true" autoIncrement="true" required="true"/>
       <column name="username" phpName="Username" type="varchar" size="15" required="true"/>
       <column name="password" phpName="Password" type="varchar" size="40" required="true"/>
@@ -56,15 +56,15 @@
         <unique-column name="username" size="8"/>
       </unique>
     </table>
-    <table name="blog_category" phpName="BlogCategory" package="Acme.Blog" namespace="Acme\Model\Blog" baseClass="Acme\Model\ActiveRecord" description="The list of categories">
+    <table name="blog_category" phpName="BlogCategory" package="Acme.Blog" namespace="\Acme\Model\Blog" baseClass="\Acme\Model\ActiveRecord" description="The list of categories">
       <column name="id" phpName="Id" type="tinyint" size="2" primaryKey="true" autoIncrement="true" required="true"/>
       <column name="name" phpName="Name" type="varchar" size="40" required="true"/>
     </table>
-    <table name="blog_tag" phpName="BlogTag" package="Acme.Blog" namespace="Acme\Model\Blog" baseClass="Acme\Model\ActiveRecord" description="The list of tags">
+    <table name="blog_tag" phpName="BlogTag" package="Acme.Blog" namespace="\Acme\Model\Blog" baseClass="\Acme\Model\ActiveRecord" description="The list of tags">
       <column name="id" phpName="Id" type="integer" size="7" primaryKey="true" autoIncrement="true" required="true"/>
       <column name="name" phpName="Name" type="varchar" size="40" required="true"/>
     </table>
-    <table name="blog_post_tag" phpName="BlogPostTag" package="Acme.Blog" namespace="Acme\Model\Blog" isCrossRef="true" baseClass="Acme\Model\ActiveRecord">
+    <table name="blog_post_tag" phpName="BlogPostTag" package="Acme.Blog" namespace="\Acme\Model\Blog" isCrossRef="true" baseClass="\Acme\Model\ActiveRecord" description="This table was given with an absolute namespace">
       <column name="post_id" phpName="PostId" type="integer" size="7" primaryKey="true" required="true"/>
       <column name="tag_id" phpName="TagId" type="integer" size="7" primaryKey="true" required="true"/>
       <foreign-key foreignTable="blog_post" name="fk_post_has_tags" phpName="Post" defaultJoin="Criteria::LEFT_JOIN" onDelete="CASCADE">
@@ -77,7 +77,7 @@
         <index-column name="tag_id"/>
       </index>
     </table>
-    <table name="cms_page" phpName="Page" package="Acme.Cms" namespace="Acme\Model\Cms" baseClass="Acme\Model\PublicationActiveRecord">
+    <table name="cms_page" phpName="Page" package="Acme.Cms" namespace="\Acme\Model\Cms" baseClass="\Acme\Model\PublicationActiveRecord">
       <column name="id" phpName="Id" type="integer" size="5" primaryKey="true" autoIncrement="true" required="true"/>
       <column name="title" phpName="Title" type="varchar" size="150" required="true"/>
       <column name="content" phpName="Content" type="clob">
@@ -96,6 +96,12 @@
       <vendor type="mysql">
         <parameter name="Engine" value="MyISAM"/>
       </vendor>
+    </table>
+    <table name="external_table" phpName="ExternalTable" package="Acme" namespace="\External" baseClass="\Acme\Model\ActiveRecord" description="A table in the \External namespace">
+      <column name="id" phpName="Id" type="integer" primaryKey="true" required="true"/>
+    </table>
+    <table name="acme_base" phpName="AcmeBase" package="Acme" baseClass="\Acme\Model\ActiveRecord" description="A table in the \Acme\Model namespace should not have a namespace declaration">
+      <column name="id" phpName="Id" type="integer" primaryKey="true" required="true"/>
     </table>
   </database>
 </app-data>


### PR DESCRIPTION
Lots of users, including me, have stumbled over doubled namespaces after `database:reverse` (see #1233). For example, calling `prople database:reverse --namespace=My\Namespace ...` will lead to a schema like
```xml
<database namespace="My\Namespace">
  <table PhpName="MyTable" namespace="My\Namespace">
  </table>
</database>
```
 which will generate files in the namespace `My\Namespace\My\Namespace`, not the specified `My\Namespace`, and hence the confusion.
 
 The reason for this is actually quite straight forward. Propel differentiates between absolute namespaces and relative namespaces (as documented [here](http://propelorm.org/documentation/cookbook/namespaces.html#namespace-declaration-and-inheritance)). Absolute namespaces begin with a backslash, while relative namespaces do not. So if there is a namespace on the database element (doesn't matter if absolute or relative), and a table has a relative namespace, the names are combined. This is what causes the doubled namespace in above example and the output from `database:reverse`.
 
So, simple workaround is to use an absolute namespace in the reverse command, i.e. `propel database:reverse --namespace=\\My\\Namespace ...` (or `--namespace='\My\Namespace'`, but not `--namespace=\My\Namespace`). However, most user probably don't do a deep dive into the documentation while occupied with reverse engineering (and the issue runs a bit deeper).

Anyway, fix is quite simple: Let XmlDumper write absolute namespaces to schema.xml. Once tables are added to their database, they store the full namespace anyway, just without the leading backslash. Adding those leading backslashes again removes the pitfall of accidentally causing namespace extension. Beneficial side-effect is that users will see how absolute path look like, and probably identify the error should it ever come up again.

Of course, users can still use namespace extension in their schema. And there is no issue with backwards compatibility for existing schemas. Running `database:reverse` will generate a different schema than before, but I cannot think of a scenario where this causes issues with BC. 

If merged, this resolves #1233 and #1235, and fixes #1241
