### PR TITLE
Tests for #1507: Import MySQL column/table descriptions during database:reverse & added PDODataFetcher::fetchAll()

### DIFF
--- a/src/Propel/Generator/Reverse/MysqlSchemaParser.php
+++ b/src/Propel/Generator/Reverse/MysqlSchemaParser.php
@@ -113,6 +113,10 @@ class MysqlSchemaParser extends AbstractSchemaParser
 
         // Now add indices and constraints.
         foreach ($database->getTables() as $table) {
+            $this->addTableDescription($table);
+            foreach ($table->getColumns() as $column) {
+                $this->addColumnDescription($column);
+            }
             $this->addForeignKeys($table);
             $this->addIndexes($table);
             $this->addPrimaryKey($table);
@@ -281,6 +285,51 @@ class MysqlSchemaParser extends AbstractSchemaParser
         }
 
         return $column;
+    }
+
+    /**
+     * Load a comment for this table.
+     *
+     * @param \Propel\Generator\Model\Table $table
+     *
+     * @return void
+     */
+    protected function addTableDescription(Table $table)
+    {
+        $tableName = $this->getPlatform()->quote($table->getName());
+        /** @var \Propel\Runtime\DataFetcher\PDODataFetcher $dataFetcher */
+        $dataFetcher = $this->dbh->query("
+SELECT table_comment
+FROM INFORMATION_SCHEMA.TABLES
+WHERE table_schema=DATABASE()
+  AND table_name=({$tableName})");
+        [$comment] = $dataFetcher->fetch();
+        if ($comment !== '' && $comment !== null) {
+            $table->setDescription($comment);
+        }
+    }
+
+    /**
+     * Load a comment for this column.
+     *
+     * @param \Propel\Generator\Model\Column $column
+     *
+     * @return void
+     */
+    protected function addColumnDescription(Column $column)
+    {
+        $tableName = $this->getPlatform()->quote($column->getTableName());
+        $columnName = $this->getPlatform()->quote($column->getName());
+        /** @var \Propel\Runtime\DataFetcher\PDODataFetcher $dataFetcher */
+        $dataFetcher = $this->dbh->query("
+SELECT column_comment FROM INFORMATION_SCHEMA.COLUMNS
+WHERE table_schema=DATABASE()
+  AND table_name=({$tableName})
+  AND column_name=({$columnName})");
+        [$comment] = $dataFetcher->fetch();
+        if ($comment !== '' && $comment !== null) {
+            $column->setDescription($comment);
+        }
     }
 
     /**

--- a/src/Propel/Generator/Reverse/MysqlSchemaParser.php
+++ b/src/Propel/Generator/Reverse/MysqlSchemaParser.php
@@ -17,6 +17,8 @@ use Propel\Generator\Model\Index;
 use Propel\Generator\Model\PropelTypes;
 use Propel\Generator\Model\Table;
 use Propel\Generator\Model\Unique;
+use Propel\Generator\Platform\MysqlPlatform;
+use Propel\Runtime\Connection\ConnectionInterface;
 
 /**
  * Mysql database schema parser.
@@ -90,6 +92,16 @@ class MysqlSchemaParser extends AbstractSchemaParser
     }
 
     /**
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $dbh Optional database connection
+     */
+    public function __construct(?ConnectionInterface $dbh = null)
+    {
+        parent::__construct($dbh);
+
+        $this->setPlatform(new MysqlPlatform());
+    }
+
+    /**
      * @param \Propel\Generator\Model\Database $database
      * @param \Propel\Generator\Model\Table[] $additionalTables
      *
@@ -113,15 +125,13 @@ class MysqlSchemaParser extends AbstractSchemaParser
 
         // Now add indices and constraints.
         foreach ($database->getTables() as $table) {
-            $this->addTableDescription($table);
-            foreach ($table->getColumns() as $column) {
-                $this->addColumnDescription($column);
-            }
             $this->addForeignKeys($table);
             $this->addIndexes($table);
             $this->addPrimaryKey($table);
 
             $this->addTableVendorInfo($table);
+            $this->addDescriptionToTable($table);
+            $this->addColumnDescriptionsToTable($table);
         }
 
         return count($database->getTables());
@@ -288,25 +298,56 @@ class MysqlSchemaParser extends AbstractSchemaParser
     }
 
     /**
-     * Load a comment for this table.
+     * Load and set table description.
      *
      * @param \Propel\Generator\Model\Table $table
      *
      * @return void
      */
-    protected function addTableDescription(Table $table)
+    protected function addDescriptionToTable(Table $table): void
+    {
+        $tableDescription = $this->loadTableDescription($table);
+        if ($tableDescription) {
+            $table->setDescription($tableDescription);
+        }
+    }
+
+    /**
+     * Sets column descriptions according to source.
+     *
+     * @param \Propel\Generator\Model\Table $table
+     *
+     * @return void
+     */
+    protected function addColumnDescriptionsToTable(Table $table): void
+    {
+        foreach ($table->getColumns() as $column) {
+            $columnDescription = $this->loadColumnDescription($column);
+            if ($columnDescription) {
+                $column->setDescription($columnDescription);
+            }
+        }
+    }
+
+    /**
+     * Load a comment for this table.
+     *
+     * @param \Propel\Generator\Model\Table $table
+     *
+     * @return string|null
+     */
+    protected function loadTableDescription(Table $table): ?string
     {
         $tableName = $this->getPlatform()->quote($table->getName());
-        /** @var \Propel\Runtime\DataFetcher\PDODataFetcher $dataFetcher */
-        $dataFetcher = $this->dbh->query("
+        $query = <<< EOT
 SELECT table_comment
 FROM INFORMATION_SCHEMA.TABLES
 WHERE table_schema=DATABASE()
-  AND table_name=({$tableName})");
-        [$comment] = $dataFetcher->fetch();
-        if ($comment !== '' && $comment !== null) {
-            $table->setDescription($comment);
-        }
+  AND table_name=($tableName)
+EOT;
+
+        /** @var string|null */
+        return $this->dbh->query($query)->fetchColumn();
     }
 
     /**
@@ -314,22 +355,22 @@ WHERE table_schema=DATABASE()
      *
      * @param \Propel\Generator\Model\Column $column
      *
-     * @return void
+     * @return string|null
      */
-    protected function addColumnDescription(Column $column)
+    protected function loadColumnDescription(Column $column): ?string
     {
         $tableName = $this->getPlatform()->quote($column->getTableName());
         $columnName = $this->getPlatform()->quote($column->getName());
-        /** @var \Propel\Runtime\DataFetcher\PDODataFetcher $dataFetcher */
-        $dataFetcher = $this->dbh->query("
-SELECT column_comment FROM INFORMATION_SCHEMA.COLUMNS
+        $query = <<< EOT
+SELECT column_comment
+FROM INFORMATION_SCHEMA.COLUMNS
 WHERE table_schema=DATABASE()
-  AND table_name=({$tableName})
-  AND column_name=({$columnName})");
-        [$comment] = $dataFetcher->fetch();
-        if ($comment !== '' && $comment !== null) {
-            $column->setDescription($comment);
-        }
+  AND table_name=($tableName)
+  AND column_name=($columnName)
+EOT;
+
+        /** @var string|null */
+        return $this->dbh->query($query)->fetchColumn();
     }
 
     /**

--- a/src/Propel/Runtime/DataFetcher/PDODataFetcher.php
+++ b/src/Propel/Runtime/DataFetcher/PDODataFetcher.php
@@ -84,6 +84,24 @@ class PDODataFetcher extends AbstractDataFetcher
     }
 
     /**
+     * @see \PDOStatement::fetchAll()
+     *
+     * @param int|null $style
+     * @param int|string|object|null $fetch_argument
+     * @param array|null $ctor_args
+     *
+     * @return array
+     */
+    public function fetchAll(?int $style = null, $fetch_argument = null, ?array $ctor_args = null): array
+    {
+        if ($style === null) {
+            $style = $this->style;
+        }
+
+        return $this->getDataObject()->fetchAll($style, $fetch_argument, $ctor_args);
+    }
+
+    /**
      * @return void
      */
     public function next()

--- a/tests/Propel/Tests/Generator/Reverse/AbstractSchemaParserTest.php
+++ b/tests/Propel/Tests/Generator/Reverse/AbstractSchemaParserTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Tests\Generator\Reverse;
+
+use PDO;
+use Propel\Generator\Config\QuickGeneratorConfig;
+use Propel\Generator\Model\Database;
+use Propel\Generator\Platform\DefaultPlatform;
+use Propel\Tests\Helpers\Bookstore\BookstoreTestBase;
+
+/**
+ * Abstract base class for database schema parser tests.
+ *
+ * @author Moritz Ringler
+ *
+ * @abstract
+ *
+ * @group database
+ */
+abstract class AbstractSchemaParserTest extends BookstoreTestBase
+{
+    /**
+     * @var \Propel\Generator\Reverse\SchemaParserInterface
+     */
+    protected $parser;
+
+    /**
+     * @var \Propel\Generator\Model\Database
+     */
+    protected $parsedDatabase;
+
+    /**
+     * @abstract
+     *
+     * @return string
+     */
+    abstract protected function getSchemaParserClass(): string;
+
+    /**
+     * @abstract
+     *
+     * @return string
+     */
+    abstract protected function getDriverName(): string;
+
+    /**
+     * @return void
+     */
+    protected function init(): void
+    {
+        $parserClass = $this->getSchemaParserClass();
+        $parser = new $parserClass($this->con);
+        $parser->setGeneratorConfig(new QuickGeneratorConfig());
+
+        $database = new Database();
+        $database->setPlatform(new DefaultPlatform());
+
+        $parser->parse($database);
+
+        $this->parser = $parser;
+        $this->parsedDatabase = $database;
+    }
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $expectedDriverName = $this->getDriverName();
+        $currentDriverName = $this->con->getAttribute(PDO::ATTR_DRIVER_NAME);
+        if ($currentDriverName !== $expectedDriverName) {
+            $this->markTestSkipped("This test is designed for $expectedDriverName and cannot be run with $currentDriverName");
+
+            return;
+        }
+
+        if ($this->parser === null) {
+            $this->init();
+        }
+    }
+}

--- a/tests/Propel/Tests/Generator/Reverse/MysqlSchemaParserTest.php
+++ b/tests/Propel/Tests/Generator/Reverse/MysqlSchemaParserTest.php
@@ -8,12 +8,9 @@
 
 namespace Propel\Tests\Generator\Reverse;
 
-use Propel\Generator\Config\QuickGeneratorConfig;
-use Propel\Generator\Model\Database;
-use Propel\Generator\Platform\DefaultPlatform;
+use PDO;
 use Propel\Generator\Reverse\MysqlSchemaParser;
-use Propel\Runtime\Propel;
-use Propel\Tests\TestCaseFixturesDatabase;
+use Propel\Tests\Bookstore\Map\BookTableMap;
 
 /**
  * Tests for Mysql database schema parser.
@@ -21,29 +18,67 @@ use Propel\Tests\TestCaseFixturesDatabase;
  * @author William Durand
  *
  * @group database
+ * @group mysql
  */
-class MysqlSchemaParserTest extends TestCaseFixturesDatabase
+class MysqlSchemaParserTest extends AbstractSchemaParserTest
 {
+    /**
+     * @return string
+     */
+    protected function getDriverName(): string
+    {
+        return 'mysql';
+    }
+
+    /**
+     * @return string
+     */
+    protected function getSchemaParserClass(): string
+    {
+        return MysqlSchemaParser::class;
+    }
+
     /**
      * @return void
      */
-    public function testParse()
+    public function testParseImportsAllTables(): void
     {
-        $this->markTestSkipped('Skipped as we now use one database for the whole test suite');
+        $query = <<< EOT
+SELECT table_name
+FROM INFORMATION_SCHEMA.TABLES
+WHERE table_schema=DATABASE()
+AND table_name NOT LIKE 'propel_migration'
+EOT;
+        $expectedTableNames = $this->con->query($query)->fetchAll(PDO::FETCH_COLUMN, 0);
 
-        $parser = new MysqlSchemaParser(Propel::getServiceContainer()->getConnection('reverse-bookstore'));
-        $parser->setGeneratorConfig(new QuickGeneratorConfig());
+        $importedTables = $this->parsedDatabase->getTables();
+        $importedTableNames = array_map(function ($table) {
+            return $table->getName();
+        }, $importedTables);
 
-        $database = new Database();
-        $database->setPlatform(new DefaultPlatform());
+        $this->assertEqualsCanonicalizing($expectedTableNames, $importedTableNames);
+    }
 
-        $this->assertEquals(1, $parser->parse($database), 'One table and one view defined should return one as we exclude views');
+    /**
+     * @return void
+     */
+    public function testParseImportsBookTable(): void
+    {
+        $parsedBookTable = $this->parsedDatabase->getTable('book');
+        $sourceBookTable = BookTableMap::getTableMap();
 
-        $tables = $database->getTables();
-        $this->assertEquals(1, count($tables));
+        $columns = $sourceBookTable->getColumns();
+        $expectedNumberOfColumns = count($columns);
+        $this->assertCount($expectedNumberOfColumns, $parsedBookTable->getColumns());
+    }
 
-        $table = $tables[0];
-        $this->assertEquals('Book', $table->getPhpName());
-        $this->assertEquals(4, count($table->getColumns()));
+    /**
+     * @return void
+     */
+    public function testDescriptionsAreImported(): void
+    {
+        $bookTable = $this->parsedDatabase->getTable('book');
+        $this->assertEquals('Book Table', $bookTable->getDescription());
+        $this->assertEquals('Book Title', $bookTable->getColumn('title')->getDescription());
     }
 }

--- a/tests/Propel/Tests/Runtime/Formatter/DataFetcherTest.php
+++ b/tests/Propel/Tests/Runtime/Formatter/DataFetcherTest.php
@@ -8,6 +8,7 @@
 
 namespace Propel\Tests\Runtime\Formatter;
 
+use PDO;
 use Propel\Runtime\DataFetcher\ArrayDataFetcher;
 use Propel\Runtime\Map\TableMap;
 use Propel\Runtime\Propel;
@@ -94,6 +95,42 @@ class DataFetcherTest extends BookstoreEmptyTestBase
         }
         $this->assertCount(4, $rows);
         $this->assertEquals('The Tin Drum', $last[1]);
+    }
+
+    /**
+     * @return void
+     */
+    public function testPDODataFetcherFetchAllReturnsAllRowsAsArray()
+    {
+        $query = 'SELECT id, title FROM book';
+        $fetcher = $this->con->query($query);
+        $rows = $fetcher->fetchAll();
+
+        $this->assertIsArray($rows, 'PDODataFetcher::fetchAll() should return an array');
+        $this->assertCount($fetcher->count(), $rows, 'Expected number of rows should be returned');
+    }
+
+    /**
+     * @return void
+     */
+    public function testPDODataFetcherFetchAllUsesFetchStyle()
+    {
+        $query = 'SELECT id, title FROM book';
+        $keyOptions = [
+            PDO::FETCH_BOTH => ['id', 0, 'title', 1],
+            PDO::FETCH_NUM => [0, 1],
+            PDO::FETCH_ASSOC => ['id', 'title'],
+        ];
+
+        foreach ($keyOptions as $fetchStyle => $expectedKeys) {
+            $fetcher = $this->con->query($query);
+            $rows = $fetcher->fetchAll($fetchStyle);
+            $this->assertNotEmpty($rows);
+            foreach ($rows as $row) {
+                $keys = array_keys($row);
+                $this->assertEquals($expectedKeys, $keys);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Added tests for #1507, which adds an import of column and table descriptions during `database:reverse` on a MySQL database.

Also, while writing the tests, I again missed `PDODataFetcher::fetchAll()` (the class has a `fetch()` method, and in general just wraps PDO methods), so I added it in its own commit (didn't want to put it into its own PR, as I need it in the tests).

If merged, #1507 can be closed.