### PR TITLE
propagate output interface in init command

### DIFF
--- a/src/Propel/Generator/Command/InitCommand.php
+++ b/src/Propel/Generator/Command/InitCommand.php
@@ -290,13 +290,15 @@ class InitCommand extends AbstractCommand
         $this->writeFile($output, sprintf('%s/propel.%s', getcwd(), $options['format']), $config->render($options));
         $this->writeFile($output, sprintf('%s/propel.%s.dist', getcwd(), $options['format']), $distConfig->render($options));
 
-        $this->buildSqlAndModelsAndConvertConfig();
+        $this->buildSqlAndModelsAndConvertConfig($output);
     }
 
     /**
+     * @param \Symfony\Component\Console\Output\OutputInterface|null $output
+     *
      * @return void
      */
-    private function buildSqlAndModelsAndConvertConfig()
+    private function buildSqlAndModelsAndConvertConfig(?OutputInterface $output = null)
     {
         $this->getApplication()->setAutoExit(false);
 
@@ -307,7 +309,8 @@ class InitCommand extends AbstractCommand
         ];
 
         foreach ($followupCommands as $command) {
-            if ($this->getApplication()->run(new ArrayInput([$command])) !== 0) {
+            $input = new ArrayInput([$command]);
+            if ($this->getApplication()->run($input, $output) !== 0) {
                 exit(1);
             }
         }

--- a/tests/Propel/Tests/Generator/Command/InitCommandTest.php
+++ b/tests/Propel/Tests/Generator/Command/InitCommandTest.php
@@ -75,7 +75,9 @@ class InitCommandTest extends TestCaseFixtures
         $commandTester->setInputs($this->getInputsArray());
         $commandTester->execute(['command' => $command->getName()]);
 
-        $this->assertStringContainsString('Propel 2 is ready to be used!', $commandTester->getDisplay());
+        $output = $commandTester->getDisplay();
+        $this->assertStringContainsString('Propel 2 is ready to be used!', $output);
+        $this->assertStringContainsString('Successfully wrote PHP configuration in file', $output);
         $this->assertTrue(file_exists($this->dir . '/schema.xml'), 'Example schema file created.');
         $this->assertTrue(file_exists($this->dir . '/propel.yml'), 'Configuration file created.');
         $this->assertTrue(file_exists($this->dir . '/propel.yml.dist'), 'Dist configuration file created.');


### PR DESCRIPTION
Ok, this is really menial. Still annoyed me after seeing it a million times. Ever wondered what is going on with that one console output ('Successfully wrote PHP configuration in file "/tmp/propel_init/generated-conf/config.php"') during tests?
 The one around 39%:
```
> phpunit --colors=always
Tests started in temp /tmp.
PHPUnit 9.5.2 by Sebastian Bergmann and contributors.

.....SS......................................................   61 / 3548 (  1%)
.............................................................  122 / 3548 (  3%)
.............................................................  183 / 3548 (  5%)
.............................................................  244 / 3548 (  6%)
.............................................................  305 / 3548 (  8%)
.............................................................  366 / 3548 ( 10%)
.............................................................  427 / 3548 ( 12%)
.......................S.....................................  488 / 3548 ( 13%)
.............................................................  549 / 3548 ( 15%)
..........................II.................................  610 / 3548 ( 17%)
...........................S.................................  671 / 3548 ( 18%)
.............................................................  732 / 3548 ( 20%)
.............................................................  793 / 3548 ( 22%)
.............................................................  854 / 3548 ( 24%)
.............................................................  915 / 3548 ( 25%)
.............................................................  976 / 3548 ( 27%)
............................................................. 1037 / 3548 ( 29%)
............................................................. 1098 / 3548 ( 30%)
............................................................. 1159 / 3548 ( 32%)
...............................SSSSSSSS.....S................ 1220 / 3548 ( 34%)
............................................................. 1281 / 3548 ( 36%)
............................................................. 1342 / 3548 ( 37%)
.........................Successfully wrote PHP configuration in file "/tmp/propel_init/generated-conf/config.php".
.................................... 1403 / 3548 ( 39%)
...........................................S................. 1464 / 3548 ( 41%)
............................................................. 1525 / 3548 ( 42%)
............................................................. 1586 / 3548 ( 44%)
...
```
Why does that command create output, while the others do not?

It's pretty simple, the `Init` command just didn't propagate its output to the nested commands, so the default console output was used, instead of the wrapped output.

Again, menial, but gone is gone.