### PR TITLE
Bugfixes for abstract tables

### DIFF
--- a/src/Propel/Generator/Builder/Om/ExtensionQueryBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ExtensionQueryBuilder.php
@@ -40,6 +40,7 @@ class ExtensionQueryBuilder extends AbstractOMBuilder
         $table = $this->getTable();
         $tableName = $table->getName();
         $tableDesc = $table->getDescription();
+        $className = $this->getUnqualifiedClassName();
         $baseClassName = $this->getClassNameFromBuilder($this->getQueryBuilder());
 
         if ($this->getBuildProperty('generator.objectModel.addClassLevelComment')) {
@@ -64,7 +65,7 @@ class ExtensionQueryBuilder extends AbstractOMBuilder
  */";
         }
         $script .= "
-class " . $this->getUnqualifiedClassName() . " extends $baseClassName
+class $className extends $baseClassName
 {
 ";
     }

--- a/src/Propel/Generator/Builder/Om/TableMapBuilder.php
+++ b/src/Propel/Generator/Builder/Om/TableMapBuilder.php
@@ -958,7 +958,6 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
             \$pks = [];
             ";
 
-            $pks = [];
             foreach ($table->getColumns() as $col) {
                 if (!$col->isLazyLoad()) {
                     if ($col->isPrimaryKey()) {
@@ -1125,16 +1124,21 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      */
     protected function addGetOMClass_NoInheritance_Abstract(&$script)
     {
+        $objectClassName = $this->getObjectClassName();
+
         $script .= "
     /**
      * The class that the tableMap will make instances of.
      *
      * This method must be overridden by the stub subclass, because
-     * " . $this->getObjectClassName() . " is declared abstract in the schema.
+     * $objectClassName is declared abstract in the schema.
      *
      * @param boolean \$withPrefix
      */
-    abstract public static function getOMClass(\$withPrefix = true);
+    public static function getOMClass(\$withPrefix = true)
+    {
+        throw new PropelException('$objectClassName is declared abstract, it cannot be instantiated.');
+    }
 ";
     }
 

--- a/src/Propel/Generator/Model/Table.php
+++ b/src/Propel/Generator/Model/Table.php
@@ -545,7 +545,7 @@ class Table extends ScopedMappingModel implements IdMethod
     /**
      * Returns a delimiter-delimited string list of column names.
      *
-     * @see Platform::getColumnList() if quoting is required
+     * @see \Propel\Generator\Platform\PlatformInterface::getColumnListDDL() if quoting is required
      *
      * @param array $columns
      * @param string $delimiter
@@ -799,6 +799,16 @@ class Table extends ScopedMappingModel implements IdMethod
     public function getChildrenColumn()
     {
         return $this->inheritanceColumn;
+    }
+
+    /**
+     * Checks whether the table uses concrete inheritance
+     *
+     * @return bool
+     */
+    public function usesConcreteInheritance(): bool
+    {
+        return ($this->inheritanceColumn !== null);
     }
 
     /**

--- a/tests/Propel/Tests/Generator/Builder/Om/TestableQueryBuilder.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/TestableQueryBuilder.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Tests\Generator\Builder\Om;
+
+use Propel\Generator\Builder\Om\QueryBuilder;
+use Propel\Generator\Builder\Util\SchemaReader;
+use Propel\Generator\Config\QuickGeneratorConfig;
+use Propel\Generator\Platform\DefaultPlatform;
+
+/**
+ * Utility class for QueryBuilder.
+ */
+class TestableQueryBuilder extends QueryBuilder
+{
+    /**
+     * Build a TestableQueryBuilder for a table given in schema xml format.
+     *
+     * @param string $schemaXml
+     * @param string $tableName
+     *
+     * @return self
+     */
+    public static function forTableFromXml(string $schemaXml, string $tableName): self
+    {
+        $reader = new SchemaReader();
+        $schema = $reader->parseString($schemaXml);
+        $table = $schema->getDatabase()->getTable($tableName);
+        $builder = new static($table);
+        $builder->setGeneratorConfig(new QuickGeneratorConfig());
+        $builder->setPlatform(new DefaultPlatform());
+
+        return $builder;
+    }
+
+    /**
+     * Call a (usually protected) script builder function by name and return the result.
+     *
+     * @param string $scriptBuilderFunctionName
+     *
+     * @return string
+     */
+    public function buildScript(string $scriptBuilderFunctionName): string
+    {
+        $script = '';
+        call_user_func_array([$this, $scriptBuilderFunctionName], [&$script]);
+
+        return $script;
+    }
+}


### PR DESCRIPTION
I want to mark a table abstract, since it is only used for inheritance:
```xml
<table name="person" skipSql="true" abstract="true">...</table>
```
But the classes built from that schema have errors in them. Marking a table abstract seems to do exactly two things, both cause errors with PHP.

Current behavior 1: The user model class is set to abstract
Introduced problem: The query class is still set to instantiate objects from a now abstract class, which is not allowed
Proposed solution: If table is abstract, calling methods that usually create instances (`findPkSimple()`) throw an exception (unless when the table uses  concrete_inheritance, which creates instances from other classes).

Current behavior 2:  In the table map, set `OM_CLASS` to empty string and make the function `getOMClass()` abstract
Introduced problem: The table map class is not declared abstract, so it is not allowed to use abstract methods
Proposed solution: Instead of making it abstract, let the method throw an exception

On the way, I also did some housecleaning (mostly removal of unused variables).