### PR TITLE
Bugfix: Escape quotes in behavior 

### DIFF
--- a/src/Propel/Generator/Behavior/AggregateMultipleColumns/templates/objectCompute.php
+++ b/src/Propel/Generator/Behavior/AggregateMultipleColumns/templates/objectCompute.php
@@ -8,7 +8,7 @@
  */
 public function compute<?=$aggregationName?>(ConnectionInterface $con)
 {
-    $stmt = $con->prepare('<?=$sql?>');
+    $stmt = $con->prepare(<?= var_export($sql, true) ?>);
 <?php foreach ($bindings as $key => $binding):?>
     $stmt->bindValue(':p<?=$key?>', $this->get<?=$binding?>());
 <?php endforeach;?>

--- a/src/Propel/Generator/Builder/Om/templates/tableMapClearRelatedInstancePool.php
+++ b/src/Propel/Generator/Builder/Om/templates/tableMapClearRelatedInstancePool.php
@@ -1,3 +1,4 @@
+
     /**
      * Method to invalidate the instance pool of all tables related to <?= $tableName ?>
      * by a foreign key with ON DELETE CASCADE


### PR DESCRIPTION
I am getting errors in the generated map- and model-files when using AggregateMultipleColumnsBehavior with single quotes in the filter condition. Problem is that strings are written to file without escaping those quotes.

In the model-file, it is a problem with the behavior, when the SQL query is not escaped.
In the map-file, it is a problem with the TableMapBuilder, which only escapes in arrays.

Also, `addGetBehaviors()` function in TableMapBuilder replaced all spaces in stringified arrays, probably to adjust the format of `var_export`. Because, what could go wrong...
Also a newline was missing at the beginning of the template added after the `getBehaviors()` function.

I did not change AggregateColumnsBehavior, even though it suffers from the same problem. Reason is that it would break the current workaround, which is to escape the single quotes in schema.xml, and I am not sure if you prefer the fix over backward compatibility. Let me know if I should change it, too.
AggregateMultipleColumnsBehavior is new, so BC is no concern.
