### PR TITLE
Add test for integration BC.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,13 +191,13 @@ jobs:
               run: cd suite && composer install
 
             - name: Generate transfer objects
-              run: cd suite && vendor/bin/console transfer:generate
+              run: cd suite && APPLICATION_ENV=development vendor/bin/console transfer:generate
 
             - name: Generate transfer databuilder objects
-              run: cd suite && vendor/bin/console transfer:databuilder:generate
+              run: cd suite && APPLICATION_ENV=development vendor/bin/console transfer:databuilder:generate
 
             - name: Propel install
               run: |
-                  cd suite && vendor/bin/console propel:schema:copy
-                  cd suite && vendor/bin/console propel:model:build
-                  cd suite && vendor/bin/console transfer:entity:generate
+                  cd suite && APPLICATION_ENV=development vendor/bin/console propel:schema:copy
+                  cd suite && APPLICATION_ENV=development vendor/bin/console propel:model:build
+                  cd suite && APPLICATION_ENV=development vendor/bin/console transfer:entity:generate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,3 +158,46 @@ jobs:
 
             - name: Psalm
               run: composer psalm
+
+    integration:
+        runs-on: ubuntu-18.04
+        steps:
+            - name: Setup PHP 7.4
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: 7.4
+                  extensions: json, libxml, pdo, pdo_mysql, pdo_sqlite, pdo_pgsql, sqlite3
+                  coverage: pcov
+
+            - uses: actions/checkout@v2
+
+            - name: Composer get cache directory
+              id: composer-cache
+              run: |
+                  echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+            - name: Composer cache
+              uses: actions/cache@v2
+              with:
+                  path: ${{ steps.composer-cache.outputs.dir }}
+                  key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-composer-
+
+            - name: Install integration demo shop
+              run: git clone https://github.com/spryker-shop/suite.git
+
+            - name: Setup
+              run: cd suite && composer install
+
+            - name: Generate transfer objects
+              run: cd suite && vendor/bin/console transfer:generate
+
+            - name: Generate transfer databuilder objects
+              run: cd suite && vendor/bin/console transfer:databuilder:generate
+
+            - name: Propel install
+              run: |
+                  cd suite && vendor/bin/console propel:schema:copy
+                  cd suite && vendor/bin/console propel:model:build
+                  cd suite && vendor/bin/console transfer:entity:generate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,123 +2,9 @@ name: CI
 
 on:
   push:
-    branches:
-      - 'master'
   pull_request:
-  schedule:
-    - cron: "0 0 * * *"
 
 jobs:
-    testsuite:
-        runs-on: ubuntu-18.04
-        strategy:
-            fail-fast: false
-            matrix:
-                php-version: [ '7.2', '7.4', '8.0' ]
-                db-type: [ sqlite, mysql, pgsql, agnostic ]
-                symfony-version: [ '3-min', '3-max', '4-min', '4-max', '5-min', '5-max' ]
-                exclude:
-                  - php-version: '8.0'
-                    symfony-version: '4-min'
-        steps:
-            - name: Install PostgreSQL latest
-              if: matrix.db-type == 'pgsql' && matrix.php-version != '7.2'
-              uses: CasperWA/postgresql-action@v1.2
-              with:
-                  postgresql db: 'propel-tests'
-                  postgresql user: 'postgres'
-                  postgresql password: 'postgres'
-
-            - name: Install PostgreSQL min
-              if: matrix.db-type == 'pgsql' && matrix.php-version == '7.2'
-              uses: CasperWA/postgresql-action@v1.2
-              with:
-                  postgresql version: 9
-                  postgresql db: 'propel-tests'
-                  postgresql user: 'postgres'
-                  postgresql password: 'postgres'
-
-            - name: Install MariaDb latest
-              if: matrix.db-type == 'mysql' && matrix.php-version != '7.2'
-              uses: getong/mariadb-action@v1.1
-
-            - name: Install MariaDb min
-              if: matrix.db-type == 'mysql' && matrix.php-version == '7.2'
-              uses: getong/mariadb-action@v1.1
-              with:
-                  mariadb version: '10.2'
-
-            - name: Setup PHP, with composer and extensions
-              uses: shivammathur/setup-php@v2
-              with:
-                  php-version: ${{ matrix.php-version }}
-                  extensions: json, libxml, pdo, pdo_mysql, pdo_sqlite, pdo_pgsql, sqlite3
-                  coverage: pcov
-
-            - name: Checkout
-              uses: actions/checkout@v2
-
-            - name: Composer get cache directory
-              id: composer-cache
-              run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-            - name: Composer cache dependencies
-              uses: actions/cache@v1
-              with:
-                  path: ${{ steps.composer-cache.outputs.dir }}
-                  key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-                  restore-keys: ${{ runner.os }}-composer-
-
-            - name: Move specific composer.json (Symfony version ${{ matrix.symfony-version }})
-              run: mv tests/composer/composer-symfony${{ matrix.symfony-version }}.json composer.json
-
-            - name: Composer install (Symfony version ${{ matrix.symfony-version }})
-              run: composer install --no-progress --prefer-dist --optimize-autoloader
-
-            - name: Setup Postgresql database for test suite
-              if: matrix.db-type == 'pgsql'
-              run: tests/bin/setup.pgsql.sh
-              env:
-                  PGPASSWORD: 'postgres'
-                  DB_NAME: 'propel-tests'
-                  DB_USER: 'postgres'
-                  DB_PW: 'postgres'
-
-            - name: Setup the database for test suite
-              if: matrix.db-type != 'agnostic' && matrix.db-type != 'pgsql'
-              run: tests/bin/setup.${{ matrix.db-type }}.sh
-
-            - name: Run PostgreSQL tests
-              if: matrix.db-type == 'pgsql'
-              shell: 'script -q -e -c "bash {0}"'
-              run: |
-                  if [[ ${{ matrix.php-version }} == '7.4' && ${{ matrix.symfony-version == '5-max' }} ]]; then
-                    export CODECOVERAGE=1 && vendor/bin/phpunit -c tests/pgsql.phpunit.xml --verbose --coverage-clover=tests/coverage.xml
-                  else
-                    vendor/bin/phpunit -c tests/pgsql.phpunit.xml
-                  fi
-              env:
-                  DB_NAME: 'propel-tests'
-                  DB_USER: 'postgres'
-                  DB_PW: 'postgres'
-
-            - name: Run ${{ matrix.db-type }} tests
-              if: matrix.db-type != 'pgsql'
-              shell: 'script -q -e -c "bash {0}"'
-              run: |
-                  if [[ ${{ matrix.php-version }} == '7.4' && ${{ matrix.symfony-version == '5-max' }} ]]; then
-                    export CODECOVERAGE=1 && vendor/bin/phpunit -c tests/${{ matrix.db-type }}.phpunit.xml --verbose --coverage-clover=tests/coverage.xml
-                  else
-                    vendor/bin/phpunit -c tests/${{ matrix.db-type }}.phpunit.xml
-                  fi
-
-            - name: Code Coverage Report
-              if: success() && matrix.php-version == '7.4' && matrix.symfony-version == '5-max'
-              uses: codecov/codecov-action@v1
-              with:
-                  flags: ${{ matrix.php-version }}, ${{ matrix.db-type }}, ${{ matrix.symfony-version }}
-                  file: tests/coverage.xml
-
     code-style-and-static-analysis:
         runs-on: ubuntu-18.04
         steps:
@@ -198,6 +84,7 @@ jobs:
 
             - name: Propel install
               run: |
-                  cd suite && APPLICATION_ENV=development vendor/bin/console propel:schema:copy
-                  cd suite && APPLICATION_ENV=development vendor/bin/console propel:model:build
-                  cd suite && APPLICATION_ENV=development vendor/bin/console transfer:entity:generate
+                  cd suite
+                  APPLICATION_ENV=development vendor/bin/console propel:schema:copy
+                  APPLICATION_ENV=development vendor/bin/console propel:model:build
+                  APPLICATION_ENV=development vendor/bin/console transfer:entity:generate


### PR DESCRIPTION
We would like to use an active demo project to verify that integration of the latest propel code as well as PRs work without unknown or hidden bc breaks.
So this check may fail, if BC breaks are known or expected.
Otherwise we will have to check in detail if a change is applicable into a minor or patch release or needs to be postponed until a major can be done again.

Feedback?


WIP
will require the current branch to be checked out using
```
composer require propel/propel:"dev-... as ..."
```
not sure how we can access that dynamically, or if we can just copy over the existing checked out propel code into the vendor dir?