### PR TITLE
Misc test fixes

### DIFF
--- a/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaTest.php
@@ -516,42 +516,6 @@ class CriteriaTest extends BookstoreTestBase
     /**
      * @return void
      */
-    public function testJoinObject()
-    {
-        $j = new Join('TABLE_A.COL_1', 'TABLE_B.COL_2');
-        $this->assertEquals('INNER JOIN', $j->getJoinType());
-        $this->assertEquals('TABLE_A.COL_1', $j->getLeftColumn());
-        $this->assertEquals('TABLE_A', $j->getLeftTableName());
-        $this->assertEquals('COL_1', $j->getLeftColumnName());
-        $this->assertEquals('TABLE_B.COL_2', $j->getRightColumn());
-        $this->assertEquals('TABLE_B', $j->getRightTableName());
-        $this->assertEquals('COL_2', $j->getRightColumnName());
-
-        $j = new Join('TABLE_A.COL_1', 'TABLE_B.COL_1', Criteria::LEFT_JOIN);
-        $this->assertEquals('LEFT JOIN', $j->getJoinType());
-        $this->assertEquals('TABLE_A.COL_1', $j->getLeftColumn());
-        $this->assertEquals('TABLE_B.COL_1', $j->getRightColumn());
-
-        $j = new Join('TABLE_A.COL_1', 'TABLE_B.COL_1', Criteria::RIGHT_JOIN);
-        $this->assertEquals('RIGHT JOIN', $j->getJoinType());
-        $this->assertEquals('TABLE_A.COL_1', $j->getLeftColumn());
-        $this->assertEquals('TABLE_B.COL_1', $j->getRightColumn());
-
-        $j = new Join('TABLE_A.COL_1', 'TABLE_B.COL_1', Criteria::INNER_JOIN);
-        $this->assertEquals('INNER JOIN', $j->getJoinType());
-        $this->assertEquals('TABLE_A.COL_1', $j->getLeftColumn());
-        $this->assertEquals('TABLE_B.COL_1', $j->getRightColumn());
-
-        $j = new Join(['TABLE_A.COL_1', 'TABLE_A.COL_2'], ['TABLE_B.COL_1', 'TABLE_B.COL_2'], Criteria::INNER_JOIN);
-        $this->assertEquals('TABLE_A.COL_1', $j->getLeftColumn(0));
-        $this->assertEquals('TABLE_A.COL_2', $j->getLeftColumn(1));
-        $this->assertEquals('TABLE_B.COL_1', $j->getRightColumn(0));
-        $this->assertEquals('TABLE_B.COL_2', $j->getRightColumn(1));
-    }
-
-    /**
-     * @return void
-     */
     public function testAddStraightJoin()
     {
         $c = new Criteria();

--- a/tests/mysql.phpunit.xml
+++ b/tests/mysql.phpunit.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true" bootstrap="bootstrap.php">
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+    colors="true"
+    bootstrap="bootstrap.php"
+>
 
     <testsuites>
         <testsuite name="propel2">
@@ -21,29 +26,28 @@
         <env name="DB_USER" value="root"/>
     </php>
 
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>../src/Propel/</directory>
-            <exclude>
-                <directory>../src/Propel/Generator/Builder/SQL/Mssql</directory>
-                <directory>../src/Propel/Generator/Builder/SQL/Oracle</directory>
-                <directory>../src/Propel/Generator/Builder/SQL/Sqlsrv</directory>
+        </include>
+        <exclude>
+            <directory>../src/Propel/Generator/Builder/SQL/Mssql</directory>
+            <directory>../src/Propel/Generator/Builder/SQL/Oracle</directory>
+            <directory>../src/Propel/Generator/Builder/SQL/Sqlsrv</directory>
 
-                <file>../src/Propel/Generator/Platform/MssqlPlatform.php</file>
-                <file>../src/Propel/Generator/Platform/OraclePlatform.php</file>
-                <file>../src/Propel/Generator/Platform/SqlsrvPlatform.php</file>
+            <file>../src/Propel/Generator/Platform/MssqlPlatform.php</file>
+            <file>../src/Propel/Generator/Platform/OraclePlatform.php</file>
+            <file>../src/Propel/Generator/Platform/SqlsrvPlatform.php</file>
 
-                <file>../src/Propel/Generator/Reverse/MssqlSchemaParser.php</file>
-                <file>../src/Propel/Generator/Reverse/OracleSchemaParser.php</file>
-                <file>../src/Propel/Generator/Reverse/SqlsrvSchemaParser.php</file>
+            <file>../src/Propel/Generator/Reverse/MssqlSchemaParser.php</file>
+            <file>../src/Propel/Generator/Reverse/OracleSchemaParser.php</file>
+            <file>../src/Propel/Generator/Reverse/SqlsrvSchemaParser.php</file>
 
-                <directory>../src/Propel/Runtime/Adapter/MSSQL</directory>
-                <file>../src/Propel/Runtime/Adapter/Pdo/MssqlAdapter.php</file>
-                <file>../src/Propel/Runtime/Adapter/Pdo/OracleAdapter.php</file>
-                <file>../src/Propel/Runtime/Adapter/Pdo/SqlsrvAdapter.php</file>
-
-                <file>../src/Propel/Runtime/Adapter/Pdo/SqlsrvAdapter.php</file>
-            </exclude>
-        </whitelist>
-    </filter>
+            <directory>../src/Propel/Runtime/Adapter/MSSQL</directory>
+            <file>../src/Propel/Runtime/Adapter/Pdo/MssqlAdapter.php</file>
+            <file>../src/Propel/Runtime/Adapter/Pdo/OracleAdapter.php</file>
+            <file>../src/Propel/Runtime/Adapter/Pdo/SqlsrvAdapter.php</file>
+            <file>../src/Propel/Runtime/Adapter/Pdo/SqlsrvAdapter.php</file>
+        </exclude>
+    </coverage>
 </phpunit>

--- a/tests/pgsql.phpunit.xml
+++ b/tests/pgsql.phpunit.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true" bootstrap="bootstrap.php">
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+    colors="true"
+    bootstrap="bootstrap.php"
+>
 
     <testsuites>
         <testsuite name="propel2">
@@ -22,29 +27,29 @@
         <env name="DB_NAME" value="postgres"/>
     </php>
 
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>../src/Propel/</directory>
-            <exclude>
-                <directory>../src/Propel/Generator/Builder/SQL/Mssql</directory>
-                <directory>../src/Propel/Generator/Builder/SQL/Oracle</directory>
-                <directory>../src/Propel/Generator/Builder/SQL/Sqlsrv</directory>
+        </include>
+        <exclude>
+            <directory>../src/Propel/Generator/Builder/SQL/Mssql</directory>
+            <directory>../src/Propel/Generator/Builder/SQL/Oracle</directory>
+            <directory>../src/Propel/Generator/Builder/SQL/Sqlsrv</directory>
 
-                <file>../src/Propel/Generator/Platform/MssqlPlatform.php</file>
-                <file>../src/Propel/Generator/Platform/OraclePlatform.php</file>
-                <file>../src/Propel/Generator/Platform/SqlsrvPlatform.php</file>
+            <file>../src/Propel/Generator/Platform/MssqlPlatform.php</file>
+            <file>../src/Propel/Generator/Platform/OraclePlatform.php</file>
+            <file>../src/Propel/Generator/Platform/SqlsrvPlatform.php</file>
 
-                <file>../src/Propel/Generator/Reverse/MssqlSchemaParser.php</file>
-                <file>../src/Propel/Generator/Reverse/OracleSchemaParser.php</file>
-                <file>../src/Propel/Generator/Reverse/SqlsrvSchemaParser.php</file>
+            <file>../src/Propel/Generator/Reverse/MssqlSchemaParser.php</file>
+            <file>../src/Propel/Generator/Reverse/OracleSchemaParser.php</file>
+            <file>../src/Propel/Generator/Reverse/SqlsrvSchemaParser.php</file>
 
-                <directory>../src/Propel/Runtime/Adapter/MSSQL</directory>
-                <file>../src/Propel/Runtime/Adapter/Pdo/MssqlAdapter.php</file>
-                <file>../src/Propel/Runtime/Adapter/Pdo/OracleAdapter.php</file>
-                <file>../src/Propel/Runtime/Adapter/Pdo/SqlsrvAdapter.php</file>
+            <directory>../src/Propel/Runtime/Adapter/MSSQL</directory>
+            <file>../src/Propel/Runtime/Adapter/Pdo/MssqlAdapter.php</file>
+            <file>../src/Propel/Runtime/Adapter/Pdo/OracleAdapter.php</file>
+            <file>../src/Propel/Runtime/Adapter/Pdo/SqlsrvAdapter.php</file>
 
-                <file>../src/Propel/Runtime/Adapter/Pdo/SqlsrvAdapter.php</file>
-            </exclude>
-        </whitelist>
-    </filter>
+            <file>../src/Propel/Runtime/Adapter/Pdo/SqlsrvAdapter.php</file>
+        </exclude>
+    </coverage>
 </phpunit>

--- a/tests/sqlite.phpunit.xml
+++ b/tests/sqlite.phpunit.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true" bootstrap="bootstrap.php">
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+    colors="true"
+    bootstrap="bootstrap.php"
+>
 
     <testsuites>
         <testsuite name="propel2">
@@ -21,29 +26,29 @@
         <env name="DB" value="sqlite"/>
     </php>
 
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>../src/Propel/</directory>
-            <exclude>
-                <directory>../src/Propel/Generator/Builder/SQL/Mssql</directory>
-                <directory>../src/Propel/Generator/Builder/SQL/Oracle</directory>
-                <directory>../src/Propel/Generator/Builder/SQL/Sqlsrv</directory>
+        </include>
+        <exclude>
+            <directory>../src/Propel/Generator/Builder/SQL/Mssql</directory>
+            <directory>../src/Propel/Generator/Builder/SQL/Oracle</directory>
+            <directory>../src/Propel/Generator/Builder/SQL/Sqlsrv</directory>
 
-                <file>../src/Propel/Generator/Platform/MssqlPlatform.php</file>
-                <file>../src/Propel/Generator/Platform/OraclePlatform.php</file>
-                <file>../src/Propel/Generator/Platform/SqlsrvPlatform.php</file>
+            <file>../src/Propel/Generator/Platform/MssqlPlatform.php</file>
+            <file>../src/Propel/Generator/Platform/OraclePlatform.php</file>
+            <file>../src/Propel/Generator/Platform/SqlsrvPlatform.php</file>
 
-                <file>../src/Propel/Generator/Reverse/MssqlSchemaParser.php</file>
-                <file>../src/Propel/Generator/Reverse/OracleSchemaParser.php</file>
-                <file>../src/Propel/Generator/Reverse/SqlsrvSchemaParser.php</file>
+            <file>../src/Propel/Generator/Reverse/MssqlSchemaParser.php</file>
+            <file>../src/Propel/Generator/Reverse/OracleSchemaParser.php</file>
+            <file>../src/Propel/Generator/Reverse/SqlsrvSchemaParser.php</file>
 
-                <directory>../src/Propel/Runtime/Adapter/MSSQL</directory>
-                <file>../src/Propel/Runtime/Adapter/Pdo/MssqlAdapter.php</file>
-                <file>../src/Propel/Runtime/Adapter/Pdo/OracleAdapter.php</file>
-                <file>../src/Propel/Runtime/Adapter/Pdo/SqlsrvAdapter.php</file>
+            <directory>../src/Propel/Runtime/Adapter/MSSQL</directory>
+            <file>../src/Propel/Runtime/Adapter/Pdo/MssqlAdapter.php</file>
+            <file>../src/Propel/Runtime/Adapter/Pdo/OracleAdapter.php</file>
+            <file>../src/Propel/Runtime/Adapter/Pdo/SqlsrvAdapter.php</file>
 
-                <file>../src/Propel/Runtime/Adapter/Pdo/SqlsrvAdapter.php</file>
-            </exclude>
-        </whitelist>
-    </filter>
+            <file>../src/Propel/Runtime/Adapter/Pdo/SqlsrvAdapter.php</file>
+        </exclude>
+    </coverage>
 </phpunit>


### PR DESCRIPTION
Had this lying around, it's just some cleanup in tests:
- Updated the phpunit.xml files for mysql, postgres and sqlite to current phpunit format
- A test was skipped with the message "Famous cross join problem, to be solved one day". Obviously, I couldn't resist - what mystery and excitement would await me? The answer is that join type defaults to inner join (in `Join::getJoinType()`), so you will not end up with a cross join when you omit the type. Bit of a letdown to be honest. No need to call Nancy Drew.
- Also stumbled over a unstructured and repetitive (and misplaced) test of the join class in CriteriaTest, which I removed, and instead added to JoinTest  the parts that were not covered before.

It's all pretty random, but it is probably still better to have it than not.