### PR TITLE
Add table map initializer

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -439,6 +439,11 @@
       <code>$removeInstancePoolKeySnippetPks</code>
     </UndefinedGlobalVariable>
   </file>
+  <file src="src/Propel/Generator/Builder/Om/templates/tableMapLoaderScript.php">
+    <UndefinedGlobalVariable occurrences="1">
+      <code>$databaseNameToTableMapNames</code>
+    </UndefinedGlobalVariable>
+  </file>
   <file src="src/Propel/Generator/Builder/Util/SchemaReader.php">
     <UndefinedFunction occurrences="2">
       <code>'endElement'</code>
@@ -556,9 +561,8 @@
     </UndefinedConstant>
   </file>
   <file src="src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php">
-    <UndefinedMethod occurrences="2">
+    <UndefinedMethod occurrences="1">
       <code>find</code>
-      <code>static::getShortName($this-&gt;modelName)</code>
     </UndefinedMethod>
   </file>
   <file src="src/Propel/Runtime/ActiveQuery/Criteria.php">
@@ -571,9 +575,6 @@
     <InvalidReturnType occurrences="1">
       <code>$this|\Propel\Runtime\ActiveQuery\Criteria</code>
     </InvalidReturnType>
-    <NullArgument occurrences="1">
-      <code>null</code>
-    </NullArgument>
   </file>
   <file src="src/Propel/Runtime/ActiveQuery/ModelCriteria.php">
     <UndefinedClass occurrences="1">

--- a/src/Propel/Common/Config/PropelConfiguration.php
+++ b/src/Propel/Common/Config/PropelConfiguration.php
@@ -85,6 +85,7 @@ class PropelConfiguration implements ConfigurationInterface
                         ->scalarNode('outputDir')->defaultValue(getcwd())->end()
                         ->scalarNode('phpDir')->defaultValue(getcwd() . '/generated-classes')->end()
                         ->scalarNode('phpConfDir')->defaultValue(getcwd() . '/generated-conf')->end()
+                        ->scalarNode('loaderScriptDir')->end()
                         ->scalarNode('sqlDir')->defaultValue(getcwd() . '/generated-sql')->end()
                         ->scalarNode('migrationDir')->defaultValue(getcwd() . '/generated-migrations')->end()
                         ->scalarNode('composerDir')->defaultNull()->end()

--- a/src/Propel/Generator/Builder/Om/TableMapBuilder.php
+++ b/src/Propel/Generator/Builder/Om/TableMapBuilder.php
@@ -173,8 +173,6 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
             $this->addGetTableMap($script);
         }
 
-        $this->addBuildTableMap($script);
-
         $this->addDoDelete($script);
         $this->addDoDeleteAll($script);
 
@@ -496,37 +494,11 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      */
     protected function addClassClose(&$script)
     {
+        $unqualifiedClassName = $this->getUnqualifiedClassName();
         $script .= "
-} // " . $this->getUnqualifiedClassName() . "
-// This is the static code needed to register the TableMap for this table with the main Propel class.
-//
-" . $this->getUnqualifiedClassName() . "::buildTableMap();
+} // $unqualifiedClassName
 ";
         $this->applyBehaviorModifier('tableMapFilter', $script, '');
-    }
-
-    /**
-     * Adds the buildTableMap() method.
-     *
-     * @param string $script The script will be modified in this method.
-     *
-     * @return void
-     */
-    protected function addBuildTableMap(&$script)
-    {
-        $this->declareClassFromBuilder($this->getTableMapBuilder());
-        $script .= "
-    /**
-     * Add a TableMap instance to the database for this tableMap class.
-     */
-    public static function buildTableMap()
-    {
-        \$dbMap = Propel::getServiceContainer()->getDatabaseMap(" . $this->getTableMapClass() . "::DATABASE_NAME);
-        if (!\$dbMap->hasTable(" . $this->getTableMapClass() . "::TABLE_NAME)) {
-            \$dbMap->addTableObject(new " . $this->getTableMapClass() . "());
-        }
-    }
-";
     }
 
     /**

--- a/src/Propel/Generator/Builder/Om/TableMapLoaderScriptBuilder.php
+++ b/src/Propel/Generator/Builder/Om/TableMapLoaderScriptBuilder.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Generator\Builder\Om;
+
+use Propel\Generator\Builder\Util\PropelTemplate;
+use Propel\Generator\Config\GeneratorConfigInterface;
+use Propel\Generator\Model\Table;
+use SplFileInfo;
+
+/**
+ * Generates a database loader file, which is used to register all table maps with the DatabaseMap.
+ */
+class TableMapLoaderScriptBuilder
+{
+    public const FILENAME = 'loadDatabase.php';
+
+    /**
+     * @var \Propel\Generator\Config\GeneratorConfigInterface $generatorConfig
+     */
+    protected $generatorConfig;
+
+    /**
+     * @param \Propel\Generator\Config\GeneratorConfigInterface $generatorConfig
+     */
+    public function __construct(GeneratorConfigInterface $generatorConfig)
+    {
+        $this->generatorConfig = $generatorConfig;
+    }
+
+    /**
+     * @param array $schemas
+     *
+     * @return string
+     */
+    public function build(array $schemas): string
+    {
+        $vars = $this->buildVars($schemas);
+
+        return $this->renderTemplate($vars);
+    }
+
+    /**
+     * @param \Propel\Generator\Model\Schema[] $schemas
+     *
+     * @return array
+     */
+    protected function buildVars(array $schemas): array
+    {
+        $databaseNameToTableMapNames = [];
+
+        foreach ($schemas as $schema) {
+            foreach ($schema->getDatabases(false) as $database) {
+                $databaseName = $database->getName();
+                $tableMapNames = array_map([$this, 'getFullyQualifiedTableMapClassName'], $database->getTables());
+                if (array_key_exists($databaseName, $databaseNameToTableMapNames)) {
+                    $existing = $databaseNameToTableMapNames[$databaseName];
+                    $tableMapNames = array_merge($existing, $tableMapNames);
+                }
+                sort($tableMapNames);
+                $databaseNameToTableMapNames[$databaseName] = $tableMapNames;
+            }
+        }
+
+        return [
+            'databaseNameToTableMapNames' => $databaseNameToTableMapNames,
+        ];
+    }
+
+    /**
+     * @param \Propel\Generator\Model\Table $table
+     *
+     * @return string
+     */
+    protected function getFullyQualifiedTableMapClassName(Table $table): string
+    {
+        $builder = new TableMapBuilder($table);
+        $builder->setGeneratorConfig($this->generatorConfig);
+
+        return $builder->getFullyQualifiedClassName();
+    }
+
+    /**
+     * @param array $vars
+     *
+     * @return string
+     */
+    protected function renderTemplate(array $vars): string
+    {
+        $filePath = implode(DIRECTORY_SEPARATOR, [__DIR__, 'templates', 'tableMapLoaderScript.php']);
+        $template = new PropelTemplate();
+        $template->setTemplateFile($filePath);
+
+        return $template->render($vars);
+    }
+
+    /**
+     * Return file info object pointing to the designated script location. The file does not necessarily exist.
+     *
+     * @return \SplFileInfo
+     */
+    public function getFile(): SplFileInfo
+    {
+        $configDir = $this->generatorConfig->getConfigProperty('paths.loaderScriptDir') ?? $this->generatorConfig->getConfigProperty('paths.phpConfDir');
+
+        return new SplFileInfo($configDir . DIRECTORY_SEPARATOR . self::FILENAME);
+    }
+}

--- a/src/Propel/Generator/Builder/Om/templates/tableMapLoaderScript.php
+++ b/src/Propel/Generator/Builder/Om/templates/tableMapLoaderScript.php
@@ -1,0 +1,4 @@
+<?= '<?php'?>
+
+$serviceContainer = \Propel\Runtime\Propel::getServiceContainer();
+$serviceContainer->initDatabaseMaps(<?= var_export($databaseNameToTableMapNames, true) ?>);

--- a/src/Propel/Generator/Command/ModelBuildCommand.php
+++ b/src/Propel/Generator/Command/ModelBuildCommand.php
@@ -44,6 +44,7 @@ class ModelBuildCommand extends AbstractCommand
             ->addOption('disable-package-object-model', null, InputOption::VALUE_NONE, 'Disable schema database merging (packageObjectModel)')
             ->addOption('disable-namespace-auto-package', null, InputOption::VALUE_NONE, 'Disable namespace auto-packaging')
             ->addOption('composer-dir', null, InputOption::VALUE_REQUIRED, 'Directory in which your composer.json resides', null)
+            ->addOption('loader-script-dir', null, InputOption::VALUE_REQUIRED, 'Target folder of the database table map loader script. Defaults to paths.loaderScriptDir', null)
             ->setName('model:build')
             ->setAliases(['build'])
             ->setDescription('Build the model classes based on Propel XML schemas');
@@ -66,6 +67,10 @@ class ModelBuildCommand extends AbstractCommand
                         break;
                     case 'output-dir':
                         $configOptions['propel']['paths']['phpDir'] = $option;
+
+                        break;
+                    case 'loader-script-dir':
+                        $configOptions['propel']['paths']['loaderScriptDir'] = $option;
 
                         break;
                     case 'object-class':

--- a/src/Propel/Generator/Command/TestPrepareCommand.php
+++ b/src/Propel/Generator/Command/TestPrepareCommand.php
@@ -140,6 +140,7 @@ class TestPrepareCommand extends AbstractCommand
                 'command' => 'config:convert',
                 '--output-dir' => './build/conf',
                 '--output-file' => sprintf('%s-conf.php', $connections[0]), // the first connection is the main one
+                '--loader-script-dir' => './build/conf',
             ]);
 
             $command = $this->getApplication()->find('config:convert');
@@ -151,6 +152,7 @@ class TestPrepareCommand extends AbstractCommand
                 'command' => 'model:build',
                 '--schema-dir' => '.',
                 '--output-dir' => 'build/classes/',
+                '--loader-script-dir' => './build/conf',
                 '--platform' => ucfirst($input->getOption('vendor')) . 'Platform',
                 '--verbose' => $input->getOption('verbose'),
             ]);

--- a/src/Propel/Runtime/Map/DatabaseMap.php
+++ b/src/Propel/Runtime/Map/DatabaseMap.php
@@ -90,7 +90,12 @@ class DatabaseMap
     public function addTableObject(TableMap $table)
     {
         $table->setDatabaseMap($this);
-        $this->tables[$table->getName()] = $table;
+
+        $tableName = $table->getName();
+        if (!$this->hasTable($tableName)) {
+            $this->tables[$tableName] = $table;
+        }
+
         $phpName = $table->getClassName();
         if ($phpName && $phpName[0] !== '\\') {
             $phpName = '\\' . $phpName;
@@ -108,11 +113,7 @@ class DatabaseMap
     public function addTableFromMapClass($tableMapClass)
     {
         $table = new $tableMapClass();
-        if (!$this->hasTable($table->getName())) {
-            $this->addTableObject($table);
-
-            return $table;
-        }
+        $this->addTableObject($table);
 
         return $this->getTable($table->getName());
     }
@@ -145,7 +146,7 @@ class DatabaseMap
     public function getTable($name)
     {
         if (!isset($this->tables[$name])) {
-            throw new TableNotFoundException(sprintf('Cannot fetch TableMap for undefined table: %s.', $name));
+            throw new TableNotFoundException(sprintf('Cannot fetch TableMap for undefined table %s in database %s.', $name, $this->getName()));
         }
 
         return $this->tables[$name];
@@ -213,7 +214,7 @@ class DatabaseMap
             }
         }
 
-        throw new TableNotFoundException(sprintf('Cannot fetch TableMap for undefined table phpName: %s.', $phpName));
+        throw new TableNotFoundException(sprintf('Cannot fetch TableMap for undefined table phpName: %s in database %s.', $phpName, $this->getName()));
     }
 
     /**

--- a/src/Propel/Runtime/ServiceContainer/ServiceContainerInterface.php
+++ b/src/Propel/Runtime/ServiceContainer/ServiceContainerInterface.php
@@ -152,4 +152,13 @@ interface ServiceContainerInterface
      * @return \Psr\Log\LoggerInterface
      */
     public function getLogger($name = 'defaultLogger');
+
+    /**
+     * Initialize the internal database maps array
+     *
+     * @param array $databaseNameToTableMapClassNames
+     *
+     * @return void
+     */
+    public function initDatabaseMaps(array $databaseNameToTableMapClassNames = []): void;
 }

--- a/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
+++ b/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
@@ -18,15 +18,24 @@ use Propel\Runtime\Adapter\Exception\AdapterException;
 use Propel\Runtime\Connection\ConnectionInterface;
 use Propel\Runtime\Connection\ConnectionManagerInterface;
 use Propel\Runtime\Connection\ConnectionManagerSingle;
+use Propel\Runtime\Exception\PropelException;
 use Propel\Runtime\Exception\RuntimeException;
 use Propel\Runtime\Exception\UnexpectedValueException;
 use Propel\Runtime\Map\DatabaseMap;
-use Propel\Runtime\Propel;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
 class StandardServiceContainer implements ServiceContainerInterface
 {
+    /**
+     * Expected version of the configuration file.
+     *
+     * @see StandardServiceContainer::checkVersion()
+     *
+     * @var int
+     */
+    public const CONFIGURATION_VERSION = 2;
+
     /**
      * @var \Propel\Runtime\Adapter\AdapterInterface[] List of database adapter instances
      */
@@ -50,9 +59,10 @@ class StandardServiceContainer implements ServiceContainerInterface
     protected $databaseMapClass = ServiceContainerInterface::DEFAULT_DATABASE_MAP_CLASS;
 
     /**
-     * @var \Propel\Runtime\Map\DatabaseMap[] List of database map instances
+     * @var \Propel\Runtime\Map\DatabaseMap[]|null List of database map instances. Is null if not initialized.
+     * @see StandardServiceContainer::initDatabaseMaps();
      */
-    protected $databaseMaps = [];
+    protected $databaseMaps;
 
     /**
      * @var \Propel\Runtime\Connection\ConnectionManagerInterface[] List of connection managers
@@ -206,24 +216,38 @@ class StandardServiceContainer implements ServiceContainerInterface
     }
 
     /**
-     * check whether the given propel generator version has the same version as
-     * the propel runtime.
+     * Checks if the given propel generator version is outdated.
      *
      * @param string $generatorVersion
+     *
+     * @throws \Propel\Runtime\Exception\PropelException Thrown when the configuration is outdated.
      *
      * @return void
      */
     public function checkVersion($generatorVersion)
     {
-        if ($generatorVersion === Propel::VERSION) {
+        if ($generatorVersion === static::CONFIGURATION_VERSION) {
             return;
         }
 
-        $warning = "Version mismatch: The generated model was build using propel '" . $generatorVersion;
-        $warning .= " while the current runtime is at version '" . Propel::VERSION . "'";
+        throw new PropelException('Your configuration is outdated. Please rebuild it with the config:convert command.');
+    }
 
-        $logger = $this->getLogger();
-        $logger->warning($warning);
+    /**
+     * @param array $databaseNameToTableMapClassNames
+     *
+     * @return void
+     */
+    public function initDatabaseMaps(array $databaseNameToTableMapClassNames = []): void
+    {
+        if ($this->databaseMaps === null) {
+            $this->databaseMaps = [];
+        }
+
+        foreach ($databaseNameToTableMapClassNames as $databaseName => $tableMapClassNames) {
+            $databaseMap = $this->getDatabaseMap($databaseName);
+            array_map([$databaseMap, 'addTableFromMapClass'], $tableMapClassNames);
+        }
     }
 
     /**
@@ -245,12 +269,17 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @param string|null $name The datasource name
      *
+     * @throws \Propel\Runtime\Exception\PropelException
+     *
      * @return \Propel\Runtime\Map\DatabaseMap
      */
     public function getDatabaseMap($name = null)
     {
-        if ($name === null) {
+        if (!$name) {
             $name = $this->getDefaultDatasource();
+        }
+        if ($this->databaseMaps === null) {
+            throw new PropelException('Database map was not initialized. Please check the database loader script included by your conf');
         }
         if (!isset($this->databaseMaps[$name])) {
             $class = $this->databaseMapClass;

--- a/tests/Propel/Tests/Generator/Config/ArrayToPhpConverterTest.php
+++ b/tests/Propel/Tests/Generator/Config/ArrayToPhpConverterTest.php
@@ -32,8 +32,6 @@ class ArrayToPhpConverterTest extends TestCase
             ],
         ];
         $expected = <<<EOF
-\$serviceContainer = \Propel\Runtime\Propel::getServiceContainer();
-\$serviceContainer->checkVersion('2.0.0-dev');
 \$serviceContainer->setAdapterClass('bookstore', 'mysql');
 \$manager = new \Propel\Runtime\Connection\ConnectionManagerSingle();
 \$manager->setConfiguration(array (
@@ -75,8 +73,6 @@ EOF;
             ],
         ];
         $expected = <<<'EOF'
-$serviceContainer = \Propel\Runtime\Propel::getServiceContainer();
-$serviceContainer->checkVersion('2.0.0-dev');
 $serviceContainer->setAdapterClass('bookstore-cms', 'mysql');
 $manager = new \Propel\Runtime\Connection\ConnectionManagerMasterSlave();
 $manager->setReadConfiguration(array (
@@ -114,8 +110,6 @@ EOF;
             'outerGlue' => ' | ',
         ]];
         $expected = <<<'EOF'
-$serviceContainer = \Propel\Runtime\Propel::getServiceContainer();
-$serviceContainer->checkVersion('2.0.0-dev');
 $serviceContainer->setProfilerClass('\Propel\Runtime\Util\Profiler');
 $serviceContainer->setProfilerConfiguration(array (
   'slowTreshold' => 0.2,
@@ -149,8 +143,6 @@ EOF;
             'path' => '/var/log/propel.log',
         ]]];
         $expected = <<<'EOF'
-$serviceContainer = \Propel\Runtime\Propel::getServiceContainer();
-$serviceContainer->checkVersion('2.0.0-dev');
 $serviceContainer->setLoggerConfiguration('defaultLogger', array (
   'type' => 'stream',
   'level' => '300',
@@ -178,8 +170,6 @@ EOF;
             ],
         ]];
         $expected = <<<'EOF'
-$serviceContainer = \Propel\Runtime\Propel::getServiceContainer();
-$serviceContainer->checkVersion('2.0.0-dev');
 $serviceContainer->setLoggerConfiguration('defaultLogger', array (
   'type' => 'stream',
   'path' => '/var/log/propel.log',
@@ -234,8 +224,6 @@ EOF;
             'defaultConnection' => 'bookstore',
         ];
         $expected = <<<'EOF'
-$serviceContainer = \Propel\Runtime\Propel::getServiceContainer();
-$serviceContainer->checkVersion('2.0.0-dev');
 $serviceContainer->setAdapterClass('bookstore', 'mysql');
 $manager = new \Propel\Runtime\Connection\ConnectionManagerSingle();
 $manager->setConfiguration(array (

--- a/tests/Propel/Tests/Runtime/ServiceContainer/StandardServiceContainerTest.php
+++ b/tests/Propel/Tests/Runtime/ServiceContainer/StandardServiceContainerTest.php
@@ -14,6 +14,7 @@ use Propel\Runtime\Adapter\Pdo\MysqlAdapter;
 use Propel\Runtime\Adapter\Pdo\SqliteAdapter;
 use Propel\Runtime\Connection\ConnectionManagerSingle;
 use Propel\Runtime\Connection\PdoConnection;
+use Propel\Runtime\Exception\PropelException;
 use Propel\Runtime\Exception\RuntimeException;
 use Propel\Runtime\Map\DatabaseMap;
 use Propel\Runtime\Propel;
@@ -35,6 +36,7 @@ class StandardServiceContainerTest extends BaseTestCase
     protected function setUp(): void
     {
         $this->sc = new StandardServiceContainer();
+        $this->sc->initDatabaseMaps([]);
     }
 
     /**
@@ -190,31 +192,106 @@ class StandardServiceContainerTest extends BaseTestCase
     /**
      * @return void
      */
-    public function testCheckInvalidVersion()
+    public function testCheckInvalidVersion(): void
     {
-        $logger = $this->getMockBuilder('Monolog\Logger')
-            ->setMethods(['warning'])
-            ->setConstructorArgs(['mylogger'])
-            ->getMock();
-        $logger->expects($this->once())->method('warning');
+        $this->expectException(PropelException::class);
+        $this->sc->checkVersion(-1);
+    }
 
-        $this->sc->setLogger('defaultLogger', $logger);
-        $this->sc->checkVersion('1.0.0-invalid');
+    /**
+     * @doesNotPerformAssertions
+     *
+     * @return void
+     */
+    public function testCheckValidVersion(): void
+    {
+        try {
+            $this->sc->checkVersion(StandardServiceContainer::CONFIGURATION_VERSION);
+        } catch (PropelException $e) {
+            $this->fail('The current configuration version should pass a check');
+        }
     }
 
     /**
      * @return void
      */
-    public function testCheckValidVersion()
+    public function testUninitializedDatabaseMapThrowsException(): void
     {
-        $logger = $this->getMockBuilder('Monolog\Logger')
-            ->setMethods(['warning'])
-            ->setConstructorArgs(['mylogger'])
-            ->getMock();
-        $logger->expects($this->never())->method('warning');
+        $sc = new StandardServiceContainer();
+        try {
+            $sc->getDatabaseMap('a database name');
+            $this->fail('Accessing database map before initialization should throw exception.');
+        } catch (PropelException $e) {
+            $expectedMessage = 'Database map was not initialized. Please check the database loader script included by your conf';
+            $this->assertSame($expectedMessage, $e->getMessage());
+        }
+    }
 
-        $this->sc->setLogger('defaultLogger', $logger);
-        $this->sc->checkVersion(Propel::VERSION);
+    /**
+     * @return void
+     */
+    public function testInitializedDatabaseMapContainsTableMaps(): void
+    {
+        $sc = new StandardServiceContainer();
+        $dbName = 'myBookstore';
+        $dbMap = [
+            $dbName => [
+                '\\Propel\\Tests\\Bookstore\\Map\\AuthorTableMap',
+                '\\Propel\\Tests\\Bookstore\\Map\\BookTableMap',
+            ],
+        ];
+        $this->runInitDatabaseMapsOnContainer($sc, $dbMap);
+        $dbMap = $sc->getDatabaseMap($dbName);
+
+        $this->assertTrue($dbMap->hasTable('author'));
+        $this->assertTrue($dbMap->hasTable('book'));
+    }
+
+    /**
+     * @return void
+     */
+    public function testInitializingdDatabaseMapsAccumulates(): void
+    {
+        $sc = new StandardServiceContainer();
+        $dbName = 'myBookstore';
+        $dbMap1 = [
+            $dbName => [
+                '\\Propel\\Tests\\Bookstore\\Map\\AuthorTableMap',
+                '\\Propel\\Tests\\Bookstore\\Map\\BookTableMap',
+            ],
+        ];
+
+        $dbMap2 = [
+            $dbName => [
+                '\\Propel\\Tests\\Bookstore\\Map\\AuthorTableMap',
+                '\\Propel\\Tests\\Bookstore\\Map\\EssayTableMap',
+            ],
+        ];
+
+        $this->runInitDatabaseMapsOnContainer($sc, $dbMap1);
+        $this->runInitDatabaseMapsOnContainer($sc, $dbMap2);
+        $dbMap = $sc->getDatabaseMap($dbName);
+
+        $this->assertTrue($dbMap->hasTable('author'));
+        $this->assertTrue($dbMap->hasTable('book'));
+        $this->assertTrue($dbMap->hasTable('essay'));
+    }
+
+    /**
+     * @param \Propel\Runtime\ServiceContainer\StandardServiceContainer $sc
+     * @param String[][] $dbMap
+     *
+     * @return void
+     */
+    private function runInitDatabaseMapsOnContainer(StandardServiceContainer $sc, array $dbMap): void
+    {
+        $initialServiceContainer = Propel::getServiceContainer();
+        try {
+            Propel::setServiceContainer($sc);
+            $sc->initDatabaseMaps($dbMap);
+        } finally {
+            Propel::setServiceContainer($initialServiceContainer);
+        }
     }
 
     /**


### PR DESCRIPTION
This PR fixes the issue with missing table registration when using PHP 7.4 preloading (see #1695).

This is a big one, and I am not sure how much I like it. But there is probably no way around it.

### tl;dr
- Instead of relying on automatic registration of tables, which does not work with preloading, the tables are now registered explicitly through a script.
- Script creation and importing is done in a way where it does not impact existing projects.
- However, users have to rebuild their configuration and their models with the `config:convert` and `model:build` command.
- If they are not aware of that, exceptions will tell them what to do.

### Background
The metadata for tables is stored in table map files, which are generated by the `model:build` command (i.e. BookTableMap.php). They are registered in database maps in the global ServiceContainer. Every reference to a table in Propel is resolved through these files. Without the table map files, Propel knows nothing about the table and will not be able to work with it.

Currently, the table map files register themselves when being loaded. This is done through a static call, which is inserted after the class declaration in each table map file:

```php
class BookTableMap extends TableMap
{
    ...

     /**
     * Add a TableMap instance to the database for this tableMap class.
     */
    public static function buildTableMap()
    {
        $dbMap = Propel::getServiceContainer()->getDatabaseMap(BookTableMap::DATABASE_NAME);
        if (!$dbMap->hasTable(BookTableMap::TABLE_NAME)) {
            $dbMap->addTableObject(new BookTableMap());
        }
    }
} // BookTableMap
// This is the static code needed to register the TableMap for this table with the main Propel class.
//
BookTableMap::buildTableMap()
```
 This approach is often used to bridge the issue of missing static class initializers in PHP. It is pretty nice, because no additional structure is needed - the classes just make themselves known to the ServiceContainer.

### The problem
 When using PHP 7.4 preloading, the static call is executed during preloading, but the result is removed when preloading finishes. The static calls are not run again when restoring from cache (see for example [here](https://stackoverflow.com/a/61577684/4883195) or #1695), leading to an empty database schema. This means that it is currently impossible to preload the table map files.

### Proposed solution
So, there is an easy part and a hard part to fixing this.

The easy part is to extract the static table map initialization calls into a standalone script, which can be run manually during Propel initialization. This can easily be done during the 'model:build' command.

The hard part is figuring out how to run the script without having users to adjust their code base. Because while it would be easy to have them import the file manually, like the configuration, it means that they have to be aware of the change and know what to do, which will lead to endless bug reports.

I think the least annoying approach is to add an import statement at the end of the configuration. It is the only file directly imported into a Propel project, making it the only candidate for piggybacking. It is also auto-generated, so we can change it in a structured manner.
Very nice, however, creating the configuration and creating the table loader script is done in different commands - `config:convert`  and `model:build`. So after building the configuration, it contains an import statement for a file, which is yet to be created. And  `model:build` needs to know where the configuration expects the table loader script, but doesn't even know where the configuration file is. Also, the process has to work without users necessarily being aware of it.

Long story short, this is what I came up with:
- running `config:convert` creates an updated configuration which imports the table loader script, and creates a dummy file at the expected location
- running `model:build` will create the actual table loader script at the expected location
- The expected location is either shared through the `paths` property of the raw configuration (like `propel.json`), or by passing a value via parameter to both commands:
    - either the parameter `--loader-script-dir` has to be passed to both commands for manual setup
    - setting the new `paths.loaderScriptDir` property in the raw configuration allows to set a custom location
    - if none of the above is given, the script will be put at the location of `paths.phpConfigDir` (which default to `./generated-conf/`)
 - if a user updates Propel without rebuilding the configuration, an exception is thrown upon reading it, telling them to run `config:convert`
 - if a user has updated the configuration, but has not rebuild the models, the service container will throw an exception when accessing the database map, telling him to check the script, and if it is the dummy script, it will tell them to run `model:build`

So this changes some substantial mechanisms in Propel, and I a bit anxious about that. Probably why the topic was gracefully dropped in #361. Then again, I don't think there is a way around it. I have looked for easier ways, like fiddling with the composer autoload mechanism, or just searching for all table map classes during initialization, but those introduce performance issues among other problems.

Of course, I am always happy to discuss.