### PR TITLE
Feature/untangle criteria class

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -431,51 +431,6 @@ parameters:
 			path: src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
 
 		-
-			message: "#^Call to an undefined method Propel\\\\Runtime\\\\Adapter\\\\AdapterInterface\\:\\:createSelectSqlPart\\(\\)\\.$#"
-			count: 1
-			path: src/Propel/Runtime/ActiveQuery/Criteria.php
-
-		-
-			message: "#^Call to an undefined method Propel\\\\Runtime\\\\Adapter\\\\AdapterInterface\\:\\:applyLimit\\(\\)\\.$#"
-			count: 1
-			path: src/Propel/Runtime/ActiveQuery/Criteria.php
-
-		-
-			message: "#^Call to an undefined method Propel\\\\Runtime\\\\Adapter\\\\AdapterInterface\\:\\:applyLock\\(\\)\\.$#"
-			count: 1
-			path: src/Propel/Runtime/ActiveQuery/Criteria.php
-
-		-
-			message: "#^Call to an undefined method Propel\\\\Runtime\\\\Adapter\\\\AdapterInterface\\:\\:cleanupSQL\\(\\)\\.$#"
-			count: 1
-			path: src/Propel/Runtime/ActiveQuery/Criteria.php
-
-		-
-			message: "#^Call to an undefined method Propel\\\\Runtime\\\\Adapter\\\\AdapterInterface\\:\\:bindValues\\(\\)\\.$#"
-			count: 3
-			path: src/Propel/Runtime/ActiveQuery/Criteria.php
-
-		-
-			message: "#^Result of && is always false\\.$#"
-			count: 1
-			path: src/Propel/Runtime/ActiveQuery/Criterion/AbstractCriterion.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between string and null will always evaluate to false\\.$#"
-			count: 1
-			path: src/Propel/Runtime/ActiveQuery/Criterion/AbstractCriterion.php
-
-		-
-			message: "#^Result of && is always false\\.$#"
-			count: 1
-			path: src/Propel/Runtime/ActiveQuery/Criterion/AbstractModelCriterion.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between string and null will always evaluate to false\\.$#"
-			count: 1
-			path: src/Propel/Runtime/ActiveQuery/Criterion/AbstractModelCriterion.php
-
-		-
 			message: "#^Call to an undefined method Propel\\\\Runtime\\\\Adapter\\\\AdapterInterface\\:\\:ignoreCase\\(\\)\\.$#"
 			count: 2
 			path: src/Propel/Runtime/ActiveQuery/Criterion/LikeCriterion.php

--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -2046,9 +2046,10 @@ class Criteria
      */
     public function createSelectSql(&$params)
     {
-        [$sql, $params] = SelectQuerySqlBuilder::createSelectSql($this, $params);
+        $preparedStatementDto = SelectQuerySqlBuilder::createSelectSql($this, $params);
+        $params = $preparedStatementDto->getParameters();
 
-        return $sql;
+        return $preparedStatementDto->getSqlStatement();
     }
 
     /**

--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -16,11 +16,15 @@ use Propel\Runtime\ActiveQuery\Criterion\CustomCriterion;
 use Propel\Runtime\ActiveQuery\Criterion\InCriterion;
 use Propel\Runtime\ActiveQuery\Criterion\LikeCriterion;
 use Propel\Runtime\ActiveQuery\Criterion\RawCriterion;
+use Propel\Runtime\ActiveQuery\QueryExecutor\CountQueryExecutor;
+use Propel\Runtime\ActiveQuery\QueryExecutor\DeleteAllQueryExecutor;
+use Propel\Runtime\ActiveQuery\QueryExecutor\DeleteQueryExecutor;
+use Propel\Runtime\ActiveQuery\QueryExecutor\InsertQueryExecutor;
+use Propel\Runtime\ActiveQuery\QueryExecutor\SelectQueryExecutor;
+use Propel\Runtime\ActiveQuery\QueryExecutor\UpdateQueryExecutor;
+use Propel\Runtime\ActiveQuery\SqlBuilder\SelectQuerySqlBuilder;
 use Propel\Runtime\Connection\ConnectionInterface;
-use Propel\Runtime\Connection\ConnectionWrapper;
-use Propel\Runtime\Connection\StatementWrapper;
 use Propel\Runtime\Exception\LogicException;
-use Propel\Runtime\Exception\PropelException;
 use Propel\Runtime\Propel;
 use Propel\Runtime\Util\PropelConditionalProxy;
 
@@ -2042,205 +2046,7 @@ class Criteria
      */
     public function createSelectSql(&$params)
     {
-        $adapter = Propel::getServiceContainer()->getAdapter($this->getDbName());
-        $dbMap = Propel::getServiceContainer()->getDatabaseMap($this->getDbName());
-
-        $fromClause = [];
-        $joinClause = [];
-        $joinTables = [];
-        $whereClause = [];
-        $orderByClause = [];
-
-        $orderBy = $this->getOrderByColumns();
-
-        // get the first part of the SQL statement, the SELECT part
-        $selectSql = $adapter->createSelectSqlPart($this, $fromClause);
-        $this->replaceNames($selectSql);
-
-        // Handle joins
-        // joins with a null join type will be added to the FROM clause and the condition added to the WHERE clause.
-        // joins of a specified type: the LEFT side will be added to the fromClause and the RIGHT to the joinClause
-        foreach ($this->getJoins() as $join) {
-            $join->setAdapter($adapter);
-
-            // add 'em to the queues..
-            if (!$fromClause) {
-                $fromClause[] = $join->getLeftTableWithAlias();
-            }
-            $joinTables[] = $join->getRightTableWithAlias();
-            $joinClauseString = $join->getClause($params);
-            $this->replaceNames($joinClauseString);
-            $joinClause[] = $joinClauseString;
-        }
-
-        // add the criteria to WHERE clause
-        // this will also add the table names to the FROM clause if they are not already
-        // included via a LEFT JOIN
-        foreach ($this->keys() as $key) {
-            $criterion = $this->getCriterion($key);
-            $table = null;
-            foreach ($criterion->getAttachedCriterion() as $attachedCriterion) {
-                $tableName = $attachedCriterion->getTable();
-
-                $table = $this->getTableForAlias($tableName);
-                if ($table !== null) {
-                    $fromClause[] = $table . ' ' . $tableName;
-                } else {
-                    $fromClause[] = $tableName;
-                    $table = $tableName;
-                }
-
-                if (
-                    $this->isIgnoreCase() && method_exists($attachedCriterion, 'setIgnoreCase')
-                    && $dbMap->getTable($table)->getColumn($attachedCriterion->getColumn())->isText()
-                ) {
-                    $attachedCriterion->setIgnoreCase(true);
-                }
-            }
-
-            $criterion->setAdapter($adapter);
-
-            $sb = '';
-            $criterion->appendPsTo($sb, $params);
-            $this->replaceNames($sb);
-            $whereClause[] = $sb;
-        }
-
-        // Unique from clause elements
-        $fromClause = array_unique($fromClause);
-        $fromClause = array_diff($fromClause, ['']);
-
-        // tables should not exist in both the from and join clauses
-        if ($joinTables && $fromClause) {
-            foreach ($fromClause as $fi => $ftable) {
-                if (in_array($ftable, $joinTables)) {
-                    unset($fromClause[$fi]);
-                }
-            }
-        }
-
-        $having = $this->getHaving();
-        $havingString = null;
-        if ($having !== null) {
-            $sb = '';
-            $having->appendPsTo($sb, $params);
-            $this->replaceNames($sb);
-            $havingString = $sb;
-        }
-
-        if (!empty($orderBy)) {
-            foreach ($orderBy as $orderByColumn) {
-                // Add function expression as-is.
-                if (strpos($orderByColumn, '(') !== false) {
-                    $orderByClause[] = $orderByColumn;
-
-                    continue;
-                }
-
-                // Split orderByColumn (i.e. "table.column DESC")
-                $dotPos = strrpos($orderByColumn, '.');
-
-                if ($dotPos !== false) {
-                    $tableName = substr($orderByColumn, 0, $dotPos);
-                    $columnName = substr($orderByColumn, $dotPos + 1);
-                } else {
-                    $tableName = '';
-                    $columnName = $orderByColumn;
-                }
-
-                $spacePos = strpos($columnName, ' ');
-
-                if ($spacePos !== false) {
-                    $direction = substr($columnName, $spacePos);
-                    $columnName = substr($columnName, 0, $spacePos);
-                } else {
-                    $direction = '';
-                }
-
-                $tableAlias = $tableName;
-                $aliasTableName = $this->getTableForAlias($tableName);
-                if ($aliasTableName) {
-                    $tableName = $aliasTableName;
-                }
-
-                $columnAlias = $columnName;
-                $asColumnName = $this->getColumnForAs($columnName);
-                if ($asColumnName) {
-                    $columnName = $asColumnName;
-                }
-
-                $column = $tableName ? $dbMap->getTable($tableName)->getColumn($columnName) : null;
-
-                if ($this->isIgnoreCase() && $column && $column->isText()) {
-                    $ignoreCaseColumn = $adapter->ignoreCaseInOrderBy("$tableAlias.$columnAlias");
-                    $this->replaceNames($ignoreCaseColumn);
-                    $orderByClause[] = $ignoreCaseColumn . $direction;
-                    $selectSql .= ', ' . $ignoreCaseColumn;
-                } else {
-                    $this->replaceNames($orderByColumn);
-                    $orderByClause[] = $orderByColumn;
-                }
-            }
-        }
-
-        // tables should not exist as alias of subQuery
-        if ($this->hasSelectQueries()) {
-            foreach ($fromClause as $index => $ftable) {
-                if (strpos($ftable, ' ') !== false) {
-                    [, $tableName] = explode(' ', $ftable);
-                } else {
-                    $tableName = $ftable;
-                }
-                if ($this->hasSelectQuery($tableName)) {
-                    unset($fromClause[$index]);
-                }
-            }
-        }
-
-        // from / join tables quoted if it is necessary
-        $fromClause = array_map([$this, 'quoteIdentifierTable'], $fromClause);
-        $joinClause = $joinClause ? $joinClause : array_map([$this, 'quoteIdentifierTable'], $joinClause);
-
-        // add subQuery to From after adding quotes
-        foreach ($this->getSelectQueries() as $subQueryAlias => $subQueryCriteria) {
-            $fromClause[] = '(' . $subQueryCriteria->createSelectSql($params) . ') AS ' . $subQueryAlias;
-        }
-
-        if (empty($fromClause) && $this->getPrimaryTableName()) {
-            $fromClause[] = $this->getPrimaryTableName();
-        }
-
-        // build from-clause
-        $from = '';
-        if (!empty($joinClause) && count($fromClause) > 1) {
-            $from .= implode(' CROSS JOIN ', $fromClause);
-        } else {
-            $from .= implode(', ', $fromClause);
-        }
-
-        $from .= $joinClause ? ' ' . implode(' ', $joinClause) : '';
-
-        // Build the SQL from the arrays we compiled
-        $sql = $selectSql
-            . ' FROM ' . $from
-            . ($whereClause ? ' WHERE ' . implode(' AND ', $whereClause) : '');
-
-        $groupBy = $adapter->getGroupBy($this);
-        if ($groupBy) {
-            $this->replaceNames($groupBy);
-            $sql .= $groupBy;
-        }
-
-        $sql .= ($havingString ? ' HAVING ' . $havingString : '')
-             . ($orderByClause ? ' ORDER BY ' . implode(',', $orderByClause) : '');
-
-        if ($this->getLimit() >= 0 || $this->getOffset()) {
-            $adapter->applyLimit($sql, $this->getOffset(), $this->getLimit(), $this);
-        }
-
-        if (null !== $this->lock) {
-            $adapter->applyLock($sql, $this->lock);
-        }
+        [$sql, $params] = SelectQuerySqlBuilder::createSelectSql($this, $params);
 
         return $sql;
     }
@@ -2289,38 +2095,6 @@ class Criteria
 
                     return $adapter->quote($string);
                 }
-            }
-        }
-
-        return $string;
-    }
-
-    /**
-     * @param string $string
-     *
-     * @return string
-     */
-    public function quoteIdentifierTable($string)
-    {
-        $realTableName = $string;
-        if (($pos = strrpos($string, ' ')) !== false) {
-            $realTableName = substr($string, 0, $pos);
-        }
-
-        $dbMap = Propel::getServiceContainer()->getDatabaseMap($this->getDbName());
-
-        if ($this->isIdentifierQuotingEnabled()) {
-            $adapter = Propel::getServiceContainer()->getAdapter($this->getDbName());
-
-            return $adapter->quoteIdentifierTable($string);
-        }
-
-        if ($dbMap->hasTable($realTableName)) {
-            $tableMap = $dbMap->getTable($realTableName);
-            if ($tableMap->isIdentifierQuotingEnabled()) {
-                $adapter = Propel::getServiceContainer()->getAdapter($this->getDbName());
-
-                return $adapter->quoteIdentifierTable($string);
             }
         }
 
@@ -2415,91 +2189,11 @@ class Criteria
      *
      * @param \Propel\Runtime\Connection\ConnectionInterface|null $con A ConnectionInterface connection.
      *
-     * @throws \Propel\Runtime\Exception\PropelException
-     *
      * @return mixed The primary key for the new row if the primary key is auto-generated. Otherwise will return null.
      */
     public function doInsert(?ConnectionInterface $con = null)
     {
-        // The primary key
-        $id = null;
-        if ($con === null) {
-            $con = Propel::getServiceContainer()->getWriteConnection($this->getDbName());
-        }
-        $db = Propel::getServiceContainer()->getAdapter($this->getDbName());
-
-        // Get the table name and method for determining the primary
-        // key value.
-        $keys = $this->keys();
-        if (!empty($keys)) {
-            $tableName = $this->getTableName($keys[0]);
-        } else {
-            throw new PropelException('Database insert attempted without anything specified to insert.');
-        }
-
-        $tableName = $this->getTableName($keys[0]);
-        $dbMap = Propel::getServiceContainer()->getDatabaseMap($this->getDbName());
-        $tableMap = $dbMap->getTable($tableName);
-        $keyInfo = $tableMap->getPrimaryKeyMethodInfo();
-        $useIdGen = $tableMap->isUseIdGenerator();
-        //$keyGen = $con->getIdGenerator();
-
-        $pk = $this->getPrimaryKey();
-
-        // only get a new key value if you need to
-        // the reason is that a primary key might be defined
-        // but you are still going to set its value. for example:
-        // a join table where both keys are primary and you are
-        // setting both columns with your own values
-
-        // pk will be null if there is no primary key defined for the table
-        // we're inserting into.
-        if ($pk !== null && $useIdGen && !$this->keyContainsValue($pk->getFullyQualifiedName()) && $db->isGetIdBeforeInsert()) {
-            try {
-                $id = $db->getId($con, $keyInfo);
-            } catch (Exception $e) {
-                throw new PropelException('Unable to get sequence id.', 0, $e);
-            }
-            $this->add($pk->getFullyQualifiedName(), $id);
-        }
-
-        $qualifiedCols = $this->keys(); // we need table.column cols when populating values
-        $columns = []; // but just 'column' cols for the SQL
-        foreach ($qualifiedCols as $qualifiedCol) {
-            $columns[] = substr($qualifiedCol, strrpos($qualifiedCol, '.') + 1);
-        }
-        $columns = array_map([$this, 'quoteIdentifier'], $columns);
-        $columnCsv = implode(',', $columns);
-
-        $parameterIndexes = (count($columns) === 0) ? [] : range(1, count($columns));
-        $parameterPlaceholders = preg_filter('/^/', ':p', $parameterIndexes); // prefix each element with ':p'
-        $parameterPlaceholdersCsv = implode(',', $parameterPlaceholders);
-
-        $tableName = $this->quoteIdentifierTable($tableName);
-        $sql = "INSERT INTO $tableName ($columnCsv) VALUES ($parameterPlaceholdersCsv)";
-
-        $stmt = null;
-        $params = $this->buildParams($qualifiedCols);
-        try {
-            $db->cleanupSQL($sql, $params, $this, $dbMap);
-
-            $stmt = $con->prepare($sql);
-            $db->bindValues($stmt, $params, $dbMap, $db);
-            $stmt->execute();
-        } catch (Exception $e) {
-            $this->handleStatementException($e, $sql, $con, $stmt);
-        }
-
-        // If the primary key column is auto-incremented, get the id now.
-        if ($pk !== null && $useIdGen && $db->isGetIdAfterInsert()) {
-            try {
-                $id = $db->getId($con, $keyInfo);
-            } catch (Exception $e) {
-                throw new PropelException('Unable to get autoincrement id.', 0, $e);
-            }
-        }
-
-        return $id;
+        return InsertQueryExecutor::execute($this, $con);
     }
 
     /**
@@ -2551,191 +2245,17 @@ class Criteria
      */
     public function doUpdate($updateValues, ConnectionInterface $con)
     {
-        /** @var \Propel\Runtime\Adapter\Pdo\PdoAdapter $db */
-        $db = Propel::getServiceContainer()->getAdapter($this->getDbName());
-        $dbMap = Propel::getServiceContainer()->getDatabaseMap($this->getDbName());
-
-        // Get list of required tables, containing all columns
-        $tablesColumns = $this->getTablesColumns();
-        if (empty($tablesColumns) && ($table = $this->getPrimaryTableName())) {
-            $tablesColumns = [$table => []];
-        }
-
-        // we also need the columns for the update SQL
-        $updateTablesColumns = $updateValues->getTablesColumns();
-
-        // If no columns are changing values, we may get here with
-        // an empty array in $updateTablesColumns.  In that case,
-        // there is nothing to do, so we return the rows affected,
-        // which is 0.  Fixes a bug in which an UPDATE statement
-        // would fail in this instance.
-
-        if (empty($updateTablesColumns)) {
-            return 0;
-        }
-
-        $affectedRows = 0; // initialize this in case the next loop has no iterations.
-
-        foreach ($tablesColumns as $tableName => $columns) {
-            $whereClause = [];
-            $params = [];
-            $stmt = null;
-            $sql = null;
-
-            try {
-                $sql = 'UPDATE ';
-                $queryComment = $this->getComment();
-                if ($queryComment) {
-                    $sql .= '/* ' . $queryComment . ' */ ';
-                }
-                // is it a table alias?
-                $realTableName = $this->getTableForAlias($tableName);
-                if ($realTableName) {
-                    $updateTable = $realTableName . ' ' . $tableName;
-                    $tableName = $realTableName;
-                } else {
-                    $updateTable = $tableName;
-                }
-                $sql .= $this->quoteIdentifierTable($updateTable);
-                $sql .= ' SET ';
-                $p = 1;
-                foreach ($updateTablesColumns[$tableName] as $col) {
-                    $updateColumnName = substr($col, strrpos($col, '.') + 1);
-                    // add identifiers for the actual database?
-                    $updateColumnName = $this->quoteIdentifier($updateColumnName, $tableName);
-                    if ($updateValues->getComparison($col) != Criteria::CUSTOM_EQUAL) {
-                        $sql .= $updateColumnName . '=:p' . $p++ . ', ';
-                    } else {
-                        $param = $updateValues->get($col);
-                        $sql .= $updateColumnName . ' = ';
-                        if (is_array($param)) {
-                            if (isset($param['raw'])) {
-                                $raw = $param['raw'];
-                                $rawcvt = '';
-                                // parse the $params['raw'] for ? chars
-                                for ($r = 0, $len = strlen($raw); $r < $len; $r++) {
-                                    if ($raw[$r] === '?') {
-                                        $rawcvt .= ':p' . $p++;
-                                    } else {
-                                        $rawcvt .= $raw[$r];
-                                    }
-                                }
-                                $sql .= $rawcvt . ', ';
-                            } else {
-                                $sql .= ':p' . $p++ . ', ';
-                            }
-                            if (isset($param['value'])) {
-                                $updateValues->put($col, $param['value']);
-                            }
-                        } else {
-                            $updateValues->remove($col);
-                            $sql .= $param . ', ';
-                        }
-                    }
-                }
-
-                $params = $this->buildParams($updateTablesColumns[$tableName], $updateValues);
-
-                $sql = substr($sql, 0, -2);
-                if (!empty($columns)) {
-                    foreach ($columns as $colName) {
-                        $sb = '';
-                        $this->getCriterion($colName)->appendPsTo($sb, $params);
-                        $this->replaceNames($sb);
-                        $whereClause[] = $sb;
-                    }
-                    $sql .= ' WHERE ' . implode(' AND ', $whereClause);
-                }
-
-                $db->cleanupSQL($sql, $params, $updateValues, $dbMap);
-                $stmt = $con->prepare($sql);
-                $db->bindValues($stmt, $params, $dbMap);
-                $stmt->execute();
-                $affectedRows = $stmt->rowCount();
-            } catch (Exception $e) {
-                $this->handleStatementException($e, $sql, $con, $stmt);
-            }
-        }
-
-        return $affectedRows;
-    }
-
-    /**
-     * @param string[] $columns
-     * @param \Propel\Runtime\ActiveQuery\Criteria|null $values
-     *
-     * @return array
-     */
-    public function buildParams($columns, ?Criteria $values = null)
-    {
-        if (!$values) {
-            $values = $this;
-        }
-        $params = [];
-        foreach ($columns as $key) {
-            if ($values->containsKey($key)) {
-                $crit = $values->getCriterion($key);
-                $params[] = [
-                    'column' => $crit->getColumn(),
-                    'table' => $crit->getTable(),
-                    'value' => $crit->getValue(),
-                ];
-            }
-        }
-
-        return $params;
+        return UpdateQueryExecutor::execute($this, $updateValues, $con);
     }
 
     /**
      * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
      *
-     * @throws \Propel\Runtime\Exception\LogicException
-     *
      * @return \Propel\Runtime\DataFetcher\DataFetcherInterface
      */
     public function doCount(?ConnectionInterface $con = null)
     {
-        $dbMap = Propel::getServiceContainer()->getDatabaseMap($this->getDbName());
-        /** @var \Propel\Runtime\Adapter\SqlAdapterInterface $db */
-        $db = Propel::getServiceContainer()->getAdapter($this->getDbName());
-
-        if ($con === null) {
-            $con = Propel::getServiceContainer()->getReadConnection($this->getDbName());
-        }
-
-        $needsComplexCount = $this->getGroupByColumns()
-            || $this->getOffset()
-            || $this->getLimit() >= 0
-            || $this->getHaving()
-            || in_array(Criteria::DISTINCT, $this->getSelectModifiers())
-            || count($this->selectQueries) > 0;
-
-        $params = [];
-        if ($needsComplexCount) {
-            if ($this->needsSelectAliases()) {
-                if ($this->getHaving()) {
-                    throw new LogicException('Propel cannot create a COUNT query when using HAVING and  duplicate column names in the SELECT part');
-                }
-                $db->turnSelectColumnsToAliases($this);
-            }
-            $selectSql = $this->createSelectSql($params);
-            $sql = 'SELECT COUNT(*) FROM (' . $selectSql . ') propelmatch4cnt';
-        } else {
-            // Replace SELECT columns with COUNT(*)
-            $this->clearSelectColumns()->addSelectColumn('COUNT(*)');
-            $sql = $this->createSelectSql($params);
-        }
-
-        $stmt = null;
-        try {
-            $stmt = $con->prepare($sql);
-            $db->bindValues($stmt, $params, $dbMap);
-            $stmt->execute();
-        } catch (Exception $e) {
-            $this->handleStatementException($e, $sql, $con, $stmt);
-        }
-
-        return $con->getDataFetcher($stmt);
+        return CountQueryExecutor::execute($this, $con);
     }
 
     /**
@@ -2769,60 +2289,24 @@ class Criteria
      *
      * @param \Propel\Runtime\Connection\ConnectionInterface|null $con a connection object
      *
-     * @throws \Propel\Runtime\Exception\PropelException
-     *
      * @return int the number of deleted rows
      */
     public function doDelete(?ConnectionInterface $con = null)
     {
-        if ($con === null) {
-            $con = Propel::getServiceContainer()->getWriteConnection($this->getDbName());
-        }
+        return DeleteQueryExecutor::execute($this, $con);
+    }
 
-        $adapter = Propel::getServiceContainer()->getAdapter($this->getDbName());
-        $dbMap = Propel::getServiceContainer()->getDatabaseMap($this->getDbName());
-
-        // join are not supported with DELETE statement
-        if (count($this->getJoins())) {
-            throw new PropelException('Delete does not support join');
-        }
-
-        // Set up a list of required tables (one DELETE statement will
-        // be executed per table)
-        $tables = $this->getTablesColumns();
-        if (empty($tables)) {
-            throw new PropelException('Cannot delete from an empty Criteria');
-        }
-
-        $affectedRows = 0; // initialize this in case the next loop has no iterations.
-
-        foreach ($tables as $tableName => $columns) {
-            $whereClause = [];
-            $params = [];
-            $stmt = null;
-            $sql = null;
-            try {
-                $sql = $adapter->getDeleteFromClause($this, $tableName);
-
-                foreach ($columns as $colName) {
-                    $sb = '';
-                    $this->getCriterion($colName)->appendPsTo($sb, $params);
-                    $this->replaceNames($sb);
-                    $whereClause[] = $sb;
-                }
-                $sql .= ' WHERE ' . implode(' AND ', $whereClause);
-
-                $stmt = $con->prepare($sql);
-
-                $adapter->bindValues($stmt, $params, $dbMap);
-                $stmt->execute();
-                $affectedRows = $stmt->rowCount();
-            } catch (Exception $e) {
-                $this->handleStatementException($e, $sql, $con, $stmt);
-            }
-        }
-
-        return $affectedRows;
+    /**
+     * Issue a DELETE query based on the current ModelCriteria deleting all rows in the table
+     * This method is called by ModelCriteria::deleteAll() inside a transaction
+     *
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con a connection object
+     *
+     * @return int the number of deleted rows
+     */
+    public function doDeleteAll(?ConnectionInterface $con = null)
+    {
+        return DeleteAllQueryExecutor::execute($this, $con);
     }
 
     /**
@@ -2834,66 +2318,7 @@ class Criteria
      */
     public function doSelect(?ConnectionInterface $con = null)
     {
-        if ($con === null) {
-            $con = Propel::getServiceContainer()->getReadConnection($this->getDbName());
-        }
-        $dbMap = Propel::getServiceContainer()->getDatabaseMap($this->getDbName());
-        $db = Propel::getServiceContainer()->getAdapter($this->getDbName());
-
-        $params = [];
-        $sql = $this->createSelectSql($params);
-        $stmt = null;
-        try {
-            $stmt = $con->prepare($sql);
-            $db->bindValues($stmt, $params, $dbMap);
-            $stmt->execute();
-        } catch (Exception $e) {
-            $this->handleStatementException($e, $sql, $con, $stmt);
-        }
-
-        return $con->getDataFetcher($stmt);
-    }
-
-    /**
-     * Logs an exception and adds the complete SQL statement to the exception.
-     *
-     * @param \Exception $e The initial exception.
-     * @param string|null $sql The SQL statement which triggered the exception.
-     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con Used to determine if debug mode is enabled. In debug mode, exception messages
-     *                                  are more verbose, but might unveil sensitive data.
-     * @param \Propel\Runtime\Connection\StatementInterface|\PDOStatement|null $stmt The prepared statement.
-     *
-     * @throws \Propel\Runtime\Exception\PropelException
-     *
-     * @return void
-     */
-    protected function handleStatementException(Exception $e, ?string $sql, ?ConnectionInterface $con = null, $stmt = null): void
-    {
-        $internalMessage = $e->getMessage();
-        Propel::log($internalMessage, Propel::LOG_ERR);
-
-        $isDebugMode = $this->connectionIsInDebugMode($con);
-        if ($isDebugMode && $stmt instanceof StatementWrapper) {
-            $sql = $stmt->getExecutedQueryString();
-        }
-        $publicMessage = "Unable to execute statement [$sql]";
-        if ($isDebugMode) {
-            $publicMessage .= "\nReason: [$internalMessage]";
-        }
-
-        throw new PropelException($publicMessage, 0, $e);
-    }
-
-    /**
-     * Check if the connection has debug mode enabled
-     *
-     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
-     *
-     * @return bool
-     */
-    protected function connectionIsInDebugMode(?ConnectionInterface $con): bool
-    {
-        return ($con instanceof ConnectionWrapper && $con->useDebug);
+        return SelectQueryExecutor::execute($this, $con);
     }
 
     // Fluid operators

--- a/src/Propel/Runtime/ActiveQuery/Criterion/AbstractCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/AbstractCriterion.php
@@ -171,7 +171,7 @@ abstract class AbstractCriterion
     /**
      * Get the table name.
      *
-     * @return string A String with the table name.
+     * @return string|null A String with the table name.
      */
     public function getTable()
     {

--- a/src/Propel/Runtime/ActiveQuery/QueryExecutor/AbstractQueryExecutor.php
+++ b/src/Propel/Runtime/ActiveQuery/QueryExecutor/AbstractQueryExecutor.php
@@ -60,7 +60,7 @@ abstract class AbstractQueryExecutor
         $dbName = $criteria->getDbName();
         $serviceContainer = Propel::getServiceContainer();
 
-        $this->con = ($con) ? $con : $this->getConnection($serviceContainer, $dbName, static::NEEDS_WRITE_CONNECTION);
+        $this->con = $con ?: $this->retrieveConnection($serviceContainer, $dbName, static::NEEDS_WRITE_CONNECTION);
 
         /** @var \Propel\Runtime\Adapter\SqlAdapterInterface $adapter */
         $adapter = $serviceContainer->getAdapter($dbName);
@@ -78,7 +78,7 @@ abstract class AbstractQueryExecutor
      *
      * @return \Propel\Runtime\Connection\ConnectionInterface
      */
-    protected function getConnection(ServiceContainerInterface $sc, string $dbName, bool $getWritableConnection = true): ConnectionInterface
+    protected function retrieveConnection(ServiceContainerInterface $sc, string $dbName, bool $getWritableConnection = true): ConnectionInterface
     {
         return ($getWritableConnection) ? $sc->getWriteConnection($dbName) : $sc->getReadConnection($dbName);
     }

--- a/src/Propel/Runtime/ActiveQuery/QueryExecutor/AbstractQueryExecutor.php
+++ b/src/Propel/Runtime/ActiveQuery/QueryExecutor/AbstractQueryExecutor.php
@@ -1,0 +1,150 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Runtime\ActiveQuery\QueryExecutor;
+
+use Exception;
+use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\Connection\ConnectionInterface;
+use Propel\Runtime\Connection\ConnectionWrapper;
+use Propel\Runtime\Connection\StatementWrapper;
+use Propel\Runtime\Propel;
+use Propel\Runtime\ServiceContainer\ServiceContainerInterface;
+
+/**
+ * This class produces the base object class (e.g. BaseMyTable) which contains
+ * all the custom-built accessor and setter methods.
+ */
+abstract class AbstractQueryExecutor
+{
+    /**
+     * Indicates if the executor performs writes.
+     * Defaults to true, but is overridden by subclasses.
+     *
+     * @see AbstractQueryExecutor::getConnection()
+     *
+     * @var bool
+     */
+    protected const NEEDS_WRITE_CONNECTION = true;
+
+    /**
+     * @var \Propel\Runtime\Connection\ConnectionInterface
+     */
+    protected $con;
+
+    /**
+     * @var \Propel\Runtime\Adapter\SqlAdapterInterface
+     */
+    protected $adapter;
+
+    /**
+     * @var \Propel\Runtime\ActiveQuery\Criteria
+     */
+    protected $criteria;
+
+    /**
+     * @var \Propel\Runtime\Map\DatabaseMap
+     */
+    protected $dbMap;
+
+    /**
+     * @param \Propel\Runtime\ActiveQuery\Criteria $criteria
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
+     */
+    public function __construct(Criteria $criteria, ?ConnectionInterface $con = null)
+    {
+        $this->criteria = $criteria;
+
+        $dbName = $criteria->getDbName();
+        $sc = Propel::getServiceContainer();
+
+        $this->con = ($con) ? $con : $this->getConnection($sc, $dbName, static::NEEDS_WRITE_CONNECTION);
+
+        /** @var \Propel\Runtime\Adapter\SqlAdapterInterface $adapter */
+        $adapter = $sc->getAdapter($dbName);
+        $this->adapter = $adapter;
+
+        $this->dbMap = $sc->getDatabaseMap($dbName);
+    }
+
+    /**
+     * Retrieves a read or write connection from the service container.
+     *
+     * @param \Propel\Runtime\ServiceContainer\ServiceContainerInterface $sc
+     * @param string $dbName
+     * @param bool $getWritableConnection
+     *
+     * @return \Propel\Runtime\Connection\ConnectionInterface
+     */
+    protected function getConnection(ServiceContainerInterface $sc, string $dbName, bool $getWritableConnection = true): ConnectionInterface
+    {
+        return ($getWritableConnection) ? $sc->getWriteConnection($dbName) : $sc->getReadConnection($dbName);
+    }
+
+    /**
+     * @param string $sql
+     * @param mixed[] $params
+     *
+     * @return \PDOStatement|\Propel\Runtime\Connection\StatementInterface|bool|null
+     */
+    protected function executeStatement(string $sql, array $params = [])
+    {
+        $this->adapter->cleanupSQL($sql, $params, $this->criteria, $this->dbMap);
+
+        $stmt = null;
+        try {
+            $stmt = $this->con->prepare($sql);
+            if ($params) {
+                $this->adapter->bindValues($stmt, $params, $this->dbMap);
+            }
+            $stmt->execute();
+        } catch (Exception $e) {
+            $this->handleStatementException($e, $sql, $stmt);
+        }
+
+        return $stmt;
+    }
+
+    /**
+     * Logs an exception and adds the complete SQL statement to the exception.
+     *
+     * @param \Exception $e The initial exception.
+     * @param string|null $sql The SQL statement which triggered the exception.
+     * @param \Propel\Runtime\Connection\StatementInterface|\PDOStatement|null $stmt The prepared statement.
+     *
+     * @throws \Propel\Runtime\ActiveQuery\QueryExecutor\QueryExecutionException
+     *
+     * @return void
+     */
+    protected function handleStatementException(Exception $e, ?string $sql, $stmt = null): void
+    {
+        $internalMessage = $e->getMessage();
+        Propel::log($internalMessage, Propel::LOG_ERR);
+
+        $isDebugMode = $this->connectionIsInDebugMode();
+        if ($isDebugMode && $stmt instanceof StatementWrapper) {
+            $sql = $stmt->getExecutedQueryString();
+        }
+        $publicMessage = "Unable to execute statement [$sql]";
+        if ($isDebugMode) {
+            $publicMessage .= "\nReason: [$internalMessage]";
+        }
+
+        throw new QueryExecutionException($publicMessage, 0, $e);
+    }
+
+    /**
+     * Check if the current connection has debug mode enabled
+     *
+     * @return bool
+     */
+    protected function connectionIsInDebugMode(): bool
+    {
+        return ($this->con instanceof ConnectionWrapper && $this->con->useDebug);
+    }
+}

--- a/src/Propel/Runtime/ActiveQuery/QueryExecutor/CountQueryExecutor.php
+++ b/src/Propel/Runtime/ActiveQuery/QueryExecutor/CountQueryExecutor.php
@@ -13,10 +13,6 @@ use Propel\Runtime\ActiveQuery\SqlBuilder\CountQuerySqlBuilder;
 use Propel\Runtime\Connection\ConnectionInterface;
 use Propel\Runtime\DataFetcher\DataFetcherInterface;
 
-/**
- * This class produces the base object class (e.g. BaseMyTable) which contains
- * all the custom-built accessor and setter methods.
- */
 class CountQueryExecutor extends AbstractQueryExecutor
 {
     /**
@@ -37,10 +33,10 @@ class CountQueryExecutor extends AbstractQueryExecutor
      *
      * @return \Propel\Runtime\DataFetcher\DataFetcherInterface
      */
-    public function runCount(): DataFetcherInterface
+    protected function runCount(): DataFetcherInterface
     {
-        [$sql, $params] = CountQuerySqlBuilder::createCountSql($this->criteria);
-        $stmt = $this->executeStatement($sql, $params);
+        $preparedStatementDto = CountQuerySqlBuilder::createCountSql($this->criteria);
+        $stmt = $this->executeStatement($preparedStatementDto);
 
         return $this->con->getDataFetcher($stmt);
     }

--- a/src/Propel/Runtime/ActiveQuery/QueryExecutor/CountQueryExecutor.php
+++ b/src/Propel/Runtime/ActiveQuery/QueryExecutor/CountQueryExecutor.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Runtime\ActiveQuery\QueryExecutor;
+
+use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\ActiveQuery\SqlBuilder\CountQuerySqlBuilder;
+use Propel\Runtime\Connection\ConnectionInterface;
+use Propel\Runtime\DataFetcher\DataFetcherInterface;
+
+/**
+ * This class produces the base object class (e.g. BaseMyTable) which contains
+ * all the custom-built accessor and setter methods.
+ */
+class CountQueryExecutor extends AbstractQueryExecutor
+{
+    /**
+     * @param \Propel\Runtime\ActiveQuery\Criteria $criteria
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con a connection object
+     *
+     * @return \Propel\Runtime\DataFetcher\DataFetcherInterface
+     */
+    public static function execute(Criteria $criteria, ?ConnectionInterface $con = null): DataFetcherInterface
+    {
+        $executor = new CountQueryExecutor($criteria, $con);
+
+        return $executor->runCount();
+    }
+
+    /**
+     * Execute a count statement.
+     *
+     * @return \Propel\Runtime\DataFetcher\DataFetcherInterface
+     */
+    public function runCount(): DataFetcherInterface
+    {
+        [$sql, $params] = CountQuerySqlBuilder::createCountSql($this->criteria);
+        $stmt = $this->executeStatement($sql, $params);
+
+        return $this->con->getDataFetcher($stmt);
+    }
+}

--- a/src/Propel/Runtime/ActiveQuery/QueryExecutor/DeleteAllQueryExecutor.php
+++ b/src/Propel/Runtime/ActiveQuery/QueryExecutor/DeleteAllQueryExecutor.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Runtime\ActiveQuery\QueryExecutor;
+
+use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\ActiveQuery\SqlBuilder\DeleteQuerySqlBuilder;
+use Propel\Runtime\Connection\ConnectionInterface;
+use Propel\Runtime\Exception\PropelException;
+
+/**
+ * This class produces the base object class (e.g. BaseMyTable) which contains
+ * all the custom-built accessor and setter methods.
+ */
+class DeleteAllQueryExecutor extends AbstractQueryExecutor
+{
+    /**
+     * @param \Propel\Runtime\ActiveQuery\Criteria $criteria
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con a connection object
+     *
+     * @return int The number of deleted rows
+     */
+    public static function execute(Criteria $criteria, ?ConnectionInterface $con = null): int
+    {
+        $executor = new DeleteAllQueryExecutor($criteria, $con);
+
+        return $executor->runDeleteAll();
+    }
+
+    /**
+     * Issue a DELETE query based on the current ModelCriteria
+     *
+     * @throws \Propel\Runtime\Exception\PropelException
+     *
+     * @return int the number of deleted rows
+     */
+    public function runDeleteAll(): int
+    {
+        if ($this->criteria->getJoins()) {
+            throw new PropelException('Delete does not support join');
+        }
+
+        $tableName = $this->criteria->getPrimaryTableName();
+        if (!$tableName) {
+            throw new PropelException('No table name available');
+        }
+
+        $sql = DeleteQuerySqlBuilder::createDeleteAllSql($this->criteria, $tableName);
+        $stmt = $this->executeStatement($sql);
+
+        return $stmt->rowCount();
+    }
+}

--- a/src/Propel/Runtime/ActiveQuery/QueryExecutor/DeleteAllQueryExecutor.php
+++ b/src/Propel/Runtime/ActiveQuery/QueryExecutor/DeleteAllQueryExecutor.php
@@ -13,10 +13,6 @@ use Propel\Runtime\ActiveQuery\SqlBuilder\DeleteQuerySqlBuilder;
 use Propel\Runtime\Connection\ConnectionInterface;
 use Propel\Runtime\Exception\PropelException;
 
-/**
- * This class produces the base object class (e.g. BaseMyTable) which contains
- * all the custom-built accessor and setter methods.
- */
 class DeleteAllQueryExecutor extends AbstractQueryExecutor
 {
     /**
@@ -39,7 +35,7 @@ class DeleteAllQueryExecutor extends AbstractQueryExecutor
      *
      * @return int the number of deleted rows
      */
-    public function runDeleteAll(): int
+    protected function runDeleteAll(): int
     {
         if ($this->criteria->getJoins()) {
             throw new PropelException('Delete does not support join');
@@ -50,8 +46,8 @@ class DeleteAllQueryExecutor extends AbstractQueryExecutor
             throw new PropelException('No table name available');
         }
 
-        $sql = DeleteQuerySqlBuilder::createDeleteAllSql($this->criteria, $tableName);
-        $stmt = $this->executeStatement($sql);
+        $preparedStatementDto = DeleteQuerySqlBuilder::createDeleteAllSql($this->criteria, $tableName);
+        $stmt = $this->executeStatement($preparedStatementDto);
 
         return $stmt->rowCount();
     }

--- a/src/Propel/Runtime/ActiveQuery/QueryExecutor/DeleteQueryExecutor.php
+++ b/src/Propel/Runtime/ActiveQuery/QueryExecutor/DeleteQueryExecutor.php
@@ -13,10 +13,6 @@ use Propel\Runtime\ActiveQuery\SqlBuilder\DeleteQuerySqlBuilder;
 use Propel\Runtime\Connection\ConnectionInterface;
 use Propel\Runtime\Exception\PropelException;
 
-/**
- * This class produces the base object class (e.g. BaseMyTable) which contains
- * all the custom-built accessor and setter methods.
- */
 class DeleteQueryExecutor extends AbstractQueryExecutor
 {
     /**
@@ -39,7 +35,7 @@ class DeleteQueryExecutor extends AbstractQueryExecutor
      *
      * @return int the number of deleted rows
      */
-    public function runDelete(): int
+    protected function runDelete(): int
     {
         if ($this->criteria->getJoins()) {
             throw new PropelException('Delete does not support join');
@@ -53,8 +49,8 @@ class DeleteQueryExecutor extends AbstractQueryExecutor
         $affectedRows = 0;
         $builder = new DeleteQuerySqlBuilder($this->criteria);
         foreach ($tables as $tableName => $columnNames) {
-            [$sql, $params] = $builder->build($tableName, $columnNames);
-            $stmt = $this->executeStatement($sql, $params);
+            $preparedStatementDto = $builder->build($tableName, $columnNames);
+            $stmt = $this->executeStatement($preparedStatementDto);
             $affectedRows += $stmt->rowCount();
         }
 

--- a/src/Propel/Runtime/ActiveQuery/QueryExecutor/DeleteQueryExecutor.php
+++ b/src/Propel/Runtime/ActiveQuery/QueryExecutor/DeleteQueryExecutor.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Runtime\ActiveQuery\QueryExecutor;
+
+use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\ActiveQuery\SqlBuilder\DeleteQuerySqlBuilder;
+use Propel\Runtime\Connection\ConnectionInterface;
+use Propel\Runtime\Exception\PropelException;
+
+/**
+ * This class produces the base object class (e.g. BaseMyTable) which contains
+ * all the custom-built accessor and setter methods.
+ */
+class DeleteQueryExecutor extends AbstractQueryExecutor
+{
+    /**
+     * @param \Propel\Runtime\ActiveQuery\Criteria $criteria
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con a connection object
+     *
+     * @return int The number of deleted rows
+     */
+    public static function execute(Criteria $criteria, ?ConnectionInterface $con = null): int
+    {
+        $executor = new DeleteQueryExecutor($criteria, $con);
+
+        return $executor->runDelete();
+    }
+
+    /**
+     * Issue a DELETE query based on the current ModelCriteria
+     *
+     * @throws \Propel\Runtime\Exception\PropelException
+     *
+     * @return int the number of deleted rows
+     */
+    public function runDelete(): int
+    {
+        if ($this->criteria->getJoins()) {
+            throw new PropelException('Delete does not support join');
+        }
+
+        $tables = $this->criteria->getTablesColumns();
+        if (!$tables) {
+            throw new PropelException('Cannot delete from an empty Criteria');
+        }
+
+        $affectedRows = 0;
+        $builder = new DeleteQuerySqlBuilder($this->criteria);
+        foreach ($tables as $tableName => $columnNames) {
+            [$sql, $params] = $builder->build($tableName, $columnNames);
+            $stmt = $this->executeStatement($sql, $params);
+            $affectedRows += $stmt->rowCount();
+        }
+
+        return $affectedRows;
+    }
+}

--- a/src/Propel/Runtime/ActiveQuery/QueryExecutor/InsertQueryExecutor.php
+++ b/src/Propel/Runtime/ActiveQuery/QueryExecutor/InsertQueryExecutor.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Runtime\ActiveQuery\QueryExecutor;
+
+use Exception;
+use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\ActiveQuery\SqlBuilder\InsertQuerySqlBuilder;
+use Propel\Runtime\Connection\ConnectionInterface;
+use Propel\Runtime\Exception\PropelException;
+
+/**
+ * This class produces the base object class (e.g. BaseMyTable) which contains
+ * all the custom-built accessor and setter methods.
+ */
+class InsertQueryExecutor extends AbstractQueryExecutor
+{
+    /**
+     * @var \Propel\Runtime\Map\ColumnMap|null
+     */
+    protected $primaryKeyColumn;
+
+    /**
+     * @param \Propel\Runtime\ActiveQuery\Criteria $criteria
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
+     */
+    public function __construct(Criteria $criteria, ?ConnectionInterface $con = null)
+    {
+        parent::__construct($criteria, $con);
+
+        $this->primaryKeyColumn = $criteria->getPrimaryKey();
+    }
+
+    /**
+     * @see InsertQuerySqlBuilder::runInsert()
+     *
+     * @param \Propel\Runtime\ActiveQuery\Criteria $criteria
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
+     *
+     * @return mixed|null
+     */
+    public static function execute(Criteria $criteria, ?ConnectionInterface $con = null)
+    {
+        $executor = new InsertQueryExecutor($criteria, $con);
+
+        return $executor->runInsert();
+    }
+
+    /**
+     * Method to perform inserts based on values and keys in a
+     * Criteria.
+     * <p>
+     * If the primary key is auto incremented the data in Criteria
+     * will be inserted and the auto increment value will be returned.
+     * <p>
+     * If the primary key is included in Criteria then that value will
+     * be used to insert the row.
+     * <p>
+     * If no primary key is included in Criteria then we will try to
+     * figure out the primary key from the database map and insert the
+     * row with the next available id using util.db.IDBroker.
+     * <p>
+     * If no primary key is defined for the table the values will be
+     * inserted as specified in Criteria and null will be returned.
+     *
+     * @return mixed|null The primary key for the new row if the primary key is auto-generated. Otherwise will return null.
+     */
+    public function runInsert()
+    {
+        $this->setIdFromSequence();
+
+        [$sqlStatement, $params] = InsertQuerySqlBuilder::createInsertSql($this->criteria);
+
+        $this->executeStatement($sqlStatement, $params);
+
+        return $this->retrieveLastInsertedId();
+    }
+
+    /**
+     * @throws \Propel\Runtime\Exception\PropelException
+     *
+     * @return void
+     */
+    protected function setIdFromSequence(): void
+    {
+        if ($this->primaryKeyColumn === null || !$this->primaryKeyColumn->getTable()->isUseIdGenerator() || !$this->adapter->isGetIdBeforeInsert()) {
+            return;
+        }
+
+        $pkFullName = $this->primaryKeyColumn->getFullyQualifiedName();
+        if ($this->criteria->keyContainsValue($pkFullName)) {
+            return;
+        }
+
+        $keyInfo = $this->primaryKeyColumn->getTable()->getPrimaryKeyMethodInfo();
+        $id = null;
+        try {
+            $id = $this->adapter->getId($this->con, $keyInfo);
+        } catch (Exception $e) {
+            throw new PropelException('Unable to get sequence id.', 0, $e);
+        }
+        $this->criteria->add($pkFullName, $id);
+    }
+
+    /**
+     * @throws \Propel\Runtime\Exception\PropelException
+     *
+     * @return mixed|null
+     */
+    protected function retrieveLastInsertedId()
+    {
+        if ($this->primaryKeyColumn === null || !$this->primaryKeyColumn->getTable()->isUseIdGenerator() || !$this->adapter->isGetIdAfterInsert()) {
+            return null;
+        }
+        $keyInfo = $this->primaryKeyColumn->getTable()->getPrimaryKeyMethodInfo();
+        try {
+            return $this->adapter->getId($this->con, $keyInfo);
+        } catch (Exception $e) {
+            throw new PropelException('Unable to get autoincrement id.', 0, $e);
+        }
+    }
+}

--- a/src/Propel/Runtime/ActiveQuery/QueryExecutor/InsertQueryExecutor.php
+++ b/src/Propel/Runtime/ActiveQuery/QueryExecutor/InsertQueryExecutor.php
@@ -38,7 +38,7 @@ class InsertQueryExecutor extends AbstractQueryExecutor
      * @param \Propel\Runtime\ActiveQuery\Criteria $criteria
      * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
      *
-     * @return mixed|null
+     * @return string|int|null
      */
     public static function execute(Criteria $criteria, ?ConnectionInterface $con = null)
     {
@@ -64,7 +64,7 @@ class InsertQueryExecutor extends AbstractQueryExecutor
      * If no primary key is defined for the table the values will be
      * inserted as specified in Criteria and null will be returned.
      *
-     * @return mixed|null The primary key for the new row if the primary key is auto-generated. Otherwise will return null.
+     * @return string|int|null The primary key for the new row if the primary key is auto-generated. Otherwise will return null.
      */
     protected function runInsert()
     {
@@ -106,7 +106,7 @@ class InsertQueryExecutor extends AbstractQueryExecutor
     /**
      * @throws \Propel\Runtime\Exception\PropelException
      *
-     * @return mixed|null
+     * @return string|int|null
      */
     protected function retrieveLastInsertedId()
     {

--- a/src/Propel/Runtime/ActiveQuery/QueryExecutor/InsertQueryExecutor.php
+++ b/src/Propel/Runtime/ActiveQuery/QueryExecutor/InsertQueryExecutor.php
@@ -8,16 +8,12 @@
 
 namespace Propel\Runtime\ActiveQuery\QueryExecutor;
 
-use Exception;
 use Propel\Runtime\ActiveQuery\Criteria;
 use Propel\Runtime\ActiveQuery\SqlBuilder\InsertQuerySqlBuilder;
 use Propel\Runtime\Connection\ConnectionInterface;
 use Propel\Runtime\Exception\PropelException;
+use Throwable;
 
-/**
- * This class produces the base object class (e.g. BaseMyTable) which contains
- * all the custom-built accessor and setter methods.
- */
 class InsertQueryExecutor extends AbstractQueryExecutor
 {
     /**
@@ -29,7 +25,7 @@ class InsertQueryExecutor extends AbstractQueryExecutor
      * @param \Propel\Runtime\ActiveQuery\Criteria $criteria
      * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
      */
-    public function __construct(Criteria $criteria, ?ConnectionInterface $con = null)
+    protected function __construct(Criteria $criteria, ?ConnectionInterface $con = null)
     {
         parent::__construct($criteria, $con);
 
@@ -70,13 +66,13 @@ class InsertQueryExecutor extends AbstractQueryExecutor
      *
      * @return mixed|null The primary key for the new row if the primary key is auto-generated. Otherwise will return null.
      */
-    public function runInsert()
+    protected function runInsert()
     {
         $this->setIdFromSequence();
 
-        [$sqlStatement, $params] = InsertQuerySqlBuilder::createInsertSql($this->criteria);
+        $preparedStatementDto = InsertQuerySqlBuilder::createInsertSql($this->criteria);
 
-        $this->executeStatement($sqlStatement, $params);
+        $this->executeStatement($preparedStatementDto);
 
         return $this->retrieveLastInsertedId();
     }
@@ -101,7 +97,7 @@ class InsertQueryExecutor extends AbstractQueryExecutor
         $id = null;
         try {
             $id = $this->adapter->getId($this->con, $keyInfo);
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             throw new PropelException('Unable to get sequence id.', 0, $e);
         }
         $this->criteria->add($pkFullName, $id);
@@ -120,7 +116,7 @@ class InsertQueryExecutor extends AbstractQueryExecutor
         $keyInfo = $this->primaryKeyColumn->getTable()->getPrimaryKeyMethodInfo();
         try {
             return $this->adapter->getId($this->con, $keyInfo);
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             throw new PropelException('Unable to get autoincrement id.', 0, $e);
         }
     }

--- a/src/Propel/Runtime/ActiveQuery/QueryExecutor/QueryExecutionException.php
+++ b/src/Propel/Runtime/ActiveQuery/QueryExecutor/QueryExecutionException.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Runtime\ActiveQuery\QueryExecutor;
+
+use Propel\Runtime\Exception\RuntimeException;
+
+class QueryExecutionException extends RuntimeException
+{
+}

--- a/src/Propel/Runtime/ActiveQuery/QueryExecutor/SelectQueryExecutor.php
+++ b/src/Propel/Runtime/ActiveQuery/QueryExecutor/SelectQueryExecutor.php
@@ -13,10 +13,6 @@ use Propel\Runtime\ActiveQuery\SqlBuilder\SelectQuerySqlBuilder;
 use Propel\Runtime\Connection\ConnectionInterface;
 use Propel\Runtime\DataFetcher\DataFetcherInterface;
 
-/**
- * This class produces the base object class (e.g. BaseMyTable) which contains
- * all the custom-built accessor and setter methods.
- */
 class SelectQueryExecutor extends AbstractQueryExecutor
 {
     /**
@@ -46,11 +42,11 @@ class SelectQueryExecutor extends AbstractQueryExecutor
      *
      * @return \Propel\Runtime\DataFetcher\DataFetcherInterface A dataFetcher using the connection, ready to be fetched
      */
-    public function runSelect(): DataFetcherInterface
+    protected function runSelect(): DataFetcherInterface
     {
         $params = [];
-        [$sql, $params] = SelectQuerySqlBuilder::createSelectSql($this->criteria, $params);
-        $stmt = $this->executeStatement($sql, $params);
+        $preparedStatementDto = SelectQuerySqlBuilder::createSelectSql($this->criteria, $params);
+        $stmt = $this->executeStatement($preparedStatementDto);
 
         return $this->con->getDataFetcher($stmt);
     }

--- a/src/Propel/Runtime/ActiveQuery/QueryExecutor/SelectQueryExecutor.php
+++ b/src/Propel/Runtime/ActiveQuery/QueryExecutor/SelectQueryExecutor.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Runtime\ActiveQuery\QueryExecutor;
+
+use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\ActiveQuery\SqlBuilder\SelectQuerySqlBuilder;
+use Propel\Runtime\Connection\ConnectionInterface;
+use Propel\Runtime\DataFetcher\DataFetcherInterface;
+
+/**
+ * This class produces the base object class (e.g. BaseMyTable) which contains
+ * all the custom-built accessor and setter methods.
+ */
+class SelectQueryExecutor extends AbstractQueryExecutor
+{
+    /**
+     * @see AbstractQueryExecutor::NEEDS_WRITE_CONNECTION
+     *
+     * @var bool
+     */
+    protected const NEEDS_WRITE_CONNECTION = false;
+
+    /**
+     * @see SelectQueryExecutor::runInsert()
+     *
+     * @param \Propel\Runtime\ActiveQuery\Criteria $criteria
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
+     *
+     * @return \Propel\Runtime\DataFetcher\DataFetcherInterface
+     */
+    public static function execute(Criteria $criteria, ?ConnectionInterface $con = null): DataFetcherInterface
+    {
+        $executor = new SelectQueryExecutor($criteria, $con);
+
+        return $executor->runSelect();
+    }
+
+    /**
+     * Builds, binds and executes a SELECT query based on the current object.
+     *
+     * @return \Propel\Runtime\DataFetcher\DataFetcherInterface A dataFetcher using the connection, ready to be fetched
+     */
+    public function runSelect(): DataFetcherInterface
+    {
+        $params = [];
+        [$sql, $params] = SelectQuerySqlBuilder::createSelectSql($this->criteria, $params);
+        $stmt = $this->executeStatement($sql, $params);
+
+        return $this->con->getDataFetcher($stmt);
+    }
+}

--- a/src/Propel/Runtime/ActiveQuery/QueryExecutor/UpdateQueryExecutor.php
+++ b/src/Propel/Runtime/ActiveQuery/QueryExecutor/UpdateQueryExecutor.php
@@ -12,10 +12,6 @@ use Propel\Runtime\ActiveQuery\Criteria;
 use Propel\Runtime\ActiveQuery\SqlBuilder\UpdateQuerySqlBuilder;
 use Propel\Runtime\Connection\ConnectionInterface;
 
-/**
- * This class produces the base object class (e.g. BaseMyTable) which contains
- * all the custom-built accessor and setter methods.
- */
 class UpdateQueryExecutor extends AbstractQueryExecutor
 {
     /**
@@ -49,7 +45,7 @@ class UpdateQueryExecutor extends AbstractQueryExecutor
      *             Note that the return value does require that this information is returned
      *             (supported) by the Propel db driver.
      */
-    public function runUpdate(Criteria $updateValues): int
+    protected function runUpdate(Criteria $updateValues): int
     {
         $updateTablesColumns = $updateValues->getTablesColumns();
 
@@ -67,8 +63,8 @@ class UpdateQueryExecutor extends AbstractQueryExecutor
 
         $affectedRows = 0;
         foreach ($tablesColumns as $tableName => $columns) {
-            [$sql, $params] = $builder->build($tableName, $columns);
-            $stmt = $this->executeStatement($sql, $params);
+            $preparedStatementDto = $builder->build($tableName, $columns);
+            $stmt = $this->executeStatement($preparedStatementDto);
             $affectedRows += $stmt->rowCount();
         }
 

--- a/src/Propel/Runtime/ActiveQuery/QueryExecutor/UpdateQueryExecutor.php
+++ b/src/Propel/Runtime/ActiveQuery/QueryExecutor/UpdateQueryExecutor.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Runtime\ActiveQuery\QueryExecutor;
+
+use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\ActiveQuery\SqlBuilder\UpdateQuerySqlBuilder;
+use Propel\Runtime\Connection\ConnectionInterface;
+
+/**
+ * This class produces the base object class (e.g. BaseMyTable) which contains
+ * all the custom-built accessor and setter methods.
+ */
+class UpdateQueryExecutor extends AbstractQueryExecutor
+{
+    /**
+     * @param \Propel\Runtime\ActiveQuery\Criteria $criteria
+     * @param \Propel\Runtime\ActiveQuery\Criteria $updateValues
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
+     *
+     * @return int
+     */
+    public static function execute(Criteria $criteria, Criteria $updateValues, ?ConnectionInterface $con = null): int
+    {
+        $executor = new UpdateQueryExecutor($criteria, $con);
+
+        return $executor->runUpdate($updateValues);
+    }
+
+    /**
+     * Method used to update rows in the DB. Rows are selected based
+     * on selectCriteria and updated using values in updateValues.
+     * <p>
+     * Use this method for performing an update of the kind:
+     * <p>
+     * WHERE some_column = some value AND could_have_another_column =
+     * another value AND so on.
+     *
+     * @param \Propel\Runtime\ActiveQuery\Criteria $updateValues A Criteria object containing values used in set clause.
+     *
+     * @return int The number of rows affected by last update statement.
+     *             For most uses there is only one update statement executed, so this number will
+     *             correspond to the number of rows affected by the call to this method.
+     *             Note that the return value does require that this information is returned
+     *             (supported) by the Propel db driver.
+     */
+    public function runUpdate(Criteria $updateValues): int
+    {
+        $updateTablesColumns = $updateValues->getTablesColumns();
+
+        if (!$updateTablesColumns) {
+            return 0;
+        }
+
+        $tablesColumns = $this->criteria->getTablesColumns();
+        $table = $this->criteria->getPrimaryTableName();
+        if (!$tablesColumns && $table) {
+            $tablesColumns = [$table => []];
+        }
+
+        $builder = new UpdateQuerySqlBuilder($this->criteria, $updateValues);
+
+        $affectedRows = 0;
+        foreach ($tablesColumns as $tableName => $columns) {
+            [$sql, $params] = $builder->build($tableName, $columns);
+            $stmt = $this->executeStatement($sql, $params);
+            $affectedRows += $stmt->rowCount();
+        }
+
+        return $affectedRows;
+    }
+}

--- a/src/Propel/Runtime/ActiveQuery/SqlBuilder/AbstractSqlQueryBuilder.php
+++ b/src/Propel/Runtime/ActiveQuery/SqlBuilder/AbstractSqlQueryBuilder.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Runtime\ActiveQuery\SqlBuilder;
+
+use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\ActiveQuery\Criterion\AbstractCriterion;
+use Propel\Runtime\Propel;
+
+/**
+ * This class produces the base object class (e.g. BaseMyTable) which contains
+ * all the custom-built accessor and setter methods.
+ */
+abstract class AbstractSqlQueryBuilder
+{
+    /**
+     * @var \Propel\Runtime\ActiveQuery\Criteria
+     */
+    protected $criteria;
+
+    /**
+     * @var \Propel\Runtime\Adapter\SqlAdapterInterface
+     */
+    protected $adapter;
+
+    /**
+     * @var \Propel\Runtime\Map\DatabaseMap
+     */
+    protected $dbMap;
+
+    /**
+     * @param \Propel\Runtime\ActiveQuery\Criteria $criteria
+     */
+    public function __construct(Criteria $criteria)
+    {
+        $this->criteria = $criteria;
+
+        $dbName = $criteria->getDbName();
+        $serviceContainer = Propel::getServiceContainer();
+
+        /** @var \Propel\Runtime\Adapter\SqlAdapterInterface $adapter */
+        $adapter = $serviceContainer->getAdapter($dbName);
+        $this->adapter = $adapter;
+
+        $this->dbMap = $serviceContainer->getDatabaseMap($dbName);
+    }
+
+    /**
+     * @psalm-return array{null|string, null|string}
+     *
+     * @param string|null $tableName
+     *
+     * @return string[]
+     */
+    protected function getTableNameWithAlias(?string $tableName): array
+    {
+        $realTableName = $this->criteria->getTableForAlias($tableName);
+        if (!$realTableName) {
+            return [$tableName, $tableName];
+        }
+        $aliasedTableName = $realTableName . ' ' . $tableName;
+
+        return [$realTableName, $aliasedTableName];
+    }
+
+    /**
+     * @param string $rawTableName
+     *
+     * @return string
+     */
+    public function quoteIdentifierTable(string $rawTableName)
+    {
+        if ($this->criteria->isIdentifierQuotingEnabled()) {
+            return $this->adapter->quoteIdentifierTable($rawTableName);
+        }
+
+        $realTableName = $rawTableName;
+        $spacePos = strrpos($rawTableName, ' ');
+        if ($spacePos !== false) {
+            $realTableName = substr($rawTableName, 0, $spacePos);
+        }
+
+        if ($this->dbMap->hasTable($realTableName)) {
+            $tableMap = $this->dbMap->getTable($realTableName);
+            if ($tableMap->isIdentifierQuotingEnabled()) {
+                return $this->adapter->quoteIdentifierTable($rawTableName);
+            }
+        }
+
+        return $rawTableName;
+    }
+
+    /**
+     * @param string[] $columnNames
+     * @param \Propel\Runtime\ActiveQuery\Criteria|null $values
+     *
+     * @return array
+     */
+    public function buildParams($columnNames, ?Criteria $values = null)
+    {
+        if (!$values) {
+            $values = $this->criteria;
+        }
+
+        $params = [];
+        foreach ($columnNames as $key) {
+            if (!$values->containsKey($key)) {
+                continue;
+            }
+            $crit = $values->getCriterion($key);
+            $params[] = [
+                'column' => $crit->getColumn(),
+                'table' => $crit->getTable(),
+                'value' => $crit->getValue(),
+            ];
+        }
+
+        return $params;
+    }
+
+    /**
+     * Build sql statement from a criteria and add it to the given statement collector.
+     *
+     * @param \Propel\Runtime\ActiveQuery\Criterion\AbstractCriterion $criterion
+     * @param mixed[]|null $params
+     *
+     * @return string
+     */
+    protected function buildStatementFromCriterion(AbstractCriterion $criterion, ?array &$params): string
+    {
+        $criterionSql = '';
+        $criterion->appendPsTo($criterionSql, $params);
+        $this->criteria->replaceNames($criterionSql);
+
+        return $criterionSql;
+    }
+}

--- a/src/Propel/Runtime/ActiveQuery/SqlBuilder/CountQuerySqlBuilder.php
+++ b/src/Propel/Runtime/ActiveQuery/SqlBuilder/CountQuerySqlBuilder.php
@@ -16,9 +16,9 @@ class CountQuerySqlBuilder extends AbstractSqlQueryBuilder
     /**
      * @param \Propel\Runtime\ActiveQuery\Criteria $criteria
      *
-     * @return array
+     * @return \Propel\Runtime\ActiveQuery\SqlBuilder\PreparedStatementDto
      */
-    public static function createCountSql(Criteria $criteria): array
+    public static function createCountSql(Criteria $criteria): PreparedStatementDto
     {
         $builder = new CountQuerySqlBuilder($criteria);
 
@@ -30,9 +30,9 @@ class CountQuerySqlBuilder extends AbstractSqlQueryBuilder
      *
      * @throws \Propel\Runtime\Exception\LogicException
      *
-     * @return array
+     * @return \Propel\Runtime\ActiveQuery\SqlBuilder\PreparedStatementDto
      */
-    public function build(): array
+    public function build(): PreparedStatementDto
     {
         $needsComplexCount = $this->criteria->getGroupByColumns()
             || $this->criteria->getOffset()
@@ -58,10 +58,12 @@ class CountQuerySqlBuilder extends AbstractSqlQueryBuilder
 
             $this->adapter->turnSelectColumnsToAliases($this->criteria);
         }
-        [$baseSelectSql, $params] = SelectQuerySqlBuilder::createSelectSql($this->criteria);
+        $preparedStatementDto = SelectQuerySqlBuilder::createSelectSql($this->criteria);
+        $baseSelectSql = $preparedStatementDto->getSqlStatement();
+        $params = $preparedStatementDto->getParameters();
 
         $countStatment = "SELECT COUNT(*) FROM ($baseSelectSql) propelmatch4cnt";
 
-        return [$countStatment, $params];
+        return new PreparedStatementDto($countStatment, $params);
     }
 }

--- a/src/Propel/Runtime/ActiveQuery/SqlBuilder/CountQuerySqlBuilder.php
+++ b/src/Propel/Runtime/ActiveQuery/SqlBuilder/CountQuerySqlBuilder.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Runtime\ActiveQuery\SqlBuilder;
+
+use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\Exception\LogicException;
+
+class CountQuerySqlBuilder extends AbstractSqlQueryBuilder
+{
+    /**
+     * @param \Propel\Runtime\ActiveQuery\Criteria $criteria
+     *
+     * @return array
+     */
+    public static function createCountSql(Criteria $criteria): array
+    {
+        $builder = new CountQuerySqlBuilder($criteria);
+
+        return $builder->build();
+    }
+
+    /**
+     * Create a Sql COUNT statement.
+     *
+     * @throws \Propel\Runtime\Exception\LogicException
+     *
+     * @return array
+     */
+    public function build(): array
+    {
+        $needsComplexCount = $this->criteria->getGroupByColumns()
+            || $this->criteria->getOffset()
+            || $this->criteria->getLimit() >= 0
+            || $this->criteria->getHaving()
+            || in_array(Criteria::DISTINCT, $this->criteria->getSelectModifiers(), true)
+            || $this->criteria->hasSelectQueries();
+
+        if (!$needsComplexCount) {
+            $this->criteria
+                ->clearSelectColumns()
+                ->addSelectColumn('COUNT(*)');
+
+            return SelectQuerySqlBuilder::createSelectSql($this->criteria);
+        }
+
+        if ($this->criteria->needsSelectAliases()) {
+            if ($this->criteria->getHaving()) {
+                $errorMessage = 'Propel cannot create a COUNT query when using HAVING and duplicate column names in the SELECT part';
+
+                throw new LogicException($errorMessage);
+            }
+
+            $this->adapter->turnSelectColumnsToAliases($this->criteria);
+        }
+        [$baseSelectSql, $params] = SelectQuerySqlBuilder::createSelectSql($this->criteria);
+
+        $countStatment = "SELECT COUNT(*) FROM ($baseSelectSql) propelmatch4cnt";
+
+        return [$countStatment, $params];
+    }
+}

--- a/src/Propel/Runtime/ActiveQuery/SqlBuilder/DeleteQuerySqlBuilder.php
+++ b/src/Propel/Runtime/ActiveQuery/SqlBuilder/DeleteQuerySqlBuilder.php
@@ -32,7 +32,7 @@ class DeleteQuerySqlBuilder extends AbstractSqlQueryBuilder
      * Create a Sql DELETE statement.
      *
      * @param string $tableName
-     * @param array $columnNames
+     * @param string[] $columnNames
      *
      * @return \Propel\Runtime\ActiveQuery\SqlBuilder\PreparedStatementDto
      */
@@ -77,7 +77,7 @@ class DeleteQuerySqlBuilder extends AbstractSqlQueryBuilder
     /**
      * Build WHERE clause from the given column names.
      *
-     * @param array $columnNames
+     * @param string[] $columnNames
      *
      * @return \Propel\Runtime\ActiveQuery\SqlBuilder\PreparedStatementDto
      */

--- a/src/Propel/Runtime/ActiveQuery/SqlBuilder/DeleteQuerySqlBuilder.php
+++ b/src/Propel/Runtime/ActiveQuery/SqlBuilder/DeleteQuerySqlBuilder.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Runtime\ActiveQuery\SqlBuilder;
+
+use Propel\Runtime\ActiveQuery\Criteria;
+
+class DeleteQuerySqlBuilder extends AbstractSqlQueryBuilder
+{
+    /**
+     * Build a Sql DELETE statment which deletes all data
+     *
+     * @param \Propel\Runtime\ActiveQuery\Criteria $criteria
+     * @param string $tableName
+     *
+     * @return string
+     */
+    public static function createDeleteAllSql(Criteria $criteria, string $tableName): string
+    {
+        $builder = new DeleteQuerySqlBuilder($criteria);
+
+        return $builder->buildDeleteFromClause($tableName);
+    }
+
+    /**
+     * Create a Sql DELETE statement.
+     *
+     * @param string $tableName
+     * @param array $columnNames
+     *
+     * @return array
+     */
+    public function build(string $tableName, array $columnNames): array
+    {
+        $deleteFrom = $this->buildDeleteFromClause($tableName);
+        [$where, $params] = $this->buildWhereClause($columnNames);
+        $deleteStatement = "$deleteFrom $where";
+
+        return [$deleteStatement, $params];
+    }
+
+    /**
+     * @param string $tableName
+     *
+     * @return string
+     */
+    protected function buildDeleteFromClause(string $tableName): string
+    {
+        $sql = ['DELETE'];
+        if ($queryComment = $this->criteria->getComment()) {
+            $sql[] = '/* ' . $queryComment . ' */';
+        }
+
+        $realTableName = $this->criteria->getTableForAlias($tableName);
+        if (!$realTableName) {
+            $tableName = $this->quoteIdentifierTable($tableName);
+            $sql[] = "FROM $tableName";
+        } else {
+            $realTableName = $this->quoteIdentifierTable($realTableName);
+            if ($this->adapter->supportsAliasesInDelete()) {
+                $sql[] = $tableName;
+            }
+            $sql[] = "FROM $realTableName AS $tableName";
+        }
+
+        return implode(' ', $sql);
+    }
+
+    /**
+     * Build WHERE clause from the given column names.
+     *
+     * @param array $columnNames
+     *
+     * @return array
+     */
+    protected function buildWhereClause(array $columnNames): array
+    {
+        $whereClause = [];
+        $params = [];
+        foreach ($columnNames as $columnName) {
+            $filter = $this->criteria->getCriterion($columnName);
+            $whereClause[] = $this->buildStatementFromCriterion($filter, $params);
+        }
+        $whereStatement = 'WHERE ' . implode(' AND ', $whereClause);
+
+        return [$whereStatement, $params];
+    }
+}

--- a/src/Propel/Runtime/ActiveQuery/SqlBuilder/DeleteQuerySqlBuilder.php
+++ b/src/Propel/Runtime/ActiveQuery/SqlBuilder/DeleteQuerySqlBuilder.php
@@ -18,13 +18,14 @@ class DeleteQuerySqlBuilder extends AbstractSqlQueryBuilder
      * @param \Propel\Runtime\ActiveQuery\Criteria $criteria
      * @param string $tableName
      *
-     * @return string
+     * @return \Propel\Runtime\ActiveQuery\SqlBuilder\PreparedStatementDto
      */
-    public static function createDeleteAllSql(Criteria $criteria, string $tableName): string
+    public static function createDeleteAllSql(Criteria $criteria, string $tableName): PreparedStatementDto
     {
         $builder = new DeleteQuerySqlBuilder($criteria);
+        $sqlStatement = $builder->buildDeleteFromClause($tableName);
 
-        return $builder->buildDeleteFromClause($tableName);
+        return new PreparedStatementDto($sqlStatement);
     }
 
     /**
@@ -33,15 +34,17 @@ class DeleteQuerySqlBuilder extends AbstractSqlQueryBuilder
      * @param string $tableName
      * @param array $columnNames
      *
-     * @return array
+     * @return \Propel\Runtime\ActiveQuery\SqlBuilder\PreparedStatementDto
      */
-    public function build(string $tableName, array $columnNames): array
+    public function build(string $tableName, array $columnNames): PreparedStatementDto
     {
         $deleteFrom = $this->buildDeleteFromClause($tableName);
-        [$where, $params] = $this->buildWhereClause($columnNames);
+        $whereDto = $this->buildWhereClause($columnNames);
+        $where = $whereDto->getSqlStatement();
         $deleteStatement = "$deleteFrom $where";
+        $params = $whereDto->getParameters();
 
-        return [$deleteStatement, $params];
+        return new PreparedStatementDto($deleteStatement, $params);
     }
 
     /**
@@ -76,9 +79,9 @@ class DeleteQuerySqlBuilder extends AbstractSqlQueryBuilder
      *
      * @param array $columnNames
      *
-     * @return array
+     * @return \Propel\Runtime\ActiveQuery\SqlBuilder\PreparedStatementDto
      */
-    protected function buildWhereClause(array $columnNames): array
+    protected function buildWhereClause(array $columnNames): PreparedStatementDto
     {
         $whereClause = [];
         $params = [];
@@ -88,6 +91,6 @@ class DeleteQuerySqlBuilder extends AbstractSqlQueryBuilder
         }
         $whereStatement = 'WHERE ' . implode(' AND ', $whereClause);
 
-        return [$whereStatement, $params];
+        return new PreparedStatementDto($whereStatement, $params);
     }
 }

--- a/src/Propel/Runtime/ActiveQuery/SqlBuilder/InsertQuerySqlBuilder.php
+++ b/src/Propel/Runtime/ActiveQuery/SqlBuilder/InsertQuerySqlBuilder.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Runtime\ActiveQuery\SqlBuilder;
+
+use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\Exception\PropelException;
+
+class InsertQuerySqlBuilder extends AbstractSqlQueryBuilder
+{
+    /**
+     * Build an Sql Insert statment for the given criteria.
+     *
+     * @param \Propel\Runtime\ActiveQuery\Criteria $criteria
+     *
+     * @return array
+     */
+    public static function createInsertSql(Criteria $criteria): array
+    {
+        $builder = new InsertQuerySqlBuilder($criteria);
+
+        return $builder->build();
+    }
+
+    /**
+     * @throws \Propel\Runtime\Exception\PropelException
+     *
+     * @return array
+     */
+    public function build(): array
+    {
+        $qualifiedColumnNames = $this->criteria->keys();
+        if (empty($qualifiedColumnNames)) {
+            throw new PropelException('Database insert attempted without anything specified to insert.');
+        }
+
+        $tableName = $this->criteria->getTableName($qualifiedColumnNames[0]);
+        $tableName = $this->quoteIdentifierTable($tableName);
+
+        $columnCsv = $this->buildSimpleColumnNamesCsv($qualifiedColumnNames);
+
+        $numberOfColumns = count($qualifiedColumnNames);
+        $parameterPlaceholdersCsv = $this->buildParameterPlaceholdersCsv($numberOfColumns);
+
+        $insertStatement = "INSERT INTO $tableName ($columnCsv) VALUES ($parameterPlaceholdersCsv)";
+        $params = $this->buildParams($qualifiedColumnNames);
+
+        return [$insertStatement, $params];
+    }
+
+    /**
+     * @param array $qualifiedColumnNames
+     *
+     * @return string
+     */
+    protected function buildSimpleColumnNamesCsv(array $qualifiedColumnNames): string
+    {
+        $columnNames = [];
+        foreach ($qualifiedColumnNames as $qualifiedCol) {
+            $dotPos = strrpos($qualifiedCol, '.');
+            $columnNames[] = substr($qualifiedCol, $dotPos + 1);
+        }
+        $columnNames = array_map([$this->criteria, 'quoteIdentifier'], $columnNames);
+
+        return implode(',', $columnNames);
+    }
+
+    /**
+     * @param int $numberOfPlaceholders
+     *
+     * @return string
+     */
+    protected function buildParameterPlaceholdersCsv(int $numberOfPlaceholders): string
+    {
+        $parameterIndexes = ($numberOfPlaceholders < 1) ? [] : range(1, $numberOfPlaceholders);
+        $parameterPlaceholders = preg_filter('/^/', ':p', $parameterIndexes); // prefix each element with ':p'
+
+        return implode(',', $parameterPlaceholders);
+    }
+}

--- a/src/Propel/Runtime/ActiveQuery/SqlBuilder/InsertQuerySqlBuilder.php
+++ b/src/Propel/Runtime/ActiveQuery/SqlBuilder/InsertQuerySqlBuilder.php
@@ -18,9 +18,9 @@ class InsertQuerySqlBuilder extends AbstractSqlQueryBuilder
      *
      * @param \Propel\Runtime\ActiveQuery\Criteria $criteria
      *
-     * @return array
+     * @return \Propel\Runtime\ActiveQuery\SqlBuilder\PreparedStatementDto
      */
-    public static function createInsertSql(Criteria $criteria): array
+    public static function createInsertSql(Criteria $criteria): PreparedStatementDto
     {
         $builder = new InsertQuerySqlBuilder($criteria);
 
@@ -30,9 +30,9 @@ class InsertQuerySqlBuilder extends AbstractSqlQueryBuilder
     /**
      * @throws \Propel\Runtime\Exception\PropelException
      *
-     * @return array
+     * @return \Propel\Runtime\ActiveQuery\SqlBuilder\PreparedStatementDto
      */
-    public function build(): array
+    public function build(): PreparedStatementDto
     {
         $qualifiedColumnNames = $this->criteria->keys();
         if (empty($qualifiedColumnNames)) {
@@ -50,7 +50,7 @@ class InsertQuerySqlBuilder extends AbstractSqlQueryBuilder
         $insertStatement = "INSERT INTO $tableName ($columnCsv) VALUES ($parameterPlaceholdersCsv)";
         $params = $this->buildParams($qualifiedColumnNames);
 
-        return [$insertStatement, $params];
+        return new PreparedStatementDto($insertStatement, $params);
     }
 
     /**

--- a/src/Propel/Runtime/ActiveQuery/SqlBuilder/InsertQuerySqlBuilder.php
+++ b/src/Propel/Runtime/ActiveQuery/SqlBuilder/InsertQuerySqlBuilder.php
@@ -54,7 +54,7 @@ class InsertQuerySqlBuilder extends AbstractSqlQueryBuilder
     }
 
     /**
-     * @param array $qualifiedColumnNames
+     * @param string[] $qualifiedColumnNames
      *
      * @return string
      */

--- a/src/Propel/Runtime/ActiveQuery/SqlBuilder/PreparedStatementDto.php
+++ b/src/Propel/Runtime/ActiveQuery/SqlBuilder/PreparedStatementDto.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Runtime\ActiveQuery\SqlBuilder;
+
+class PreparedStatementDto
+{
+    /**
+     * @var string
+     */
+    private $sqlStatement;
+
+    /**
+     * @var mixed[]
+     */
+    private $parameters;
+
+    /**
+     * @param string $sqlStatement
+     * @param array $parameters
+     */
+    public function __construct(string $sqlStatement, array &$parameters = [])
+    {
+        $this->sqlStatement = $sqlStatement;
+        $this->parameters = $parameters;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSqlStatement(): string
+    {
+        return $this->sqlStatement;
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function getParameters(): array
+    {
+        return $this->parameters;
+    }
+}

--- a/src/Propel/Runtime/ActiveQuery/SqlBuilder/SelectQuerySqlBuilder.php
+++ b/src/Propel/Runtime/ActiveQuery/SqlBuilder/SelectQuerySqlBuilder.php
@@ -21,9 +21,9 @@ class SelectQuerySqlBuilder extends AbstractSqlQueryBuilder
      * @param \Propel\Runtime\ActiveQuery\Criteria $criteria
      * @param mixed[] $params
      *
-     * @return array
+     * @return \Propel\Runtime\ActiveQuery\SqlBuilder\PreparedStatementDto
      */
-    public static function createSelectSql(Criteria $criteria, array &$params = []): array
+    public static function createSelectSql(Criteria $criteria, array &$params = []): PreparedStatementDto
     {
         $builder = new SelectQuerySqlBuilder($criteria);
 
@@ -40,9 +40,9 @@ class SelectQuerySqlBuilder extends AbstractSqlQueryBuilder
      *
      * @param mixed[] $params
      *
-     * @return array
+     * @return \Propel\Runtime\ActiveQuery\SqlBuilder\PreparedStatementDto
      */
-    public function build(array &$params): array
+    public function build(array &$params): PreparedStatementDto
     {
         $sourceTableNamesCollector = [];
 
@@ -88,7 +88,7 @@ class SelectQuerySqlBuilder extends AbstractSqlQueryBuilder
             $this->adapter->applyLock($sql, $lock);
         }
 
-        return [$sql, $params];
+        return new PreparedStatementDto($sql, $params);
     }
 
     /**
@@ -160,9 +160,9 @@ class SelectQuerySqlBuilder extends AbstractSqlQueryBuilder
             return;
         }
 
-        foreach ($sourceTableNames as $index => $ftable) {
-            $spacePos = strpos($ftable, ' ');
-            $tableName = ($spacePos !== false) ? substr($ftable, $spacePos + 1) : $ftable;
+        foreach ($sourceTableNames as $index => $rawTableName) {
+            $spacePos = strpos($rawTableName, ' ');
+            $tableName = ($spacePos !== false) ? substr($rawTableName, $spacePos + 1) : $rawTableName;
 
             if ($this->criteria->hasSelectQuery($tableName)) {
                 unset($sourceTableNames[$index]);

--- a/src/Propel/Runtime/ActiveQuery/SqlBuilder/SelectQuerySqlBuilder.php
+++ b/src/Propel/Runtime/ActiveQuery/SqlBuilder/SelectQuerySqlBuilder.php
@@ -1,0 +1,359 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Runtime\ActiveQuery\SqlBuilder;
+
+use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\ActiveQuery\Criterion\AbstractCriterion;
+
+/**
+ * This class produces the base object class (e.g. BaseMyTable) which contains
+ * all the custom-built accessor and setter methods.
+ */
+class SelectQuerySqlBuilder extends AbstractSqlQueryBuilder
+{
+    /**
+     * @param \Propel\Runtime\ActiveQuery\Criteria $criteria
+     * @param mixed[] $params
+     *
+     * @return array
+     */
+    public static function createSelectSql(Criteria $criteria, array &$params = []): array
+    {
+        $builder = new SelectQuerySqlBuilder($criteria);
+
+        return $builder->build($params);
+    }
+
+    /**
+     * Method to create an SQL query based on values in a Criteria.
+     *
+     * This method creates only prepared statement SQL (using ? where values
+     * will go). The second parameter ($params) stores the values that need
+     * to be set before the statement is executed. The reason we do it this way
+     * is to let the PDO layer handle all escaping & value formatting.
+     *
+     * @param mixed[] $params
+     *
+     * @return array
+     */
+    public function build(array &$params): array
+    {
+        $sourceTableNamesCollector = [];
+
+        $selectSql = $this->buildSelectClause($sourceTableNamesCollector);
+        $joinClauses = $this->buildJoinClauses($params, $sourceTableNamesCollector); // we want params from joins resolved before params from where
+        $whereSql = $this->buildWhereClause($params, $sourceTableNamesCollector);
+        $fromSql = $this->buildFromClause($params, $sourceTableNamesCollector, $joinClauses);
+
+        [$orderBySql, $additionalSelectStatements] = $this->buildOrderByClause($params);
+        $selectSql .= $additionalSelectStatements;
+
+        $sqlClauses = [$selectSql, $fromSql];
+
+        if ($whereSql) {
+            $sqlClauses[] = $whereSql;
+        }
+
+        $groupBy = $this->adapter->getGroupBy($this->criteria);
+        if ($groupBy) {
+            $this->criteria->replaceNames($groupBy);
+            $sqlClauses[] = $groupBy;
+        }
+
+        $havingSql = $this->buildHavingClause($params);
+        if ($havingSql) {
+            $sqlClauses[] = $havingSql;
+        }
+
+        if ($orderBySql) {
+            $sqlClauses[] = $orderBySql;
+        }
+
+        $sql = implode(' ', $sqlClauses);
+
+        $limit = $this->criteria->getLimit();
+        $offset = $this->criteria->getOffset();
+        if ($limit >= 0 || $offset) {
+            $this->adapter->applyLimit($sql, $offset, $limit, $this->criteria);
+        }
+
+        $lock = $this->criteria->getLock();
+        if ($lock !== null) {
+            $this->adapter->applyLock($sql, $lock);
+        }
+
+        return [$sql, $params];
+    }
+
+    /**
+     * @param string[] $sourceTableNamesCollector
+     *
+     * @return string
+     */
+    protected function buildSelectClause(array &$sourceTableNamesCollector): string
+    {
+        $selectSql = $this->adapter->createSelectSqlPart($this->criteria, $sourceTableNamesCollector);
+        $this->criteria->replaceNames($selectSql);
+
+        return $selectSql;
+    }
+
+    /**
+     * @param mixed[]|null $params
+     * @param string[] $sourceTableNames
+     * @param string[] $joinClause
+     *
+     * @return string
+     */
+    protected function buildFromClause(?array &$params, array $sourceTableNames, array $joinClause): string
+    {
+        $sourceTableNames = array_filter($sourceTableNames);
+        $sourceTableNames = array_unique($sourceTableNames);
+
+        $joinTableNames = $this->getJoinTableNames();
+        if ($joinTableNames) {
+            $sourceTableNames = array_diff($sourceTableNames, $joinTableNames);
+        }
+
+        $this->removeRecursiveSubqueryTableAliases($sourceTableNames);
+
+        $sourceTableNames = array_map([$this, 'quoteIdentifierTable'], $sourceTableNames);
+
+        foreach ($this->criteria->getSelectQueries() as $subQueryAlias => $subQueryCriteria) {
+            $sourceTableNames[] = '(' . $subQueryCriteria->createSelectSql($params) . ') AS ' . $subQueryAlias;
+        }
+
+        if (empty($sourceTableNames) && $this->criteria->getPrimaryTableName()) {
+            $primaryTable = $this->criteria->getPrimaryTableName();
+            $sourceTableNames[] = $this->quoteIdentifierTable($primaryTable);
+        }
+
+        $glue = ($joinClause && count($sourceTableNames) > 1) ? ' CROSS JOIN ' : ', ';
+        $from = 'FROM ' . implode($glue, $sourceTableNames);
+
+        if ($joinClause) {
+            $from .= ' ' . implode(' ', $joinClause);
+        }
+
+        return $from;
+    }
+
+    /**
+     * If a subqueries uses the same table as the outer query, it adds an alias to the parent query (legacy behavior).
+     * This method removes those aliases from the list of source table names.
+     *
+     * @see \Propel\Runtime\ActiveQuery\ModelCriteria::addSelectQuery()
+     *
+     * @param string[] $sourceTableNames
+     *
+     * @return void
+     */
+    protected function removeRecursiveSubqueryTableAliases(array &$sourceTableNames): void
+    {
+        if (!$this->criteria->hasSelectQueries()) {
+            return;
+        }
+
+        foreach ($sourceTableNames as $index => $ftable) {
+            $spacePos = strpos($ftable, ' ');
+            $tableName = ($spacePos !== false) ? substr($ftable, $spacePos + 1) : $ftable;
+
+            if ($this->criteria->hasSelectQuery($tableName)) {
+                unset($sourceTableNames[$index]);
+            }
+        }
+    }
+
+    /**
+     * Handle joins
+     *  joins with a null join type will be added to the FROM clause and the condition added to the WHERE clause.
+     *  joins of a specified type: the LEFT side will be added to the fromClause and the RIGHT to the joinClause
+     *
+     * @param mixed[]|null $params
+     * @param string[] $sourceTableNamesCollector
+     *
+     * @return string[]
+     */
+    protected function buildJoinClauses(?array &$params, array &$sourceTableNamesCollector): array
+    {
+        $joinClause = [];
+
+        foreach ($this->criteria->getJoins() as $join) {
+            if (!$sourceTableNamesCollector) {
+                $sourceTableNamesCollector[] = $join->getLeftTableWithAlias();
+            }
+            $join->setAdapter($this->adapter);
+            $joinClauseString = $join->getClause($params);
+            $this->criteria->replaceNames($joinClauseString);
+            $joinClause[] = $joinClauseString;
+        }
+
+        return $joinClause;
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function getJoinTableNames(): array
+    {
+        $joinTables = [];
+        foreach ($this->criteria->getJoins() as $join) {
+            $joinTables[] = $join->getRightTableWithAlias();
+        }
+
+        return $joinTables;
+    }
+
+    /**
+     * this will also add the table names to the FROM clause if they are not already included via a LEFT JOIN
+     *
+     * @param mixed[]|null $params
+     * @param string[] $sourceTableNamesCollector
+     *
+     * @return string|null
+     */
+    protected function buildWhereClause(?array &$params, array &$sourceTableNamesCollector): ?string
+    {
+        $columnNameToCriterions = $this->criteria->getMap();
+        if (!$columnNameToCriterions) {
+            return null;
+        }
+
+        $whereClause = [];
+
+        foreach ($columnNameToCriterions as $criterion) {
+            foreach ($criterion->getAttachedCriterion() as $attachedCriterion) {
+                $rawTableName = $attachedCriterion->getTable();
+                if (!$rawTableName) {
+                    continue;
+                }
+                [$realTableName, $sourceTableNamesCollector[]] = $this->getTableNameWithAlias($rawTableName);
+                $this->setCriterionsIgnoreCase($attachedCriterion, $realTableName);
+            }
+            $criterion->setAdapter($this->adapter);
+
+            $whereClause[] = $this->buildStatementFromCriterion($criterion, $params);
+        }
+
+        return 'WHERE ' . implode(' AND ', $whereClause);
+    }
+
+    /**
+     * Set the criterion to be case insensitive if requested.
+     *
+     * @param \Propel\Runtime\ActiveQuery\Criterion\AbstractCriterion $criterion
+     * @param string $realTableName
+     *
+     * @return void
+     */
+    protected function setCriterionsIgnoreCase(AbstractCriterion $criterion, string $realTableName): void
+    {
+        if (!$this->criteria->isIgnoreCase()) {
+            return;
+        }
+
+        if (!method_exists($criterion, 'setIgnoreCase')) {
+            return;
+        }
+
+        $column = $criterion->getColumn();
+        $isTextColumn = $this->dbMap->getTable($realTableName)->getColumn($column)->isText();
+        if (!$isTextColumn) {
+            return;
+        }
+
+        $criterion->setIgnoreCase(true);
+    }
+
+    /**
+     * @param mixed[] $params
+     *
+     * @return string[]
+     */
+    protected function buildOrderByClause(array &$params): array
+    {
+        $orderBy = $this->criteria->getOrderByColumns();
+        if (!$orderBy) {
+            return ['', ''];
+        }
+        $orderByClause = [];
+        $additionalSelectStatements = [];
+
+        foreach ($orderBy as $orderByColumn) {
+            $parenthesesOpenPos = strpos($orderByColumn, '(');
+            $isFunctionStatement = ($parenthesesOpenPos !== false);
+            if ($isFunctionStatement) {
+                $orderByClause[] = $orderByColumn;
+
+                continue;
+            }
+
+            $dotPos = strrpos($orderByColumn, '.');
+            if ($dotPos !== false) {
+                $tableName = substr($orderByColumn, 0, $dotPos);
+                $columnName = substr($orderByColumn, $dotPos + 1);
+            } else {
+                $tableName = '';
+                $columnName = $orderByColumn;
+            }
+
+            $spacePos = strpos($columnName, ' ');
+            if ($spacePos !== false) {
+                $direction = substr($columnName, $spacePos); // keep leading space
+                $columnName = substr($columnName, 0, $spacePos);
+            } else {
+                $direction = '';
+            }
+
+            $tableAlias = $tableName;
+            $aliasTableName = $this->criteria->getTableForAlias($tableName);
+            if ($aliasTableName) {
+                $tableName = $aliasTableName;
+            }
+
+            $columnAlias = $columnName;
+            $asColumnName = $this->criteria->getColumnForAs($columnName);
+            if ($asColumnName) {
+                $columnName = $asColumnName;
+            }
+
+            $column = ($tableName) ? $this->dbMap->getTable($tableName)->getColumn($columnName) : null;
+            if ($this->criteria->isIgnoreCase() && $column && $column->isText()) {
+                $ignoreCaseColumn = $this->adapter->ignoreCaseInOrderBy("$tableAlias.$columnAlias");
+                $this->criteria->replaceNames($ignoreCaseColumn);
+                $orderByClause[] = $ignoreCaseColumn . $direction;
+                $additionalSelectStatements[] = ', ' . $ignoreCaseColumn;
+            } else {
+                $this->criteria->replaceNames($orderByColumn);
+                $orderByClause[] = $orderByColumn;
+            }
+        }
+
+        $orderBySql = 'ORDER BY ' . implode(',', $orderByClause);
+        $additionalSelect = implode('', $additionalSelectStatements);
+
+        return [$orderBySql, $additionalSelect];
+    }
+
+    /**
+     * @param mixed[] $params
+     *
+     * @return string|null
+     */
+    protected function buildHavingClause(array &$params): ?string
+    {
+        $havingCriterion = $this->criteria->getHaving();
+        if (!$havingCriterion) {
+            return null;
+        }
+        $havingStatement = $this->buildStatementFromCriterion($havingCriterion, $params);
+
+        return "HAVING $havingStatement";
+    }
+}

--- a/src/Propel/Runtime/ActiveQuery/SqlBuilder/UpdateQuerySqlBuilder.php
+++ b/src/Propel/Runtime/ActiveQuery/SqlBuilder/UpdateQuerySqlBuilder.php
@@ -42,9 +42,9 @@ class UpdateQuerySqlBuilder extends AbstractSqlQueryBuilder
      * @param string $tableName
      * @param string[] $qualifiedTableColumnNames
      *
-     * @return array
+     * @return \Propel\Runtime\ActiveQuery\SqlBuilder\PreparedStatementDto
      */
-    public function build(string $tableName, array $qualifiedTableColumnNames): array
+    public function build(string $tableName, array $qualifiedTableColumnNames): PreparedStatementDto
     {
         [$tableName, $updateTable] = $this->getTableNameWithAlias($tableName);
         $tableColumnNames = $this->updateTablesColumns[$tableName];
@@ -66,7 +66,7 @@ class UpdateQuerySqlBuilder extends AbstractSqlQueryBuilder
         }
         $updateSql = implode(' ', $updateSql);
 
-        return [$updateSql, $params];
+        return new PreparedStatementDto($updateSql, $params);
     }
 
     /**

--- a/src/Propel/Runtime/ActiveQuery/SqlBuilder/UpdateQuerySqlBuilder.php
+++ b/src/Propel/Runtime/ActiveQuery/SqlBuilder/UpdateQuerySqlBuilder.php
@@ -1,0 +1,165 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Runtime\ActiveQuery\SqlBuilder;
+
+use Propel\Runtime\ActiveQuery\Criteria;
+
+/**
+ * This class produces the base object class (e.g. BaseMyTable) which contains
+ * all the custom-built accessor and setter methods.
+ */
+class UpdateQuerySqlBuilder extends AbstractSqlQueryBuilder
+{
+    /**
+     * @var \Propel\Runtime\ActiveQuery\Criteria
+     */
+    protected $updateValues;
+
+    /**
+     * @psalm-var array<string, string[]>
+     * @var string[]
+     */
+    protected $updateTablesColumns;
+
+    /**
+     * @param \Propel\Runtime\ActiveQuery\Criteria $criteria
+     * @param \Propel\Runtime\ActiveQuery\Criteria $updateValues
+     */
+    public function __construct(Criteria $criteria, Criteria $updateValues)
+    {
+        parent::__construct($criteria);
+        $this->updateValues = $updateValues;
+        $this->updateTablesColumns = $updateValues->getTablesColumns();
+    }
+
+    /**
+     * @param string $tableName
+     * @param string[] $qualifiedTableColumnNames
+     *
+     * @return array
+     */
+    public function build(string $tableName, array $qualifiedTableColumnNames): array
+    {
+        [$tableName, $updateTable] = $this->getTableNameWithAlias($tableName);
+        $tableColumnNames = $this->updateTablesColumns[$tableName];
+
+        $updateSql = ['UPDATE'];
+        $queryComment = $this->criteria->getComment();
+        if ($queryComment) {
+            $updateSql[] = '/* ' . $queryComment . ' */';
+        }
+        $updateSql[] = $this->quoteIdentifierTable($updateTable);
+        $updateSql[] = 'SET';
+        $updateSql[] = $this->buildAssignmentList($tableName, $tableColumnNames);
+
+        $params = $this->buildParams($tableColumnNames, $this->updateValues);
+        $whereClause = $this->buildWhereClause($qualifiedTableColumnNames, $params);
+        if ($whereClause) {
+            $updateSql[] = 'WHERE';
+            $updateSql[] = $whereClause;
+        }
+        $updateSql = implode(' ', $updateSql);
+
+        return [$updateSql, $params];
+    }
+
+    /**
+     * @psalm-param array<string, string> $qualifiedTableColumnNames
+     *
+     * @param string $tableName
+     * @param string[] $qualifiedTableColumnNames
+     *
+     * @return string
+     */
+    protected function buildAssignmentList(string $tableName, array $qualifiedTableColumnNames): string
+    {
+        $positionIndex = 1;
+        $assignmentClauses = [];
+        foreach ($qualifiedTableColumnNames as $qualifiedColumnName) {
+            $assignmentClauses[] = $this->buildAssignementClause($tableName, $qualifiedColumnName, $positionIndex);
+        }
+
+        return implode(', ', $assignmentClauses);
+    }
+
+    /**
+     * @param string $tableName
+     * @param string $qualifiedColumnName
+     * @param int $positionIndex
+     *
+     * @return string
+     */
+    protected function buildAssignementClause(string $tableName, string $qualifiedColumnName, int &$positionIndex): string
+    {
+        $dotPos = strrpos($qualifiedColumnName, '.');
+        $columnNameInUpdate = substr($qualifiedColumnName, $dotPos + 1);
+        $columnNameInUpdate = $this->criteria->quoteIdentifier($columnNameInUpdate, $tableName);
+
+        $columnEquals = $columnNameInUpdate . '=';
+
+        if ($this->updateValues->getComparison($qualifiedColumnName) !== Criteria::CUSTOM_EQUAL) {
+            return $columnEquals . ':p' . $positionIndex++;
+        }
+
+        $param = $this->updateValues->get($qualifiedColumnName);
+        if (!is_array($param)) {
+            $this->updateValues->remove($qualifiedColumnName);
+
+            return $columnEquals . $param;
+        }
+
+        if (isset($param['value'])) {
+            $this->updateValues->put($qualifiedColumnName, $param['value']);
+        }
+
+        if (isset($param['raw'])) {
+            $rawParameter = $param['raw'];
+
+            return $columnEquals . $this->buildRawParameter($rawParameter, $positionIndex);
+        }
+
+        return $columnEquals . ':p' . $positionIndex++;
+    }
+
+    /**
+     * Replaces question mark symbols with potsitional parameter placeholders (i.e. ':p2' for the second update parameter)
+     *
+     * @param string $rawParameter
+     * @param int $positionIndex
+     *
+     * @return string
+     */
+    protected function buildRawParameter(string $rawParameter, int &$positionIndex): string
+    {
+        return preg_replace_callback('#\?#', function (array $match) use (&$positionIndex) {
+            return ':p' . $positionIndex++;
+        }, $rawParameter);
+    }
+
+    /**
+     * @param string[] $qualifiedTableColumnNames
+     * @param mixed[]|null $params
+     *
+     * @return string|null
+     */
+    protected function buildWhereClause(array $qualifiedTableColumnNames, ?array &$params): ?string
+    {
+        if (!$qualifiedTableColumnNames) {
+            return null;
+        }
+
+        $whereClause = [];
+        foreach ($qualifiedTableColumnNames as $qualifiedTableColumnName) {
+            $filter = $this->criteria->getCriterion($qualifiedTableColumnName);
+            $whereClause[] = $this->buildStatementFromCriterion($filter, $params);
+        }
+
+        return implode(' AND ', $whereClause);
+    }
+}

--- a/src/Propel/Runtime/Adapter/AdapterInterface.php
+++ b/src/Propel/Runtime/Adapter/AdapterInterface.php
@@ -149,7 +149,7 @@ interface AdapterInterface
      * @param \Propel\Runtime\Connection\ConnectionInterface $con
      * @param string|null $name
      *
-     * @return mixed
+     * @return string|int|null
      */
     public function getId(ConnectionInterface $con, $name = null);
 

--- a/src/Propel/Runtime/Adapter/AdapterInterface.php
+++ b/src/Propel/Runtime/Adapter/AdapterInterface.php
@@ -144,16 +144,6 @@ interface AdapterInterface
     public function isGetIdAfterInsert();
 
     /**
-     * Returns the "DELETE FROM <table> [AS <alias>]" part of DELETE query.
-     *
-     * @param \Propel\Runtime\ActiveQuery\Criteria $criteria
-     * @param string $tableName
-     *
-     * @return string
-     */
-    public function getDeleteFromClause(Criteria $criteria, $tableName);
-
-    /**
      * Gets the generated ID (either last ID for autoincrement or next sequence ID).
      *
      * @param \Propel\Runtime\Connection\ConnectionInterface $con

--- a/src/Propel/Runtime/Adapter/Pdo/MssqlAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/MssqlAdapter.php
@@ -27,7 +27,7 @@ class MssqlAdapter extends PdoAdapter implements SqlAdapterInterface
     /**
      * MS SQL Server does not support SET NAMES
      *
-     * @see AdapterInterface::setCharset()
+     * @see \Propel\Runtime\Adapter\AdapterInterface::setCharset()
      *
      * @param \Propel\Runtime\Connection\ConnectionInterface $con
      * @param string $charset
@@ -86,7 +86,7 @@ class MssqlAdapter extends PdoAdapter implements SqlAdapterInterface
     }
 
     /**
-     * @see AdapterInterface::quoteIdentifier()
+     * @see \Propel\Runtime\Adapter\AdapterInterface::quoteIdentifier()
      *
      * @param string $text
      *
@@ -98,7 +98,7 @@ class MssqlAdapter extends PdoAdapter implements SqlAdapterInterface
     }
 
     /**
-     * @see AdapterInterface::quoteIdentifierTable()
+     * @see \Propel\Runtime\Adapter\AdapterInterface::quoteIdentifierTable()
      *
      * @param string $table
      *
@@ -111,7 +111,7 @@ class MssqlAdapter extends PdoAdapter implements SqlAdapterInterface
     }
 
     /**
-     * @see AdapterInterface::random()
+     * @see SqlAdapterInterface::random()
      *
      * @param string|null $seed
      *
@@ -130,11 +130,12 @@ class MssqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @author Benjamin Runnels <kraven@kraven.org>
      *
-     * @see AdapterInterface::applyLimit()
+     * @see SqlAdapterInterface::applyLimit()
      *
      * @param string $sql
      * @param int $offset
      * @param int $limit
+     * @param \Propel\Runtime\ActiveQuery\Criteria|null $criteria
      *
      * @throws \Propel\Runtime\Exception\InvalidArgumentException
      * @throws \Propel\Runtime\Adapter\Exception\ColumnNotFoundException
@@ -142,7 +143,7 @@ class MssqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return void
      */
-    public function applyLimit(&$sql, $offset, $limit)
+    public function applyLimit(&$sql, $offset, $limit, $criteria = null)
     {
         // make sure offset and limit are numeric
         if (!is_numeric($offset) || !is_numeric($limit)) {
@@ -331,7 +332,7 @@ class MssqlAdapter extends PdoAdapter implements SqlAdapterInterface
     }
 
     /**
-     * @see AdapterInterface::applyLock()
+     * @see SqlAdapterInterface::applyLock()
      *
      * @param string $sql
      * @param \Propel\Runtime\ActiveQuery\Lock $lock

--- a/src/Propel/Runtime/Adapter/Pdo/MysqlAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/MysqlAdapter.php
@@ -90,7 +90,7 @@ class MysqlAdapter extends PdoAdapter implements SqlAdapterInterface
     }
 
     /**
-     * @see AdapterInterface::quoteIdentifier()
+     * @see SqlAdapterInterface::quoteIdentifier()
      *
      * @param string $text
      *
@@ -102,7 +102,7 @@ class MysqlAdapter extends PdoAdapter implements SqlAdapterInterface
     }
 
     /**
-     * @see AdapterInterface::quoteIdentifierTable()
+     * @see SqlAdapterInterface::quoteIdentifierTable()
      *
      * @param string $table
      *
@@ -115,15 +115,16 @@ class MysqlAdapter extends PdoAdapter implements SqlAdapterInterface
     }
 
     /**
-     * @see AdapterInterface::applyLimit()
+     * @see SqlAdapterInterface::applyLimit()
      *
      * @param string $sql
      * @param int $offset
      * @param int $limit
+     * @param \Propel\Runtime\ActiveQuery\Criteria|null $criteria
      *
      * @return void
      */
-    public function applyLimit(&$sql, $offset, $limit)
+    public function applyLimit(&$sql, $offset, $limit, $criteria = null)
     {
         $offset = (int)$offset;
         $limit = (int)$limit;
@@ -136,7 +137,7 @@ class MysqlAdapter extends PdoAdapter implements SqlAdapterInterface
     }
 
     /**
-     * @see AdapterInterface::random()
+     * @see SqlAdapterInterface::random()
      *
      * @param string|null $seed
      *
@@ -148,7 +149,7 @@ class MysqlAdapter extends PdoAdapter implements SqlAdapterInterface
     }
 
     /**
-     * @see AdapterInterface::bindValue()
+     * @see SqlAdapterInterface::bindValue()
      *
      * @param \Propel\Runtime\Connection\StatementInterface $stmt
      * @param string $parameter
@@ -204,7 +205,7 @@ class MysqlAdapter extends PdoAdapter implements SqlAdapterInterface
     }
 
     /**
-     * @see AdapterInterface::applyLock()
+     * @see SqlAdapterInterface::applyLock()
      *
      * @param string $sql
      * @param \Propel\Runtime\ActiveQuery\Lock $lock

--- a/src/Propel/Runtime/Adapter/Pdo/PdoAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/PdoAdapter.php
@@ -451,13 +451,9 @@ abstract class PdoAdapter
                         $tableName = substr($tableName, $lastSpace + 1);
                     }
                 }
-                // is it a table alias?
-                $tableName2 = $criteria->getTableForAlias($tableName);
-                if ($tableName2 !== null) {
-                    $fromClause[] = $tableName2 . ' ' . $tableName;
-                } else {
-                    $fromClause[] = $tableName;
-                }
+                // resolve table alias
+                $sourceTableName = $criteria->getTableForAlias($tableName);
+                $fromClause[] = ($sourceTableName) ? $sourceTableName . ' ' . $tableName : $tableName;
             }
         }
 

--- a/src/Propel/Runtime/Adapter/Pdo/PgsqlAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/PgsqlAdapter.php
@@ -25,6 +25,13 @@ use Propel\Runtime\Propel;
 class PgsqlAdapter extends PdoAdapter implements SqlAdapterInterface
 {
     /**
+     * @see PdoAdapter::SUPPORTS_ALIASES_IN_DELETE
+     *
+     * @var bool
+     */
+    protected const SUPPORTS_ALIASES_IN_DELETE = false;
+
+    /**
      * Returns SQL which concatenates the second string to the first.
      *
      * @param string $s1 String to concatenate.
@@ -127,10 +134,11 @@ class PgsqlAdapter extends PdoAdapter implements SqlAdapterInterface
      * @param string $sql
      * @param int $offset
      * @param int $limit
+     * @param \Propel\Runtime\ActiveQuery\Criteria|null $criteria
      *
      * @return void
      */
-    public function applyLimit(&$sql, $offset, $limit)
+    public function applyLimit(&$sql, $offset, $limit, $criteria = null)
     {
         if ($limit >= 0) {
             $sql .= sprintf(' LIMIT %u', $limit);
@@ -168,7 +176,7 @@ class PgsqlAdapter extends PdoAdapter implements SqlAdapterInterface
         }
 
         if ($groupBy) {
-            return ' GROUP BY ' . implode(',', $groupBy);
+            return 'GROUP BY ' . implode(',', $groupBy);
         }
 
         return '';
@@ -184,31 +192,6 @@ class PgsqlAdapter extends PdoAdapter implements SqlAdapterInterface
     public function random($seed = null)
     {
         return 'random()';
-    }
-
-    /**
-     * @see PdoAdapter::getDeleteFromClause()
-     *
-     * @param \Propel\Runtime\ActiveQuery\Criteria $criteria
-     * @param string $tableName
-     *
-     * @return string
-     */
-    public function getDeleteFromClause(Criteria $criteria, $tableName)
-    {
-        $sql = 'DELETE ';
-        if ($queryComment = $criteria->getComment()) {
-            $sql .= '/* ' . $queryComment . ' */ ';
-        }
-        if ($realTableName = $criteria->getTableForAlias($tableName)) {
-            $realTableName = $criteria->quoteIdentifierTable($realTableName);
-            $sql .= 'FROM ' . $realTableName . ' AS ' . $tableName;
-        } else {
-            $tableName = $criteria->quoteIdentifierTable($tableName);
-            $sql .= 'FROM ' . $tableName;
-        }
-
-        return $sql;
     }
 
     /**

--- a/src/Propel/Runtime/Adapter/Pdo/SqliteAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/SqliteAdapter.php
@@ -91,7 +91,7 @@ class SqliteAdapter extends PdoAdapter implements SqlAdapterInterface
     }
 
     /**
-     * @see AdapterInterface::quoteIdentifier()
+     * @see \Propel\Runtime\Adapter\AdapterInterface::quoteIdentifier()
      *
      * @param string $text
      *
@@ -103,15 +103,16 @@ class SqliteAdapter extends PdoAdapter implements SqlAdapterInterface
     }
 
     /**
-     * @see AdapterInterface::applyLimit()
+     * @see SqlAdapterInterface::applyLimit()
      *
      * @param string $sql
      * @param int $offset
      * @param int $limit
+     * @param \Propel\Runtime\ActiveQuery\Criteria|null $criteria
      *
      * @return void
      */
-    public function applyLimit(&$sql, $offset, $limit)
+    public function applyLimit(&$sql, $offset, $limit, $criteria = null)
     {
         if ($limit >= 0) {
             $sql .= ' LIMIT ' . $limit . ($offset > 0 ? ' OFFSET ' . $offset : '');
@@ -131,7 +132,7 @@ class SqliteAdapter extends PdoAdapter implements SqlAdapterInterface
     }
 
     /**
-     * @see AdapterInterface::applyLock()
+     * @see SqlAdapterInterface::applyLock()
      *
      * @param string $sql
      * @param \Propel\Runtime\ActiveQuery\Lock $lock

--- a/src/Propel/Runtime/Adapter/Pdo/SqlsrvAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/SqlsrvAdapter.php
@@ -97,7 +97,7 @@ class SqlsrvAdapter extends MssqlAdapter implements SqlAdapterInterface
     }
 
     /**
-     * @see AdapterInterface::bindValue()
+     * @see SqlAdapterInterface::bindValue()
      *
      * @param \Propel\Runtime\Connection\StatementInterface $stmt
      * @param string $parameter

--- a/src/Propel/Runtime/Adapter/SqlAdapterInterface.php
+++ b/src/Propel/Runtime/Adapter/SqlAdapterInterface.php
@@ -55,10 +55,11 @@ interface SqlAdapterInterface extends AdapterInterface
      * @param string $sql
      * @param int $offset
      * @param int $limit
+     * @param \Propel\Runtime\ActiveQuery\Criteria|null $criteria
      *
      * @return void
      */
-    public function applyLimit(&$sql, $offset, $limit);
+    public function applyLimit(&$sql, $offset, $limit, $criteria = null);
 
     /**
      * Modifies the passed-in SQL to add locking capabilities
@@ -78,16 +79,6 @@ interface SqlAdapterInterface extends AdapterInterface
      * @return string
      */
     public function random($seed = null);
-
-    /**
-     * Returns the "DELETE FROM <table> [AS <alias>]" part of DELETE query.
-     *
-     * @param \Propel\Runtime\ActiveQuery\Criteria $criteria
-     * @param string $tableName
-     *
-     * @return string
-     */
-    public function getDeleteFromClause(Criteria $criteria, $tableName);
 
     /**
      * Builds the SELECT part of a SQL statement based on a Criteria
@@ -150,4 +141,12 @@ interface SqlAdapterInterface extends AdapterInterface
      * @return bool
      */
     public function bindValue(StatementInterface $stmt, $parameter, $value, ColumnMap $cMap, $position = null);
+
+    /**
+     * Indicates if the database system can process DELETE statements with
+     * aliases like 'DELETE t FROM my_table t JOIN my_other_table o ON ...'
+     *
+     * @return bool
+     */
+    public function supportsAliasesInDelete(): bool;
 }

--- a/tests/Propel/Tests/Runtime/ActiveQuery/QueryExecutor/AbstractQueryExecutorTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/QueryExecutor/AbstractQueryExecutorTest.php
@@ -74,11 +74,11 @@ class AbstractQueryExecutorTest extends BookstoreTestBase
         $executor = new class ($query) extends AbstractQueryExecutor{
             public $isWriteConnection;
 
-            protected function getConnection(ServiceContainerInterface $sc, string $dbName, bool $getWritableConnection = false): ConnectionInterface
+            protected function retrieveConnection(ServiceContainerInterface $sc, string $dbName, bool $getWritableConnection = false): ConnectionInterface
             {
                 $this->isWriteConnection = $getWritableConnection;
 
-                return parent::getConnection($sc, $dbName, $getWritableConnection);
+                return parent::retrieveConnection($sc, $dbName, $getWritableConnection);
             }
         };
 

--- a/tests/Propel/Tests/Runtime/ActiveQuery/QueryExecutor/AbstractQueryExecutorTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/QueryExecutor/AbstractQueryExecutorTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Tests\Runtime\ActiveQuery\QueryExecutor;
+
+use Propel\Runtime\ActiveQuery\QueryExecutor\AbstractQueryExecutor;
+use Propel\Runtime\ActiveQuery\QueryExecutor\QueryExecutionException;
+use Propel\Runtime\Connection\ConnectionInterface;
+use Propel\Runtime\Connection\ConnectionWrapper;
+use Propel\Runtime\Exception\PropelException;
+use Propel\Runtime\ServiceContainer\ServiceContainerInterface;
+use Propel\Tests\Bookstore\BookQuery;
+use Propel\Tests\Helpers\Bookstore\BookstoreTestBase;
+
+/**
+ * @group database
+ */
+class AbstractQueryExecutorTest extends BookstoreTestBase
+{
+    /**
+     * @return array
+     */
+    public function queryExceptionOutputFormatDataProvider()
+    {
+        // [$useDebug, $sqlStatement, $internalErrorMessage, $expectedPublicMessage]
+        return [
+            [false, '<SQL>', '<ERROR>', 'Unable to execute statement [<SQL>]'],
+            [true, '<SQL>', '<ERROR>', "Unable to execute statement [<SQL>]\nReason: [<ERROR>]"],
+        ];
+    }
+
+    /**
+     * @dataProvider queryExceptionOutputFormatDataProvider
+     *
+     * @param bool $useDebug
+     * @param string $sqlStatement
+     * @param string $internalErrorMessage
+     * @param string $expectedPublicMessage
+     *
+     * @return void
+     */
+    public function testQueryExceptionOutputFormat($useDebug, $sqlStatement, $internalErrorMessage, $expectedPublicMessage)
+    {
+        $query = BookQuery::create();
+        $con = new ConnectionWrapper($this->con->getWrappedConnection());
+        $con->useDebug($useDebug);
+
+        $c = new class ($query, $con) extends AbstractQueryExecutor {
+            public function simulateException($msg, $sql, $con)
+            {
+                return $this->handleStatementException(new PropelException($msg), $sql);
+            }
+        };
+
+        try {
+            $c->simulateException($internalErrorMessage, $sqlStatement, $con);
+            $this->fail('Cannot test without exception');
+        } catch (QueryExecutionException $e) {
+            $this->assertEquals($expectedPublicMessage, $e->getMessage());
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetConnectionDefaultsToWritableConnection(): void
+    {
+        $query = BookQuery::create();
+        $executor = new class ($query) extends AbstractQueryExecutor{
+            public $isWriteConnection;
+
+            protected function getConnection(ServiceContainerInterface $sc, string $dbName, bool $getWritableConnection = false): ConnectionInterface
+            {
+                $this->isWriteConnection = $getWritableConnection;
+
+                return parent::getConnection($sc, $dbName, $getWritableConnection);
+            }
+        };
+
+        $this->assertTrue($executor->isWriteConnection, 'AbstractQueryExecutor should default to a writable connection');
+    }
+}

--- a/tests/Propel/Tests/Runtime/ActiveQuery/QueryExecutor/SelectQueryExecutorTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/QueryExecutor/SelectQueryExecutorTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Tests\Runtime\ActiveQuery\QueryExecutor;
+
+use Propel\Runtime\ActiveQuery\QueryExecutor\SelectQueryExecutor;
+use Propel\Runtime\Connection\ConnectionInterface;
+use Propel\Runtime\ServiceContainer\ServiceContainerInterface;
+use Propel\Tests\Bookstore\BookQuery;
+use Propel\Tests\Helpers\Bookstore\BookstoreTestBase;
+
+/**
+ * @group database
+ */
+class SelectQueryExecutorTest extends BookstoreTestBase
+{
+    /**
+     * @return void
+     */
+    public function testGetConnectionReturnsReadConnection(): void
+    {
+        $query = BookQuery::create();
+        $executor = new class ($query) extends SelectQueryExecutor{
+            public $isWriteConnection;
+
+            protected function getConnection(ServiceContainerInterface $sc, string $dbName, bool $getWritableConnection = false): ConnectionInterface
+            {
+                $this->isWriteConnection = $getWritableConnection;
+
+                return parent::getConnection($sc, $dbName, $getWritableConnection);
+            }
+        };
+
+        $this->assertFalse($executor->isWriteConnection, 'SelectQueryExecutor should use a read connection');
+    }
+}

--- a/tests/Propel/Tests/Runtime/ActiveQuery/QueryExecutor/SelectQueryExecutorTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/QueryExecutor/SelectQueryExecutorTest.php
@@ -28,11 +28,11 @@ class SelectQueryExecutorTest extends BookstoreTestBase
         $executor = new class ($query) extends SelectQueryExecutor{
             public $isWriteConnection;
 
-            protected function getConnection(ServiceContainerInterface $sc, string $dbName, bool $getWritableConnection = false): ConnectionInterface
+            protected function retrieveConnection(ServiceContainerInterface $sc, string $dbName, bool $getWritableConnection = false): ConnectionInterface
             {
                 $this->isWriteConnection = $getWritableConnection;
 
-                return parent::getConnection($sc, $dbName, $getWritableConnection);
+                return parent::retrieveConnection($sc, $dbName, $getWritableConnection);
             }
         };
 

--- a/tests/Propel/Tests/Runtime/ActiveQuery/SqlBuilder/SelectQuerySqlBuilderTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/SqlBuilder/SelectQuerySqlBuilderTest.php
@@ -1,0 +1,159 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Tests\Runtime\ActiveQuery\SqlBuilder;
+
+use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\ActiveQuery\SqlBuilder\SelectQuerySqlBuilder;
+use Propel\Tests\Bookstore\BookQuery;
+use Propel\Tests\TestCaseFixtures;
+
+class SelectQuerySqlBuilderTest extends TestCaseFixtures
+{
+    /**
+     * @var bool
+     */
+    protected $configLoaded = false;
+
+    /**
+     * @return void
+     */
+    protected function loadConfig(): void
+    {
+        if ($this->configLoaded) {
+            return;
+        }
+        parent::setUp();
+        $this->setupWasExecuted = true;
+    }
+
+    /**
+     * @return mixed[][]
+     */
+    public function havingClauseDataProvider(): array
+    {
+        $this->loadConfig();
+
+        return [
+            // [<criteria>, <having clause>, <params>, <message>]]
+            [BookQuery::create(), null, [], 'Empty HAVING clause should build to null'],
+            [
+                BookQuery::create()->addHaving('Price', 42, Criteria::GREATER_THAN),
+                'HAVING Price>:p1',
+                [['table' => null, 'column' => 'Price', 'value' => 42]],
+               'HAVING clause should build to statement'],
+        ];
+    }
+
+    /**
+     * @dataProvider havingClauseDataProvider
+     *
+     * @param \Propel\Runtime\ActiveQuery\Criteria $query
+     * @param string|null $expectedClause
+     * @param array $expectedParams
+     * @param string $message
+     *
+     * @return void
+     */
+    public function testBuildHavingClause(Criteria $query, ?string $expectedClause, array $expectedParams, string $message): void
+    {
+        $builder = new class ($query) extends SelectQuerySqlBuilder{
+            public function doBuildHavingClause(array &$params): ?string
+            {
+                return $this->buildHavingClause($params);
+            }
+        };
+        $params = [];
+        $clause = $builder->doBuildHavingClause($params);
+
+        $this->assertSame($expectedClause, $clause, $message);
+        $this->assertSame($expectedParams, $params, 'Generated query parameter array does not match');
+    }
+
+    /**
+     * @return mixed[][]
+     */
+    public function fromClauseDataProvider(): array
+    {
+        return [
+            // [<query>, <from tables>, <expected clause>, <expected params>, <message>]
+            [BookQuery::create(), [], 'FROM book', [], 'Build simple from should work' ],
+            [BookQuery::create(), ['book', 'book', '', null], 'FROM book', [], 'Builder should remove duplicates and emptie values' ],
+            [BookQuery::create()->innerJoinAuthor(), [], 'FROM book INNER JOIN author ON (book.author_id=author.id)', [], 'Builder should build FROM with simple join' ],
+            [BookQuery::create()->innerJoinAuthor(), ['author'], 'FROM book INNER JOIN author ON (book.author_id=author.id)', [], 'Builder should remove duplicate join tables' ],
+
+        ];
+    }
+
+    /**
+     * @dataProvider fromClauseDataProvider
+     *
+     * @param \Propel\Runtime\ActiveQuery\Criteria $query
+     * @param array $fromTables
+     * @param string $expectedClause
+     * @param array $expectedParams
+     * @param string $message
+     *
+     * @return void
+     */
+    public function testBuildFromClause(Criteria $query, array $fromTables, string $expectedClause, array $expectedParams, string $message): void
+    {
+        $builder = new class ($query) extends SelectQuerySqlBuilder{
+            public function doBuildFromClause(array &$params, array $fromTables): ?string
+            {
+                $joinClauses = $this->buildJoinClauses($params, $fromTables);
+
+                return $this->buildFromClause($params, $fromTables, $joinClauses);
+            }
+        };
+        $params = [];
+        $clause = $builder->doBuildFromClause($params, $fromTables);
+
+        $this->assertSame($expectedClause, $clause, $message);
+        $this->assertSame($expectedParams, $params, 'Generated query parameter array does not match');
+    }
+
+    /**
+     * @return mixed[][]
+     */
+    public function removeRecursiveSubqueryTableAliasesDataProvider(): array
+    {
+        $this->loadConfig();
+
+        $query = BookQuery::create()->addSelectQuery(BookQuery::create(), 'subquery');
+
+        return [
+            // [<query>, <from table names>, <expected table names>, <message>]
+            [BookQuery::create(), ['book'], ['book'], 'Queries without subqueries should not change'],
+            [$query, ['book subquery'], [], 'Queries with subqueries should remove the table alias'],
+        ];
+    }
+
+    /**
+     * @dataProvider removeRecursiveSubqueryTableAliasesDataProvider
+     *
+     * @param \Propel\Runtime\ActiveQuery\Criteria $query
+     * @param array $fromTableNames
+     * @param array $expectedTableNames
+     * @param string $message
+     *
+     * @return void
+     */
+    public function testRemoveRecursiveSubqueryTableAliases(Criteria $query, array $fromTableNames, array $expectedTableNames, string $message): void
+    {
+        $builder = new class ($query) extends SelectQuerySqlBuilder{
+            public function doResolve(array &$fromTableNames): ?string
+            {
+                return $this->removeRecursiveSubqueryTableAliases($fromTableNames);
+            }
+        };
+        $builder->doResolve($fromTableNames);
+
+        $this->assertSame($expectedTableNames, $fromTableNames, $message);
+    }
+}

--- a/tests/Propel/Tests/Runtime/Util/TableMapExceptionsTest.php
+++ b/tests/Propel/Tests/Runtime/Util/TableMapExceptionsTest.php
@@ -9,48 +9,28 @@
 namespace Propel\Tests\Runtime\Util;
 
 use Propel\Runtime\ActiveQuery\Criteria;
-use Propel\Runtime\Connection\ConnectionInterface;
-use Propel\Runtime\Connection\ConnectionWrapper;
-use Propel\Runtime\Exception\PropelException;
+use Propel\Runtime\ActiveQuery\QueryExecutor\QueryExecutionException;
 use Propel\Runtime\Propel;
+use Propel\Tests\Bookstore\BookQuery;
 use Propel\Tests\Bookstore\Map\BookTableMap;
 use Propel\Tests\Helpers\Bookstore\BookstoreTestBase;
-use Exception;
-use Propel\Tests\Bookstore\BookQuery;
 
 /**
  * Tests the exceptions thrown by the TableMap classes.
  *
  * @see BookstoreDataPopulator
- * @author Francois Zaninotto
  *
  * @group database
  */
 class TableMapExceptionsTest extends BookstoreTestBase
 {
     /**
-     * Get BookQuery child class through method, since the parent class is not always available on CI tool.
-     *
-     * @throws CorrectlyHandledException
-     * @return BookQuery class instance
-     */
-    public static function createHandledBookQuery() : BookQuery
-    {
-        return new class() extends BookQuery{
-            protected function handleStatementException(Exception $e, ?string $sql, ?ConnectionInterface $con = null, $stmt = null): void
-            {
-                throw new CorrectlyHandledException();
-            }
-        };
-    }
-    
-    /**
      * @return void
      */
     public function testDoSelectExceptionsAreHandledCorrectly()
     {
-        $this->expectException(CorrectlyHandledException::class);
-        self::createHandledBookQuery()->where('oh this is no sql')->find();
+        $this->expectException(QueryExecutionException::class);
+        BookQuery::create()->where('oh this is no sql')->find();
     }
 
     /**
@@ -58,8 +38,8 @@ class TableMapExceptionsTest extends BookstoreTestBase
      */
     public function testDoCountExceptionsAreHandledCorrectly()
     {
-        $this->expectException(CorrectlyHandledException::class);
-        self::createHandledBookQuery()->where('oh this is no sql')->count();
+        $this->expectException(QueryExecutionException::class);
+        BookQuery::create()->where('oh this is no sql')->count();
     }
 
     /**
@@ -67,8 +47,8 @@ class TableMapExceptionsTest extends BookstoreTestBase
      */
     public function testDoDeleteExceptionsAreHandledCorrectly()
     {
-        $this->expectException(CorrectlyHandledException::class);
-        self::createHandledBookQuery()->where('oh this is no sql')->delete();
+        $this->expectException(QueryExecutionException::class);
+        BookQuery::create()->where('oh this is no sql')->delete();
     }
 
     /**
@@ -76,13 +56,13 @@ class TableMapExceptionsTest extends BookstoreTestBase
      */
     public function testDoUpdateExceptionsAreHandledCorrectly()
     {
-        $c1 = new TableMapExceptionsTestCriteria();
+        $c1 = new Criteria();
         $c1->setPrimaryTableName(BookTableMap::TABLE_NAME);
         $c1->add(BookTableMap::COL_ID, 12, ' BAD SQL');
         $c2 = new Criteria();
         $c2->add(BookTableMap::COL_TITLE, 'Foo');
 
-        $this->expectException(CorrectlyHandledException::class);
+        $this->expectException(QueryExecutionException::class);
         $c1->doUpdate($c2, Propel::getServiceContainer()->getWriteConnection(BookTableMap::DATABASE_NAME));
     }
 
@@ -91,67 +71,12 @@ class TableMapExceptionsTest extends BookstoreTestBase
      */
     public function testDoInsertExceptionsAreHandledCorrectly()
     {
-
-        $c = new TableMapExceptionsTestCriteria();
+        $c = new Criteria();
         $c->setPrimaryTableName(BookTableMap::TABLE_NAME);
         $c->add(BookTableMap::COL_ID, 'lkhlkhj');
         $c->add(BookTableMap::COL_AUTHOR_ID, 'lkhlkhj');
 
-        $this->expectException(CorrectlyHandledException::class);
+        $this->expectException(QueryExecutionException::class);
         $c->doInsert($this->con);
-    }
-
-    /**
-     * @return array
-     */
-    public function queryExceptionOutputFormatDataProvider()
-    {
-        // [$useDebug, $sqlStatement, $internalErrorMessage, $expectedPublicMessage]
-        return [
-            [false, '<SQL>', '<ERROR>', 'Unable to execute statement [<SQL>]'],
-            [true, '<SQL>', '<ERROR>', "Unable to execute statement [<SQL>]\nReason: [<ERROR>]"],
-        ];
-    }
-
-    /**
-     * @dataProvider queryExceptionOutputFormatDataProvider
-     *
-     * @param bool $useDebug
-     * @param string $sqlStatement
-     * @param string $internalErrorMessage
-     * @param string $expectedPublicMessage
-     *
-     * @return void
-     */
-    public function testQueryExceptionOutputFormat($useDebug, $sqlStatement, $internalErrorMessage, $expectedPublicMessage)
-    {
-        $c = new class () extends Criteria {
-            public function simulateException($msg, $sql, $con)
-            {
-                return $this->handleStatementException(new PropelException($msg), $sql, $con);
-            }
-        };
-
-        $con = new ConnectionWrapper($this->con->getWrappedConnection());
-        $con->useDebug($useDebug);
-
-        try {
-            $c->simulateException($internalErrorMessage, $sqlStatement, $con);
-            $this->fail('Cannot test without exception');
-        } catch (PropelException $e) {
-            $this->assertEquals($expectedPublicMessage, $e->getMessage());
-        }
-    }
-}
-
-class CorrectlyHandledException extends Exception
-{
-}
-
-class TableMapExceptionsTestCriteria extends Criteria
-{
-    protected function handleStatementException(Exception $e, ?string $sql, ?ConnectionInterface $con = null, $stmt = null): void
-    {
-        throw new CorrectlyHandledException();
     }
 }


### PR DESCRIPTION
I was in the mood for some refactoring, and decided it is time to go for the white whale, aka the `Criteria` classes.

I believe those are Propel's achilles heel, since they are the center classes of ActiveQuery and parent class to all Query classes, and completely unmaintainable - with together almost 6000 lines of code, a fuzzy extension hierarchy, and them doing literally dozens of things at once.
In practice, that is acceptable, as long as everything works perfectly. But almost all bugs I have fixed were in those three classes, and I am pretty sure there are more. Also, I am pretty sure that a lot of performance is lost by hacky workarounds, of which I have seen plenty. I think those bugs and workarounds show that the information flow in those classes is not understandable anymore. 

 So here is a proposal to start getting things back in order by removing sql query generation and execution out of those classes. This already removes more than 500 lines of code.

The basic idea is to have the `doSelect()`, `doInsert()`, `do...()` methods delegate to dedicated classes. Here is an overview of the new classes (not sure if the `tree` output renders in all browsers):

```
ActiveQuery
├── BaseModelCriteria.php
├── Criteria.php
├── ModelCriteria.php
├── ...
├── QueryExecutor
│   ├── AbstractQueryExecutor.php
│   ├── CountQueryExecutor.php
│   ├── DeleteAllQueryExecutor.php
│   ├── DeleteQueryExecutor.php
│   ├── InsertQueryExecutor.php
│   ├── QueryExecutionException.php
│   ├── SelectQueryExecutor.php
│   └── UpdateQueryExecutor.php
└── SqlBuilder
    ├── AbstractSqlQueryBuilder.php
    ├── CountQuerySqlBuilder.php
    ├── DeleteQuerySqlBuilder.php
    ├── InsertQuerySqlBuilder.php
    ├── SelectQuerySqlBuilder.php
    └── UpdateQuerySqlBuilder.php

``` 
The changes are very thoroughly tested through the Criteria classes and a few new tests.