### PR TITLE
fix tests

### DIFF
--- a/src/Propel/Generator/Command/TestPrepareCommand.php
+++ b/src/Propel/Generator/Command/TestPrepareCommand.php
@@ -98,6 +98,7 @@ class TestPrepareCommand extends AbstractCommand
                 $result = $run;
             }
         }
+        chdir($this->root);
 
         return $result;
     }
@@ -206,8 +207,6 @@ class TestPrepareCommand extends AbstractCommand
             $command = $this->getApplication()->find('sql:insert');
             $command->run($in, $output);
         }
-
-        chdir($this->root);
 
         return static::CODE_SUCCESS;
     }


### PR DESCRIPTION
So, currently all CI tests fail before start (see [here](https://github.com/propelorm/Propel2/pull/1747#issuecomment-854687723)). Output looks like this:
```
> phpunit --colors=always '-c' 'tests/agnostic.phpunit.xml' '--stop-on-error'
Tests started in temp /tmp.

PHPUnit 9.5.4 by Sebastian Bergmann and contributors.
Could not read "tests/agnostic.phpunit.xml".
Script phpunit --colors=always handling the test event returned with error code 2
Script @test -c tests/agnostic.phpunit.xml was called via test:agnostic
```

Reason for this is that TestPrepareCommand (`Propel\Generator\Command\TestPrepareCommand`) changes directory when building tests, but does not change back on early return:
```php
    protected function buildFixtures($fixturesDir, $connections, InputInterface $input, OutputInterface $output): int
    {
        chdir($this->root . '/' . $fixturesDir);
        ...
        if ($input->getOption('exclude-database')) {
            return static::CODE_SUCCESS;
        }
        ...
        chdir($this->root);

        return static::CODE_SUCCESS;
    }

```
So we end up in the wrong directory, and phpunit cannot find the config file.

This bug was created back in 2014 and has been present ever since, but did not show before. Apparently, until now, the fixture that was built last did not use the early return, so the command ultimately left back in the correct working directory.

I could make an educated guess why the order in which Fixtures are built has changed so that the error suddenly showed up in an unrelated PR, but it doesn't matter. Simple solution is to move the `chdir()` to the end of the command's `execute()` function, so we are sure we leave at where we entered.