### PR TITLE
fix stan

### DIFF
--- a/src/Propel/Common/Config/XmlToArrayConverter.php
+++ b/src/Propel/Common/Config/XmlToArrayConverter.php
@@ -20,6 +20,8 @@ class XmlToArrayConverter
     /**
      * Create a PHP array from the XML file
      *
+     * @psalm-return array<scalar, mixed>
+     *
      * @param string $xmlToParse The XML file or a string containing xml to parse
      *
      * @throws \Propel\Common\Config\Exception\XmlParseException if parse errors occur
@@ -77,6 +79,8 @@ class XmlToArrayConverter
      * Recursive function that converts an SimpleXML object into an array.
      *
      * @author Christophe VG (based on code form php.net manual comment)
+     *
+     * @psalm-return array<scalar, mixed>
      *
      * @param \SimpleXMLElement $xml SimpleXML object.
      *


### PR DESCRIPTION
Stan started to complain about `XmlToArrayConverter` (see [here](https://github.com/propelorm/Propel2/pull/1747/checks?check_run_id=2818857394)):

```
ERROR: InvalidReturnType - src/Propel/Common/Config/XmlToArrayConverter.php:83:16 - The declared return type 'array<array-key, mixed>' for Propel\Common\Config\XmlToArrayConverter::simpleXmlToArray is incorrect, got 'array<scalar, array<array-key, array<array-key, array<array-key, mixed|scalar>|mixed|scalar>|mixed|scalar>|scalar>' (see https://psalm.dev/011)
     * @return array Array representation of SimpleXML object.


ERROR: InvalidReturnStatement - src/Propel/Common/Config/XmlToArrayConverter.php:131:16 - The inferred type 'array<scalar, array<array-key, array<array-key, array<array-key, mixed|scalar>|mixed|scalar>|mixed|scalar>|scalar>' does not match the declared return type 'array<array-key, mixed>' for Propel\Common\Config\XmlToArrayConverter::simpleXmlToArray (see https://psalm.dev/128)
        return $ar;
```
Interestingly #1750 recently changed this class, but not the offending method. The return type of the method is just `array`, so I don't even understand the issue.
Anyway, adding simple `psalm-return` type seems to fix the issue. Not sure if just using `mixed` is the best way to go. But using `array<scalar, array<array-key, array<array-key, array<array-key, mixed|scalar>|mixed|scalar>|mixed|scalar>|scalar>` is just as vague, just with more chars. Let me know if you want another type to be used here.