### PR TITLE
add howto url to missing loader script exception

### DIFF
--- a/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
+++ b/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
@@ -39,9 +39,12 @@ class StandardServiceContainer implements ServiceContainerInterface
     /**
      * Used in exception when the configuration is outdated.
      *
+     * @see StandardServiceContainer::checkVersion()
+     * @see StandardServiceContainer::getDatabaseMap()
+     *
      * @var string
      */
-    public const HOWTO_FIX_MISSING_LOADER_SCRIPT_URL = 'https://github.com/propelorm/Propel2/wiki/Exception-Target:-Loading-the-database';
+    protected const HOWTO_FIX_MISSING_LOADER_SCRIPT_URL = 'https://github.com/propelorm/Propel2/wiki/Exception-Target:-Loading-the-database';
 
     /**
      * @var \Propel\Runtime\Adapter\AdapterInterface[] List of database adapter instances
@@ -239,7 +242,7 @@ class StandardServiceContainer implements ServiceContainerInterface
 
         $message = 'Your configuration is outdated. Please rebuild it with the config:convert command.';
         if (!is_int($generatorVersion) || $generatorVersion < 2) {
-            $message .= ' Visist ' . self::HOWTO_FIX_MISSING_LOADER_SCRIPT_URL . ' for information on how to fix this.';
+            $message .= sprintf(' Visist %s for information on how to fix this.', self::HOWTO_FIX_MISSING_LOADER_SCRIPT_URL);
         }
 
         throw new PropelException($message);
@@ -291,8 +294,11 @@ class StandardServiceContainer implements ServiceContainerInterface
             $name = $this->getDefaultDatasource();
         }
         if ($this->databaseMaps === null) {
-            throw new PropelException('Database map was not initialized. Please check the database loader script included by your conf.' .
-                ' Visist ' . self::HOWTO_FIX_MISSING_LOADER_SCRIPT_URL . ' for information on how to fix this.');
+            $messageFormat = 'Database map was not initialized. Please check the database loader script included by your conf. '
+                . 'Visist %s for information on how to fix this.';
+            $message = sprintf($messageFormat, self::HOWTO_FIX_MISSING_LOADER_SCRIPT_URL);
+
+            throw new PropelException($message);
         }
         if (!isset($this->databaseMaps[$name])) {
             $class = $this->databaseMapClass;

--- a/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
+++ b/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
@@ -242,7 +242,7 @@ class StandardServiceContainer implements ServiceContainerInterface
 
         $message = 'Your configuration is outdated. Please rebuild it with the config:convert command.';
         if (!is_int($generatorVersion) || $generatorVersion < 2) {
-            $message .= sprintf(' Visist %s for information on how to fix this.', self::HOWTO_FIX_MISSING_LOADER_SCRIPT_URL);
+            $message .= sprintf(' Visit %s for information on how to fix this.', self::HOWTO_FIX_MISSING_LOADER_SCRIPT_URL);
         }
 
         throw new PropelException($message);
@@ -295,7 +295,7 @@ class StandardServiceContainer implements ServiceContainerInterface
         }
         if ($this->databaseMaps === null) {
             $messageFormat = 'Database map was not initialized. Please check the database loader script included by your conf. '
-                . 'Visist %s for information on how to fix this.';
+                . 'Visit %s for information on how to fix this.';
             $message = sprintf($messageFormat, self::HOWTO_FIX_MISSING_LOADER_SCRIPT_URL);
 
             throw new PropelException($message);

--- a/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
+++ b/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
@@ -37,6 +37,13 @@ class StandardServiceContainer implements ServiceContainerInterface
     public const CONFIGURATION_VERSION = 2;
 
     /**
+     * Used in exception when the configuration is outdated.
+     *
+     * @var string
+     */
+    public const HOWTO_FIX_MISSING_LOADER_SCRIPT_URL = 'https://github.com/propelorm/Propel2/wiki/Exception-Target:-Loading-the-database';
+
+    /**
      * @var \Propel\Runtime\Adapter\AdapterInterface[] List of database adapter instances
      */
     protected $adapters = [];
@@ -218,7 +225,7 @@ class StandardServiceContainer implements ServiceContainerInterface
     /**
      * Checks if the given propel generator version is outdated.
      *
-     * @param string $generatorVersion
+     * @param string|int $generatorVersion
      *
      * @throws \Propel\Runtime\Exception\PropelException Thrown when the configuration is outdated.
      *
@@ -230,7 +237,12 @@ class StandardServiceContainer implements ServiceContainerInterface
             return;
         }
 
-        throw new PropelException('Your configuration is outdated. Please rebuild it with the config:convert command.');
+        $message = 'Your configuration is outdated. Please rebuild it with the config:convert command.';
+        if (!is_int($generatorVersion) || $generatorVersion < 2) {
+            $message .= ' Visist ' . self::HOWTO_FIX_MISSING_LOADER_SCRIPT_URL . ' for information on how to fix this.';
+        }
+
+        throw new PropelException($message);
     }
 
     /**
@@ -279,7 +291,8 @@ class StandardServiceContainer implements ServiceContainerInterface
             $name = $this->getDefaultDatasource();
         }
         if ($this->databaseMaps === null) {
-            throw new PropelException('Database map was not initialized. Please check the database loader script included by your conf');
+            throw new PropelException('Database map was not initialized. Please check the database loader script included by your conf.' .
+                ' Visist ' . self::HOWTO_FIX_MISSING_LOADER_SCRIPT_URL . ' for information on how to fix this.');
         }
         if (!isset($this->databaseMaps[$name])) {
             $class = $this->databaseMapClass;

--- a/tests/Propel/Tests/Runtime/ServiceContainer/StandardServiceContainerTest.php
+++ b/tests/Propel/Tests/Runtime/ServiceContainer/StandardServiceContainerTest.php
@@ -208,7 +208,7 @@ class StandardServiceContainerTest extends BaseTestCase
         try {
             $this->sc->checkVersion(StandardServiceContainer::CONFIGURATION_VERSION);
         } catch (PropelException $e) {
-            $this->fail('The current configuration version should pass a check');
+            $this->fail('The current configuration version should pass a check, but failed with message: ' . $e->getMessage());
         }
     }
 
@@ -218,13 +218,10 @@ class StandardServiceContainerTest extends BaseTestCase
     public function testUninitializedDatabaseMapThrowsException(): void
     {
         $sc = new StandardServiceContainer();
-        try {
-            $sc->getDatabaseMap('a database name');
-            $this->fail('Accessing database map before initialization should throw exception.');
-        } catch (PropelException $e) {
-            $expectedMessage = 'Database map was not initialized. Please check the database loader script included by your conf';
-            $this->assertSame($expectedMessage, $e->getMessage());
-        }
+        $this->expectException(PropelException::class);
+        $this->expectExceptionMessage('Database map was not initialized. Please check the database loader script included by your conf.');
+
+        $sc->getDatabaseMap('a database name');
     }
 
     /**


### PR DESCRIPTION
In order to reduce confusion and resulting bug reports about an outdated configuration or missing database import, I have created a howto page in the Propel2 wiki at https://github.com/propelorm/Propel2/wiki/Exception-Target:-Loading-the-database, and I have added the URL to the exception message.

I am not sure if the wiki is the correct location, but I am not sure if the official documentation is still maintained, so the wiki seems like the next best thing. Please let me know if the howto should go somewhere else. I'd prefer a perma link