### PR TITLE
PropelConfiguration: avoid deprecation notice

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -22,7 +22,6 @@ parameters:
         - '%rootDir%/../../../src/Propel/Generator/Command/InitCommand.php'
     ignoreErrors:
         - '#Call to an undefined method .+Collection::.+Array\(\)#'
-        - '#Class .+TreeBuilder constructor invoked with 0 parameters, 1-3 required#'
         -
         	message: "#^Call to an undefined method Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\TreeBuilder\\:\\:root\\(\\)\\.$#"
         	path: src/Propel/Common/Config/PropelConfiguration.php

--- a/psalm.xml
+++ b/psalm.xml
@@ -26,5 +26,10 @@
         <ImplementedReturnTypeMismatch errorLevel="suppress"/>
         <ImplicitToStringCast errorLevel="suppress"/>
         <UndefinedMagicMethod errorLevel="suppress"/>
+        <UndefinedMethod>
+            <errorLevel type="suppress">
+                <referencedMethod name="Symfony\Component\Config\Definition\Builder\TreeBuilder::root"/>
+            </errorLevel>
+        </UndefinedMethod>
     </issueHandlers>
 </psalm>

--- a/src/Propel/Common/Config/PropelConfiguration.php
+++ b/src/Propel/Common/Config/PropelConfiguration.php
@@ -27,14 +27,13 @@ class PropelConfiguration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $isBeforeSymfony5 = method_exists(TreeBuilder::class, 'root');
+        $treeBuilder = new TreeBuilder('propel');
 
-        if ($isBeforeSymfony5) {
-            $treeBuilder = new TreeBuilder();
-            $rootNode = $treeBuilder->root('propel');
-        } else {
-            $treeBuilder = new TreeBuilder('propel');
+        if (\method_exists($treeBuilder, 'getRootNode')) {
             $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $treeBuilder->root('propel');
         }
 
         $this->addGeneralSection($rootNode);

--- a/src/Propel/Common/Config/PropelConfiguration.php
+++ b/src/Propel/Common/Config/PropelConfiguration.php
@@ -29,7 +29,7 @@ class PropelConfiguration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder('propel');
 
-        if (\method_exists($treeBuilder, 'getRootNode')) {
+        if (method_exists($treeBuilder, 'getRootNode')) {
             $rootNode = $treeBuilder->getRootNode();
         } else {
             // BC layer for symfony/config 4.1 and older


### PR DESCRIPTION
After this PR the new way is already used for sf 4.2 - 4.4, to avoid the deprecation notice.