### PR TITLE
Quote primary table name if identifier quoting is enabled

### DIFF
--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -2207,7 +2207,7 @@ class Criteria
         }
 
         if (empty($fromClause) && $this->getPrimaryTableName()) {
-            $fromClause[] = $this->getPrimaryTableName();
+            $fromClause[] = $this->quoteIdentifierTable($this->getPrimaryTableName());
         }
 
         // build from-clause

--- a/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaTest.php
@@ -234,6 +234,26 @@ class CriteriaTest extends BookstoreTestBase
     /**
      * @return void
      */
+    public function testPrimaryTableNameQuoting()
+    {
+        $tableName = 'myTable1';
+        $this->c->setPrimaryTableName($tableName);
+        $countSelect = 'COUNT(*)';
+        $this->c->addSelectColumn($countSelect);
+        $adapter = Propel::getServiceContainer()->getAdapter('bookstore');
+        $escapedTableName = $adapter->quoteIdentifierTable($tableName);
+
+        $this->c->setIdentifierQuoting(true);
+        $params = [];
+        $this->assertEquals(
+            "SELECT {$countSelect} FROM {$escapedTableName}",
+            $this->c->createSelectSql($params)
+        );
+    }
+
+    /**
+     * @return void
+     */
     public function testAddOrDistinctColumns()
     {
         $table1 = 'myTable1';


### PR DESCRIPTION
With the latest `master` build we ran into the problem that `COUNT(*)`-queries to our `order` table failed. This patch ensures that the setting for identifier quoting is properly observed.

Note that I deliberately ignored the `getSql` helper-function in the test, as this behaviour is precisely what the `getSql` helper-function hides.