### PR TITLE
Allow default-value for concrete-inheritance to be instantiable

### DIFF
--- a/src/Propel/Generator/Builder/Om/TableMapBuilder.php
+++ b/src/Propel/Generator/Builder/Om/TableMapBuilder.php
@@ -1051,7 +1051,9 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
             } /* foreach */
             $script .= "
                 default:
-                    \$omClass = {$this->getTableMapClassName()}::CLASS_DEFAULT;
+                    \$omClass = \$withPrefix
+                        ? {$this->getTableMapClassName()}::CLASS_DEFAULT
+                        : {$this->getTableMapClassName()}::OM_CLASS;
 ";
             $script .= "
             } // switch
@@ -1067,7 +1069,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
         }
         $script .= "
         } catch (\Exception \$e) {
-            throw new PropelException('Unable to get OM class.', \$e);
+            throw new PropelException('Unable to get OM class.', 0, \$e);
         }
 
         return \$omClass;


### PR DESCRIPTION
We use concrete-inheritance for our 'setting' table[1], and encountered the buggy situation in which we had application crashes on development environments (lots of branch-switching) where a recently-introduced type present in the database would instantiate a nonexisting class.

This patch defaults the behaviour of `SettingQuery()->find()` to return the base class for unknown types, instead of `Package\\Setting`, by using the (correctly-namespaced) classname in `TableMap::OM_CLASS`.

I added a test that verifies that the base class name is returned from `TableMap::getOMClass()` with an unexpected value.

[1]: example column.
```xml
        <column
            name="type"
            type="ENUM"
            required="true"
            default="string"
            valueSet="'string','int','boolean','datetime','country'"
            inheritance="single"
        >
            <inheritance key="string" class="Setting" />
            <inheritance key="int" class="IntegerSetting" extends="Setting" />
            <inheritance key="boolean" class="BooleanSetting" extends="Setting" />
            <inheritance key="datetime" class="DateTimeSetting" extends="Setting" />
            <inheritance key="country" class="CountrySetting" extends="Setting" /><!-- recently introduced -->
        </column>
```