### PR TITLE
[#1284] pluralise 'Box' to 'Boxes'

### DIFF
--- a/src/Propel/Common/Pluralizer/StandardEnglishPluralizer.php
+++ b/src/Propel/Common/Pluralizer/StandardEnglishPluralizer.php
@@ -84,7 +84,7 @@ class StandardEnglishPluralizer implements PluralizerInterface
         'goose' => 'geese',
         'genus' => 'genera',
         'sex' => 'sexes',
-        'ox' => 'oxen',
+        '^ox' => 'oxen',
         'child' => 'children',
         'man' => 'men',
         'tooth' => 'teeth',

--- a/tests/Propel/Tests/Common/Pluralizer/EnglishPluralizerTest.php
+++ b/tests/Propel/Tests/Common/Pluralizer/EnglishPluralizerTest.php
@@ -87,6 +87,8 @@ class EnglishPluralizerTest extends TestCase
             ['Tooth', 'Teeth'],
             ['tooth', 'teeth'],
             ['Foot', 'Feet'],
+            ['Box', 'Boxes'],
+            ['ox', 'oxen'],
         ];
     }
 


### PR DESCRIPTION
Time to fix some old bug-reports!

Although the [Jargon File](http://www.catb.org/jargon/html/B/boxen.html) suggests that 'Boxen' should be a valid pluralisation 😜