### PR TITLE
BC break: rename functions with underscores for PSR2 compat

### DIFF
--- a/config/phpcs.xml
+++ b/config/phpcs.xml
@@ -31,8 +31,5 @@
     <rule ref="Squiz.PHP.Eval">
         <severity>0</severity>
     </rule>
-    <rule ref="PSR1.Methods.CamelCapsMethodName">
-        <severity>0</severity>
-    </rule>
 
 </ruleset>

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -3778,12 +3778,12 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
     {
         $pkeys = $this->getTable()->getPrimaryKey();
         if (count($pkeys) == 1) {
-            $this->addGetPrimaryKey_SinglePK($script);
+            $this->addGetPrimaryKeySinglePK($script);
         } elseif (count($pkeys) > 1) {
-            $this->addGetPrimaryKey_MultiPK($script);
+            $this->addGetPrimaryKeyMultiPK($script);
         } else {
             // no primary key -- this is deprecated, since we don't *need* this method anymore
-            $this->addGetPrimaryKey_NoPK($script);
+            $this->addGetPrimaryKeyNoPK($script);
         }
     }
 
@@ -3794,7 +3794,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addGetPrimaryKey_SinglePK(&$script)
+    protected function addGetPrimaryKeySinglePK(&$script)
     {
         $table = $this->getTable();
         $pkeys = $table->getPrimaryKey();
@@ -3819,7 +3819,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addGetPrimaryKey_MultiPK(&$script)
+    protected function addGetPrimaryKeyMultiPK(&$script)
     {
         $script .= "
     /**
@@ -3855,7 +3855,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addGetPrimaryKey_NoPK(&$script)
+    protected function addGetPrimaryKeyNoPK(&$script)
     {
         $script .= "
     /**
@@ -3881,12 +3881,12 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
     {
         $pkeys = $this->getTable()->getPrimaryKey();
         if (count($pkeys) == 1) {
-            $this->addSetPrimaryKey_SinglePK($script);
+            $this->addSetPrimaryKeySinglePK($script);
         } elseif (count($pkeys) > 1) {
-            $this->addSetPrimaryKey_MultiPK($script);
+            $this->addSetPrimaryKeyMultiPK($script);
         } else {
             // no primary key -- this is deprecated, since we don't *need* this method anymore
-            $this->addSetPrimaryKey_NoPK($script);
+            $this->addSetPrimaryKeyNoPK($script);
         }
     }
 
@@ -3897,7 +3897,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addSetPrimaryKey_SinglePK(&$script)
+    protected function addSetPrimaryKeySinglePK(&$script)
     {
         $pkeys = $this->getTable()->getPrimaryKey();
         $col = $pkeys[0];
@@ -3925,7 +3925,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addSetPrimaryKey_MultiPK(&$script)
+    protected function addSetPrimaryKeyMultiPK(&$script)
     {
         $script .= "
     /**
@@ -3959,7 +3959,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addSetPrimaryKey_NoPK(&$script)
+    protected function addSetPrimaryKeyNoPK(&$script)
     {
         $script .= "
     /**

--- a/src/Propel/Generator/Builder/Om/TableMapBuilder.php
+++ b/src/Propel/Generator/Builder/Om/TableMapBuilder.php
@@ -998,12 +998,12 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
     {
         $table = $this->getTable();
         if ($table->getChildrenColumn()) {
-            $this->addGetOMClass_Inheritance($script);
+            $this->addGetOMClassInheritance($script);
         } else {
             if ($table->isAbstract()) {
-                $this->addGetOMClass_NoInheritance_Abstract($script);
+                $this->addGetOMClassNoInheritanceAbstract($script);
             } else {
-                $this->addGetOMClass_NoInheritance($script);
+                $this->addGetOMClassNoInheritance($script);
             }
         }
     }
@@ -1015,7 +1015,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @return void
      */
-    protected function addGetOMClass_Inheritance(&$script)
+    protected function addGetOMClassInheritance(&$script)
     {
         $col = $this->getTable()->getChildrenColumn();
         $script .= "
@@ -1084,7 +1084,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @return void
      */
-    protected function addGetOMClass_NoInheritance(&$script)
+    protected function addGetOMClassNoInheritance(&$script)
     {
         $script .= "
     /**
@@ -1112,7 +1112,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @return void
      */
-    protected function addGetOMClass_NoInheritance_Abstract(&$script)
+    protected function addGetOMClassNoInheritanceAbstract(&$script)
     {
         $objectClassName = $this->getObjectClassName();
 


### PR DESCRIPTION
Fixes #1638

I chose not to to the 'each class in its own file' rule as suggested in the referenced issue, as test files are currently not covered by the PHPCS checks.