### PR TITLE
Use object-equality instead of reference-equality to compare object properties

### DIFF
--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -2535,8 +2535,13 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
                 $fmt = $this->getTemporalFormatter($col);
                 $accessor = "\$this->$clo && \$this->{$clo}->format('$fmt')";
             }
+            $notEquals = '!==';
+            $defaultValueString = $this->getDefaultValueString($col);
+            if (strpos($defaultValueString, 'new ') === 0) {
+                $notEquals = '!='; // allow object-comparison for custom PHP types
+            }
             $script .= "
-            if ($accessor !== " . $this->getDefaultValueString($col) . ") {
+            if ($accessor $notEquals $defaultValueString) {
                 return false;
             }
 ";

--- a/tests/Propel/Tests/Common/BoxedString.php
+++ b/tests/Propel/Tests/Common/BoxedString.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Propel\Tests\Common;
+
+final class BoxedString
+{
+    /** @var string */
+    private $s;
+
+    public function __construct(string $s)
+    {
+        $this->s = $s;
+    }
+
+    public function __toString()
+    {
+        return $this->s;
+    }
+}

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectTest.php
@@ -59,6 +59,7 @@ use Propel\Tests\Bookstore\Map\ReviewTableMap;
 use Propel\Tests\Bookstore\Publisher;
 use Propel\Tests\Bookstore\PublisherQuery;
 use Propel\Tests\Bookstore\Review;
+use Propel\Tests\Common\BoxedString;
 use Propel\Tests\Helpers\Bookstore\Behavior\TestAuthor;
 use Propel\Tests\Helpers\Bookstore\Behavior\TestAuthorDeleteFalse;
 use Propel\Tests\Helpers\Bookstore\Behavior\TestAuthorSaveFalse;
@@ -699,6 +700,37 @@ class GeneratedObjectTest extends BookstoreTestBase
         $r = new Review();
         $r->setReviewDate(new DateTime('now'));
         $this->assertFalse($r->hasOnlyDefaultValues());
+    }
+
+    /**
+     * @return void
+     */
+    public function testHasOnlyDefaultValuesObjectType()
+    {
+        $databaseXml = <<<XML
+        <database namespace="ExampleNamespace" package="Things">
+            <table name="thing">
+                <column name="id" type="integer"/>
+                <column
+                    name="boxedstring"
+                    type="VARCHAR"
+                    phpType="\Propel\Tests\Common\BoxedString"
+                    default="asdf"
+                    required="true"
+                />
+            </table>
+        </database>
+XML;
+        $builder = new QuickBuilder();
+        $builder->setSchema($databaseXml);
+        $builder->build();
+
+        $t = new \ExampleNamespace\Thing();
+        $this->assertEquals(new BoxedString('asdf'), $t->getBoxedstring());
+        $this->assertTrue(
+            $t->hasOnlyDefaultValues(),
+            'default boxed string should be reported as Object has only default values'
+        );
     }
 
     /**


### PR DESCRIPTION
Sometimes we use boxed primitives for types that have more specific semantics than just `string` or `int`. This allows us to define methods on the boxed primitives, enabling greater class coherence.

However, entities with boxed primitives are always reported as 'does not have only default values', because the `hasOnlyDefaultValues` function uses `!==`. Generally this is a good idea, but for objects this compares the _references_ instead of the _contents_.

This patch inspects the default-value initialiser for 'starts with `new `', as a proxy for 'is this an object type'.

There's a test to validate this behaviour. I validated that the test fails with the unpatched `ObjectBuilder` code.