### PR TITLE
1317-parent-constructor

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -181,11 +181,6 @@ parameters:
 			path: src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
 
 		-
-			message: "#^Result of \\|\\| is always true\\.$#"
-			count: 2
-			path: src/Propel/Generator/Builder/Om/ObjectBuilder.php
-
-		-
 			message: "#^Variable \\$mysqlInvalidDateString might not be defined\\.$#"
 			count: 1
 			path: src/Propel/Generator/Builder/Om/ObjectBuilder.php

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -218,12 +218,13 @@ class ObjectBuilder extends AbstractObjectBuilder
      *
      * @return string|null
      */
-    protected function getParentClass()
+    protected function getParentClass(): ?string
     {
         $parentClass = $this->getBehaviorContent('parentClass');
         if ($parentClass !== null) {
             return $parentClass;
         }
+
         return ClassTools::classname($this->getBaseClass());
     }
 
@@ -240,7 +241,8 @@ class ObjectBuilder extends AbstractObjectBuilder
         $tableName = $table->getName();
         $tableDesc = $table->getDescription();
 
-        if (($parentClass = $this->getParentClass()) !== null) {
+        $parentClass = $this->getParentClass();
+        if ($parentClass !== null) {
             $parentClass = ' extends ' . $parentClass;
         }
 
@@ -645,9 +647,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
     {
         $this->addConstructorComment($script);
         $this->addConstructorOpen($script);
-        if ($this->hasDefaultValues()) {
-            $this->addConstructorBody($script);
-        }
+        $this->addConstructorBody($script);
         $this->addConstructorClose($script);
     }
 
@@ -694,8 +694,14 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      */
     protected function addConstructorBody(&$script)
     {
-        $script .= "
+        if ($this->getParentClass() !== null) {
+            $script .= "
+        parent::__construct();";
+        }
+        if ($this->hasDefaultValues()) {
+            $script .= "
         \$this->applyDefaultValues();";
+        }
     }
 
     /**

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -214,6 +214,20 @@ class ObjectBuilder extends AbstractObjectBuilder
     }
 
     /**
+     * Return the parent class name, or null.
+     *
+     * @return string|null
+     */
+    protected function getParentClass()
+    {
+        $parentClass = $this->getBehaviorContent('parentClass');
+        if ($parentClass !== null) {
+            return $parentClass;
+        }
+        return ClassTools::classname($this->getBaseClass());
+    }
+
+    /**
      * Adds class phpdoc comment and opening of class.
      *
      * @param string $script The script will be modified in this method.
@@ -226,10 +240,7 @@ class ObjectBuilder extends AbstractObjectBuilder
         $tableName = $table->getName();
         $tableDesc = $table->getDescription();
 
-        if (
-            ($parentClass = $this->getBehaviorContent('parentClass')) !== null ||
-            ($parentClass = ClassTools::classname($this->getBaseClass())) !== null
-        ) {
+        if (($parentClass = $this->getParentClass()) !== null) {
             $parentClass = ' extends ' . $parentClass;
         }
 
@@ -729,10 +740,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
             }
         }
 
-        if (
-            $this->getBehaviorContent('parentClass') !== null ||
-            ClassTools::classname($this->getBaseClass()) !== null
-        ) {
+        if ($this->getParentClass() !== null) {
             $hooks['hasBaseClass'] = true;
         } else {
             $hooks['hasBaseClass'] = false;


### PR DESCRIPTION
Fixes #1317

I have tried to add a test for this in `tests/Propel/Tests/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceBehaviorTest.php`, but because of the on-the-fly generated classes I was not able to override the constructor of `ConcreteContentSetPk`.