### PR TITLE
Remove outdated & on method

### DIFF
--- a/src/Propel/Runtime/Collection/Collection.php
+++ b/src/Propel/Runtime/Collection/Collection.php
@@ -99,7 +99,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
      *
      * @return mixed
      */
-    public function &offsetGet($offset)
+    public function offsetGet($offset)
     {
         if (isset($this->data[$offset])) {
             return $this->data[$offset];


### PR DESCRIPTION
Refs https://github.com/propelorm/Propel2/issues/972

Lets see if that breaks something

Result:
```
There was 1 error:

1) Propel\Tests\Runtime\Collection\ArrayCollectionTest::testSave
Indirect modification of overloaded element of Propel\Runtime\Collection\ArrayCollection has no effect

/home/runner/work/Propel2/Propel2/tests/Propel/Tests/Runtime/Collection/ArrayCollectionTest.php:49
```