### PR TITLE
Add return-typehint for generated buildRelations, to bring it in line with the base class typehint

### DIFF
--- a/src/Propel/Generator/Builder/Om/TableMapBuilder.php
+++ b/src/Propel/Generator/Builder/Om/TableMapBuilder.php
@@ -618,6 +618,8 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
         $script .= "
     /**
      * Build the RelationMap objects for this table relationships
+     *
+     * @return void
      */
     public function buildRelations()
     {";


### PR DESCRIPTION
Our 'symfony debug autoloader' was spamming messages for every generated `TableMap`-class on every request. This patch should bring the typehint of the generated `TableMap` implementations in line with the typehint of the base class