### PR TITLE
Added `isSelfSelected` property to the `clear` method

### DIFF
--- a/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
@@ -994,6 +994,7 @@ class ModelCriteria extends BaseModelCriteria
         $this->primaryCriteria = null;
         $this->formatter = null;
         $this->select = null;
+        $this->isSelfSelected = false;
 
         return $this;
     }

--- a/tests/Propel/Tests/Runtime/ActiveQuery/PropelQueryTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/PropelQueryTest.php
@@ -176,4 +176,16 @@ class PropelQueryTest extends BookstoreTestBase
         $object = Table6Query::create()->findPk($key);
         $this->assertSame($object, Table6TableMap::getInstanceFromPool($key));
     }
+
+    /**
+     * @return void
+     */
+    public function testFindShouldNotThrowExceptionWhenSelectAndClearMethodsWereExecuted()
+    {
+        $bookQuery = BookQuery::create();
+
+        $bookQuery->select(['Title'])->find();
+
+        $bookQuery->clear()->find();
+    }
 }


### PR DESCRIPTION
Added the `isSelfSelected` property to the `Propel\Runtime\ActiveQuery\ModelCriteria::clear()` method to avoid an empty select SQL statement after the `clear()` method was executed.