### PR TITLE
Add return types where possible.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ pom.xml
 php-cs-fixer.phar
 
 generated-classes/
+generated-conf/
+generated-sql/
 
 tests/Fixtures/namespaced/build/
 tests/Fixtures/nestedset/build/

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -16,6 +16,11 @@
 
     <rule ref="Spryker"/>
 
+    <rule ref="vendor/spryker/code-sniffer/SprykerStrict/ruleset.xml">
+        <exclude name="SprykerStrict.TypeHints.ParameterTypeHint"/>
+        <exclude name="SprykerStrict.TypeHints.PropertyTypeHint"/>
+    </rule>
+
     <!-- exclude for now -->
     <rule ref="Spryker.ControlStructures.NoInlineAssignment">
         <severity>0</severity>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -18,11 +18,14 @@ parameters:
         - '%rootDir%/../../../src/Propel/Generator/Behavior/Delegate/templates/*'
         - '%rootDir%/../../../src/Propel/Generator/Behavior/Sortable/templates/*'
         - '%rootDir%/../../../src/Propel/Generator/Behavior/NestedSet/templates/*'
-        - '%rootDir%/../../../src/Propel/Runtime/Connection/PdoConnection.php'
-        - '%rootDir%/../../../src/Propel/Generator/Command/Helper/ConsoleHelper.php'
-        - '%rootDir%/../../../src/Propel/Generator/Command/InitCommand.php'
     ignoreErrors:
         - '#Call to an undefined method .+Collection::.+Array\(\)#'
+        -
+        	message: "#^Method .+\\\\ConsoleHelper::.+\\(\\) has no return type specified#"
+        	path: src/Propel/Generator/Command/Helper/ConsoleHelper.php
+        -
+            message: "#^Method .+\\\\ConsoleHelper::.+\\(\\) has parameter \\$messages with no type specified#"
+            path: src/Propel/Generator/Command/Helper/ConsoleHelper.php
         -
         	message: "#^Call to an undefined method Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\TreeBuilder\\:\\:root\\(\\)\\.$#"
         	path: src/Propel/Common/Config/PropelConfiguration.php

--- a/src/Propel/Common/Config/ConfigurationManager.php
+++ b/src/Propel/Common/Config/ConfigurationManager.php
@@ -11,6 +11,7 @@ namespace Propel\Common\Config;
 use Propel\Common\Config\Exception\InvalidArgumentException;
 use Propel\Common\Config\Exception\InvalidConfigurationException;
 use Propel\Common\Config\Loader\DelegatingLoader;
+use RuntimeException;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException as SymfonyInvalidConfigurationException;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Finder\Finder;
@@ -52,11 +53,16 @@ class ConfigurationManager
      * @param string|null $path Configuration file name or directory in which resides the configuration file.
      * @param array|null $extraConf Array of configuration properties, to be merged with those loaded from file.
      *                              It's useful when passing configuration parameters from command line.
+     *
+     * @throws \RuntimeException
      */
     public function __construct(?string $path = null, ?array $extraConf = [])
     {
         if (!$path) {
             $path = getcwd();
+            if ($path === false) {
+                throw new RuntimeException('Cannot get the current working directory');
+            }
         }
         if ($extraConf === null) {
             $extraConf = [];

--- a/src/Propel/Common/Config/ConfigurationManager.php
+++ b/src/Propel/Common/Config/ConfigurationManager.php
@@ -70,7 +70,7 @@ class ConfigurationManager
      *
      * @return array
      */
-    public function get()
+    public function get(): array
     {
         return $this->config;
     }
@@ -83,7 +83,7 @@ class ConfigurationManager
      *
      * @return array|null
      */
-    public function getSection($section)
+    public function getSection($section): ?array
     {
         if (!array_key_exists($section, $this->config)) {
             return null;

--- a/src/Propel/Common/Config/PropelConfiguration.php
+++ b/src/Propel/Common/Config/PropelConfiguration.php
@@ -49,7 +49,7 @@ class PropelConfiguration implements ConfigurationInterface
      *
      * @return void
      */
-    protected function addGeneralSection(ArrayNodeDefinition $node)
+    protected function addGeneralSection(ArrayNodeDefinition $node): void
     {
         $node
             ->children()
@@ -68,7 +68,7 @@ class PropelConfiguration implements ConfigurationInterface
      *
      * @return void
      */
-    protected function addPathsSection(ArrayNodeDefinition $node)
+    protected function addPathsSection(ArrayNodeDefinition $node): void
     {
         $node
             ->children()
@@ -94,7 +94,7 @@ class PropelConfiguration implements ConfigurationInterface
      *
      * @return void
      */
-    protected function addDatabaseSection(ArrayNodeDefinition $node)
+    protected function addDatabaseSection(ArrayNodeDefinition $node): void
     {
         $node
             ->children()
@@ -207,7 +207,7 @@ class PropelConfiguration implements ConfigurationInterface
      *
      * @return void
      */
-    protected function addMigrationsSection(ArrayNodeDefinition $node)
+    protected function addMigrationsSection(ArrayNodeDefinition $node): void
     {
         $node
             ->children()
@@ -228,7 +228,7 @@ class PropelConfiguration implements ConfigurationInterface
      *
      * @return void
      */
-    protected function addReverseSection(ArrayNodeDefinition $node)
+    protected function addReverseSection(ArrayNodeDefinition $node): void
     {
         $node
             ->children()
@@ -246,7 +246,7 @@ class PropelConfiguration implements ConfigurationInterface
      *
      * @return void
      */
-    protected function addExcludeTablesSection(ArrayNodeDefinition $node)
+    protected function addExcludeTablesSection(ArrayNodeDefinition $node): void
     {
         $node
             ->children()
@@ -261,7 +261,7 @@ class PropelConfiguration implements ConfigurationInterface
      *
      * @return void
      */
-    protected function addRuntimeSection(ArrayNodeDefinition $node)
+    protected function addRuntimeSection(ArrayNodeDefinition $node): void
     {
         $node
             ->children()
@@ -339,7 +339,7 @@ class PropelConfiguration implements ConfigurationInterface
      *
      * @return void
      */
-    protected function addGeneratorSection(ArrayNodeDefinition $node)
+    protected function addGeneratorSection(ArrayNodeDefinition $node): void
     {
         $node
             ->children()

--- a/src/Propel/Common/Util/SetColumnConverter.php
+++ b/src/Propel/Common/Util/SetColumnConverter.php
@@ -25,12 +25,12 @@ class SetColumnConverter
      *
      * @throws \Propel\Common\Exception\SetColumnConverterException
      *
-     * @return string|int
+     * @return string Integer value as string.
      */
-    public static function convertToInt($val, array $valueSet)
+    public static function convertToInt($val, array $valueSet): string
     {
         if ($val === null) {
-            return 0;
+            return '0';
         }
         if (!is_array($val)) {
             $val = [$val];

--- a/src/Propel/Generator/Application.php
+++ b/src/Propel/Generator/Application.php
@@ -20,7 +20,7 @@ class Application extends SymfonyApplication
      *
      * @return int
      */
-    public function doRun(InputInterface $input, OutputInterface $output)
+    public function doRun(InputInterface $input, OutputInterface $output): int
     {
         if (extension_loaded('xdebug')) {
             $output->writeln(

--- a/src/Propel/Generator/Behavior/AggregateColumn/AggregateColumnBehavior.php
+++ b/src/Propel/Generator/Behavior/AggregateColumn/AggregateColumnBehavior.php
@@ -11,6 +11,9 @@ namespace Propel\Generator\Behavior\AggregateColumn;
 use InvalidArgumentException;
 use Propel\Generator\Builder\Om\ObjectBuilder;
 use Propel\Generator\Model\Behavior;
+use Propel\Generator\Model\Column;
+use Propel\Generator\Model\ForeignKey;
+use Propel\Generator\Model\Table;
 
 /**
  * Keeps an aggregate column updated with related table
@@ -22,7 +25,7 @@ class AggregateColumnBehavior extends Behavior
     /**
      * Default parameters value
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $parameters = [
         'name' => null,
@@ -37,7 +40,7 @@ class AggregateColumnBehavior extends Behavior
      *
      * @return bool
      */
-    public function allowMultiple()
+    public function allowMultiple(): bool
     {
         return true;
     }
@@ -49,7 +52,7 @@ class AggregateColumnBehavior extends Behavior
      *
      * @return void
      */
-    public function modifyTable()
+    public function modifyTable(): void
     {
         $table = $this->getTable();
         $columnName = $this->getParameter('name');
@@ -85,7 +88,7 @@ class AggregateColumnBehavior extends Behavior
      *
      * @return string
      */
-    public function objectMethods(ObjectBuilder $builder)
+    public function objectMethods(ObjectBuilder $builder): string
     {
         if (!$this->getParameter('foreign_table')) {
             throw new InvalidArgumentException(sprintf('You must define a \'foreign_table\' parameter for the \'aggregate_column\' behavior in the \'%s\' table', $this->getTable()->getName()));
@@ -104,7 +107,7 @@ class AggregateColumnBehavior extends Behavior
      *
      * @return string
      */
-    protected function addObjectCompute(ObjectBuilder $builder)
+    protected function addObjectCompute(ObjectBuilder $builder): string
     {
         $conditions = [];
         if ($this->getParameter('condition')) {
@@ -147,7 +150,7 @@ class AggregateColumnBehavior extends Behavior
     /**
      * @return string
      */
-    protected function addObjectUpdate()
+    protected function addObjectUpdate(): string
     {
         return $this->renderTemplate('objectUpdate', [
             'column' => $this->getColumn(),
@@ -157,7 +160,7 @@ class AggregateColumnBehavior extends Behavior
     /**
      * @return \Propel\Generator\Model\Table|null
      */
-    protected function getForeignTable()
+    protected function getForeignTable(): ?Table
     {
         $database = $this->getTable()->getDatabase();
         $tableName = $database->getTablePrefix() . $this->getParameter('foreign_table');
@@ -173,7 +176,7 @@ class AggregateColumnBehavior extends Behavior
      *
      * @return \Propel\Generator\Model\ForeignKey
      */
-    protected function getForeignKey()
+    protected function getForeignKey(): ForeignKey
     {
         $foreignTable = $this->getForeignTable();
         // let's infer the relation from the foreign table
@@ -189,7 +192,7 @@ class AggregateColumnBehavior extends Behavior
     /**
      * @return \Propel\Generator\Model\Column|null
      */
-    protected function getColumn()
+    protected function getColumn(): ?Column
     {
         return $this->getTable()->getColumn($this->getParameter('name'));
     }

--- a/src/Propel/Generator/Behavior/AggregateColumn/AggregateColumnRelationBehavior.php
+++ b/src/Propel/Generator/Behavior/AggregateColumn/AggregateColumnRelationBehavior.php
@@ -9,6 +9,8 @@
 namespace Propel\Generator\Behavior\AggregateColumn;
 
 use Propel\Generator\Model\Behavior;
+use Propel\Generator\Model\ForeignKey;
+use Propel\Generator\Model\Table;
 
 /**
  * Keeps an aggregate column updated with related table
@@ -20,7 +22,7 @@ class AggregateColumnRelationBehavior extends Behavior
     /**
      * Default parameters value
      *
-     * @var array<string>
+     * @var array<string, mixed>
      */
     protected $parameters = [
         'foreign_table' => '',
@@ -31,7 +33,7 @@ class AggregateColumnRelationBehavior extends Behavior
     /**
      * @return bool
      */
-    public function allowMultiple()
+    public function allowMultiple(): bool
     {
         return true;
     }
@@ -41,7 +43,7 @@ class AggregateColumnRelationBehavior extends Behavior
      *
      * @return string
      */
-    public function postSave($builder)
+    public function postSave($builder): string
     {
         $relationName = $this->getRelationName($builder);
         $aggregateName = $this->getParameter('aggregate_name');
@@ -57,7 +59,7 @@ class AggregateColumnRelationBehavior extends Behavior
      *
      * @return string
      */
-    public function objectAttributes($builder)
+    public function objectAttributes($builder): string
     {
         $relationName = $this->getRelationName($builder);
         $relatedClass = $builder->getClassNameFromBuilder($builder->getNewStubObjectBuilder($this->getForeignTable()));
@@ -75,7 +77,7 @@ protected \$old{$relationName}{$aggregateName};
      *
      * @return string
      */
-    public function objectMethods($builder)
+    public function objectMethods($builder): string
     {
         return $this->addObjectUpdateRelated($builder);
     }
@@ -85,7 +87,7 @@ protected \$old{$relationName}{$aggregateName};
      *
      * @return string
      */
-    protected function addObjectUpdateRelated($builder)
+    protected function addObjectUpdateRelated($builder): string
     {
         $relationName = $this->getRelationName($builder);
 
@@ -103,7 +105,7 @@ protected \$old{$relationName}{$aggregateName};
      *
      * @return void
      */
-    public function objectFilter(&$script, $builder)
+    public function objectFilter(&$script, $builder): void
     {
         $relationName = $this->getRelationName($builder);
         $aggregateName = $this->getParameter('aggregate_name');
@@ -123,7 +125,7 @@ protected \$old{$relationName}{$aggregateName};
      *
      * @return string
      */
-    public function preUpdateQuery($builder)
+    public function preUpdateQuery($builder): string
     {
         return $this->getFindRelated($builder);
     }
@@ -133,7 +135,7 @@ protected \$old{$relationName}{$aggregateName};
      *
      * @return string
      */
-    public function preDeleteQuery($builder)
+    public function preDeleteQuery($builder): string
     {
         return $this->getFindRelated($builder);
     }
@@ -143,7 +145,7 @@ protected \$old{$relationName}{$aggregateName};
      *
      * @return string
      */
-    protected function getFindRelated($builder)
+    protected function getFindRelated($builder): string
     {
         $relationName = $this->getRelationName($builder);
         $aggregateName = $this->getParameter('aggregate_name');
@@ -156,7 +158,7 @@ protected \$old{$relationName}{$aggregateName};
      *
      * @return string
      */
-    public function postUpdateQuery($builder)
+    public function postUpdateQuery($builder): string
     {
         return $this->getUpdateRelated($builder);
     }
@@ -166,7 +168,7 @@ protected \$old{$relationName}{$aggregateName};
      *
      * @return string
      */
-    public function postDeleteQuery($builder)
+    public function postDeleteQuery($builder): string
     {
         return $this->getUpdateRelated($builder);
     }
@@ -176,7 +178,7 @@ protected \$old{$relationName}{$aggregateName};
      *
      * @return string
      */
-    protected function getUpdateRelated($builder)
+    protected function getUpdateRelated($builder): string
     {
         $relationName = $this->getRelationName($builder);
         $aggregateName = $this->getParameter('aggregate_name');
@@ -189,7 +191,7 @@ protected \$old{$relationName}{$aggregateName};
      *
      * @return string
      */
-    public function queryMethods($builder)
+    public function queryMethods($builder): string
     {
         $script = '';
 
@@ -204,7 +206,7 @@ protected \$old{$relationName}{$aggregateName};
      *
      * @return string
      */
-    protected function addQueryFindRelated($builder)
+    protected function addQueryFindRelated($builder): string
     {
         $foreignKey = $this->getForeignKey();
         $foreignQueryBuilder = $builder->getNewStubQueryBuilder($foreignKey->getForeignTable());
@@ -230,7 +232,7 @@ protected \$old{$relationName}{$aggregateName};
      *
      * @return string
      */
-    protected function addQueryUpdateRelated($builder)
+    protected function addQueryUpdateRelated($builder): string
     {
         $relationName = $this->getRelationName($builder);
 
@@ -245,7 +247,7 @@ protected \$old{$relationName}{$aggregateName};
     /**
      * @return \Propel\Generator\Model\Table|null
      */
-    protected function getForeignTable()
+    protected function getForeignTable(): ?Table
     {
         return $this->getTable()->getDatabase()->getTable($this->getParameter('foreign_table'));
     }
@@ -253,7 +255,7 @@ protected \$old{$relationName}{$aggregateName};
     /**
      * @return \Propel\Generator\Model\ForeignKey
      */
-    protected function getForeignKey()
+    protected function getForeignKey(): ForeignKey
     {
         $foreignTable = $this->getForeignTable();
         // let's infer the relation from the foreign table
@@ -268,7 +270,7 @@ protected \$old{$relationName}{$aggregateName};
      *
      * @return string
      */
-    protected function getRelationName($builder)
+    protected function getRelationName($builder): string
     {
         return $builder->getFKPhpNameAffix($this->getForeignKey());
     }

--- a/src/Propel/Generator/Behavior/AggregateMultipleColumns/AggregateMultipleColumnsBehavior.php
+++ b/src/Propel/Generator/Behavior/AggregateMultipleColumns/AggregateMultipleColumnsBehavior.php
@@ -322,9 +322,9 @@ class AggregateMultipleColumnsBehavior extends Behavior
     }
 
     /**
-     * @return \Propel\Generator\Model\Table
+     * @return \Propel\Generator\Model\Table|null
      */
-    protected function getForeignTable(): Table
+    protected function getForeignTable(): ?Table
     {
         $database = $this->getTable()->getDatabase();
         $foreignTableName = $this->getForeignTableNameFullyQualified();

--- a/src/Propel/Generator/Behavior/AggregateMultipleColumns/AggregateMultipleColumnsBehavior.php
+++ b/src/Propel/Generator/Behavior/AggregateMultipleColumns/AggregateMultipleColumnsBehavior.php
@@ -62,7 +62,7 @@ class AggregateMultipleColumnsBehavior extends Behavior
     /**
      * Default parameters value.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $parameters = [
         self::PARAMETER_KEY_FOREIGN_TABLE => null,

--- a/src/Propel/Generator/Behavior/Archivable/ArchivableBehavior.php
+++ b/src/Propel/Generator/Behavior/Archivable/ArchivableBehavior.php
@@ -10,7 +10,9 @@ namespace Propel\Generator\Behavior\Archivable;
 
 use Propel\Generator\Exception\InvalidArgumentException;
 use Propel\Generator\Model\Behavior;
+use Propel\Generator\Model\Column;
 use Propel\Generator\Model\Index;
+use Propel\Generator\Model\Table;
 
 /**
  * Keeps tracks of an ActiveRecord object, even after deletion
@@ -22,7 +24,7 @@ class ArchivableBehavior extends Behavior
     /**
      * Default parameters value
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $parameters = [
         'archive_table' => '',
@@ -53,7 +55,7 @@ class ArchivableBehavior extends Behavior
     /**
      * @return void
      */
-    public function modifyDatabase()
+    public function modifyDatabase(): void
     {
         foreach ($this->getDatabase()->getTables() as $table) {
             if ($table->hasBehavior($this->getId())) {
@@ -74,7 +76,7 @@ class ArchivableBehavior extends Behavior
      *
      * @return void
      */
-    public function modifyTable()
+    public function modifyTable(): void
     {
         if ($this->getParameter('archive_class') && $this->getParameter('archive_table')) {
             throw new InvalidArgumentException('Please set only one of the two parameters "archive_class" and "archive_table".');
@@ -87,7 +89,7 @@ class ArchivableBehavior extends Behavior
     /**
      * @return void
      */
-    protected function addArchiveTable()
+    protected function addArchiveTable(): void
     {
         $table = $this->getTable();
         $database = $table->getDatabase();
@@ -154,7 +156,7 @@ class ArchivableBehavior extends Behavior
     /**
      * @return \Propel\Generator\Model\Table|null
      */
-    public function getArchiveTable()
+    public function getArchiveTable(): ?Table
     {
         return $this->archiveTable;
     }
@@ -164,7 +166,7 @@ class ArchivableBehavior extends Behavior
      *
      * @return string
      */
-    public function getArchiveTablePhpName($builder)
+    public function getArchiveTablePhpName($builder): string
     {
         if ($this->hasArchiveClass()) {
             return $this->getParameter('archive_class');
@@ -178,7 +180,7 @@ class ArchivableBehavior extends Behavior
      *
      * @return string
      */
-    public function getArchiveTableQueryName($builder)
+    public function getArchiveTableQueryName($builder): string
     {
         if ($this->hasArchiveClass()) {
             return $this->getParameter('archive_class') . 'Query';
@@ -190,7 +192,7 @@ class ArchivableBehavior extends Behavior
     /**
      * @return bool
      */
-    public function hasArchiveClass()
+    public function hasArchiveClass(): bool
     {
         return $this->getParameter('archive_class') ? true : false;
     }
@@ -198,7 +200,7 @@ class ArchivableBehavior extends Behavior
     /**
      * @return \Propel\Generator\Model\Column|null
      */
-    public function getArchivedAtColumn()
+    public function getArchivedAtColumn(): ?Column
     {
         if ($this->getArchiveTable() && $this->getParameter('log_archived_at') === 'true') {
             return $this->getArchiveTable()->getColumn($this->getParameter('archived_at_column'));
@@ -210,7 +212,7 @@ class ArchivableBehavior extends Behavior
     /**
      * @return bool
      */
-    public function isArchiveOnInsert()
+    public function isArchiveOnInsert(): bool
     {
         return $this->getParameter('archive_on_insert') === 'true';
     }
@@ -218,7 +220,7 @@ class ArchivableBehavior extends Behavior
     /**
      * @return bool
      */
-    public function isArchiveOnUpdate()
+    public function isArchiveOnUpdate(): bool
     {
         return $this->getParameter('archive_on_update') === 'true';
     }
@@ -226,7 +228,7 @@ class ArchivableBehavior extends Behavior
     /**
      * @return bool
      */
-    public function isArchiveOnDelete()
+    public function isArchiveOnDelete(): bool
     {
         return $this->getParameter('archive_on_delete') === 'true';
     }

--- a/src/Propel/Generator/Behavior/Archivable/ArchivableBehaviorObjectBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/Archivable/ArchivableBehaviorObjectBuilderModifier.php
@@ -54,7 +54,7 @@ class ArchivableBehaviorObjectBuilderModifier
      *
      * @return string the PHP code to be added to the builder
      */
-    public function objectAttributes($builder)
+    public function objectAttributes($builder): string
     {
         $script = '';
         if ($this->behavior->isArchiveOnInsert()) {
@@ -78,7 +78,7 @@ class ArchivableBehaviorObjectBuilderModifier
      *
      * @return string|null the PHP code to be added to the builder
      */
-    public function postInsert($builder)
+    public function postInsert($builder): ?string
     {
         if ($this->behavior->isArchiveOnInsert()) {
             return "if (\$this->archiveOnInsert) {
@@ -96,7 +96,7 @@ class ArchivableBehaviorObjectBuilderModifier
      *
      * @return string|null the PHP code to be added to the builder
      */
-    public function postUpdate($builder)
+    public function postUpdate($builder): ?string
     {
         if ($this->behavior->isArchiveOnUpdate()) {
             return "if (\$this->archiveOnUpdate) {
@@ -120,7 +120,7 @@ class ArchivableBehaviorObjectBuilderModifier
      *
      * @return string|null the PHP code to be added to the builder
      */
-    public function preDelete($builder)
+    public function preDelete($builder): ?string
     {
         if ($this->behavior->isArchiveOnDelete()) {
             return $this->behavior->renderTemplate('objectPreDelete', [
@@ -137,7 +137,7 @@ class ArchivableBehaviorObjectBuilderModifier
      *
      * @return string the PHP code to be added to the builder
      */
-    public function objectMethods($builder)
+    public function objectMethods($builder): string
     {
         $this->builder = $builder;
         $script = '';
@@ -160,7 +160,7 @@ class ArchivableBehaviorObjectBuilderModifier
      *
      * @return string the PHP code to be added to the builder
      */
-    public function addGetArchive($builder)
+    public function addGetArchive($builder): string
     {
         return $this->behavior->renderTemplate('objectGetArchive', [
             'archiveTablePhpName' => $this->behavior->getArchiveTablePhpName($builder),
@@ -173,7 +173,7 @@ class ArchivableBehaviorObjectBuilderModifier
      *
      * @return string the PHP code to be added to the builder
      */
-    public function addArchive($builder)
+    public function addArchive($builder): string
     {
         return $this->behavior->renderTemplate('objectArchive', [
             'archiveTablePhpName' => $this->behavior->getArchiveTablePhpName($builder),
@@ -188,7 +188,7 @@ class ArchivableBehaviorObjectBuilderModifier
      *
      * @return string the PHP code to be added to the builder
      */
-    public function addRestoreFromArchive($builder)
+    public function addRestoreFromArchive($builder): string
     {
         return $this->behavior->renderTemplate('objectRestoreFromArchive', [
             'objectClassName' => $this->builder->getObjectClassName(),
@@ -204,7 +204,7 @@ class ArchivableBehaviorObjectBuilderModifier
      *
      * @return string the PHP code to be added to the builder
      */
-    public function addPopulateFromArchive($builder)
+    public function addPopulateFromArchive($builder): string
     {
         return $this->behavior->renderTemplate('objectPopulateFromArchive', [
             'archiveTablePhpName' => $this->behavior->getArchiveTablePhpName($builder),
@@ -219,7 +219,7 @@ class ArchivableBehaviorObjectBuilderModifier
      *
      * @return string the PHP code to be added to the builder
      */
-    public function addSaveWithoutArchive($builder)
+    public function addSaveWithoutArchive($builder): string
     {
         return $this->behavior->renderTemplate('objectSaveWithoutArchive', [
             'objectClassName' => $this->builder->getObjectClassName(),
@@ -233,7 +233,7 @@ class ArchivableBehaviorObjectBuilderModifier
      *
      * @return string the PHP code to be added to the builder
      */
-    public function addDeleteWithoutArchive($builder)
+    public function addDeleteWithoutArchive($builder): string
     {
         return $this->behavior->renderTemplate('objectDeleteWithoutArchive', [
             'objectClassName' => $this->builder->getObjectClassName(),

--- a/src/Propel/Generator/Behavior/Archivable/ArchivableBehaviorQueryBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/Archivable/ArchivableBehaviorQueryBuilderModifier.php
@@ -49,7 +49,7 @@ class ArchivableBehaviorQueryBuilderModifier
      *
      * @return string
      */
-    public function queryAttributes($builder)
+    public function queryAttributes($builder): string
     {
         $script = '';
         if ($this->behavior->isArchiveOnUpdate()) {
@@ -69,7 +69,7 @@ class ArchivableBehaviorQueryBuilderModifier
      *
      * @return string|null
      */
-    public function preDeleteQuery($builder)
+    public function preDeleteQuery($builder): ?string
     {
         if ($this->behavior->isArchiveOnDelete()) {
             return "
@@ -89,7 +89,7 @@ if (\$this->archiveOnDelete) {
      *
      * @return string|null
      */
-    public function postUpdateQuery($builder)
+    public function postUpdateQuery($builder): ?string
     {
         if ($this->behavior->isArchiveOnUpdate()) {
             return "
@@ -109,7 +109,7 @@ if (\$this->archiveOnUpdate) {
      *
      * @return string the PHP code to be added to the builder
      */
-    public function queryMethods($builder)
+    public function queryMethods($builder): string
     {
         $script = '';
         $script .= $this->addArchive($builder);
@@ -130,7 +130,7 @@ if (\$this->archiveOnUpdate) {
      *
      * @return string the PHP code to be added to the builder
      */
-    protected function addArchive($builder)
+    protected function addArchive($builder): string
     {
         return $this->behavior->renderTemplate('queryArchive', [
             'archiveTablePhpName' => $this->behavior->getArchiveTablePhpName($builder),
@@ -143,7 +143,7 @@ if (\$this->archiveOnUpdate) {
      *
      * @return string the PHP code to be added to the builder
      */
-    public function addSetArchiveOnUpdate($builder)
+    public function addSetArchiveOnUpdate($builder): string
     {
         return $this->behavior->renderTemplate('querySetArchiveOnUpdate');
     }
@@ -153,7 +153,7 @@ if (\$this->archiveOnUpdate) {
      *
      * @return string the PHP code to be added to the builder
      */
-    public function addUpdateWithoutArchive($builder)
+    public function addUpdateWithoutArchive($builder): string
     {
         return $this->behavior->renderTemplate('queryUpdateWithoutArchive');
     }
@@ -163,7 +163,7 @@ if (\$this->archiveOnUpdate) {
      *
      * @return string the PHP code to be added to the builder
      */
-    public function addSetArchiveOnDelete($builder)
+    public function addSetArchiveOnDelete($builder): string
     {
         return $this->behavior->renderTemplate('querySetArchiveOnDelete');
     }
@@ -173,7 +173,7 @@ if (\$this->archiveOnUpdate) {
      *
      * @return string the PHP code to be added to the builder
      */
-    public function addDeleteWithoutArchive($builder)
+    public function addDeleteWithoutArchive($builder): string
     {
         return $this->behavior->renderTemplate('queryDeleteWithoutArchive');
     }

--- a/src/Propel/Generator/Behavior/Archivable/templates/objectPopulateFromArchive.php
+++ b/src/Propel/Generator/Behavior/Archivable/templates/objectPopulateFromArchive.php
@@ -4,7 +4,7 @@
  *
  * @param      <?php echo $archiveTablePhpName ?> $archive An archived object based on the same class
  <?php if ($usesAutoIncrement): ?>
- * @param      Boolean $populateAutoIncrementPrimaryKeys
+ * @param      bool $populateAutoIncrementPrimaryKeys
  *               If true, autoincrement columns are copied from the archive object.
  *               If false, autoincrement columns are left intact.
  <?php endif; ?>

--- a/src/Propel/Generator/Behavior/Archivable/templates/queryArchive.php
+++ b/src/Propel/Generator/Behavior/Archivable/templates/queryArchive.php
@@ -7,7 +7,7 @@
  * Warning: This termination methods issues 2n+1 queries.
  *
  * @param      ConnectionInterface $con    Connection to use.
- * @param      Boolean $useLittleMemory    Whether to use OnDemandFormatter to retrieve objects.
+ * @param      bool $useLittleMemory    Whether to use OnDemandFormatter to retrieve objects.
  *               Set to false if the identity map matters.
  *               Set to true (default) to use less memory.
  *

--- a/src/Propel/Generator/Behavior/Archivable/templates/queryDeleteWithoutArchive.php
+++ b/src/Propel/Generator/Behavior/Archivable/templates/queryDeleteWithoutArchive.php
@@ -6,7 +6,7 @@
  *
  * @return integer the number of deleted rows
  */
-public function deleteWithoutArchive($con = null)
+public function deleteWithoutArchive($con = null): int
 {
     $this->archiveOnDelete = false;
 
@@ -20,7 +20,7 @@ public function deleteWithoutArchive($con = null)
  *
  * @return integer the number of deleted rows
  */
-public function deleteAllWithoutArchive($con = null)
+public function deleteAllWithoutArchive($con = null): int
 {
     $this->archiveOnDelete = false;
 

--- a/src/Propel/Generator/Behavior/Archivable/templates/querySetArchiveOnDelete.php
+++ b/src/Propel/Generator/Behavior/Archivable/templates/querySetArchiveOnDelete.php
@@ -2,7 +2,7 @@
 /**
  * Enable/disable auto-archiving on delete for the next query.
  *
- * @param boolean True if the query must archive deleted objects, false otherwise.
+ * @param bool True if the query must archive deleted objects, false otherwise.
  */
 public function setArchiveOnDelete($archiveOnDelete)
 {

--- a/src/Propel/Generator/Behavior/Archivable/templates/querySetArchiveOnUpdate.php
+++ b/src/Propel/Generator/Behavior/Archivable/templates/querySetArchiveOnUpdate.php
@@ -2,7 +2,7 @@
 /**
  * Enable/disable auto-archiving on update for the next query.
  *
- * @param boolean True if the query must archive updated objects, false otherwise.
+ * @param bool True if the query must archive updated objects, false otherwise.
  */
 public function setArchiveOnUpdate($archiveOnUpdate)
 {

--- a/src/Propel/Generator/Behavior/Archivable/templates/queryUpdateWithoutArchive.php
+++ b/src/Propel/Generator/Behavior/Archivable/templates/queryUpdateWithoutArchive.php
@@ -8,7 +8,7 @@
  *
  * @return integer the number of deleted rows
  */
-public function updateWithoutArchive($values, $con = null, $forceIndividualSaves = false)
+public function updateWithoutArchive($values, $con = null, $forceIndividualSaves = false): int
 {
     $this->archiveOnUpdate = false;
 

--- a/src/Propel/Generator/Behavior/Archivable/templates/queryUpdateWithoutArchive.php
+++ b/src/Propel/Generator/Behavior/Archivable/templates/queryUpdateWithoutArchive.php
@@ -4,7 +4,7 @@
  *
  * @param      array $values Associative array of keys and values to replace
  * @param      ConnectionInterface $con an optional connection object
- * @param      boolean $forceIndividualSaves If false (default), the resulting call is a Criteria::doUpdate(), ortherwise it is a series of save() calls on all the found objects
+ * @param      bool $forceIndividualSaves If false (default), the resulting call is a Criteria::doUpdate(), ortherwise it is a series of save() calls on all the found objects
  *
  * @return integer the number of deleted rows
  */

--- a/src/Propel/Generator/Behavior/AutoAddPk/AutoAddPkBehavior.php
+++ b/src/Propel/Generator/Behavior/AutoAddPk/AutoAddPkBehavior.php
@@ -20,7 +20,7 @@ class AutoAddPkBehavior extends Behavior
     /**
      * Default parameters value
      *
-     * @var array<string>
+     * @var array<string, mixed>
      */
     protected $parameters = [
         'name' => 'id',
@@ -34,7 +34,7 @@ class AutoAddPkBehavior extends Behavior
      *
      * @return void
      */
-    public function modifyDatabase()
+    public function modifyDatabase(): void
     {
         foreach ($this->getDatabase()->getTables() as $table) {
             if (!$table->hasPrimaryKey()) {
@@ -49,7 +49,7 @@ class AutoAddPkBehavior extends Behavior
      *
      * @return void
      */
-    public function modifyTable()
+    public function modifyTable(): void
     {
         $table = $this->getTable();
         if (!$table->hasPrimaryKey() && !$table->hasBehavior('concrete_inheritance')) {

--- a/src/Propel/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceBehavior.php
+++ b/src/Propel/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceBehavior.php
@@ -11,6 +11,7 @@ namespace Propel\Generator\Behavior\ConcreteInheritance;
 use Propel\Generator\Exception\InvalidArgumentException;
 use Propel\Generator\Model\Behavior;
 use Propel\Generator\Model\ForeignKey;
+use Propel\Generator\Model\Table;
 
 /**
  * Makes a model inherit another one. The model with this behavior gets a copy
@@ -31,7 +32,7 @@ class ConcreteInheritanceBehavior extends Behavior
     /**
      * Default parameters value
      *
-     * @var array<string>
+     * @var array<string, mixed>
      */
     protected $parameters = [
         'extends' => '',
@@ -45,7 +46,7 @@ class ConcreteInheritanceBehavior extends Behavior
     /**
      * @return void
      */
-    public function modifyTable()
+    public function modifyTable(): void
     {
         $table = $this->getTable();
         $parentTable = $this->getParentTable();
@@ -143,7 +144,7 @@ class ConcreteInheritanceBehavior extends Behavior
      *
      * @return \Propel\Generator\Model\Table
      */
-    protected function getParentTable()
+    protected function getParentTable(): Table
     {
         $database = $this->getTable()->getDatabase();
         $tableName = $database->getTablePrefix() . $this->getParameter('extends');
@@ -162,7 +163,7 @@ class ConcreteInheritanceBehavior extends Behavior
     /**
      * @return bool
      */
-    protected function isCopyData()
+    protected function isCopyData(): bool
     {
         return $this->getParameter('copy_data_to_parent') === 'true';
     }
@@ -188,7 +189,7 @@ class ConcreteInheritanceBehavior extends Behavior
      *
      * @return string|null
      */
-    public function parentClass($builder)
+    public function parentClass($builder): ?string
     {
         $parentTable = $this->getParentTable();
         switch (get_class($builder)) {
@@ -204,7 +205,7 @@ class ConcreteInheritanceBehavior extends Behavior
     /**
      * @return string
      */
-    public function preSave()
+    public function preSave(): string
     {
         if ($this->isCopyData()) {
             $script = "\$parent = \$this->getSyncParent(\$con);
@@ -227,7 +228,7 @@ class ConcreteInheritanceBehavior extends Behavior
      *
      * @return string
      */
-    public function postDelete($script)
+    public function postDelete($script): string
     {
         if ($this->isCopyData()) {
             return "\$this->getParentOrCreate(\$con)->delete(\$con);
@@ -242,7 +243,7 @@ class ConcreteInheritanceBehavior extends Behavior
      *
      * @return string
      */
-    public function objectMethods($builder)
+    public function objectMethods($builder): string
     {
         $script = '';
         $this->builder = $builder;
@@ -264,7 +265,7 @@ class ConcreteInheritanceBehavior extends Behavior
      *
      * @return void
      */
-    protected function addSyncParentToChild(&$script)
+    protected function addSyncParentToChild(&$script): void
     {
         $parentTable = $this->getParentTable();
         $parentClass = $this->builder->getClassNameFromBuilder($this->builder->getNewStubObjectBuilder($parentTable));
@@ -280,7 +281,7 @@ class ConcreteInheritanceBehavior extends Behavior
  *
  * @param $parentClass \$parent The parent object
  */
-public function syncParentToChild($parentClass \$parent)
+public function syncParentToChild($parentClass \$parent): void
 {
     ";
 
@@ -320,7 +321,7 @@ public function syncParentToChild($parentClass \$parent)
      *
      * @return void
      */
-    protected function addObjectGetParentOrCreate(&$script)
+    protected function addObjectGetParentOrCreate(&$script): void
     {
         $parentTable = $this->getParentTable();
         $parentClass = $this->builder->getClassNameFromBuilder($this->builder->getNewStubObjectBuilder($parentTable));
@@ -360,7 +361,7 @@ public function getParentOrCreate(\$con = null)
      *
      * @return void
      */
-    protected function addObjectGetSyncParent(&$script)
+    protected function addObjectGetSyncParent(&$script): void
     {
         $parentTable = $this->getParentTable();
         $pkeys = $parentTable->getPrimaryKey();

--- a/src/Propel/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceParentBehavior.php
+++ b/src/Propel/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceParentBehavior.php
@@ -27,7 +27,7 @@ class ConcreteInheritanceParentBehavior extends Behavior
     /**
      * Default parameters value
      *
-     * @var array<string>
+     * @var array<string, mixed>
      */
     protected $parameters = [
         'descendant_column' => 'descendant_class',
@@ -36,7 +36,7 @@ class ConcreteInheritanceParentBehavior extends Behavior
     /**
      * @return void
      */
-    public function modifyTable()
+    public function modifyTable(): void
     {
         $table = $this->getTable();
         if (!$table->hasColumn($this->getParameter('descendant_column'))) {
@@ -51,7 +51,7 @@ class ConcreteInheritanceParentBehavior extends Behavior
     /**
      * @return string
      */
-    protected function getColumnGetter()
+    protected function getColumnGetter(): string
     {
         return 'get' . $this->getColumnForParameter('descendant_column')->getPhpName();
     }
@@ -61,7 +61,7 @@ class ConcreteInheritanceParentBehavior extends Behavior
      *
      * @return string
      */
-    public function objectMethods($builder)
+    public function objectMethods($builder): string
     {
         $this->builder = $builder;
         $this->builder->declareClasses('Propel\Runtime\ActiveQuery\PropelQuery');
@@ -77,7 +77,7 @@ class ConcreteInheritanceParentBehavior extends Behavior
      *
      * @return void
      */
-    protected function addHasChildObject(&$script)
+    protected function addHasChildObject(&$script): void
     {
         $script .= "
 /**
@@ -85,7 +85,7 @@ class ConcreteInheritanceParentBehavior extends Behavior
  *
  * @return    bool
  */
-public function hasChildObject()
+public function hasChildObject(): bool
 {
     return \$this->" . $this->getColumnGetter() . "() !== null;
 }
@@ -97,7 +97,7 @@ public function hasChildObject()
      *
      * @return void
      */
-    protected function addGetChildObject(&$script)
+    protected function addGetChildObject(&$script): void
     {
         $script .= "
 /**

--- a/src/Propel/Generator/Behavior/Delegate/DelegateBehavior.php
+++ b/src/Propel/Generator/Behavior/Delegate/DelegateBehavior.php
@@ -14,6 +14,7 @@ use Propel\Generator\Model\Behavior;
 use Propel\Generator\Model\Column;
 use Propel\Generator\Model\ForeignKey;
 use Propel\Generator\Model\NameGeneratorInterface;
+use Propel\Generator\Model\Table;
 use Propel\Generator\Util\PhpParser;
 
 /**
@@ -36,7 +37,7 @@ class DelegateBehavior extends Behavior
     /**
      * Default parameters value
      *
-     * @var array<string>
+     * @var array<string, mixed>
      */
     protected $parameters = [
         'to' => '',
@@ -60,7 +61,7 @@ class DelegateBehavior extends Behavior
      *
      * @return void
      */
-    public function modifyTable()
+    public function modifyTable(): void
     {
         $table = $this->getTable();
         $database = $table->getDatabase();
@@ -107,7 +108,7 @@ class DelegateBehavior extends Behavior
      *
      * @return void
      */
-    protected function relateDelegateToMainTable($delegateTable, $mainTable)
+    protected function relateDelegateToMainTable($delegateTable, $mainTable): void
     {
         $pks = $mainTable->getPrimaryKey();
         foreach ($pks as $column) {
@@ -136,7 +137,7 @@ class DelegateBehavior extends Behavior
      *
      * @return \Propel\Generator\Model\Table|null
      */
-    protected function getDelegateTable($delegateTableName)
+    protected function getDelegateTable($delegateTableName): ?Table
     {
         return $this->getTable()->getDatabase()->getTable($delegateTableName);
     }
@@ -146,7 +147,7 @@ class DelegateBehavior extends Behavior
      *
      * @return string
      */
-    public function objectCall($builder)
+    public function objectCall($builder): string
     {
         $plural = false;
         $script = '';
@@ -185,7 +186,7 @@ if (method_exists({$ARFQCN}::class, \$name)) {
      *
      * @return void
      */
-    public function objectFilter(&$script)
+    public function objectFilter(&$script): void
     {
         $p = new PhpParser($script, true);
         $text = $p->findMethod('toArray');
@@ -221,7 +222,7 @@ if (method_exists({$ARFQCN}::class, \$name)) {
      *
      * @return bool
      */
-    protected function isColumnForeignKeyOrDuplicated(Column $column)
+    protected function isColumnForeignKeyOrDuplicated(Column $column): bool
     {
         $delegateTable = $column->getTable();
         $table = $this->getTable();
@@ -265,7 +266,7 @@ if (method_exists({$ARFQCN}::class, \$name)) {
     /**
      * @return string
      */
-    public function queryAttributes()
+    public function queryAttributes(): string
     {
         $script = '';
         $collations = '';
@@ -298,7 +299,7 @@ protected \$delegatedFields = [
      *
      * @return string
      */
-    public function queryMethods(QueryBuilder $builder)
+    public function queryMethods(QueryBuilder $builder): string
     {
         $script = '';
 

--- a/src/Propel/Generator/Behavior/I18n/I18nBehavior.php
+++ b/src/Propel/Generator/Behavior/I18n/I18nBehavior.php
@@ -11,8 +11,10 @@ namespace Propel\Generator\Behavior\I18n;
 use Propel\Generator\Behavior\Validate\ValidateBehavior;
 use Propel\Generator\Exception\EngineException;
 use Propel\Generator\Model\Behavior;
+use Propel\Generator\Model\Column;
 use Propel\Generator\Model\ForeignKey;
 use Propel\Generator\Model\PropelTypes;
+use Propel\Generator\Model\Table;
 
 /**
  * Allows translation of text columns through transparent one-to-many
@@ -30,7 +32,7 @@ class I18nBehavior extends Behavior
     /**
      * Default parameters value
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $parameters = [
         'i18n_table' => '%TABLE%_i18n',
@@ -66,7 +68,7 @@ class I18nBehavior extends Behavior
     /**
      * @return void
      */
-    public function modifyDatabase()
+    public function modifyDatabase(): void
     {
         foreach ($this->getDatabase()->getTables() as $table) {
             if ($table->hasBehavior('i18n') && !$table->getBehavior('i18n')->getParameter('default_locale')) {
@@ -81,7 +83,7 @@ class I18nBehavior extends Behavior
     /**
      * @return string
      */
-    public function getDefaultLocale()
+    public function getDefaultLocale(): string
     {
         $defaultLocale = $this->getParameter('default_locale');
         if (!$defaultLocale) {
@@ -94,7 +96,7 @@ class I18nBehavior extends Behavior
     /**
      * @return \Propel\Generator\Model\Table
      */
-    public function getI18nTable()
+    public function getI18nTable(): Table
     {
         return $this->i18nTable;
     }
@@ -102,7 +104,7 @@ class I18nBehavior extends Behavior
     /**
      * @return \Propel\Generator\Model\ForeignKey|null
      */
-    public function getI18nForeignKey()
+    public function getI18nForeignKey(): ?ForeignKey
     {
         foreach ($this->i18nTable->getForeignKeys() as $fk) {
             if ($fk->getForeignTableName() == $this->table->getName()) {
@@ -116,7 +118,7 @@ class I18nBehavior extends Behavior
     /**
      * @return \Propel\Generator\Model\Column
      */
-    public function getLocaleColumn()
+    public function getLocaleColumn(): Column
     {
         return $this->getI18nTable()->getColumn($this->getLocaleColumnName());
     }
@@ -124,7 +126,7 @@ class I18nBehavior extends Behavior
     /**
      * @return array<\Propel\Generator\Model\Column>
      */
-    public function getI18nColumns()
+    public function getI18nColumns(): array
     {
         $columns = [];
         $i18nTable = $this->getI18nTable();
@@ -154,7 +156,7 @@ class I18nBehavior extends Behavior
      *
      * @return string
      */
-    public function replaceTokens($string)
+    public function replaceTokens($string): string
     {
         $table = $this->getTable();
 
@@ -193,7 +195,7 @@ class I18nBehavior extends Behavior
      *
      * @return string
      */
-    public function staticAttributes($builder)
+    public function staticAttributes($builder): string
     {
         return $this->renderTemplate('staticAttributes', [
             'defaultLocale' => $this->getDefaultLocale(),
@@ -203,7 +205,7 @@ class I18nBehavior extends Behavior
     /**
      * @return void
      */
-    public function modifyTable()
+    public function modifyTable(): void
     {
         $this->addI18nTable();
         $this->relateI18nTableToMainTable();
@@ -214,7 +216,7 @@ class I18nBehavior extends Behavior
     /**
      * @return void
      */
-    protected function addI18nTable()
+    protected function addI18nTable(): void
     {
         $table = $this->getTable();
         $database = $table->getDatabase();
@@ -245,7 +247,7 @@ class I18nBehavior extends Behavior
      *
      * @return void
      */
-    protected function relateI18nTableToMainTable()
+    protected function relateI18nTableToMainTable(): void
     {
         $table = $this->getTable();
         $i18nTable = $this->i18nTable;
@@ -285,7 +287,7 @@ class I18nBehavior extends Behavior
     /**
      * @return void
      */
-    protected function addLocaleColumnToI18n()
+    protected function addLocaleColumnToI18n(): void
     {
         $localeColumnName = $this->getLocaleColumnName();
 
@@ -307,7 +309,7 @@ class I18nBehavior extends Behavior
      *
      * @return void
      */
-    protected function moveI18nColumns()
+    protected function moveI18nColumns(): void
     {
         $table = $this->getTable();
         $i18nTable = $this->i18nTable;
@@ -355,7 +357,7 @@ class I18nBehavior extends Behavior
     /**
      * @return string
      */
-    protected function getI18nTableName()
+    protected function getI18nTableName(): string
     {
         return $this->replaceTokens($this->getParameter('i18n_table'));
     }
@@ -363,7 +365,7 @@ class I18nBehavior extends Behavior
     /**
      * @return string
      */
-    protected function getI18nTablePhpName()
+    protected function getI18nTablePhpName(): string
     {
         return $this->replaceTokens($this->getParameter('i18n_phpname'));
     }
@@ -371,7 +373,7 @@ class I18nBehavior extends Behavior
     /**
      * @return string
      */
-    protected function getLocaleColumnName()
+    protected function getLocaleColumnName(): string
     {
         return $this->replaceTokens($this->getParameter('locale_column'));
     }
@@ -379,7 +381,7 @@ class I18nBehavior extends Behavior
     /**
      * @return array<string>
      */
-    protected function getI18nColumnNamesFromConfig()
+    protected function getI18nColumnNamesFromConfig(): array
     {
         $columnNames = explode(',', $this->getParameter('i18n_columns'));
         foreach ($columnNames as $key => $columnName) {

--- a/src/Propel/Generator/Behavior/I18n/I18nBehavior.php
+++ b/src/Propel/Generator/Behavior/I18n/I18nBehavior.php
@@ -116,9 +116,9 @@ class I18nBehavior extends Behavior
     }
 
     /**
-     * @return \Propel\Generator\Model\Column
+     * @return \Propel\Generator\Model\Column|null
      */
-    public function getLocaleColumn(): Column
+    public function getLocaleColumn(): ?Column
     {
         return $this->getI18nTable()->getColumn($this->getLocaleColumnName());
     }

--- a/src/Propel/Generator/Behavior/I18n/I18nBehavior.php
+++ b/src/Propel/Generator/Behavior/I18n/I18nBehavior.php
@@ -318,7 +318,7 @@ class I18nBehavior extends Behavior
         foreach ($this->getI18nColumnNamesFromConfig() as $columnName) {
             if (!$i18nTable->hasColumn($columnName)) {
                 if (!$table->hasColumn($columnName)) {
-                    throw new EngineException(sprintf('No column named %s found in table %s', $columnName, $table->getName()));
+                    throw new EngineException(sprintf('No column named `%s` found in table `%s`', $columnName, $table->getName()));
                 }
 
                 $column = $table->getColumn($columnName);

--- a/src/Propel/Generator/Behavior/I18n/I18nBehaviorObjectBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/I18n/I18nBehaviorObjectBuilderModifier.php
@@ -48,7 +48,7 @@ class I18nBehaviorObjectBuilderModifier
      *
      * @return string|null
      */
-    public function postDelete($builder)
+    public function postDelete($builder): ?string
     {
         $this->builder = $builder;
         if (!$builder->getPlatform()->supportsNativeDeleteTrigger() && !$builder->getBuildProperty('generator.objectModel.emulateForeignKeyConstraints')) {
@@ -68,7 +68,7 @@ class I18nBehaviorObjectBuilderModifier
      *
      * @return string
      */
-    public function objectAttributes($builder)
+    public function objectAttributes($builder): string
     {
         return $this->behavior->renderTemplate('objectAttributes', [
             'defaultLocale' => $this->behavior->getDefaultLocale(),
@@ -81,7 +81,7 @@ class I18nBehaviorObjectBuilderModifier
      *
      * @return string
      */
-    public function objectClearReferences($builder)
+    public function objectClearReferences($builder): string
     {
         return $this->behavior->renderTemplate('objectClearReferences', [
             'defaultLocale' => $this->behavior->getDefaultLocale(),
@@ -93,7 +93,7 @@ class I18nBehaviorObjectBuilderModifier
      *
      * @return string
      */
-    public function objectMethods($builder)
+    public function objectMethods($builder): string
     {
         $this->builder = $builder;
 
@@ -121,7 +121,7 @@ class I18nBehaviorObjectBuilderModifier
     /**
      * @return string
      */
-    protected function addSetLocale()
+    protected function addSetLocale(): string
     {
         return $this->behavior->renderTemplate('objectSetLocale', [
             'objectClassName' => $this->builder->getClassNameFromBuilder($this->builder->getStubObjectBuilder()),
@@ -133,7 +133,7 @@ class I18nBehaviorObjectBuilderModifier
     /**
      * @return string
      */
-    protected function addGetLocale()
+    protected function addGetLocale(): string
     {
         return $this->behavior->renderTemplate('objectGetLocale', [
             'localeColumnName' => $this->behavior->getLocaleColumn()->getPhpName(),
@@ -145,7 +145,7 @@ class I18nBehaviorObjectBuilderModifier
      *
      * @return string
      */
-    protected function addSetLocaleAlias($alias)
+    protected function addSetLocaleAlias($alias): string
     {
         return $this->behavior->renderTemplate('objectSetLocaleAlias', [
             'objectClassName' => $this->builder->getClassNameFromBuilder($this->builder->getStubObjectBuilder()),
@@ -160,7 +160,7 @@ class I18nBehaviorObjectBuilderModifier
      *
      * @return string
      */
-    protected function addGetLocaleAlias($alias)
+    protected function addGetLocaleAlias($alias): string
     {
         return $this->behavior->renderTemplate('objectGetLocaleAlias', [
             'alias' => ucfirst($alias),
@@ -171,7 +171,7 @@ class I18nBehaviorObjectBuilderModifier
     /**
      * @return string
      */
-    protected function addGetTranslation()
+    protected function addGetTranslation(): string
     {
         $plural = false;
         $i18nTable = $this->behavior->getI18nTable();
@@ -190,7 +190,7 @@ class I18nBehaviorObjectBuilderModifier
     /**
      * @return string
      */
-    protected function addRemoveTranslation()
+    protected function addRemoveTranslation(): string
     {
         $i18nTable = $this->behavior->getI18nTable();
         $fk = $this->behavior->getI18nForeignKey();
@@ -207,7 +207,7 @@ class I18nBehaviorObjectBuilderModifier
     /**
      * @return string
      */
-    protected function addGetCurrentTranslation()
+    protected function addGetCurrentTranslation(): string
     {
         return $this->behavior->renderTemplate('objectGetCurrentTranslation', [
             'i18nTablePhpName' => $this->builder->getClassNameFromBuilder($this->builder->getNewStubObjectBuilder($this->behavior->getI18nTable())),
@@ -222,7 +222,7 @@ class I18nBehaviorObjectBuilderModifier
      *
      * @return string
      */
-    protected function addTranslatedColumnGetter(Column $column)
+    protected function addTranslatedColumnGetter(Column $column): string
     {
         $objectBuilder = $this->builder->getNewObjectBuilder($this->behavior->getI18nTable());
         $comment = '';
@@ -253,7 +253,7 @@ class I18nBehaviorObjectBuilderModifier
      *
      * @return string
      */
-    protected function addTranslatedColumnSetter(Column $column)
+    protected function addTranslatedColumnSetter(Column $column): string
     {
         $i18nTablePhpName = $this->builder->getClassNameFromBuilder($this->builder->getNewStubObjectBuilder($this->behavior->getI18nTable()));
         $tablePhpName = $this->builder->getObjectClassName();
@@ -286,7 +286,7 @@ class I18nBehaviorObjectBuilderModifier
      *
      * @return void
      */
-    public function objectFilter(&$script, $builder)
+    public function objectFilter(&$script, $builder): void
     {
         $i18nTable = $this->behavior->getI18nTable();
         $i18nTablePhpName = $this->builder->getNewStubObjectBuilder($i18nTable)->getUnprefixedClassName();
@@ -306,7 +306,7 @@ class I18nBehaviorObjectBuilderModifier
      *
      * @return bool
      */
-    protected function isDateType($columnType)
+    protected function isDateType($columnType): bool
     {
         return in_array($columnType, [
             PropelTypes::DATE,

--- a/src/Propel/Generator/Behavior/I18n/I18nBehaviorQueryBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/I18n/I18nBehaviorQueryBuilderModifier.php
@@ -45,7 +45,7 @@ class I18nBehaviorQueryBuilderModifier
      *
      * @return string
      */
-    public function queryMethods($builder)
+    public function queryMethods($builder): string
     {
         $this->builder = $builder;
         $script = '';
@@ -59,7 +59,7 @@ class I18nBehaviorQueryBuilderModifier
     /**
      * @return string
      */
-    protected function addJoinI18n()
+    protected function addJoinI18n(): string
     {
         $fk = $this->behavior->getI18nForeignKey();
 
@@ -74,7 +74,7 @@ class I18nBehaviorQueryBuilderModifier
     /**
      * @return string
      */
-    protected function addJoinWithI18n()
+    protected function addJoinWithI18n(): string
     {
         $fk = $this->behavior->getI18nForeignKey();
 
@@ -88,7 +88,7 @@ class I18nBehaviorQueryBuilderModifier
     /**
      * @return string
      */
-    protected function addUseI18nQuery()
+    protected function addUseI18nQuery(): string
     {
         $i18nTable = $this->behavior->getI18nTable();
         $fk = $this->behavior->getI18nForeignKey();

--- a/src/Propel/Generator/Behavior/NestedSet/NestedSetBehavior.php
+++ b/src/Propel/Generator/Behavior/NestedSet/NestedSetBehavior.php
@@ -9,6 +9,7 @@
 namespace Propel\Generator\Behavior\NestedSet;
 
 use Propel\Generator\Model\Behavior;
+use Propel\Generator\Model\Column;
 
 /**
  * Behavior to adds nested set tree structure columns and abilities
@@ -20,7 +21,7 @@ class NestedSetBehavior extends Behavior
     /**
      * Default parameters value
      *
-     * @var array<string>
+     * @var array<string, mixed>
      */
     protected $parameters = [
         'left_column' => 'tree_left',
@@ -46,7 +47,7 @@ class NestedSetBehavior extends Behavior
      *
      * @return void
      */
-    public function modifyTable()
+    public function modifyTable(): void
     {
         $table = $this->getTable();
 
@@ -106,7 +107,7 @@ class NestedSetBehavior extends Behavior
     /**
      * @return bool
      */
-    public function useScope()
+    public function useScope(): bool
     {
         return $this->getParameter('use_scope') === 'true';
     }
@@ -116,7 +117,7 @@ class NestedSetBehavior extends Behavior
      *
      * @return string
      */
-    public function getColumnConstant($columnName)
+    public function getColumnConstant($columnName): string
     {
         return $this->getColumn($columnName)->getName();
     }
@@ -126,7 +127,7 @@ class NestedSetBehavior extends Behavior
      *
      * @return \Propel\Generator\Model\Column
      */
-    public function getColumn($columnName)
+    public function getColumn($columnName): Column
     {
         return $this->getColumnForParameter($columnName);
     }

--- a/src/Propel/Generator/Behavior/NestedSet/NestedSetBehaviorObjectBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/NestedSet/NestedSetBehaviorObjectBuilderModifier.php
@@ -57,7 +57,7 @@ class NestedSetBehaviorObjectBuilderModifier
      *
      * @return string
      */
-    protected function getColumnAttribute($name)
+    protected function getColumnAttribute($name): string
     {
         return strtolower($this->behavior->getColumnForParameter($name)->getName());
     }
@@ -67,7 +67,7 @@ class NestedSetBehaviorObjectBuilderModifier
      *
      * @return string
      */
-    protected function getColumnPhpName($name)
+    protected function getColumnPhpName($name): string
     {
         return $this->behavior->getColumnForParameter($name)->getPhpName();
     }
@@ -77,7 +77,7 @@ class NestedSetBehaviorObjectBuilderModifier
      *
      * @return void
      */
-    protected function setBuilder(ObjectBuilder $builder)
+    protected function setBuilder(ObjectBuilder $builder): void
     {
         $this->builder = $builder;
     }
@@ -87,7 +87,7 @@ class NestedSetBehaviorObjectBuilderModifier
      *
      * @return string
      */
-    public function preSave(ObjectBuilder $builder)
+    public function preSave(ObjectBuilder $builder): string
     {
         $queryClassName = $builder->getQueryClassName();
         $objectClassName = $builder->getObjectClassName();
@@ -126,7 +126,7 @@ class NestedSetBehaviorObjectBuilderModifier
      *
      * @return string
      */
-    public function preDelete(ObjectBuilder $builder)
+    public function preDelete(ObjectBuilder $builder): string
     {
         $queryClassName = $builder->getQueryClassName();
 
@@ -145,7 +145,7 @@ if (\$this->isInTree()) {
      *
      * @return string
      */
-    public function postDelete(ObjectBuilder $builder)
+    public function postDelete(ObjectBuilder $builder): string
     {
         $queryClassName = $builder->getQueryClassName();
 
@@ -161,7 +161,7 @@ if (\$this->isInTree()) {
      *
      * @return string
      */
-    public function objectClearReferences(ObjectBuilder $builder)
+    public function objectClearReferences(ObjectBuilder $builder): string
     {
         return "\$this->collNestedSetChildren = null;
 \$this->aNestedSetParent = null;";
@@ -172,7 +172,7 @@ if (\$this->isInTree()) {
      *
      * @return string
      */
-    public function objectMethods(ObjectBuilder $builder)
+    public function objectMethods(ObjectBuilder $builder): string
     {
         $this->setBuilder($builder);
         $script = '';
@@ -275,7 +275,7 @@ if (\$this->isInTree()) {
      *
      * @return void
      */
-    protected function addProcessNestedSetQueries(&$script)
+    protected function addProcessNestedSetQueries(&$script): void
     {
         $script .= "
 /**
@@ -299,7 +299,7 @@ protected function processNestedSetQueries(ConnectionInterface \$con)
      *
      * @return void
      */
-    protected function addGetLeft(&$script)
+    protected function addGetLeft(&$script): void
     {
         $script .= "
 /**
@@ -320,7 +320,7 @@ public function getLeftValue()
      *
      * @return void
      */
-    protected function addGetRight(&$script)
+    protected function addGetRight(&$script): void
     {
         $script .= "
 /**
@@ -341,7 +341,7 @@ public function getRightValue()
      *
      * @return void
      */
-    protected function addGetLevel(&$script)
+    protected function addGetLevel(&$script): void
     {
         $script .= "
 /**
@@ -362,7 +362,7 @@ public function getLevel()
      *
      * @return void
      */
-    protected function addGetScope(&$script)
+    protected function addGetScope(&$script): void
     {
         $script .= "
 /**
@@ -381,7 +381,7 @@ public function getScopeValue()
     /**
      * @return string
      */
-    protected function addSetLeft()
+    protected function addSetLeft(): string
     {
         return $this->behavior->renderTemplate('objectSetLeft', [
             'objectClassName' => $this->builder->getObjectClassName(),
@@ -394,7 +394,7 @@ public function getScopeValue()
      *
      * @return void
      */
-    protected function addSetRight(&$script)
+    protected function addSetRight(&$script): void
     {
         $objectClassName = $this->builder->getObjectClassName();
 
@@ -418,7 +418,7 @@ public function setRightValue(\$v)
      *
      * @return void
      */
-    protected function addSetLevel(&$script)
+    protected function addSetLevel(&$script): void
     {
         $objectClassName = $this->builder->getObjectClassName();
 
@@ -442,7 +442,7 @@ public function setLevel(\$v)
      *
      * @return void
      */
-    protected function addSetScope(&$script)
+    protected function addSetScope(&$script): void
     {
         $objectClassName = $this->builder->getObjectClassName();
 
@@ -466,7 +466,7 @@ public function setScopeValue(\$v)
      *
      * @return void
      */
-    protected function addMakeRoot(&$script)
+    protected function addMakeRoot(&$script): void
     {
         $objectClassName = $this->builder->getObjectClassName();
 
@@ -497,7 +497,7 @@ public function makeRoot()
      *
      * @return void
      */
-    protected function addIsInTree(&$script)
+    protected function addIsInTree(&$script): void
     {
         $script .= "
 /**
@@ -517,7 +517,7 @@ public function isInTree()
      *
      * @return void
      */
-    protected function addIsRoot(&$script)
+    protected function addIsRoot(&$script): void
     {
         $script .= "
 /**
@@ -537,7 +537,7 @@ public function isRoot()
      *
      * @return void
      */
-    protected function addIsLeaf(&$script)
+    protected function addIsLeaf(&$script): void
     {
         $script .= "
 /**
@@ -557,7 +557,7 @@ public function isLeaf()
      *
      * @return void
      */
-    protected function addIsDescendantOf(&$script)
+    protected function addIsDescendantOf(&$script): void
     {
         $objectClassName = $this->builder->getObjectClassName();
 
@@ -588,7 +588,7 @@ public function isDescendantOf($objectClassName \$parent)
      *
      * @return void
      */
-    protected function addIsAncestorOf(&$script)
+    protected function addIsAncestorOf(&$script): void
     {
         $objectClassName = $this->builder->getObjectClassName();
 
@@ -611,7 +611,7 @@ public function isAncestorOf($objectClassName \$child)
      *
      * @return void
      */
-    protected function addHasParent(&$script)
+    protected function addHasParent(&$script): void
     {
         $script .= "
 /**
@@ -619,7 +619,7 @@ public function isAncestorOf($objectClassName \$child)
  *
  * @return boolean
  */
-public function hasParent()
+public function hasParent(): bool
 {
     return \$this->getLevel() > 0;
 }
@@ -631,7 +631,7 @@ public function hasParent()
      *
      * @return void
      */
-    protected function addSetParent(&$script)
+    protected function addSetParent(&$script): void
     {
         $objectClassName = $this->builder->getObjectClassName();
 
@@ -658,7 +658,7 @@ public function setParent($objectClassName \$parent = null)
      *
      * @return void
      */
-    protected function addGetParent(&$script)
+    protected function addGetParent(&$script): void
     {
         $objectClassName = $this->builder->getObjectClassName();
         $queryClassName = $this->builder->getQueryClassName();
@@ -690,7 +690,7 @@ public function getParent(ConnectionInterface \$con = null)
      *
      * @return void
      */
-    protected function addHasPrevSibling(&$script)
+    protected function addHasPrevSibling(&$script): void
     {
         $queryClassName = $this->builder->getQueryClassName();
 
@@ -701,7 +701,7 @@ public function getParent(ConnectionInterface \$con = null)
  * @param      ConnectionInterface \$con Connection to use.
  * @return     bool
  */
-public function hasPrevSibling(ConnectionInterface \$con = null)
+public function hasPrevSibling(ConnectionInterface \$con = null): bool
 {
     if (!{$queryClassName}::isValid(\$this)) {
         return false;
@@ -724,7 +724,7 @@ public function hasPrevSibling(ConnectionInterface \$con = null)
      *
      * @return void
      */
-    protected function addGetPrevSibling(&$script)
+    protected function addGetPrevSibling(&$script): void
     {
         $objectClassName = $this->builder->getObjectClassName();
         $queryClassName = $this->builder->getQueryClassName();
@@ -755,7 +755,7 @@ public function getPrevSibling(ConnectionInterface \$con = null)
      *
      * @return void
      */
-    protected function addHasNextSibling(&$script)
+    protected function addHasNextSibling(&$script): void
     {
         $queryClassName = $this->builder->getQueryClassName();
 
@@ -766,7 +766,7 @@ public function getPrevSibling(ConnectionInterface \$con = null)
  * @param      ConnectionInterface \$con Connection to use.
  * @return     bool
  */
-public function hasNextSibling(ConnectionInterface \$con = null)
+public function hasNextSibling(ConnectionInterface \$con = null): bool
 {
     if (!{$queryClassName}::isValid(\$this)) {
         return false;
@@ -789,7 +789,7 @@ public function hasNextSibling(ConnectionInterface \$con = null)
      *
      * @return void
      */
-    protected function addGetNextSibling(&$script)
+    protected function addGetNextSibling(&$script): void
     {
         $objectClassName = $this->builder->getObjectClassName();
         $queryClassName = $this->builder->getQueryClassName();
@@ -820,7 +820,7 @@ public function getNextSibling(ConnectionInterface \$con = null)
      *
      * @return void
      */
-    protected function addNestedSetChildrenClear(&$script)
+    protected function addNestedSetChildrenClear(&$script): void
     {
         $script .= "
 /**
@@ -843,7 +843,7 @@ public function clearNestedSetChildren()
      *
      * @return void
      */
-    protected function addNestedSetChildrenInit(&$script)
+    protected function addNestedSetChildrenInit(&$script): void
     {
         $script .= "
 /**
@@ -866,7 +866,7 @@ public function initNestedSetChildren()
      *
      * @return void
      */
-    protected function addNestedSetChildAdd(&$script)
+    protected function addNestedSetChildAdd(&$script): void
     {
         $objectClassName = $this->builder->getObjectClassName();
         $objectName = '$' . $this->table->getCamelCaseName();
@@ -899,7 +899,7 @@ public function addNestedSetChild($objectClassName $objectName)
      *
      * @return void
      */
-    protected function addHasChildren(&$script)
+    protected function addHasChildren(&$script): void
     {
         $script .= "
 /**
@@ -907,7 +907,7 @@ public function addNestedSetChild($objectClassName $objectName)
  *
  * @return     bool
  */
-public function hasChildren()
+public function hasChildren(): bool
 {
     return (\$this->getRightValue() - \$this->getLeftValue()) > 1;
 }
@@ -919,7 +919,7 @@ public function hasChildren()
      *
      * @return void
      */
-    protected function addGetChildren(&$script)
+    protected function addGetChildren(&$script): void
     {
         $objectClassName = $this->builder->getObjectClassName();
         $queryClassName = $this->builder->getQueryClassName();
@@ -960,7 +960,7 @@ public function getChildren(Criteria \$criteria = null, ConnectionInterface \$co
      *
      * @return void
      */
-    protected function addCountChildren(&$script)
+    protected function addCountChildren(&$script): void
     {
         $queryClassName = $this->builder->getQueryClassName();
 
@@ -994,7 +994,7 @@ public function countChildren(Criteria \$criteria = null, ConnectionInterface \$
      *
      * @return void
      */
-    protected function addGetFirstChild(&$script)
+    protected function addGetFirstChild(&$script): void
     {
         $objectClassName = $this->builder->getObjectClassName();
         $queryClassName = $this->builder->getQueryClassName();
@@ -1025,7 +1025,7 @@ public function getFirstChild(Criteria \$criteria = null, ConnectionInterface \$
      *
      * @return void
      */
-    protected function addGetLastChild(&$script)
+    protected function addGetLastChild(&$script): void
     {
         $objectClassName = $this->builder->getObjectClassName();
         $queryClassName = $this->builder->getQueryClassName();
@@ -1057,7 +1057,7 @@ public function getLastChild(Criteria \$criteria = null, ConnectionInterface \$c
      *
      * @return void
      */
-    protected function addGetSiblings(&$script)
+    protected function addGetSiblings(&$script): void
     {
         $objectClassName = $this->builder->getObjectClassName();
         $queryClassName = $this->builder->getQueryClassName();
@@ -1095,7 +1095,7 @@ public function getSiblings(\$includeNode = false, Criteria \$criteria = null, C
      *
      * @return void
      */
-    protected function addGetDescendants(&$script)
+    protected function addGetDescendants(&$script): void
     {
         $objectClassName = $this->builder->getObjectClassName();
         $queryClassName = $this->builder->getQueryClassName();
@@ -1127,7 +1127,7 @@ public function getDescendants(Criteria \$criteria = null, ConnectionInterface \
      *
      * @return void
      */
-    protected function addCountDescendants(&$script)
+    protected function addCountDescendants(&$script): void
     {
         $queryClassName = $this->builder->getQueryClassName();
 
@@ -1158,7 +1158,7 @@ public function countDescendants(Criteria \$criteria = null, ConnectionInterface
      *
      * @return void
      */
-    protected function addGetBranch(&$script)
+    protected function addGetBranch(&$script): void
     {
         $objectClassName = $this->builder->getObjectClassName();
         $queryClassName = $this->builder->getQueryClassName();
@@ -1186,7 +1186,7 @@ public function getBranch(Criteria \$criteria = null, ConnectionInterface \$con 
      *
      * @return void
      */
-    protected function addGetAncestors(&$script)
+    protected function addGetAncestors(&$script): void
     {
         $objectClassName = $this->builder->getObjectClassName();
         $queryClassName = $this->builder->getQueryClassName();
@@ -1220,7 +1220,7 @@ public function getAncestors(Criteria \$criteria = null, ConnectionInterface \$c
      *
      * @return void
      */
-    protected function addAddChild(&$script)
+    protected function addAddChild(&$script): void
     {
         $objectClassName = $this->builder->getObjectClassName();
 
@@ -1251,7 +1251,7 @@ public function addChild($objectClassName \$child)
      *
      * @return void
      */
-    protected function addInsertAsFirstChildOf(&$script)
+    protected function addInsertAsFirstChildOf(&$script): void
     {
         $objectClassName = $this->builder->getObjectClassName();
         $queryClassName = $this->builder->getQueryClassName(true);
@@ -1302,7 +1302,7 @@ public function insertAsFirstChildOf($objectClassName \$parent)
     /**
      * @return string
      */
-    protected function addInsertAsLastChildOf()
+    protected function addInsertAsLastChildOf(): string
     {
         return $this->behavior->renderTemplate('objectInsertAsLastChildOf', [
             'objectClassName' => $this->builder->getObjectClassName(),
@@ -1316,7 +1316,7 @@ public function insertAsFirstChildOf($objectClassName \$parent)
      *
      * @return void
      */
-    protected function addInsertAsPrevSiblingOf(&$script)
+    protected function addInsertAsPrevSiblingOf(&$script): void
     {
         $objectClassName = $this->builder->getObjectClassName();
         $queryClassName = $this->builder->getQueryClassName(true);
@@ -1364,7 +1364,7 @@ public function insertAsPrevSiblingOf($objectClassName \$sibling)
      *
      * @return void
      */
-    protected function addInsertAsNextSiblingOf(&$script)
+    protected function addInsertAsNextSiblingOf(&$script): void
     {
         $objectClassName = $this->builder->getObjectClassName();
         $queryClassName = $this->builder->getQueryClassName(true);
@@ -1412,7 +1412,7 @@ public function insertAsNextSiblingOf($objectClassName \$sibling)
      *
      * @return void
      */
-    protected function addMoveToFirstChildOf(&$script)
+    protected function addMoveToFirstChildOf(&$script): void
     {
         $objectClassName = $this->builder->getObjectClassName();
         $script .= "
@@ -1448,7 +1448,7 @@ public function moveToFirstChildOf($objectClassName \$parent, ConnectionInterfac
      *
      * @return void
      */
-    protected function addMoveToLastChildOf(&$script)
+    protected function addMoveToLastChildOf(&$script): void
     {
         $objectClassName = $this->builder->getObjectClassName();
 
@@ -1485,7 +1485,7 @@ public function moveToLastChildOf($objectClassName \$parent, ConnectionInterface
      *
      * @return void
      */
-    protected function addMoveToPrevSiblingOf(&$script)
+    protected function addMoveToPrevSiblingOf(&$script): void
     {
         $objectClassName = $this->builder->getObjectClassName();
 
@@ -1525,7 +1525,7 @@ public function moveToPrevSiblingOf($objectClassName \$sibling, ConnectionInterf
      *
      * @return void
      */
-    protected function addMoveToNextSiblingOf(&$script)
+    protected function addMoveToNextSiblingOf(&$script): void
     {
         $objectClassName = $this->builder->getObjectClassName();
 
@@ -1565,7 +1565,7 @@ public function moveToNextSiblingOf($objectClassName \$sibling, ConnectionInterf
      *
      * @return void
      */
-    protected function addMoveSubtreeTo(&$script)
+    protected function addMoveSubtreeTo(&$script): void
     {
         $queryClassName = $this->builder->getQueryClassName();
         $tableMapClass = $this->builder->getTableMapClass();
@@ -1663,7 +1663,7 @@ protected function moveSubtreeTo(\$destLeft, \$levelDelta" . ($this->behavior->u
      *
      * @return void
      */
-    protected function addDeleteDescendants(&$script)
+    protected function addDeleteDescendants(&$script): void
     {
         $objectClassName = $this->builder->getObjectClassName();
         $queryClassName = $this->builder->getQueryClassName();
@@ -1720,7 +1720,7 @@ public function deleteDescendants(ConnectionInterface \$con = null)
      *
      * @return string
      */
-    public function objectAttributes(ObjectBuilder $builder)
+    public function objectAttributes(ObjectBuilder $builder): string
     {
         $tableName = $this->table->getName();
         $objectClassName = $builder->getObjectClassName();
@@ -1775,7 +1775,7 @@ const SCOPE_COL = '" . $tableName . '.' . $this->behavior->getColumnConstant('sc
     /**
      * @return string
      */
-    protected function addGetIterator()
+    protected function addGetIterator(): string
     {
         return $this->behavior->renderTemplate('objectGetIterator');
     }

--- a/src/Propel/Generator/Behavior/NestedSet/NestedSetBehaviorObjectBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/NestedSet/NestedSetBehaviorObjectBuilderModifier.php
@@ -131,7 +131,7 @@ class NestedSetBehaviorObjectBuilderModifier
         $queryClassName = $builder->getQueryClassName();
 
         return "if (\$this->isRoot()) {
-    throw new PropelException('Deletion of a root node is disabled for nested sets. Use $queryClassName::deleteTree(" . ($this->behavior->useScope() ? '$scope' : '') . ") instead to delete an entire tree');
+    throw new PropelException('Deletion of a root node is disabled for nested sets. Use `$queryClassName::deleteTree(" . ($this->behavior->useScope() ? '$scope' : '') . ")` instead to delete an entire tree');
 }
 
 if (\$this->isInTree()) {

--- a/src/Propel/Generator/Behavior/NestedSet/NestedSetBehaviorObjectBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/NestedSet/NestedSetBehaviorObjectBuilderModifier.php
@@ -617,7 +617,7 @@ public function isAncestorOf($objectClassName \$child)
 /**
  * Tests if object has an ancestor
  *
- * @return boolean
+ * @return bool
  */
 public function hasParent(): bool
 {
@@ -1066,7 +1066,7 @@ public function getLastChild(Criteria \$criteria = null, ConnectionInterface \$c
 /**
  * Gets the siblings of the given node
  *
- * @param boolean             \$includeNode Whether to include the current node or not
+ * @param bool                \$includeNode Whether to include the current node or not
  * @param Criteria            \$criteria Criteria to filter results.
  * @param ConnectionInterface \$con Connection to use.
  *

--- a/src/Propel/Generator/Behavior/NestedSet/NestedSetBehaviorQueryBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/NestedSet/NestedSetBehaviorQueryBuilderModifier.php
@@ -9,6 +9,7 @@
 namespace Propel\Generator\Behavior\NestedSet;
 
 use Propel\Generator\Builder\Om\QueryBuilder;
+use Propel\Generator\Model\Column;
 
 /**
  * Behavior to adds nested set tree structure columns and abilities
@@ -71,7 +72,7 @@ class NestedSetBehaviorQueryBuilderModifier
      *
      * @return \Propel\Generator\Model\Column
      */
-    protected function getColumn($name)
+    protected function getColumn($name): Column
     {
         return $this->behavior->getColumnForParameter($name);
     }
@@ -81,7 +82,7 @@ class NestedSetBehaviorQueryBuilderModifier
      *
      * @return void
      */
-    protected function setBuilder(QueryBuilder $builder)
+    protected function setBuilder(QueryBuilder $builder): void
     {
         $this->builder = $builder;
         $this->objectClassName = $builder->getObjectClassName();
@@ -94,7 +95,7 @@ class NestedSetBehaviorQueryBuilderModifier
      *
      * @return string
      */
-    public function queryMethods(QueryBuilder $builder)
+    public function queryMethods(QueryBuilder $builder): string
     {
         $this->setBuilder($builder);
         $script = '';
@@ -147,7 +148,7 @@ class NestedSetBehaviorQueryBuilderModifier
      *
      * @return void
      */
-    protected function addTreeRoots(&$script)
+    protected function addTreeRoots(&$script): void
     {
         $script .= "
 /**
@@ -167,7 +168,7 @@ public function treeRoots()
      *
      * @return void
      */
-    protected function addInTree(&$script)
+    protected function addInTree(&$script): void
     {
         $script .= "
 /**
@@ -189,7 +190,7 @@ public function inTree(\$scope = null)
      *
      * @return void
      */
-    protected function addDescendantsOf(&$script)
+    protected function addDescendantsOf(&$script): void
     {
         $objectName = '$' . $this->table->getCamelCaseName();
         $script .= "
@@ -219,7 +220,7 @@ public function descendantsOf($this->objectClassName $objectName)
      *
      * @return void
      */
-    protected function addBranchOf(&$script)
+    protected function addBranchOf(&$script): void
     {
         $objectName = '$' . $this->table->getCamelCaseName();
         $script .= "
@@ -250,7 +251,7 @@ public function branchOf($this->objectClassName $objectName)
      *
      * @return void
      */
-    protected function addChildrenOf(&$script)
+    protected function addChildrenOf(&$script): void
     {
         $objectName = '$' . $this->table->getCamelCaseName();
         $script .= "
@@ -275,7 +276,7 @@ public function childrenOf($this->objectClassName $objectName)
      *
      * @return void
      */
-    protected function addSiblingsOf(&$script)
+    protected function addSiblingsOf(&$script): void
     {
         $objectName = '$' . $this->table->getCamelCaseName();
         $script .= "
@@ -307,7 +308,7 @@ public function siblingsOf($this->objectClassName $objectName, ConnectionInterfa
      *
      * @return void
      */
-    protected function addAncestorsOf(&$script)
+    protected function addAncestorsOf(&$script): void
     {
         $objectName = '$' . $this->table->getCamelCaseName();
         $script .= "
@@ -337,7 +338,7 @@ public function ancestorsOf($this->objectClassName $objectName)
      *
      * @return void
      */
-    protected function addRootsOf(&$script)
+    protected function addRootsOf(&$script): void
     {
         $objectName = '$' . $this->table->getCamelCaseName();
         $script .= "
@@ -368,7 +369,7 @@ public function rootsOf($this->objectClassName $objectName)
      *
      * @return void
      */
-    protected function addOrderByBranch(&$script)
+    protected function addOrderByBranch(&$script): void
     {
         $script .= "
 /**
@@ -396,7 +397,7 @@ public function orderByBranch(\$reverse = false)
      *
      * @return void
      */
-    protected function addOrderByLevel(&$script)
+    protected function addOrderByLevel(&$script): void
     {
         $script .= "
 /**
@@ -426,7 +427,7 @@ public function orderByLevel(\$reverse = false)
      *
      * @return void
      */
-    protected function addFindRoot(&$script)
+    protected function addFindRoot(&$script): void
     {
         $useScope = $this->behavior->useScope();
         $script .= "
@@ -462,7 +463,7 @@ public function findRoot(" . ($useScope ? '$scope = null, ' : '') . "ConnectionI
      *
      * @return void
      */
-    protected function addFindRoots(&$script)
+    protected function addFindRoots(&$script): void
     {
         $script .= "
 /**
@@ -486,7 +487,7 @@ public function findRoots(ConnectionInterface \$con = null)
      *
      * @return void
      */
-    protected function addFindTree(&$script)
+    protected function addFindTree(&$script): void
     {
         $useScope = $this->behavior->useScope();
         $script .= "
@@ -522,7 +523,7 @@ public function findTree(" . ($useScope ? '$scope = null, ' : '') . "ConnectionI
      *
      * @return void
      */
-    protected function addRetrieveRoots(&$script)
+    protected function addRetrieveRoots(&$script): void
     {
         $queryClassName = $this->queryClassName;
         $objectClassName = $this->objectClassName;
@@ -553,7 +554,7 @@ static public function retrieveRoots(Criteria \$criteria = null, ConnectionInter
      *
      * @return void
      */
-    protected function addRetrieveRoot(&$script)
+    protected function addRetrieveRoot(&$script): void
     {
         $queryClassName = $this->queryClassName;
         $objectClassName = $this->objectClassName;
@@ -592,7 +593,7 @@ static public function retrieveRoot(" . ($useScope ? '$scope = null, ' : '') . "
      *
      * @return void
      */
-    protected function addRetrieveTree(&$script)
+    protected function addRetrieveTree(&$script): void
     {
         $queryClassName = $this->queryClassName;
         $objectClassName = $this->objectClassName;
@@ -634,7 +635,7 @@ static public function retrieveTree(" . ($useScope ? '$scope = null, ' : '') . "
      *
      * @return void
      */
-    protected function addIsValid(&$script)
+    protected function addIsValid(&$script): void
     {
         $objectClassName = $this->objectClassName;
 
@@ -661,7 +662,7 @@ static public function isValid($objectClassName \$node = null)
      *
      * @return void
      */
-    protected function addDeleteTree(&$script)
+    protected function addDeleteTree(&$script): void
     {
         $objectClassName = $this->objectClassName;
         $useScope = $this->behavior->useScope();
@@ -703,7 +704,7 @@ static public function deleteTree(" . ($useScope ? '$scope = null, ' : '') . "Co
      *
      * @return void
      */
-    protected function addShiftRLValues(&$script)
+    protected function addShiftRLValues(&$script): void
     {
         $objectClassName = $this->objectClassName;
         $useScope = $this->behavior->useScope();
@@ -776,7 +777,7 @@ static public function shiftRLValues(\$delta, \$first, \$last = null" . ($useSco
      *
      * @return void
      */
-    protected function addShiftLevel(&$script)
+    protected function addShiftLevel(&$script): void
     {
         $objectClassName = $this->objectClassName;
         $useScope = $this->behavior->useScope();
@@ -827,7 +828,7 @@ static public function shiftLevel(\$delta, \$first, \$last" . ($useScope ? ', $s
      *
      * @return void
      */
-    protected function addUpdateLoadedNodes(&$script)
+    protected function addUpdateLoadedNodes(&$script): void
     {
         $queryClassName = $this->queryClassName;
         $objectClassName = $this->objectClassName;
@@ -929,7 +930,7 @@ static public function updateLoadedNodes(\$prune = null, ConnectionInterface \$c
      *
      * @return void
      */
-    protected function addMakeRoomForLeaf(&$script)
+    protected function addMakeRoomForLeaf(&$script): void
     {
         $queryClassName = $this->queryClassName;
         $useScope = $this->behavior->useScope();
@@ -963,7 +964,7 @@ static public function makeRoomForLeaf(\$left" . ($useScope ? ', $scope' : '') .
      *
      * @return void
      */
-    protected function addFixLevels(&$script)
+    protected function addFixLevels(&$script): void
     {
         $objectClassName = $this->objectClassName;
         $queryClassName = $this->queryClassName;
@@ -1055,7 +1056,7 @@ static public function fixLevels(" . ($useScope ? '$scope, ' : '') . "Connection
      *
      * @return void
      */
-    protected function addSetNegativeScope(&$script)
+    protected function addSetNegativeScope(&$script): void
     {
         $objectClassName = $this->objectClassName;
         $tableMapClassName = $this->tableMapClassName;
@@ -1085,7 +1086,7 @@ public static function setNegativeScope(\$scope, ConnectionInterface \$con = nul
      *
      * @return string
      */
-    protected function getColumnPhpName($columnName)
+    protected function getColumnPhpName($columnName): string
     {
         return $this->behavior->getColumnForParameter($columnName)->getPhpName();
     }

--- a/src/Propel/Generator/Behavior/QueryCache/QueryCacheBehavior.php
+++ b/src/Propel/Generator/Behavior/QueryCache/QueryCacheBehavior.php
@@ -20,7 +20,7 @@ class QueryCacheBehavior extends Behavior
     /**
      * Default parameters value
      *
-     * @var array<string>
+     * @var array<string, mixed>
      */
     protected $parameters = [
         'backend' => 'apc',
@@ -37,7 +37,7 @@ class QueryCacheBehavior extends Behavior
      *
      * @return string
      */
-    public function queryAttributes($builder)
+    public function queryAttributes($builder): string
     {
         $script = "protected \$queryKey = '';
 ";
@@ -65,7 +65,7 @@ class QueryCacheBehavior extends Behavior
      *
      * @return string
      */
-    public function queryMethods($builder)
+    public function queryMethods($builder): string
     {
         $builder->declareClasses('\Propel\Runtime\Propel');
         $this->tableClassName = $builder->getTableMapClassName();
@@ -86,7 +86,7 @@ class QueryCacheBehavior extends Behavior
      *
      * @return void
      */
-    protected function addSetQueryKey(&$script)
+    protected function addSetQueryKey(&$script): void
     {
         $script .= "
 public function setQueryKey(\$key)
@@ -103,7 +103,7 @@ public function setQueryKey(\$key)
      *
      * @return void
      */
-    protected function addGetQueryKey(&$script)
+    protected function addGetQueryKey(&$script): void
     {
         $script .= "
 public function getQueryKey()
@@ -118,7 +118,7 @@ public function getQueryKey()
      *
      * @return void
      */
-    protected function addCacheContains(&$script)
+    protected function addCacheContains(&$script): void
     {
         $script .= "
 public function cacheContains(\$key)
@@ -153,7 +153,7 @@ public function cacheContains(\$key)
      *
      * @return void
      */
-    protected function addCacheStore(&$script)
+    protected function addCacheStore(&$script): void
     {
         $script .= "
 public function cacheStore(\$key, \$value, \$lifetime = " . $this->getParameter('lifetime') . ")
@@ -186,7 +186,7 @@ public function cacheStore(\$key, \$value, \$lifetime = " . $this->getParameter(
      *
      * @return void
      */
-    protected function addCacheFetch(&$script)
+    protected function addCacheFetch(&$script): void
     {
         $script .= "
 public function cacheFetch(\$key)
@@ -221,10 +221,10 @@ public function cacheFetch(\$key)
      *
      * @return void
      */
-    protected function addDoSelect(&$script)
+    protected function addDoSelect(&$script): void
     {
         $script .= "
-public function doSelect(ConnectionInterface \$con = null)
+public function doSelect(ConnectionInterface \$con = null): \Propel\Runtime\DataFetcher\DataFetcherInterface
 {
     // check that the columns of the main class are already added (if this is the primary ModelCriteria)
     if (!\$this->hasSelectClause() && !\$this->getPrimaryCriteria()) {
@@ -267,10 +267,10 @@ public function doSelect(ConnectionInterface \$con = null)
      *
      * @return void
      */
-    protected function addDoCount(&$script)
+    protected function addDoCount(&$script): void
     {
         $script .= "
-public function doCount(ConnectionInterface \$con = null)
+public function doCount(ConnectionInterface \$con = null): \Propel\Runtime\DataFetcher\DataFetcherInterface
 {
     \$dbMap = Propel::getServiceContainer()->getDatabaseMap(\$this->getDbName());
     \$db = Propel::getServiceContainer()->getAdapter(\$this->getDbName());

--- a/src/Propel/Generator/Behavior/Sluggable/SluggableBehavior.php
+++ b/src/Propel/Generator/Behavior/Sluggable/SluggableBehavior.php
@@ -26,7 +26,7 @@ class SluggableBehavior extends Behavior
     private $builder;
 
     /**
-     * @var array
+     * @var array<string, mixed>
      */
     protected $parameters = [
         'slug_column' => 'slug',
@@ -44,7 +44,7 @@ class SluggableBehavior extends Behavior
      *
      * @return void
      */
-    public function modifyTable()
+    public function modifyTable(): void
     {
         $table = $this->getTable();
 
@@ -69,7 +69,7 @@ class SluggableBehavior extends Behavior
      *
      * @return void
      */
-    protected function addUniqueConstraint(Table $table)
+    protected function addUniqueConstraint(Table $table): void
     {
         $unique = new Unique();
         $unique->setName($table->getCommonName() . '_slug');
@@ -85,7 +85,7 @@ class SluggableBehavior extends Behavior
      *
      * @return string The related getter, e.g. 'getSlug'
      */
-    protected function getColumnGetter()
+    protected function getColumnGetter(): string
     {
         return 'get' . $this->getColumnForParameter('slug_column')->getPhpName();
     }
@@ -95,7 +95,7 @@ class SluggableBehavior extends Behavior
      *
      * @return string The related setter, e.g. 'setSlug'
      */
-    protected function getColumnSetter()
+    protected function getColumnSetter(): string
     {
         return 'set' . $this->getColumnForParameter('slug_column')->getPhpName();
     }
@@ -107,7 +107,7 @@ class SluggableBehavior extends Behavior
      *
      * @return string The code to put at the hook
      */
-    public function preSave($builder)
+    public function preSave($builder): string
     {
         $const = $builder->getColumnConstant($this->getColumnForParameter('slug_column'));
         $script = "
@@ -133,7 +133,7 @@ if (\$this->isColumnModified($const) && \$this->{$this->getColumnGetter()}()) {
      *
      * @return string
      */
-    public function objectMethods($builder)
+    public function objectMethods($builder): string
     {
         $this->builder = $builder;
         $script = '';
@@ -155,7 +155,7 @@ if (\$this->isColumnModified($const) && \$this->{$this->getColumnGetter()}()) {
      *
      * @return void
      */
-    protected function addSlugSetter(&$script)
+    protected function addSlugSetter(&$script): void
     {
         $script .= "
 /**
@@ -176,7 +176,7 @@ public function setSlug(\$v)
      *
      * @return void
      */
-    protected function addSlugGetter(&$script)
+    protected function addSlugGetter(&$script): void
     {
         $script .= "
 /**
@@ -196,7 +196,7 @@ public function getSlug()
      *
      * @return void
      */
-    protected function addCreateSlug(&$script)
+    protected function addCreateSlug(&$script): void
     {
         $script .= "
 /**
@@ -220,7 +220,7 @@ protected function createSlug()
      *
      * @return void
      */
-    protected function addCreateRawSlug(&$script)
+    protected function addCreateRawSlug(&$script): void
     {
         $pattern = $this->getParameter('slug_pattern');
         $script .= "
@@ -247,7 +247,7 @@ protected function createRawSlug()
      *
      * @return void
      */
-    public function addCleanupSlugPart(&$script)
+    public function addCleanupSlugPart(&$script): void
     {
         $script .= "
 /**
@@ -301,7 +301,7 @@ protected static function cleanupSlugPart(\$slug, \$replacement = '" . $this->ge
      *
      * @return void
      */
-    public function addLimitSlugSize(&$script)
+    public function addLimitSlugSize(&$script): void
     {
         $size = $this->getColumnForParameter('slug_column')->getSize();
         $script .= "
@@ -330,7 +330,7 @@ protected static function limitSlugSize(\$slug, \$incrementReservedSpace = 3)
      *
      * @return void
      */
-    public function addMakeSlugUnique(&$script)
+    public function addMakeSlugUnique(&$script): void
     {
         $script .= "
 
@@ -424,7 +424,7 @@ protected function makeSlugUnique(\$slug, \$separator = '" . $this->getParameter
      *
      * @return string
      */
-    public function queryMethods($builder)
+    public function queryMethods($builder): string
     {
         $this->builder = $builder;
         $script = '';
@@ -442,7 +442,7 @@ protected function makeSlugUnique(\$slug, \$separator = '" . $this->getParameter
      *
      * @return void
      */
-    protected function addFilterBySlug(&$script)
+    protected function addFilterBySlug(&$script): void
     {
         $script .= "
 /**
@@ -464,7 +464,7 @@ public function filterBySlug(\$slug)
      *
      * @return void
      */
-    protected function addFindOneBySlug(&$script)
+    protected function addFindOneBySlug(&$script): void
     {
         $script .= "
 /**

--- a/src/Propel/Generator/Behavior/Sortable/SortableBehavior.php
+++ b/src/Propel/Generator/Behavior/Sortable/SortableBehavior.php
@@ -23,7 +23,7 @@ class SortableBehavior extends Behavior
     /**
      * Default parameters value
      *
-     * @var array<string>
+     * @var array<string, mixed>
      */
     protected $parameters = [
         'rank_column' => 'sortable_rank',
@@ -53,7 +53,7 @@ class SortableBehavior extends Behavior
      *
      * @return void
      */
-    public function modifyTable()
+    public function modifyTable(): void
     {
         $table = $this->getTable();
 
@@ -121,7 +121,7 @@ class SortableBehavior extends Behavior
     /**
      * @return bool
      */
-    public function useScope()
+    public function useScope(): bool
     {
         return $this->getParameter('use_scope') === 'true';
     }
@@ -132,7 +132,7 @@ class SortableBehavior extends Behavior
      *
      * @return array ($methodSignature, $paramsDoc, $scopeBuilder, $buildScopeVars)
      */
-    public function generateScopePhp()
+    public function generateScopePhp(): array
     {
         $methodSignature = '';
         $paramsDoc = '';
@@ -184,7 +184,7 @@ class SortableBehavior extends Behavior
      *
      * @return string
      */
-    public function getColumnGetter($name)
+    public function getColumnGetter($name): string
     {
         return 'get' . $this->getTable()->getColumn($name)->getPhpName();
     }
@@ -196,7 +196,7 @@ class SortableBehavior extends Behavior
      *
      * @return string
      */
-    public function getColumnSetter($name)
+    public function getColumnSetter($name): string
     {
         return 'set' . $this->getTable()->getColumn($name)->getPhpName();
     }
@@ -204,7 +204,7 @@ class SortableBehavior extends Behavior
     /**
      * @inheritDoc
      */
-    public function addParameter(array $parameter)
+    public function addParameter(array $parameter): void
     {
         if ($parameter['name'] === 'scope_column') {
             $this->parameters['scope_column'] .= ($this->parameters['scope_column'] ? ',' : '') . $parameter['value'];
@@ -218,7 +218,7 @@ class SortableBehavior extends Behavior
      *
      * @return array<string>
      */
-    public function getScopes()
+    public function getScopes(): array
     {
         return $this->getParameter('scope_column')
             ? explode(',', str_replace(' ', '', trim($this->getParameter('scope_column'))))
@@ -230,7 +230,7 @@ class SortableBehavior extends Behavior
      *
      * @return bool
      */
-    public function hasMultipleScopes()
+    public function hasMultipleScopes(): bool
     {
         return count($this->getScopes()) > 1;
     }

--- a/src/Propel/Generator/Behavior/Sortable/SortableBehaviorObjectBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/Sortable/SortableBehaviorObjectBuilderModifier.php
@@ -348,9 +348,9 @@ public function setRank(\$v)
 /**
  * Wrap the getter for scope value
  *
- * @param boolean \$returnNulls If true and all scope values are null, this will return null instead of a array full with nulls
+ * @param bool \$returnNulls If true and all scope values are null, this will return null instead of a array full with nulls
  *
- * @return    mixed A array or a native type
+ * @return mixed A array or a native type
  */
 public function getScopeValue(\$returnNulls = true)
 {
@@ -432,7 +432,7 @@ public function setScopeValue(\$v)
 /**
  * Check if the object is first in the list, i.e. if it has 1 for rank
  *
- * @return    boolean
+ * @return bool
  */
 public function isFirst()
 {
@@ -455,7 +455,7 @@ public function isFirst()
  *
  * @param     ConnectionInterface  \$con      optional connection
  *
- * @return    boolean
+ * @return    bool
  */
 public function isLast(ConnectionInterface \$con = null)
 {

--- a/src/Propel/Generator/Behavior/Sortable/SortableBehaviorObjectBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/Sortable/SortableBehaviorObjectBuilderModifier.php
@@ -381,7 +381,7 @@ public function getScopeValue(\$returnNulls = true)
     try {
         return SetColumnConverter::convertToInt(\$this->{$this->getColumnGetter('scope_column')}(), {$this->tableMapClassName}::getValueSet({$this->tableMapClassName}::COL_{$columnConstant}));
     } catch (SetColumnConverterException \$e) {
-        throw new PropelException(sprintf('Value \"%s\" is not accepted in this set column', \$e->getValue()), \$e->getCode(), \$e);
+        throw new PropelException(sprintf('Value `%s` is not accepted in this set column', \$e->getValue()), \$e->getCode(), \$e);
     }
             ";
         } else {

--- a/src/Propel/Generator/Behavior/Sortable/SortableBehaviorObjectBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/Sortable/SortableBehaviorObjectBuilderModifier.php
@@ -78,7 +78,7 @@ class SortableBehaviorObjectBuilderModifier
      *
      * @return string
      */
-    protected function getColumnAttribute($name)
+    protected function getColumnAttribute($name): string
     {
         return strtolower($this->behavior->getColumnForParameter($name)->getName());
     }
@@ -88,7 +88,7 @@ class SortableBehaviorObjectBuilderModifier
      *
      * @return string|null
      */
-    protected function getColumnPhpName($name)
+    protected function getColumnPhpName($name): ?string
     {
         return $this->behavior->getColumnForParameter($name)->getPhpName();
     }
@@ -98,7 +98,7 @@ class SortableBehaviorObjectBuilderModifier
      *
      * @return void
      */
-    protected function setBuilder(AbstractOMBuilder $builder)
+    protected function setBuilder(AbstractOMBuilder $builder): void
     {
         $this->builder = $builder;
         $this->objectClassName = $builder->getObjectClassName();
@@ -114,7 +114,7 @@ class SortableBehaviorObjectBuilderModifier
      *
      * @return string The related getter, e.g. 'getRank'
      */
-    protected function getColumnGetter($columnName = 'rank_column')
+    protected function getColumnGetter($columnName = 'rank_column'): string
     {
         return 'get' . $this->behavior->getColumnForParameter($columnName)->getPhpName();
     }
@@ -126,7 +126,7 @@ class SortableBehaviorObjectBuilderModifier
      *
      * @return string The related setter, e.g. 'setRank'
      */
-    protected function getColumnSetter($columnName = 'rank_column')
+    protected function getColumnSetter($columnName = 'rank_column'): string
     {
         return 'set' . $this->behavior->getColumnForParameter($columnName)->getPhpName();
     }
@@ -136,7 +136,7 @@ class SortableBehaviorObjectBuilderModifier
      *
      * @return string
      */
-    public function preSave($builder)
+    public function preSave($builder): string
     {
         return '$this->processSortableQueries($con);';
     }
@@ -146,7 +146,7 @@ class SortableBehaviorObjectBuilderModifier
      *
      * @return string
      */
-    public function preInsert($builder)
+    public function preInsert($builder): string
     {
         $useScope = $this->behavior->useScope();
         $this->setBuilder($builder);
@@ -162,7 +162,7 @@ class SortableBehaviorObjectBuilderModifier
      *
      * @return string
      */
-    public function preUpdate($builder)
+    public function preUpdate($builder): string
     {
         if ($this->behavior->useScope()) {
             $this->setBuilder($builder);
@@ -193,7 +193,7 @@ if (($condition) && !\$this->isColumnModified({$this->tableMapClassName}::RANK_C
      *
      * @return string
      */
-    public function preDelete($builder)
+    public function preDelete($builder): string
     {
         $useScope = $this->behavior->useScope();
         $this->setBuilder($builder);
@@ -209,7 +209,7 @@ if (($condition) && !\$this->isColumnModified({$this->tableMapClassName}::RANK_C
      *
      * @return string
      */
-    public function objectAttributes($builder)
+    public function objectAttributes($builder): string
     {
         $script = "
 /**
@@ -236,7 +236,7 @@ protected \$oldScope;
      *
      * @return string
      */
-    public function objectMethods($builder)
+    public function objectMethods($builder): string
     {
         $this->setBuilder($builder);
         $script = '';
@@ -274,7 +274,7 @@ protected \$oldScope;
      *
      * @return void
      */
-    public function objectFilter(&$script, $builder)
+    public function objectFilter(&$script, $builder): void
     {
         if ($this->behavior->useScope()) {
             if ($this->behavior->hasMultipleScopes()) {
@@ -309,7 +309,7 @@ protected \$oldScope;
      *
      * @return void
      */
-    protected function addRankAccessors(&$script)
+    protected function addRankAccessors(&$script): void
     {
         $script .= "
 /**
@@ -342,7 +342,7 @@ public function setRank(\$v)
      *
      * @return void
      */
-    protected function addScopeAccessors(&$script)
+    protected function addScopeAccessors(&$script): void
     {
         $script .= "
 /**
@@ -426,7 +426,7 @@ public function setScopeValue(\$v)
      *
      * @return void
      */
-    protected function addIsFirst(&$script)
+    protected function addIsFirst(&$script): void
     {
         $script .= "
 /**
@@ -446,7 +446,7 @@ public function isFirst()
      *
      * @return void
      */
-    protected function addIsLast(&$script)
+    protected function addIsLast(&$script): void
     {
         $useScope = $this->behavior->useScope();
         $script .= "
@@ -469,7 +469,7 @@ public function isLast(ConnectionInterface \$con = null)
      *
      * @return void
      */
-    protected function addGetNext(&$script)
+    protected function addGetNext(&$script): void
     {
         $useScope = $this->behavior->useScope();
         // The generateScopePhp() method below contains the following list of variables:
@@ -517,7 +517,7 @@ public function getNext(ConnectionInterface \$con = null)
      *
      * @return void
      */
-    protected function addGetPrevious(&$script)
+    protected function addGetPrevious(&$script): void
     {
         $useScope = $this->behavior->useScope();
 
@@ -566,7 +566,7 @@ public function getPrevious(ConnectionInterface \$con = null)
      *
      * @return void
      */
-    protected function addInsertAtRank(&$script)
+    protected function addInsertAtRank(&$script): void
     {
         $useScope = $this->behavior->useScope();
         $queryClassName = $this->queryFullClassName;
@@ -609,7 +609,7 @@ public function insertAtRank(\$rank, ConnectionInterface \$con = null)
      *
      * @return void
      */
-    protected function addInsertAtBottom(&$script)
+    protected function addInsertAtBottom(&$script): void
     {
         $useScope = $this->behavior->useScope();
         $script .= "
@@ -638,7 +638,7 @@ public function insertAtBottom(ConnectionInterface \$con = null)
      *
      * @return void
      */
-    protected function addInsertAtTop(&$script)
+    protected function addInsertAtTop(&$script): void
     {
         $script .= "
 /**
@@ -659,7 +659,7 @@ public function insertAtTop()
      *
      * @return void
      */
-    protected function addMoveToRank(&$script)
+    protected function addMoveToRank(&$script): void
     {
         $useScope = $this->behavior->useScope();
         $script .= "
@@ -711,7 +711,7 @@ public function moveToRank(\$newRank, ConnectionInterface \$con = null)
      *
      * @return void
      */
-    protected function addSwapWith(&$script)
+    protected function addSwapWith(&$script): void
     {
         $script .= "
 /**
@@ -761,7 +761,7 @@ public function swapWith(\$object, ConnectionInterface \$con = null)
      *
      * @return void
      */
-    protected function addMoveUp(&$script)
+    protected function addMoveUp(&$script): void
     {
         $script .= "
 /**
@@ -794,7 +794,7 @@ public function moveUp(ConnectionInterface \$con = null)
      *
      * @return void
      */
-    protected function addMoveDown(&$script)
+    protected function addMoveDown(&$script): void
     {
         $script .= "
 /**
@@ -827,7 +827,7 @@ public function moveDown(ConnectionInterface \$con = null)
      *
      * @return void
      */
-    protected function addMoveToTop(&$script)
+    protected function addMoveToTop(&$script): void
     {
         $script .= "
 /**
@@ -853,7 +853,7 @@ public function moveToTop(ConnectionInterface \$con = null)
      *
      * @return void
      */
-    protected function addMoveToBottom(&$script)
+    protected function addMoveToBottom(&$script): void
     {
         $useScope = $this->behavior->useScope();
         $script .= "
@@ -862,12 +862,12 @@ public function moveToTop(ConnectionInterface \$con = null)
  *
  * @param     ConnectionInterface \$con optional connection
  *
- * @return integer the old object's rank
+ * @return int|null The old object's rank or null if already last
  */
-public function moveToBottom(ConnectionInterface \$con = null)
+public function moveToBottom(ConnectionInterface \$con = null): ?int
 {
     if (\$this->isLast(\$con)) {
-        return false;
+        return null;
     }
     if (null === \$con) {
         \$con = Propel::getServiceContainer()->getWriteConnection({$this->tableMapClassName}::DATABASE_NAME);
@@ -887,7 +887,7 @@ public function moveToBottom(ConnectionInterface \$con = null)
      *
      * @return void
      */
-    protected function addRemoveFromList(&$script)
+    protected function addRemoveFromList(&$script): void
     {
         $useScope = $this->behavior->useScope();
         $script .= "
@@ -932,7 +932,7 @@ public function removeFromList()
      *
      * @return void
      */
-    protected function addProcessSortableQueries(&$script)
+    protected function addProcessSortableQueries(&$script): void
     {
         $script .= "
 /**

--- a/src/Propel/Generator/Behavior/Sortable/SortableBehaviorObjectBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/Sortable/SortableBehaviorObjectBuilderModifier.php
@@ -862,9 +862,9 @@ public function moveToTop(ConnectionInterface \$con = null)
  *
  * @param     ConnectionInterface \$con optional connection
  *
- * @return int|null The old object's rank or null if already last
+ * @return \$this|{$this->objectClassName}|null The old object's rank or null if already last
  */
-public function moveToBottom(ConnectionInterface \$con = null): ?int
+public function moveToBottom(ConnectionInterface \$con = null)
 {
     if (\$this->isLast(\$con)) {
         return null;

--- a/src/Propel/Generator/Behavior/Sortable/SortableBehaviorQueryBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/Sortable/SortableBehaviorQueryBuilderModifier.php
@@ -598,9 +598,9 @@ static public function doSelectOrderByRank(Criteria \$criteria = null, \$order =
  * @param     string    \$order  sorting order, to be chosen between Criteria::ASC (default) and Criteria::DESC
  * @param     ConnectionInterface \$con    optional connection
  *
- * @return    array List of sortable objects
+ * @return    \Propel\Runtime\Collection\ObjectCollection List of sortable objects
  */
-static public function retrieveList(\$scope, \$order = Criteria::ASC, ConnectionInterface \$con = null): array
+static public function retrieveList(\$scope, \$order = Criteria::ASC, ConnectionInterface \$con = null)
 {
     \$c = new Criteria();
     static::sortableApplyScopeCriteria(\$c, \$scope);
@@ -624,9 +624,9 @@ static public function retrieveList(\$scope, \$order = Criteria::ASC, Connection
  * @param     int       \$scope  the scope of the list
  * @param     ConnectionInterface \$con    optional connection
  *
- * @return    array List of sortable objects
+ * @return    int Count.
  */
-static public function countList(\$scope, ConnectionInterface \$con = null): array
+static public function countList(\$scope, ConnectionInterface \$con = null): int
 {
     \$c = new Criteria();
     \$c->add({$this->tableMapClassName}::SCOPE_COL, \$scope);

--- a/src/Propel/Generator/Behavior/Sortable/SortableBehaviorQueryBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/Sortable/SortableBehaviorQueryBuilderModifier.php
@@ -474,7 +474,7 @@ public function getMaxRankArray(" . ($useScope ? '$scope, ' : '') . "ConnectionI
  * @param     mixed               \$order id => rank pairs
  * @param     ConnectionInterface \$con   optional connection
  *
- * @return    boolean true if the reordering took place, false if a database problem prevented it
+ * @return    bool true if the reordering took place, false if a database problem prevented it
  */
 public function reorder(\$order, ConnectionInterface \$con = null)
 {

--- a/src/Propel/Generator/Behavior/Sortable/SortableBehaviorQueryBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/Sortable/SortableBehaviorQueryBuilderModifier.php
@@ -71,7 +71,7 @@ class SortableBehaviorQueryBuilderModifier
      *
      * @return \Propel\Generator\Model\Column
      */
-    protected function getColumn($name)
+    protected function getColumn($name): Column
     {
         return $this->behavior->getColumnForParameter($name);
     }
@@ -81,7 +81,7 @@ class SortableBehaviorQueryBuilderModifier
      *
      * @return void
      */
-    protected function setBuilder($builder)
+    protected function setBuilder($builder): void
     {
         $this->builder = $builder;
         $this->objectClassName = $builder->getObjectClassName();
@@ -94,7 +94,7 @@ class SortableBehaviorQueryBuilderModifier
      *
      * @return string
      */
-    public function queryMethods($builder)
+    public function queryMethods($builder): string
     {
         $this->setBuilder($builder);
         $this->builder->declareClasses(
@@ -143,7 +143,7 @@ class SortableBehaviorQueryBuilderModifier
      *
      * @return void
      */
-    public function addSortableApplyScopeCriteria(&$script)
+    public function addSortableApplyScopeCriteria(&$script): void
     {
         $script .= "
 /**
@@ -179,7 +179,7 @@ static public function sortableApplyScopeCriteria(Criteria \$criteria, \$scope, 
      *
      * @return void
      */
-    protected function addInList(&$script)
+    protected function addInList(&$script): void
     {
         [$methodSignature, $paramsDoc, $buildScope] = $this->behavior->generateScopePhp();
         $script .= "
@@ -205,7 +205,7 @@ public function inList($methodSignature)
      *
      * @return void
      */
-    protected function addFilterByRank(&$script)
+    protected function addFilterByRank(&$script): void
     {
         $useScope = $this->behavior->useScope();
         if ($useScope) {
@@ -251,7 +251,7 @@ public function filterByRank(\$rank" . ($useScope ? ", $methodSignature" : '') .
      *
      * @return void
      */
-    protected function addOrderByRank(&$script)
+    protected function addOrderByRank(&$script): void
     {
         $script .= "
 /**
@@ -284,7 +284,7 @@ public function orderByRank(\$order = Criteria::ASC)
      *
      * @return void
      */
-    protected function addFindOneByRank(&$script)
+    protected function addFindOneByRank(&$script): void
     {
         $useScope = $this->behavior->useScope();
         if ($useScope) {
@@ -325,7 +325,7 @@ public function findOneByRank(\$rank, " . ($useScope ? "$methodSignature, " : ''
      *
      * @return void
      */
-    protected function addFindList(&$script)
+    protected function addFindList(&$script): void
     {
         $useScope = $this->behavior->useScope();
         if ($useScope) {
@@ -374,7 +374,7 @@ public function findList(" . ($useScope ? "$methodSignature, " : '') . "\$con = 
      *
      * @return void
      */
-    protected function addGetMaxRank(&$script)
+    protected function addGetMaxRank(&$script): void
     {
         $useScope = $this->behavior->useScope();
         if ($useScope) {
@@ -419,7 +419,7 @@ public function getMaxRank(" . ($useScope ? "$methodSignature, " : '') . "Connec
      *
      * @return void
      */
-    protected function addGetMaxRankArray(&$script)
+    protected function addGetMaxRankArray(&$script): void
     {
         $useScope = $this->behavior->useScope();
 
@@ -461,7 +461,7 @@ public function getMaxRankArray(" . ($useScope ? '$scope, ' : '') . "ConnectionI
      *
      * @return void
      */
-    protected function addReorder(&$script)
+    protected function addReorder(&$script): void
     {
         $columnGetter = 'get' . $this->behavior->getColumnForParameter('rank_column')->getPhpName();
         $columnSetter = 'set' . $this->behavior->getColumnForParameter('rank_column')->getPhpName();
@@ -504,7 +504,7 @@ public function reorder(\$order, ConnectionInterface \$con = null)
      *
      * @return void
      */
-    protected function addRetrieveByRank(&$script)
+    protected function addRetrieveByRank(&$script): void
     {
         $useScope = $this->behavior->useScope();
         $script .= "
@@ -545,7 +545,7 @@ static public function retrieveByRank(\$rank, " . ($useScope ? '$scope = null, '
      *
      * @return void
      */
-    protected function addDoSelectOrderByRank(&$script)
+    protected function addDoSelectOrderByRank(&$script): void
     {
         $queryClassName = $this->queryClassName;
         $script .= "
@@ -588,7 +588,7 @@ static public function doSelectOrderByRank(Criteria \$criteria = null, \$order =
      *
      * @return void
      */
-    protected function addRetrieveList(&$script)
+    protected function addRetrieveList(&$script): void
     {
         $script .= "
 /**
@@ -598,9 +598,9 @@ static public function doSelectOrderByRank(Criteria \$criteria = null, \$order =
  * @param     string    \$order  sorting order, to be chosen between Criteria::ASC (default) and Criteria::DESC
  * @param     ConnectionInterface \$con    optional connection
  *
- * @return    array list of sortable objects
+ * @return    array List of sortable objects
  */
-static public function retrieveList(\$scope, \$order = Criteria::ASC, ConnectionInterface \$con = null)
+static public function retrieveList(\$scope, \$order = Criteria::ASC, ConnectionInterface \$con = null): array
 {
     \$c = new Criteria();
     static::sortableApplyScopeCriteria(\$c, \$scope);
@@ -615,7 +615,7 @@ static public function retrieveList(\$scope, \$order = Criteria::ASC, Connection
      *
      * @return void
      */
-    protected function addCountList(&$script)
+    protected function addCountList(&$script): void
     {
         $script .= "
 /**
@@ -624,9 +624,9 @@ static public function retrieveList(\$scope, \$order = Criteria::ASC, Connection
  * @param     int       \$scope  the scope of the list
  * @param     ConnectionInterface \$con    optional connection
  *
- * @return    array list of sortable objects
+ * @return    array List of sortable objects
  */
-static public function countList(\$scope, ConnectionInterface \$con = null)
+static public function countList(\$scope, ConnectionInterface \$con = null): array
 {
     \$c = new Criteria();
     \$c->add({$this->tableMapClassName}::SCOPE_COL, \$scope);
@@ -641,7 +641,7 @@ static public function countList(\$scope, ConnectionInterface \$con = null)
      *
      * @return void
      */
-    protected function addDeleteList(&$script)
+    protected function addDeleteList(&$script): void
     {
         $script .= "
 /**
@@ -652,7 +652,7 @@ static public function countList(\$scope, ConnectionInterface \$con = null)
  *
  * @return    int number of deleted objects
  */
-static public function deleteList(\$scope, ConnectionInterface \$con = null)
+static public function deleteList(\$scope, ConnectionInterface \$con = null): int
 {
     \$c = new Criteria();
     static::sortableApplyScopeCriteria(\$c, \$scope);
@@ -667,7 +667,7 @@ static public function deleteList(\$scope, ConnectionInterface \$con = null)
      *
      * @return void
      */
-    protected function addShiftRank(&$script)
+    protected function addShiftRank(&$script): void
     {
         $useScope = $this->behavior->useScope();
         $script .= "

--- a/src/Propel/Generator/Behavior/Sortable/SortableBehaviorTableMapBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/Sortable/SortableBehaviorTableMapBuilderModifier.php
@@ -39,7 +39,7 @@ class SortableBehaviorTableMapBuilderModifier
      *
      * @return string
      */
-    public function staticAttributes($builder)
+    public function staticAttributes($builder): string
     {
         $tableName = $this->table->getName();
         $col = '';
@@ -72,7 +72,7 @@ class SortableBehaviorTableMapBuilderModifier
      *
      * @return string
      */
-    protected function getColumnConstant($name)
+    protected function getColumnConstant($name): string
     {
         return $this->behavior->getColumnForParameter($name)->getName();
     }

--- a/src/Propel/Generator/Behavior/Sortable/templates/tableMapSortable.php
+++ b/src/Propel/Generator/Behavior/Sortable/templates/tableMapSortable.php
@@ -8,7 +8,7 @@ const RANK_COL = "<?php echo $tableName ?>.<?php echo $rankColumn ?>";
     <?php if ($multiScope) :?>
 /**
 * If defined, the `SCOPE_COL` contains a json_encoded array with all columns.
-* @var boolean
+* @var bool
 */
 const MULTI_SCOPE_COL = true;
 

--- a/src/Propel/Generator/Behavior/Timestampable/TimestampableBehavior.php
+++ b/src/Propel/Generator/Behavior/Timestampable/TimestampableBehavior.php
@@ -19,7 +19,7 @@ use Propel\Generator\Model\Behavior;
 class TimestampableBehavior extends Behavior
 {
     /**
-     * @var array<string>
+     * @var array<string, mixed>
      */
     protected $parameters = [
         'create_column' => 'created_at',
@@ -31,7 +31,7 @@ class TimestampableBehavior extends Behavior
     /**
      * @return bool
      */
-    protected function withUpdatedAt()
+    protected function withUpdatedAt(): bool
     {
         return !$this->booleanValue($this->getParameter('disable_updated_at'));
     }
@@ -39,7 +39,7 @@ class TimestampableBehavior extends Behavior
     /**
      * @return bool
      */
-    protected function withCreatedAt()
+    protected function withCreatedAt(): bool
     {
         return !$this->booleanValue($this->getParameter('disable_created_at'));
     }
@@ -49,7 +49,7 @@ class TimestampableBehavior extends Behavior
      *
      * @return void
      */
-    public function modifyTable()
+    public function modifyTable(): void
     {
         $table = $this->getTable();
 
@@ -74,7 +74,7 @@ class TimestampableBehavior extends Behavior
      *
      * @return string The related setter, 'setCreatedOn' or 'setUpdatedOn'
      */
-    protected function getColumnSetter($column)
+    protected function getColumnSetter($column): string
     {
         return 'set' . $this->getColumnForParameter($column)->getPhpName();
     }
@@ -85,7 +85,7 @@ class TimestampableBehavior extends Behavior
      *
      * @return string
      */
-    protected function getColumnConstant($columnName, $builder)
+    protected function getColumnConstant($columnName, $builder): string
     {
         return $builder->getColumnConstant($this->getColumnForParameter($columnName));
     }
@@ -97,7 +97,7 @@ class TimestampableBehavior extends Behavior
      *
      * @return string The code to put at the hook
      */
-    public function preUpdate($builder)
+    public function preUpdate($builder): string
     {
         if ($this->withUpdatedAt()) {
             $valueSource = strtoupper($this->getTable()->getColumn($this->getParameter('update_column'))->getType()) === 'INTEGER'
@@ -119,7 +119,7 @@ class TimestampableBehavior extends Behavior
      *
      * @return string The code to put at the hook
      */
-    public function preInsert($builder)
+    public function preInsert($builder): string
     {
         $script = '$time = time();
 $highPrecision = \\Propel\\Runtime\\Util\\PropelDateTime::createHighPrecision();';
@@ -152,7 +152,7 @@ if (!\$this->isColumnModified(" . $this->getColumnConstant('update_column', $bui
      *
      * @return string
      */
-    public function objectMethods($builder)
+    public function objectMethods($builder): string
     {
         if (!$this->withUpdatedAt()) {
             return '';
@@ -178,7 +178,7 @@ public function keepUpdateDateUnchanged()
      *
      * @return string
      */
-    public function queryMethods($builder)
+    public function queryMethods($builder): string
     {
         $queryClassName = $builder->getQueryClassName();
 

--- a/src/Propel/Generator/Behavior/Validate/ValidateBehavior.php
+++ b/src/Propel/Generator/Behavior/Validate/ValidateBehavior.php
@@ -34,7 +34,7 @@ class ValidateBehavior extends Behavior
      *
      * @return string
      */
-    public function objectMethods($builder)
+    public function objectMethods($builder): string
     {
         $array = $this->getParameters();
         if (!$array) {
@@ -72,7 +72,7 @@ class ValidateBehavior extends Behavior
      *
      * @return string The code to be added to model class
      */
-    public function objectAttributes()
+    public function objectAttributes(): string
     {
         return $this->renderTemplate('objectAttributes');
     }
@@ -85,7 +85,7 @@ class ValidateBehavior extends Behavior
      *
      * @return array The array of parameters associated to given column
      */
-    public function getParametersFromColumnName($columnName = null)
+    public function getParametersFromColumnName($columnName = null): array
     {
         $array = [];
         if ($columnName !== null) {
@@ -108,7 +108,7 @@ class ValidateBehavior extends Behavior
      *
      * @return void
      */
-    public function removeParametersFromColumnName($columnName = null)
+    public function removeParametersFromColumnName($columnName = null): void
     {
         if ($columnName !== null) {
             $newParams = [];
@@ -131,7 +131,7 @@ class ValidateBehavior extends Behavior
      *
      * @return void
      */
-    public function addRuleOnPk()
+    public function addRuleOnPk(): void
     {
         if (!count($this->getParameters())) {
             $pk = $this->getTable()->getPrimaryKey();
@@ -156,7 +156,7 @@ class ValidateBehavior extends Behavior
      *
      * @return void
      */
-    public function mergeParameters(?array $params = null)
+    public function mergeParameters(?array $params = null): void
     {
         if ($params !== null) {
             $parameters = $this->getParameters();
@@ -181,7 +181,7 @@ class ValidateBehavior extends Behavior
      *
      * @return void
      */
-    protected function cleanupParameters()
+    protected function cleanupParameters(): void
     {
         $parser = new Parser();
         $params = $this->getParameters();
@@ -200,7 +200,7 @@ class ValidateBehavior extends Behavior
      *
      * @return string
      */
-    protected function addLoadValidatorMetadataMethod()
+    protected function addLoadValidatorMetadataMethod(): string
     {
         $params = $this->getParameters();
         $constraints = [];
@@ -243,7 +243,7 @@ class ValidateBehavior extends Behavior
      *
      * @return string
      */
-    protected function getClassConstraint(array $properties)
+    protected function getClassConstraint(array $properties): string
     {
         $constraintCandidates = [
             sprintf('Propel\\Runtime\\Validator\\Constraints\\%s', $properties['validator']),
@@ -264,7 +264,7 @@ class ValidateBehavior extends Behavior
      *
      * @return string The code to be added to model class
      */
-    protected function addValidateMethod()
+    protected function addValidateMethod(): string
     {
         $table = $this->getTable();
         $foreignKeys = $table->getForeignKeys();
@@ -300,7 +300,7 @@ class ValidateBehavior extends Behavior
      *
      * @return string
      */
-    protected function addGetValidationFailuresMethod()
+    protected function addGetValidationFailuresMethod(): string
     {
         return $this->renderTemplate('objectGetValidationFailures');
     }

--- a/src/Propel/Generator/Behavior/Validate/templates/objectValidate.php
+++ b/src/Propel/Generator/Behavior/Validate/templates/objectValidate.php
@@ -4,7 +4,7 @@
  *
  * @see        getValidationFailures()
  * @param      ValidatorInterface|null $validator A Validator class instance
- * @return     boolean Whether all objects pass validation.
+ * @return     bool Whether all objects pass validation.
  */
 public function validate(ValidatorInterface $validator = null)
 {

--- a/src/Propel/Generator/Behavior/Versionable/VersionableBehavior.php
+++ b/src/Propel/Generator/Behavior/Versionable/VersionableBehavior.php
@@ -9,7 +9,9 @@
 namespace Propel\Generator\Behavior\Versionable;
 
 use Propel\Generator\Model\Behavior;
+use Propel\Generator\Model\Column;
 use Propel\Generator\Model\ForeignKey;
+use Propel\Generator\Model\Table;
 
 /**
  * Keeps tracks of all the modifications in an ActiveRecord object
@@ -21,7 +23,7 @@ class VersionableBehavior extends Behavior
     /**
      * Default parameters value
      *
-     * @var array<string>
+     * @var array<string, mixed>
      */
     protected $parameters = [
         'version_column' => 'version',
@@ -58,7 +60,7 @@ class VersionableBehavior extends Behavior
     /**
      * @return void
      */
-    public function modifyDatabase()
+    public function modifyDatabase(): void
     {
         foreach ($this->getDatabase()->getTables() as $table) {
             if ($table->hasBehavior($this->getId())) {
@@ -77,7 +79,7 @@ class VersionableBehavior extends Behavior
     /**
      * @return void
      */
-    public function modifyTable()
+    public function modifyTable(): void
     {
         $this->addVersionColumn();
         $this->addLogColumns();
@@ -88,7 +90,7 @@ class VersionableBehavior extends Behavior
     /**
      * @return void
      */
-    protected function addVersionColumn()
+    protected function addVersionColumn(): void
     {
         $table = $this->getTable();
         // add the version column
@@ -104,7 +106,7 @@ class VersionableBehavior extends Behavior
     /**
      * @return void
      */
-    protected function addLogColumns()
+    protected function addLogColumns(): void
     {
         $table = $this->getTable();
         if ($this->getParameter('log_created_at') === 'true' && !$table->hasColumn($this->getParameter('version_created_at_column'))) {
@@ -132,7 +134,7 @@ class VersionableBehavior extends Behavior
     /**
      * @return void
      */
-    protected function addVersionTable()
+    protected function addVersionTable(): void
     {
         $table = $this->getTable();
         $database = $table->getDatabase();
@@ -197,7 +199,7 @@ class VersionableBehavior extends Behavior
     /**
      * @return void
      */
-    public function addForeignKeyVersionColumns()
+    public function addForeignKeyVersionColumns(): void
     {
         $versionTable = $this->versionTable;
         foreach ($this->getVersionableFks() as $fk) {
@@ -234,7 +236,7 @@ class VersionableBehavior extends Behavior
     /**
      * @return \Propel\Generator\Model\Table
      */
-    public function getVersionTable()
+    public function getVersionTable(): Table
     {
         return $this->versionTable;
     }
@@ -242,7 +244,7 @@ class VersionableBehavior extends Behavior
     /**
      * @return string
      */
-    public function getVersionTablePhpName()
+    public function getVersionTablePhpName(): string
     {
         return $this->getTable()->getPhpName() . 'Version';
     }
@@ -250,7 +252,7 @@ class VersionableBehavior extends Behavior
     /**
      * @return array<\Propel\Generator\Model\ForeignKey>
      */
-    public function getVersionableFks()
+    public function getVersionableFks(): array
     {
         $versionableFKs = [];
         if ($fks = $this->getTable()->getForeignKeys()) {
@@ -267,7 +269,7 @@ class VersionableBehavior extends Behavior
     /**
      * @return array<\Propel\Generator\Model\ForeignKey>
      */
-    public function getVersionableReferrers()
+    public function getVersionableReferrers(): array
     {
         $versionableReferrers = [];
         if ($fks = $this->getTable()->getReferrers()) {
@@ -286,7 +288,7 @@ class VersionableBehavior extends Behavior
      *
      * @return \Propel\Generator\Model\Column|null
      */
-    public function getReferrerIdsColumn(ForeignKey $fk)
+    public function getReferrerIdsColumn(ForeignKey $fk): ?Column
     {
         $fkTableName = $fk->getTable()->getName();
         $fkIdsColumnName = $fkTableName . '_ids';
@@ -299,7 +301,7 @@ class VersionableBehavior extends Behavior
      *
      * @return \Propel\Generator\Model\Column|null
      */
-    public function getReferrerVersionsColumn(ForeignKey $fk)
+    public function getReferrerVersionsColumn(ForeignKey $fk): ?Column
     {
         $fkTableName = $fk->getTable()->getName();
         $fkIdsColumnName = $fkTableName . '_versions';

--- a/src/Propel/Generator/Behavior/Versionable/VersionableBehaviorObjectBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/Versionable/VersionableBehaviorObjectBuilderModifier.php
@@ -66,7 +66,7 @@ class VersionableBehaviorObjectBuilderModifier
      *
      * @return string
      */
-    protected function getColumnAttribute($name = 'version_column')
+    protected function getColumnAttribute($name = 'version_column'): string
     {
         return strtolower($this->behavior->getColumnForParameter($name)->getName());
     }
@@ -76,7 +76,7 @@ class VersionableBehaviorObjectBuilderModifier
      *
      * @return string
      */
-    protected function getColumnPhpName($name = 'version_column')
+    protected function getColumnPhpName($name = 'version_column'): string
     {
         return $this->behavior->getColumnForParameter($name)->getPhpName();
     }
@@ -84,7 +84,7 @@ class VersionableBehaviorObjectBuilderModifier
     /**
      * @return string
      */
-    protected function getVersionQueryClassName()
+    protected function getVersionQueryClassName(): string
     {
         return $this->builder->getClassNameFromBuilder($this->builder->getNewStubQueryBuilder($this->behavior->getVersionTable()));
     }
@@ -92,7 +92,7 @@ class VersionableBehaviorObjectBuilderModifier
     /**
      * @return string
      */
-    protected function getActiveRecordClassName()
+    protected function getActiveRecordClassName(): string
     {
         return $this->builder->getObjectClassName();
     }
@@ -102,7 +102,7 @@ class VersionableBehaviorObjectBuilderModifier
      *
      * @return void
      */
-    protected function setBuilder($builder)
+    protected function setBuilder($builder): void
     {
         $this->builder = $builder;
         $this->objectClassName = $builder->getObjectClassName();
@@ -116,7 +116,7 @@ class VersionableBehaviorObjectBuilderModifier
      *
      * @return string The related getter, e.g. 'getVersion'
      */
-    protected function getColumnGetter($name = 'version_column')
+    protected function getColumnGetter($name = 'version_column'): string
     {
         return 'get' . $this->getColumnPhpName($name);
     }
@@ -128,7 +128,7 @@ class VersionableBehaviorObjectBuilderModifier
      *
      * @return string The related setter, e.g. 'setVersion'
      */
-    protected function getColumnSetter($name = 'version_column')
+    protected function getColumnSetter($name = 'version_column'): string
     {
         return 'set' . $this->getColumnPhpName($name);
     }
@@ -138,7 +138,7 @@ class VersionableBehaviorObjectBuilderModifier
      *
      * @return string
      */
-    public function preSave($builder)
+    public function preSave($builder): string
     {
         $script = "if (\$this->isVersioningNecessary()) {
     \$this->set{$this->getColumnPhpName()}(\$this->isNew() ? 1 : \$this->getLastVersionNumber(\$con) + 1);";
@@ -161,7 +161,7 @@ class VersionableBehaviorObjectBuilderModifier
      *
      * @return string
      */
-    public function postSave($builder)
+    public function postSave($builder): string
     {
         return "if (isset(\$createVersion)) {
     \$this->addVersion(\$con);
@@ -173,7 +173,7 @@ class VersionableBehaviorObjectBuilderModifier
      *
      * @return string|null
      */
-    public function postDelete($builder)
+    public function postDelete($builder): ?string
     {
         $this->builder = $builder;
         if (!$builder->getPlatform()->supportsNativeDeleteTrigger() && !$builder->getBuildProperty('generator.objectModel.emulateForeignKeyConstraints')) {
@@ -193,7 +193,7 @@ class VersionableBehaviorObjectBuilderModifier
      *
      * @return string
      */
-    public function objectAttributes($builder)
+    public function objectAttributes($builder): string
     {
         $script = '';
 
@@ -207,7 +207,7 @@ class VersionableBehaviorObjectBuilderModifier
      *
      * @return void
      */
-    protected function addEnforceVersionAttribute(&$script)
+    protected function addEnforceVersionAttribute(&$script): void
     {
         $script .= "
 
@@ -223,7 +223,7 @@ protected \$enforceVersion = false;
      *
      * @return string
      */
-    public function objectMethods($builder)
+    public function objectMethods($builder): string
     {
         $this->setBuilder($builder);
         $script = '';
@@ -253,7 +253,7 @@ protected \$enforceVersion = false;
      *
      * @return void
      */
-    protected function addVersionSetter(&$script)
+    protected function addVersionSetter(&$script): void
     {
         $script .= "
 /**
@@ -274,7 +274,7 @@ public function setVersion(\$v)
      *
      * @return void
      */
-    protected function addVersionGetter(&$script)
+    protected function addVersionGetter(&$script): void
     {
         $script .= "
 /**
@@ -294,7 +294,7 @@ public function getVersion()
      *
      * @return void
      */
-    protected function addEnforceVersioning(&$script)
+    protected function addEnforceVersioning(&$script): void
     {
         $objectClass = $this->builder->getStubObjectBuilder()->getClassname();
         $script .= "
@@ -317,7 +317,7 @@ public function enforceVersioning()
      *
      * @return void
      */
-    protected function addIsVersioningNecessary(&$script)
+    protected function addIsVersioningNecessary(&$script): void
     {
         $queryClassName = $this->builder->getQueryClassName();
 
@@ -326,9 +326,9 @@ public function enforceVersioning()
  * Checks whether the current state must be recorded as a version
  *
  * @param   ConnectionInterface \$con The ConnectionInterface connection to use.
- * @return  boolean
+ * @return  bool
  */
-public function isVersioningNecessary(ConnectionInterface \$con = null)
+public function isVersioningNecessary(ConnectionInterface \$con = null): bool
 {
     if (\$this->alreadyInSave) {
         return false;
@@ -402,7 +402,7 @@ public function isVersioningNecessary(ConnectionInterface \$con = null)
      *
      * @return void
      */
-    protected function addAddVersion(&$script)
+    protected function addAddVersion(&$script): void
     {
         $versionTable = $this->behavior->getVersionTable();
         $versionARClassName = $this->builder->getClassNameFromBuilder($this->builder->getNewStubObjectBuilder($versionTable));
@@ -475,7 +475,7 @@ public function addVersion(ConnectionInterface \$con = null)
      *
      * @return void
      */
-    protected function addToVersion(&$script)
+    protected function addToVersion(&$script): void
     {
         $ARclassName = $this->getActiveRecordClassName();
         $script .= "
@@ -505,7 +505,7 @@ public function toVersion(\$versionNumber, ConnectionInterface \$con = null)
      *
      * @return void
      */
-    protected function addPopulateFromVersion(&$script)
+    protected function addPopulateFromVersion(&$script): void
     {
         $ARclassName = $this->getActiveRecordClassName();
         $versionTable = $this->behavior->getVersionTable();
@@ -616,7 +616,7 @@ public function populateFromVersion(\$version, \$con = null, &\$loadedObjects = 
      *
      * @return void
      */
-    protected function addGetLastVersionNumber(&$script)
+    protected function addGetLastVersionNumber(&$script): void
     {
         $script .= "
 /**
@@ -646,7 +646,7 @@ public function getLastVersionNumber(ConnectionInterface \$con = null)
      *
      * @return void
      */
-    protected function addIsLastVersion(&$script)
+    protected function addIsLastVersion(&$script): void
     {
         $script .= "
 /**
@@ -668,7 +668,7 @@ public function isLastVersion(ConnectionInterface \$con = null)
      *
      * @return void
      */
-    protected function addGetOneVersion(&$script)
+    protected function addGetOneVersion(&$script): void
     {
         $versionARClassName = $this->builder->getClassNameFromBuilder($this->builder->getNewStubObjectBuilder($this->behavior->getVersionTable()));
         $script .= "
@@ -695,7 +695,7 @@ public function getOneVersion(\$versionNumber, ConnectionInterface \$con = null)
      *
      * @return void
      */
-    protected function addGetAllVersions(&$script)
+    protected function addGetAllVersions(&$script): void
     {
         $versionTable = $this->behavior->getVersionTable();
         $versionARClassName = $this->builder->getClassNameFromBuilder($this->builder->getNewStubObjectBuilder($versionTable));
@@ -727,7 +727,7 @@ public function getAllVersions(ConnectionInterface \$con = null)
      *
      * @return void
      */
-    protected function addComputeDiff(&$script)
+    protected function addComputeDiff(&$script): void
     {
         $script .= "
 /**
@@ -798,7 +798,7 @@ protected function computeDiff(\$fromVersion, \$toVersion, \$keys = 'columns', \
      *
      * @return void
      */
-    protected function addCompareVersion(&$script)
+    protected function addCompareVersion(&$script): void
     {
         $script .= "
 /**
@@ -833,7 +833,7 @@ public function compareVersion(\$versionNumber, \$keys = 'columns', ConnectionIn
      *
      * @return void
      */
-    protected function addCompareVersions(&$script)
+    protected function addCompareVersions(&$script): void
     {
         $script .= "
 /**
@@ -869,7 +869,7 @@ public function compareVersions(\$fromVersionNumber, \$toVersionNumber, \$keys =
      *
      * @return void
      */
-    protected function addGetLastVersions(&$script)
+    protected function addGetLastVersions(&$script): void
     {
         $plural = true;
         $versionTable = $this->behavior->getVersionTable();

--- a/src/Propel/Generator/Behavior/Versionable/VersionableBehaviorObjectBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/Versionable/VersionableBehaviorObjectBuilderModifier.php
@@ -654,7 +654,7 @@ public function getLastVersionNumber(ConnectionInterface \$con = null)
  *
  * @param   ConnectionInterface \$con The ConnectionInterface connection to use.
  *
- * @return  Boolean
+ * @return  bool
  */
 public function isLastVersion(ConnectionInterface \$con = null)
 {

--- a/src/Propel/Generator/Behavior/Versionable/VersionableBehaviorQueryBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/Versionable/VersionableBehaviorQueryBuilderModifier.php
@@ -52,7 +52,7 @@ class VersionableBehaviorQueryBuilderModifier
     /**
      * @return string
      */
-    public function queryAttributes()
+    public function queryAttributes(): string
     {
         return "
 /**
@@ -77,7 +77,7 @@ static \$isVersioningEnabled = true;
      *
      * @return string
      */
-    protected function getColumnAttribute($name = 'version_column')
+    protected function getColumnAttribute($name = 'version_column'): string
     {
         return strtolower($this->behavior->getColumnForParameter($name)->getName());
     }
@@ -87,7 +87,7 @@ static \$isVersioningEnabled = true;
      *
      * @return string
      */
-    protected function getColumnPhpName($name = 'version_column')
+    protected function getColumnPhpName($name = 'version_column'): string
     {
         return $this->behavior->getColumnForParameter($name)->getPhpName();
     }
@@ -95,7 +95,7 @@ static \$isVersioningEnabled = true;
     /**
      * @return string
      */
-    protected function getVersionQueryClassName()
+    protected function getVersionQueryClassName(): string
     {
         return $this->builder->getClassNameFromBuilder($this->builder->getNewStubQueryBuilder($this->behavior->getVersionTable()));
     }
@@ -105,7 +105,7 @@ static \$isVersioningEnabled = true;
      *
      * @return void
      */
-    protected function setBuilder($builder)
+    protected function setBuilder($builder): void
     {
         $this->builder = $builder;
         $this->objectClassName = $builder->getObjectClassName();
@@ -119,7 +119,7 @@ static \$isVersioningEnabled = true;
      *
      * @return string The related getter, e.g. 'getVersion'
      */
-    protected function getColumnGetter($name = 'version_column')
+    protected function getColumnGetter($name = 'version_column'): string
     {
         return 'get' . $this->getColumnPhpName($name);
     }
@@ -131,7 +131,7 @@ static \$isVersioningEnabled = true;
      *
      * @return string The related setter, e.g. 'setVersion'
      */
-    protected function getColumnSetter($name = 'version_column')
+    protected function getColumnSetter($name = 'version_column'): string
     {
         return 'set' . $this->getColumnPhpName($name);
     }
@@ -141,7 +141,7 @@ static \$isVersioningEnabled = true;
      *
      * @return string
      */
-    public function queryMethods($builder)
+    public function queryMethods($builder): string
     {
         $this->setBuilder($builder);
         $script = '';
@@ -162,7 +162,7 @@ static \$isVersioningEnabled = true;
      *
      * @return void
      */
-    protected function addFilterByVersion(&$script)
+    protected function addFilterByVersion(&$script): void
     {
         $script .= "
 /**
@@ -184,7 +184,7 @@ public function filterByVersion(\$version = null, \$comparison = null)
      *
      * @return void
      */
-    protected function addOrderByVersion(&$script)
+    protected function addOrderByVersion(&$script): void
     {
         $script .= "
 /**
@@ -203,15 +203,15 @@ public function orderByVersion(\$order = Criteria::ASC)
     /**
      * @return string
      */
-    protected function addIsVersioningEnabled()
+    protected function addIsVersioningEnabled(): string
     {
         return "
 /**
  * Checks whether versioning is enabled
  *
- * @return boolean
+ * @return bool
  */
-static public function isVersioningEnabled()
+static public function isVersioningEnabled(): bool
 {
     return self::\$isVersioningEnabled;
 }
@@ -221,13 +221,13 @@ static public function isVersioningEnabled()
     /**
      * @return string
      */
-    protected function addEnableVersioning()
+    protected function addEnableVersioning(): string
     {
         return "
 /**
  * Enables versioning
  */
-static public function enableVersioning()
+static public function enableVersioning(): void
 {
     self::\$isVersioningEnabled = true;
 }
@@ -237,13 +237,13 @@ static public function enableVersioning()
     /**
      * @return string
      */
-    protected function addDisableVersioning()
+    protected function addDisableVersioning(): string
     {
         return "
 /**
  * Disables versioning
  */
-static public function disableVersioning()
+static public function disableVersioning(): void
 {
     self::\$isVersioningEnabled = false;
 }

--- a/src/Propel/Generator/Builder/DataModelBuilder.php
+++ b/src/Propel/Generator/Builder/DataModelBuilder.php
@@ -13,8 +13,10 @@ use Propel\Generator\Builder\Om\AbstractObjectBuilder;
 use Propel\Generator\Builder\Om\AbstractOMBuilder;
 use Propel\Generator\Builder\Om\MultiExtendObjectBuilder;
 use Propel\Generator\Builder\Om\ObjectBuilder;
+use Propel\Generator\Builder\Om\QueryBuilder;
 use Propel\Generator\Builder\Om\TableMapBuilder;
 use Propel\Generator\Config\GeneratorConfigInterface;
+use Propel\Generator\Model\Database;
 use Propel\Generator\Model\Inheritance;
 use Propel\Generator\Model\Table;
 use Propel\Generator\Platform\PlatformInterface;
@@ -133,7 +135,7 @@ abstract class DataModelBuilder
      *
      * @return \Propel\Common\Pluralizer\PluralizerInterface
      */
-    public function getPluralizer()
+    public function getPluralizer(): PluralizerInterface
     {
         if ($this->pluralizer === null) {
             $this->pluralizer = $this->getGeneratorConfig()->getConfiguredPluralizer();
@@ -147,7 +149,7 @@ abstract class DataModelBuilder
      *
      * @return \Propel\Generator\Builder\Om\ObjectBuilder
      */
-    public function getObjectBuilder()
+    public function getObjectBuilder(): ObjectBuilder
     {
         if ($this->objectBuilder === null) {
             /** @var \Propel\Generator\Builder\Om\ObjectBuilder $builder */
@@ -211,7 +213,7 @@ abstract class DataModelBuilder
      *
      * @return \Propel\Generator\Builder\Om\TableMapBuilder
      */
-    public function getTableMapBuilder()
+    public function getTableMapBuilder(): TableMapBuilder
     {
         if ($this->tablemapBuilder === null) {
             /** @var \Propel\Generator\Builder\Om\TableMapBuilder $builder */
@@ -243,7 +245,7 @@ abstract class DataModelBuilder
      *
      * @return \Propel\Generator\Builder\Om\MultiExtendObjectBuilder
      */
-    public function getMultiExtendObjectBuilder()
+    public function getMultiExtendObjectBuilder(): MultiExtendObjectBuilder
     {
         if ($this->multiExtendObjectBuilder === null) {
             /** @var \Propel\Generator\Builder\Om\MultiExtendObjectBuilder $builder */
@@ -260,9 +262,9 @@ abstract class DataModelBuilder
      * @param \Propel\Generator\Model\Table $table
      * @param string $classname The class of builder
      *
-     * @return \Propel\Generator\Builder\DataModelBuilder
+     * @return self
      */
-    public function getNewBuilder(Table $table, $classname)
+    public function getNewBuilder(Table $table, $classname): self
     {
         /** @var \Propel\Generator\Builder\DataModelBuilder $builder */
         $builder = new $classname($table);
@@ -281,7 +283,7 @@ abstract class DataModelBuilder
      *
      * @return \Propel\Generator\Builder\Om\ObjectBuilder
      */
-    public function getNewObjectBuilder(Table $table)
+    public function getNewObjectBuilder(Table $table): ObjectBuilder
     {
         /** @var \Propel\Generator\Builder\Om\ObjectBuilder $builder */
         $builder = $this->getGeneratorConfig()->getConfiguredBuilder($table, 'object');
@@ -297,11 +299,11 @@ abstract class DataModelBuilder
      *
      * @param \Propel\Generator\Model\Table $table
      *
-     * @return \Propel\Generator\Builder\Om\ObjectBuilder
+     * @return \Propel\Generator\Builder\Om\AbstractObjectBuilder
      */
-    public function getNewStubObjectBuilder(Table $table)
+    public function getNewStubObjectBuilder(Table $table): AbstractObjectBuilder
     {
-        /** @var \Propel\Generator\Builder\Om\ObjectBuilder $builder */
+        /** @var \Propel\Generator\Builder\Om\AbstractObjectBuilder $builder */
         $builder = $this->getGeneratorConfig()->getConfiguredBuilder($table, 'objectstub');
 
         return $builder;
@@ -317,7 +319,7 @@ abstract class DataModelBuilder
      *
      * @return \Propel\Generator\Builder\Om\QueryBuilder
      */
-    public function getNewQueryBuilder(Table $table)
+    public function getNewQueryBuilder(Table $table): QueryBuilder
     {
         /** @var \Propel\Generator\Builder\Om\QueryBuilder $builder */
         $builder = $this->getGeneratorConfig()->getConfiguredBuilder($table, 'query');
@@ -333,11 +335,10 @@ abstract class DataModelBuilder
      *
      * @param \Propel\Generator\Model\Table $table
      *
-     * @return \Propel\Generator\Builder\Om\QueryBuilder
+     * @return \Propel\Generator\Builder\Om\AbstractOMBuilder
      */
-    public function getNewStubQueryBuilder(Table $table)
+    public function getNewStubQueryBuilder(Table $table): AbstractOMBuilder
     {
-        /** @var \Propel\Generator\Builder\Om\QueryBuilder $builder */
         $builder = $this->getGeneratorConfig()->getConfiguredBuilder($table, 'querystub');
 
         return $builder;
@@ -348,9 +349,9 @@ abstract class DataModelBuilder
      *
      * @param \Propel\Generator\Model\Inheritance $child
      *
-     * @return \Propel\Generator\Builder\Om\QueryInheritanceBuilder
+     * @return \Propel\Generator\Builder\Om\AbstractOMBuilder
      */
-    public function getNewQueryInheritanceBuilder(Inheritance $child)
+    public function getNewQueryInheritanceBuilder(Inheritance $child): AbstractOMBuilder
     {
         /** @var \Propel\Generator\Builder\Om\QueryInheritanceBuilder $queryInheritanceBuilder */
         $queryInheritanceBuilder = $this->getGeneratorConfig()->getConfiguredBuilder($this->getTable(), 'queryinheritance');
@@ -364,9 +365,9 @@ abstract class DataModelBuilder
      *
      * @param \Propel\Generator\Model\Inheritance $child
      *
-     * @return \Propel\Generator\Builder\Om\QueryInheritanceBuilder
+     * @return \Propel\Generator\Builder\Om\AbstractOMBuilder
      */
-    public function getNewStubQueryInheritanceBuilder(Inheritance $child)
+    public function getNewStubQueryInheritanceBuilder(Inheritance $child): AbstractOMBuilder
     {
         /** @var \Propel\Generator\Builder\Om\QueryInheritanceBuilder $stubQueryInheritanceBuilder */
         $stubQueryInheritanceBuilder = $this->getGeneratorConfig()->getConfiguredBuilder($this->getTable(), 'queryinheritancestub');
@@ -382,7 +383,7 @@ abstract class DataModelBuilder
      *
      * @return \Propel\Generator\Builder\Om\TableMapBuilder
      */
-    public function getNewTableMapBuilder(Table $table)
+    public function getNewTableMapBuilder(Table $table): TableMapBuilder
     {
         /** @var \Propel\Generator\Builder\Om\TableMapBuilder $builder */
         $builder = $this->getGeneratorConfig()->getConfiguredBuilder($table, 'tablemap');
@@ -395,7 +396,7 @@ abstract class DataModelBuilder
      *
      * @return \Propel\Generator\Config\GeneratorConfigInterface
      */
-    public function getGeneratorConfig()
+    public function getGeneratorConfig(): GeneratorConfigInterface
     {
         return $this->generatorConfig;
     }
@@ -413,7 +414,7 @@ abstract class DataModelBuilder
      *
      * @return string|null
      */
-    public function getBuildProperty($name)
+    public function getBuildProperty($name): ?string
     {
         if ($this->getGeneratorConfig()) {
             return $this->getGeneratorConfig()->getConfigProperty($name);
@@ -429,7 +430,7 @@ abstract class DataModelBuilder
      *
      * @return void
      */
-    public function setGeneratorConfig(GeneratorConfigInterface $v)
+    public function setGeneratorConfig(GeneratorConfigInterface $v): void
     {
         $this->generatorConfig = $v;
     }
@@ -441,7 +442,7 @@ abstract class DataModelBuilder
      *
      * @return void
      */
-    public function setTable(Table $table)
+    public function setTable(Table $table): void
     {
         $this->table = $table;
     }
@@ -461,7 +462,7 @@ abstract class DataModelBuilder
      *
      * @return \Propel\Generator\Platform\PlatformInterface
      */
-    public function getPlatform()
+    public function getPlatform(): PlatformInterface
     {
         if ($this->platform === null) {
             // try to load the platform from the table
@@ -485,7 +486,7 @@ abstract class DataModelBuilder
      *
      * @return void
      */
-    public function setPlatform(PlatformInterface $platform)
+    public function setPlatform(PlatformInterface $platform): void
     {
         $this->platform = $platform;
     }
@@ -497,7 +498,7 @@ abstract class DataModelBuilder
      *
      * @return string
      */
-    public function quoteIdentifier($text)
+    public function quoteIdentifier($text): string
     {
         if ($this->getTable()->isIdentifierQuotingEnabled()) {
             return $this->getPlatform()->doQuoting($text);
@@ -511,7 +512,7 @@ abstract class DataModelBuilder
      *
      * @return \Propel\Generator\Model\Database
      */
-    public function getDatabase()
+    public function getDatabase(): Database
     {
         return $this->getTable()->getDatabase();
     }
@@ -523,7 +524,7 @@ abstract class DataModelBuilder
      *
      * @return void
      */
-    protected function warn($msg)
+    protected function warn($msg): void
     {
         $this->warnings[] = $msg;
     }
@@ -533,7 +534,7 @@ abstract class DataModelBuilder
      *
      * @return array<string>
      */
-    public function getWarnings()
+    public function getWarnings(): array
     {
         return $this->warnings;
     }
@@ -547,7 +548,7 @@ abstract class DataModelBuilder
      *
      * @return string
      */
-    public function prefixClassName($identifier)
+    public function prefixClassName($identifier): string
     {
         return $this->getBuildProperty('generator.objectModel.classPrefix') . $identifier;
     }

--- a/src/Propel/Generator/Builder/DataModelBuilder.php
+++ b/src/Propel/Generator/Builder/DataModelBuilder.php
@@ -394,9 +394,9 @@ abstract class DataModelBuilder
     /**
      * Gets the GeneratorConfig object.
      *
-     * @return \Propel\Generator\Config\GeneratorConfigInterface
+     * @return \Propel\Generator\Config\GeneratorConfigInterface|null
      */
-    public function getGeneratorConfig(): GeneratorConfigInterface
+    public function getGeneratorConfig(): ?GeneratorConfigInterface
     {
         return $this->generatorConfig;
     }

--- a/src/Propel/Generator/Builder/DataModelBuilder.php
+++ b/src/Propel/Generator/Builder/DataModelBuilder.php
@@ -460,9 +460,9 @@ abstract class DataModelBuilder
     /**
      * Convenience method to returns the Platform class for this table (database).
      *
-     * @return \Propel\Generator\Platform\PlatformInterface
+     * @return \Propel\Generator\Platform\PlatformInterface|null
      */
-    public function getPlatform(): PlatformInterface
+    public function getPlatform(): ?PlatformInterface
     {
         if ($this->platform === null) {
             // try to load the platform from the table
@@ -510,9 +510,9 @@ abstract class DataModelBuilder
     /**
      * Convenience method to returns the database for current table.
      *
-     * @return \Propel\Generator\Model\Database
+     * @return \Propel\Generator\Model\Database|null
      */
-    public function getDatabase(): Database
+    public function getDatabase(): ?Database
     {
         return $this->getTable()->getDatabase();
     }

--- a/src/Propel/Generator/Builder/Om/AbstractOMBuilder.php
+++ b/src/Propel/Generator/Builder/Om/AbstractOMBuilder.php
@@ -197,7 +197,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      * Gets package name for this table.
      * This is overridden by child classes that have different packages.
      *
-     * @return string
+     * @return string|null
      */
     public function getPackage(): ?string
     {

--- a/src/Propel/Generator/Builder/Om/AbstractOMBuilder.php
+++ b/src/Propel/Generator/Builder/Om/AbstractOMBuilder.php
@@ -8,7 +8,6 @@
 
 namespace Propel\Generator\Builder\Om;
 
-use InvalidArgumentException as CoreInvalidArgumentException;
 use Propel\Generator\Builder\DataModelBuilder;
 use Propel\Generator\Builder\Util\PropelTemplate;
 use Propel\Generator\Exception\InvalidArgumentException;
@@ -34,21 +33,21 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      * Declared fully qualified classnames, to build the 'namespace' statements
      * according to this table's namespace.
      *
-     * @var array
+     * @var array<string, array<string, string>>
      */
     protected $declaredClasses = [];
 
     /**
      * Mapping between fully qualified classnames and their short classname or alias
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $declaredShortClassesOrAlias = [];
 
     /**
      * List of classes that can be use without alias when model don't have namespace
      *
-     * @var array
+     * @var array<string>
      */
     protected $whiteListOfDeclaredClasses = ['PDO', 'Exception', 'DateTime'];
 
@@ -62,7 +61,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return string The resulting PHP sourcecode.
      */
-    public function build()
+    public function build(): string
     {
         $this->validateModel();
         $this->declareClass($this->getFullyQualifiedClassName());
@@ -99,7 +98,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return void
      */
-    protected function validateModel()
+    protected function validateModel(): void
     {
         // Validation is currently only implemented in the subclasses.
     }
@@ -113,7 +112,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return string Some code
      */
-    public function buildObjectInstanceCreationCode($objName, $clsName)
+    public function buildObjectInstanceCreationCode($objName, $clsName): string
     {
         return "$objName = new $clsName();";
     }
@@ -124,14 +123,14 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return string
      */
-    abstract public function getUnprefixedClassName();
+    abstract public function getUnprefixedClassName(): string;
 
     /**
      * Returns the unqualified classname (e.g. Book)
      *
      * @return string
      */
-    public function getUnqualifiedClassName()
+    public function getUnqualifiedClassName(): string
     {
         return $this->getUnprefixedClassName();
     }
@@ -141,7 +140,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return string
      */
-    public function getQualifiedClassName()
+    public function getQualifiedClassName(): string
     {
         if ($namespace = $this->getNamespace()) {
             return $namespace . '\\' . $this->getUnqualifiedClassName();
@@ -155,7 +154,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return string
      */
-    public function getFullyQualifiedClassName()
+    public function getFullyQualifiedClassName(): string
     {
         return '\\' . $this->getQualifiedClassName();
     }
@@ -165,7 +164,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return string
      */
-    public function getClassName()
+    public function getClassName(): string
     {
         return $this->getFullyQualifiedClassName();
     }
@@ -175,7 +174,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return string
      */
-    public function getClasspath()
+    public function getClasspath(): string
     {
         if ($this->getPackage()) {
             return $this->getPackage() . '.' . $this->getUnqualifiedClassName();
@@ -189,7 +188,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return string
      */
-    public function getClassFilePath()
+    public function getClassFilePath(): string
     {
         return ClassTools::createFilePath($this->getPackagePath(), $this->getUnqualifiedClassName());
     }
@@ -200,11 +199,11 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return string
      */
-    public function getPackage()
+    public function getPackage(): ?string
     {
         $pkg = ($this->getTable()->getPackage() ?: $this->getDatabase()->getPackage());
         if (!$pkg) {
-            $pkg = $this->getBuildProperty('generator.targetPackage');
+            $pkg = (string)$this->getBuildProperty('generator.targetPackage');
         }
 
         return $pkg;
@@ -215,7 +214,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return string
      */
-    public function getPackagePath()
+    public function getPackagePath(): string
     {
         $pkg = $this->getPackage();
 
@@ -254,7 +253,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return string ClassName, Alias or FQCN
      */
-    public function getClassNameFromBuilder($builder, $fqcn = false)
+    public function getClassNameFromBuilder($builder, bool $fqcn = false): string
     {
         if ($fqcn) {
             return $builder->getFullyQualifiedClassName();
@@ -281,7 +280,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return string
      */
-    public function getClassNameFromTable(Table $table, $fqcn = false)
+    public function getClassNameFromTable(Table $table, $fqcn = false): string
     {
         $namespace = $table->getNamespace();
         $class = $table->getPhpName();
@@ -290,7 +289,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
     }
 
     /**
-     * Declare a class to be use and return it's name or it's alias
+     * Declare a class to be use and return its name or its alias
      *
      * @param string $class the class name
      * @param string $namespace the namespace
@@ -298,17 +297,14 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @throws \Propel\Generator\Exception\LogicException
      *
-     * @return string the class name or it's alias
+     * @return string The class name or its alias
      */
-    public function declareClassNamespace($class, $namespace = '', $alias = false)
+    public function declareClassNamespace($class, $namespace = '', $alias = false): string
     {
         $namespace = trim($namespace, '\\');
 
         // check if the class is already declared
-        if (
-            isset($this->declaredClasses[$namespace])
-            && isset($this->declaredClasses[$namespace][$class])
-        ) {
+        if (isset($this->declaredClasses[$namespace][$class])) {
             return $this->declaredClasses[$namespace][$class];
         }
 
@@ -323,10 +319,6 @@ abstract class AbstractOMBuilder extends DataModelBuilder
         }
 
         if (!$forcedAlias && !isset($this->declaredShortClassesOrAlias[$aliasWanted])) {
-            if (!isset($this->declaredClasses[$namespace])) {
-                $this->declaredClasses[$namespace] = [];
-            }
-
             $this->declaredClasses[$namespace][$class] = $aliasWanted;
             $this->declaredShortClassesOrAlias[$aliasWanted] = $namespace . '\\' . $class;
 
@@ -365,7 +357,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return bool
      */
-    protected function needAliasForClassName($class, $classNamespace)
+    protected function needAliasForClassName($class, $classNamespace): bool
     {
         // Should remove this check by not allowing nullable return values in getNamespace
         if ($this->getNamespace() === null) {
@@ -417,7 +409,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return string the short ClassName or an alias
      */
-    public function declareClassNamespacePrefix($class, $namespace = '', $aliasPrefix = false)
+    public function declareClassNamespacePrefix($class, $namespace = '', $aliasPrefix = false): string
     {
         if ($aliasPrefix !== false && $aliasPrefix !== true) {
             $alias = $aliasPrefix . $class;
@@ -437,7 +429,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return string the short ClassName or an alias
      */
-    public function declareClass($fullyQualifiedClassName, $aliasPrefix = false)
+    public function declareClass($fullyQualifiedClassName, $aliasPrefix = false): string
     {
         $fullyQualifiedClassName = trim($fullyQualifiedClassName, '\\');
         if (($pos = strrpos($fullyQualifiedClassName, '\\')) !== false) {
@@ -454,7 +446,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return string
      */
-    public function declareClassFromBuilder(self $builder, $aliasPrefix = false)
+    public function declareClassFromBuilder(self $builder, $aliasPrefix = false): string
     {
         return $this->declareClassNamespacePrefix($builder->getUnqualifiedClassName(), $builder->getNamespace(), $aliasPrefix);
     }
@@ -462,7 +454,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
     /**
      * @return void
      */
-    public function declareClasses()
+    public function declareClasses(): void
     {
         $args = func_get_args();
         foreach ($args as $class) {
@@ -477,7 +469,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return array list of declared classes
      */
-    public function getDeclaredClasses($namespace = null)
+    public function getDeclaredClasses($namespace = null): array
     {
         if ($namespace !== null && isset($this->declaredClasses[$namespace])) {
             return $this->declaredClasses[$namespace];
@@ -491,7 +483,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return string|null
      */
-    public function getNamespaceStatement()
+    public function getNamespaceStatement(): ?string
     {
         $namespace = $this->getNamespace();
         if ($namespace) {
@@ -510,7 +502,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return string
      */
-    public function getUseStatements($ignoredNamespace = null)
+    public function getUseStatements($ignoredNamespace = null): string
     {
         $script = '';
         $declaredClasses = $this->declaredClasses;
@@ -545,7 +537,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return string (e.g. 'Myquery')
      */
-    public function getQueryClassName($fqcn = false)
+    public function getQueryClassName($fqcn = false): string
     {
         return $this->getClassNameFromBuilder($this->getStubQueryBuilder(), $fqcn);
     }
@@ -559,7 +551,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return string (e.g. 'MyTable' or 'ChildMyTable')
      */
-    public function getObjectClassName($fqcn = false)
+    public function getObjectClassName($fqcn = false): string
     {
         return $this->getClassNameFromBuilder($this->getStubObjectBuilder(), $fqcn);
     }
@@ -570,7 +562,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return string
      */
-    public function getObjectName()
+    public function getObjectName(): string
     {
         return $this->getStubObjectBuilder()->getUnqualifiedClassName();
     }
@@ -584,7 +576,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return string (e.g. 'My')
      */
-    public function getTableMapClassName($fqcn = false)
+    public function getTableMapClassName($fqcn = false): string
     {
         return $this->getClassNameFromBuilder($this->getTableMapBuilder(), $fqcn);
     }
@@ -599,7 +591,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return string If $classname is provided, then will return $classname::COLUMN_NAME; if not, then the TableMapName is looked up for current table to yield $currTableTableMap::COLUMN_NAME.
      */
-    public function getColumnConstant($col, $classname = null)
+    public function getColumnConstant($col, $classname = null): string
     {
         if ($col === null) {
             throw new InvalidArgumentException('No columns were specified.');
@@ -628,7 +620,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return string
      */
-    protected function getJoinType(ForeignKey $fk)
+    protected function getJoinType(ForeignKey $fk): string
     {
         if ($defaultJoin = $fk->getDefaultJoin()) {
             return "'" . $defaultJoin . "'";
@@ -652,7 +644,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return string
      */
-    public function getFKPhpNameAffix(ForeignKey $fk, $plural = false)
+    public function getFKPhpNameAffix(ForeignKey $fk, $plural = false): string
     {
         if ($fk->getPhpName()) {
             if ($plural) {
@@ -676,7 +668,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return string
      */
-    protected function getCrossFKsPhpNameAffix(CrossForeignKeys $crossFKs, $plural = true)
+    protected function getCrossFKsPhpNameAffix(CrossForeignKeys $crossFKs, $plural = true): string
     {
         $names = [];
 
@@ -719,7 +711,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return string
      */
-    protected function getCrossRefFKGetterName(CrossForeignKeys $crossFKs, ForeignKey $excludeFK)
+    protected function getCrossRefFKGetterName(CrossForeignKeys $crossFKs, ForeignKey $excludeFK): string
     {
         $names = [];
 
@@ -745,7 +737,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return array
      */
-    protected function getCrossFKInformation(CrossForeignKeys $crossFKs)
+    protected function getCrossFKInformation(CrossForeignKeys $crossFKs): array
     {
         $names = [];
         $signatures = [];
@@ -782,7 +774,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return array<string>
      */
-    protected function getCrossFKAddMethodInformation(CrossForeignKeys $crossFKs, $crossFK = null)
+    protected function getCrossFKAddMethodInformation(CrossForeignKeys $crossFKs, $crossFK = null): array
     {
         $signature = $shortSignature = $normalizedShortSignature = $phpDoc = [];
         if ($crossFK instanceof ForeignKey) {
@@ -824,7 +816,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
         &$shortSignature,
         &$normalizedShortSignature,
         &$phpDoc
-    ) {
+    ): void {
         foreach ($crossFKs->getCrossForeignKeys() as $fk) {
             if (is_array($crossFKToIgnore) && in_array($fk, $crossFKToIgnore)) {
                 continue;
@@ -865,7 +857,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return string
      */
-    protected function getCrossFKsVarName(CrossForeignKeys $crossFKs)
+    protected function getCrossFKsVarName(CrossForeignKeys $crossFKs): string
     {
         return 'coll' . $this->getCrossFKsPhpNameAffix($crossFKs);
     }
@@ -875,7 +867,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return string
      */
-    protected function getCrossFKVarName(ForeignKey $crossFK)
+    protected function getCrossFKVarName(ForeignKey $crossFK): string
     {
         return 'coll' . $this->getFKPhpNameAffix($crossFK, true);
     }
@@ -893,7 +885,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return string
      */
-    protected static function getRelatedBySuffix(ForeignKey $fk)
+    protected static function getRelatedBySuffix(ForeignKey $fk): string
     {
         $relCol = '';
 
@@ -933,7 +925,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return string
      */
-    public function getRefFKPhpNameAffix(ForeignKey $fk, $plural = false)
+    public function getRefFKPhpNameAffix(ForeignKey $fk, $plural = false): string
     {
         $pluralizer = $this->getPluralizer();
         if ($fk->getRefPhpName()) {
@@ -955,7 +947,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return string
      */
-    protected static function getRefRelatedBySuffix(ForeignKey $fk)
+    protected static function getRefRelatedBySuffix(ForeignKey $fk): string
     {
         $relCol = '';
         foreach ($fk->getMapping() as $mapping) {
@@ -995,7 +987,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return bool
      */
-    public function hasBehaviorModifier($hookName, $modifier)
+    public function hasBehaviorModifier($hookName, $modifier): bool
     {
         $modifierGetter = 'get' . $modifier;
         foreach ($this->getTable()->getBehaviors() as $behavior) {
@@ -1017,7 +1009,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return void
      */
-    public function applyBehaviorModifierBase($hookName, $modifier, &$script, $tab = '        ')
+    public function applyBehaviorModifierBase($hookName, $modifier, &$script, $tab = '        '): void
     {
         $modifierGetter = 'get' . $modifier;
         foreach ($this->getTable()->getBehaviors() as $behavior) {
@@ -1049,7 +1041,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return string|null
      */
-    public function getBehaviorContentBase($contentName, $modifier)
+    public function getBehaviorContentBase($contentName, $modifier): ?string
     {
         $modifierGetter = 'get' . $modifier;
         foreach ($this->getTable()->getBehaviors() as $behavior) {
@@ -1075,14 +1067,14 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return string
      */
-    public function renderTemplate($filename, $vars = [], $templateDir = '/templates/')
+    public function renderTemplate($filename, $vars = [], $templateDir = '/templates/'): string
     {
         $filePath = __DIR__ . $templateDir . $filename;
         if (!file_exists($filePath)) {
             // try with '.php' at the end
             $filePath = $filePath . '.php';
             if (!file_exists($filePath)) {
-                throw new CoreInvalidArgumentException(sprintf('Template "%s" not found in "%s" directory', $filename, __DIR__ . $templateDir));
+                throw new InvalidArgumentException(sprintf('Template "%s" not found in "%s" directory', $filename, __DIR__ . $templateDir));
             }
         }
         $template = new PropelTemplate();
@@ -1095,7 +1087,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
     /**
      * @return string
      */
-    public function getTableMapClass()
+    public function getTableMapClass(): string
     {
         return $this->getStubObjectBuilder()->getUnqualifiedClassName() . 'TableMap';
     }
@@ -1107,7 +1099,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return string
      */
-    private function clean($content)
+    private function clean($content): string
     {
         // line feed
         $content = str_replace("\r\n", "\n", $content);
@@ -1151,7 +1143,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return void
      */
-    abstract protected function addClassOpen(&$script);
+    abstract protected function addClassOpen(&$script): void;
 
     /**
      * This method adds the contents of the generated class to the script.
@@ -1165,7 +1157,7 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return void
      */
-    abstract protected function addClassBody(&$script);
+    abstract protected function addClassBody(&$script): void;
 
     /**
      * Closes class.
@@ -1174,5 +1166,5 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      *
      * @return void
      */
-    abstract protected function addClassClose(&$script);
+    abstract protected function addClassClose(&$script): void;
 }

--- a/src/Propel/Generator/Builder/Om/AbstractOMBuilder.php
+++ b/src/Propel/Generator/Builder/Om/AbstractOMBuilder.php
@@ -642,9 +642,9 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      * @param \Propel\Generator\Model\ForeignKey $fk The local FK that we need a name for.
      * @param bool $plural Whether the php name should be plural (e.g. initRelatedObjs() vs. addRelatedObj()
      *
-     * @return string
+     * @return string|null
      */
-    public function getFKPhpNameAffix(ForeignKey $fk, $plural = false): string
+    public function getFKPhpNameAffix(ForeignKey $fk, $plural = false): ?string
     {
         if ($fk->getPhpName()) {
             if ($plural) {
@@ -923,9 +923,9 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      * @param \Propel\Generator\Model\ForeignKey $fk The referrer FK that we need a name for.
      * @param bool $plural Whether the php name should be plural (e.g. initRelatedObjs() vs. addRelatedObj()
      *
-     * @return string
+     * @return string|null
      */
-    public function getRefFKPhpNameAffix(ForeignKey $fk, $plural = false): string
+    public function getRefFKPhpNameAffix(ForeignKey $fk, $plural = false): ?string
     {
         $pluralizer = $this->getPluralizer();
         if ($fk->getRefPhpName()) {

--- a/src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
@@ -30,7 +30,7 @@ abstract class AbstractObjectBuilder extends AbstractOMBuilder
      *
      * @return void
      */
-    protected function addColumnAccessorMethods(&$script)
+    protected function addColumnAccessorMethods(&$script): void
     {
         $table = $this->getTable();
 
@@ -81,7 +81,7 @@ abstract class AbstractObjectBuilder extends AbstractOMBuilder
      *
      * @return void
      */
-    protected function addColumnMutatorMethods(&$script)
+    protected function addColumnMutatorMethods(&$script): void
     {
         foreach ($this->getTable()->getColumns() as $col) {
             if ($col->getType() === PropelTypes::OBJECT) {
@@ -121,9 +121,9 @@ abstract class AbstractObjectBuilder extends AbstractOMBuilder
     /**
      * Gets the baseClass path if specified for table/db.
      *
-     * @return string
+     * @return string|null
      */
-    protected function getBaseClass()
+    protected function getBaseClass(): ?string
     {
         return $this->getTable()->getBaseClass();
     }
@@ -131,9 +131,9 @@ abstract class AbstractObjectBuilder extends AbstractOMBuilder
     /**
      * Gets the interface path if specified for current table.
      *
-     * @return string
+     * @return string|null
      */
-    protected function getInterface()
+    protected function getInterface(): ?string
     {
         return $this->getTable()->getInterface();
     }
@@ -145,7 +145,7 @@ abstract class AbstractObjectBuilder extends AbstractOMBuilder
      *
      * @return bool
      */
-    protected function isAddGenericMutators()
+    protected function isAddGenericMutators(): bool
     {
         $table = $this->getTable();
 
@@ -159,7 +159,7 @@ abstract class AbstractObjectBuilder extends AbstractOMBuilder
      *
      * @return bool
      */
-    protected function isAddGenericAccessors()
+    protected function isAddGenericAccessors(): bool
     {
         $table = $this->getTable();
 
@@ -169,7 +169,7 @@ abstract class AbstractObjectBuilder extends AbstractOMBuilder
     /**
      * @return bool
      */
-    protected function hasDefaultValues()
+    protected function hasDefaultValues(): bool
     {
         foreach ($this->getTable()->getColumns() as $col) {
             if ($col->getDefaultValue() !== null) {
@@ -188,7 +188,7 @@ abstract class AbstractObjectBuilder extends AbstractOMBuilder
      *
      * @return bool
      */
-    public function hasBehaviorModifier($hookName, $modifier = '')
+    public function hasBehaviorModifier($hookName, $modifier = ''): bool
     {
          return parent::hasBehaviorModifier($hookName, 'ObjectBuilderModifier');
     }
@@ -202,7 +202,7 @@ abstract class AbstractObjectBuilder extends AbstractOMBuilder
      *
      * @return void
      */
-    public function applyBehaviorModifier($hookName, &$script, $tab = '        ')
+    public function applyBehaviorModifier($hookName, &$script, $tab = '        '): void
     {
         $this->applyBehaviorModifierBase($hookName, 'ObjectBuilderModifier', $script, $tab);
     }
@@ -214,7 +214,7 @@ abstract class AbstractObjectBuilder extends AbstractOMBuilder
      *
      * @return string|null
      */
-    public function getBehaviorContent($contentName)
+    public function getBehaviorContent($contentName): ?string
     {
         return $this->getBehaviorContentBase($contentName, 'ObjectBuilderModifier');
     }

--- a/src/Propel/Generator/Builder/Om/ClassTools.php
+++ b/src/Propel/Generator/Builder/Om/ClassTools.php
@@ -30,13 +30,17 @@ class ClassTools
             return null;
         }
 
-        if (false !== $pos = strrpos($qualifiedName, '.')) {
+        $pos = strrpos($qualifiedName, '.');
+        if ($pos !== false) {
             return substr($qualifiedName, $pos + 1); // start just after '.'
-        } elseif (false !== $pos = strrpos($qualifiedName, '\\')) {
-            return substr($qualifiedName, $pos + 1);
-        } else {
-            return $qualifiedName; // there is no '.' in the qualified name
         }
+
+        $pos = strrpos($qualifiedName, '\\');
+        if ($pos !== false) {
+            return substr($qualifiedName, $pos + 1);
+        }
+
+        return $qualifiedName; // there is no '.' in the qualified name
     }
 
     /**

--- a/src/Propel/Generator/Builder/Om/ClassTools.php
+++ b/src/Propel/Generator/Builder/Om/ClassTools.php
@@ -50,7 +50,7 @@ class ClassTools
      *
      * @return string The constructed file path.
      */
-    public static function createFilePath($path, $classname = null, $extension = '.php')
+    public static function createFilePath($path, $classname = null, $extension = '.php'): string
     {
         if ($classname === null) {
             return $path . $extension;
@@ -70,7 +70,7 @@ class ClassTools
      *
      * @return string
      */
-    public static function getBaseClass(Table $table)
+    public static function getBaseClass(Table $table): string
     {
         return $table->getBaseClass();
     }
@@ -82,7 +82,7 @@ class ClassTools
      *
      * @return string
      */
-    public static function getInterface(Table $table)
+    public static function getInterface(Table $table): string
     {
         return $table->getInterface();
     }
@@ -92,7 +92,7 @@ class ClassTools
      *
      * @return array<string>
      */
-    public static function getPhpReservedWords()
+    public static function getPhpReservedWords(): array
     {
         return [
             'and', 'or', 'xor', 'exception', '__FILE__', '__LINE__',
@@ -111,7 +111,7 @@ class ClassTools
     /**
      * @return array<string>
      */
-    public static function getPropelReservedMethods()
+    public static function getPropelReservedMethods(): array
     {
         return [
             'isModified', 'isColumnModified', 'isNew', 'isDeleted',

--- a/src/Propel/Generator/Builder/Om/ClassTools.php
+++ b/src/Propel/Generator/Builder/Om/ClassTools.php
@@ -72,9 +72,9 @@ class ClassTools
      *
      * @param \Propel\Generator\Model\Table $table
      *
-     * @return string
+     * @return string|null
      */
-    public static function getBaseClass(Table $table): string
+    public static function getBaseClass(Table $table): ?string
     {
         return $table->getBaseClass();
     }
@@ -84,9 +84,9 @@ class ClassTools
      *
      * @param \Propel\Generator\Model\Table $table
      *
-     * @return string
+     * @return string|null
      */
-    public static function getInterface(Table $table): string
+    public static function getInterface(Table $table): ?string
     {
         return $table->getInterface();
     }

--- a/src/Propel/Generator/Builder/Om/ExtensionObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ExtensionObjectBuilder.php
@@ -23,7 +23,7 @@ class ExtensionObjectBuilder extends AbstractObjectBuilder
      *
      * @return string
      */
-    public function getUnprefixedClassName()
+    public function getUnprefixedClassName(): string
     {
         return $this->getTable()->getPhpName();
     }
@@ -35,7 +35,7 @@ class ExtensionObjectBuilder extends AbstractObjectBuilder
      *
      * @return void
      */
-    protected function addClassOpen(&$script)
+    protected function addClassOpen(&$script): void
     {
         $table = $this->getTable();
         $tableName = $table->getName();
@@ -80,7 +80,7 @@ class ExtensionObjectBuilder extends AbstractObjectBuilder
      *
      * @return void
      */
-    protected function addClassBody(&$script)
+    protected function addClassBody(&$script): void
     {
     }
 
@@ -91,7 +91,7 @@ class ExtensionObjectBuilder extends AbstractObjectBuilder
      *
      * @return void
      */
-    protected function addClassClose(&$script)
+    protected function addClassClose(&$script): void
     {
         $script .= "
 }

--- a/src/Propel/Generator/Builder/Om/ExtensionQueryBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ExtensionQueryBuilder.php
@@ -23,7 +23,7 @@ class ExtensionQueryBuilder extends AbstractOMBuilder
      *
      * @return string
      */
-    public function getUnprefixedClassName()
+    public function getUnprefixedClassName(): string
     {
         return $this->getTable()->getPhpName() . 'Query';
     }
@@ -35,7 +35,7 @@ class ExtensionQueryBuilder extends AbstractOMBuilder
      *
      * @return void
      */
-    protected function addClassOpen(&$script)
+    protected function addClassOpen(&$script): void
     {
         $table = $this->getTable();
         $tableName = $table->getName();
@@ -82,7 +82,7 @@ class $className extends $baseClassName
      *
      * @return void
      */
-    protected function addClassBody(&$script)
+    protected function addClassBody(&$script): void
     {
     }
 
@@ -93,7 +93,7 @@ class $className extends $baseClassName
      *
      * @return void
      */
-    protected function addClassClose(&$script)
+    protected function addClassClose(&$script): void
     {
         $script .= "
 }
@@ -109,7 +109,7 @@ class $className extends $baseClassName
      *
      * @return bool
      */
-    public function hasBehaviorModifier($hookName, $modifier = '')
+    public function hasBehaviorModifier($hookName, $modifier = ''): bool
     {
          return parent::hasBehaviorModifier($hookName, 'QueryBuilderModifier');
     }
@@ -123,7 +123,7 @@ class $className extends $baseClassName
      *
      * @return void
      */
-    public function applyBehaviorModifier($hookName, &$script, $tab = '        ')
+    public function applyBehaviorModifier($hookName, &$script, $tab = '        '): void
     {
         $this->applyBehaviorModifierBase($hookName, 'QueryBuilderModifier', $script, $tab);
     }
@@ -135,7 +135,7 @@ class $className extends $baseClassName
      *
      * @return string|null
      */
-    public function getBehaviorContent($contentName)
+    public function getBehaviorContent($contentName): ?string
     {
         return $this->getBehaviorContentBase($contentName, 'QueryBuilderModifier');
     }

--- a/src/Propel/Generator/Builder/Om/ExtensionQueryInheritanceBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ExtensionQueryInheritanceBuilder.php
@@ -33,7 +33,7 @@ class ExtensionQueryInheritanceBuilder extends AbstractOMBuilder
      *
      * @return string
      */
-    public function getUnprefixedClassName()
+    public function getUnprefixedClassName(): string
     {
         return $this->getChild()->getClassName() . 'Query';
     }
@@ -43,7 +43,7 @@ class ExtensionQueryInheritanceBuilder extends AbstractOMBuilder
      *
      * @return string
      */
-    public function getPackage()
+    public function getPackage(): string
     {
         return ($this->getChild()->getPackage() ?: parent::getPackage());
     }
@@ -55,7 +55,7 @@ class ExtensionQueryInheritanceBuilder extends AbstractOMBuilder
      *
      * @return void
      */
-    public function setChild(Inheritance $child)
+    public function setChild(Inheritance $child): void
     {
         $this->child = $child;
     }
@@ -67,7 +67,7 @@ class ExtensionQueryInheritanceBuilder extends AbstractOMBuilder
      *
      * @return \Propel\Generator\Model\Inheritance
      */
-    public function getChild()
+    public function getChild(): Inheritance
     {
         if (!$this->child) {
             throw new BuildException('The MultiExtendObjectBuilder needs to be told which child class to build (via setChild() method) before it can build the stub class.');
@@ -83,7 +83,7 @@ class ExtensionQueryInheritanceBuilder extends AbstractOMBuilder
      *
      * @return void
      */
-    protected function addClassOpen(&$script)
+    protected function addClassOpen(&$script): void
     {
         $table = $this->getTable();
         $tableName = $table->getName();
@@ -132,7 +132,7 @@ class " . $this->getUnqualifiedClassName() . ' extends ' . $baseClassName . "
      *
      * @return void
      */
-    protected function addClassBody(&$script)
+    protected function addClassBody(&$script): void
     {
     }
 
@@ -143,10 +143,10 @@ class " . $this->getUnqualifiedClassName() . ' extends ' . $baseClassName . "
      *
      * @return void
      */
-    protected function addClassClose(&$script)
+    protected function addClassClose(&$script): void
     {
         $script .= "
-} // " . $this->getUnqualifiedClassName() . "
+}
 ";
     }
 }

--- a/src/Propel/Generator/Builder/Om/ExtensionQueryInheritanceBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ExtensionQueryInheritanceBuilder.php
@@ -41,9 +41,9 @@ class ExtensionQueryInheritanceBuilder extends AbstractOMBuilder
     /**
      * Gets the package for the [base] object classes.
      *
-     * @return string
+     * @return string|null
      */
-    public function getPackage(): string
+    public function getPackage(): ?string
     {
         return ($this->getChild()->getPackage() ?: parent::getPackage());
     }

--- a/src/Propel/Generator/Builder/Om/InterfaceBuilder.php
+++ b/src/Propel/Generator/Builder/Om/InterfaceBuilder.php
@@ -23,7 +23,7 @@ class InterfaceBuilder extends AbstractObjectBuilder
      *
      * @return string
      */
-    public function getUnprefixedClassName()
+    public function getUnprefixedClassName(): string
     {
         return ClassTools::classname($this->getInterface());
     }
@@ -35,7 +35,7 @@ class InterfaceBuilder extends AbstractObjectBuilder
      *
      * @return void
      */
-    protected function addClassOpen(&$script)
+    protected function addClassOpen(&$script): void
     {
         $table = $this->getTable();
         $tableName = $table->getName();
@@ -77,7 +77,7 @@ interface " . $this->getUnqualifiedClassName() . "
      *
      * @return void
      */
-    protected function addClassBody(&$script)
+    protected function addClassBody(&$script): void
     {
         // there is no class body
     }
@@ -89,10 +89,10 @@ interface " . $this->getUnqualifiedClassName() . "
      *
      * @return void
      */
-    protected function addClassClose(&$script)
+    protected function addClassClose(&$script): void
     {
         $script .= "
-} // " . $this->getUnqualifiedClassName() . "
+}
 ";
     }
 }

--- a/src/Propel/Generator/Builder/Om/MultiExtendObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/MultiExtendObjectBuilder.php
@@ -42,9 +42,9 @@ class MultiExtendObjectBuilder extends AbstractObjectBuilder
     /**
      * Overrides method to return child package, if specified.
      *
-     * @return string
+     * @return string|null
      */
-    public function getPackage(): string
+    public function getPackage(): ?string
     {
         return ($this->getChild()->getPackage() ?: parent::getPackage());
     }
@@ -80,9 +80,9 @@ class MultiExtendObjectBuilder extends AbstractObjectBuilder
     /**
      * Returns classpath to parent class.
      *
-     * @return string
+     * @return string|null
      */
-    protected function getParentClasspath(): string
+    protected function getParentClasspath(): ?string
     {
         if ($this->getChild()->getAncestor()) {
             return $this->getChild()->getAncestor();
@@ -94,9 +94,9 @@ class MultiExtendObjectBuilder extends AbstractObjectBuilder
     /**
      * Returns classname of parent class.
      *
-     * @return string
+     * @return string|null
      */
-    protected function getParentClassName(): string
+    protected function getParentClassName(): ?string
     {
         return ClassTools::classname($this->getParentClasspath());
     }

--- a/src/Propel/Generator/Builder/Om/MultiExtendObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/MultiExtendObjectBuilder.php
@@ -34,7 +34,7 @@ class MultiExtendObjectBuilder extends AbstractObjectBuilder
      *
      * @return string
      */
-    public function getUnprefixedClassName()
+    public function getUnprefixedClassName(): string
     {
         return $this->getChild()->getClassName();
     }
@@ -44,7 +44,7 @@ class MultiExtendObjectBuilder extends AbstractObjectBuilder
      *
      * @return string
      */
-    public function getPackage()
+    public function getPackage(): string
     {
         return ($this->getChild()->getPackage() ?: parent::getPackage());
     }
@@ -56,7 +56,7 @@ class MultiExtendObjectBuilder extends AbstractObjectBuilder
      *
      * @return void
      */
-    public function setChild(Inheritance $child)
+    public function setChild(Inheritance $child): void
     {
         $this->child = $child;
     }
@@ -68,7 +68,7 @@ class MultiExtendObjectBuilder extends AbstractObjectBuilder
      *
      * @return \Propel\Generator\Model\Inheritance
      */
-    public function getChild()
+    public function getChild(): Inheritance
     {
         if (!$this->child) {
             throw new BuildException('The MultiExtendObjectBuilder needs to be told which child class to build (via setChild() method) before it can build the stub class.');
@@ -82,7 +82,7 @@ class MultiExtendObjectBuilder extends AbstractObjectBuilder
      *
      * @return string
      */
-    protected function getParentClasspath()
+    protected function getParentClasspath(): string
     {
         if ($this->getChild()->getAncestor()) {
             return $this->getChild()->getAncestor();
@@ -96,7 +96,7 @@ class MultiExtendObjectBuilder extends AbstractObjectBuilder
      *
      * @return string
      */
-    protected function getParentClassName()
+    protected function getParentClassName(): string
     {
         return ClassTools::classname($this->getParentClasspath());
     }
@@ -108,7 +108,7 @@ class MultiExtendObjectBuilder extends AbstractObjectBuilder
      *
      * @return void
      */
-    protected function addClassOpen(&$script)
+    protected function addClassOpen(&$script): void
     {
         if ($this->getChild()->getAncestor()) {
             $ancestorClassName = $this->getChild()->getAncestor();
@@ -164,7 +164,7 @@ class " . $this->getUnqualifiedClassName() . ' extends ' . $this->getParentClass
      *
      * @return void
      */
-    protected function addClassBody(&$script)
+    protected function addClassBody(&$script): void
     {
         $child = $this->getChild();
         $col = $child->getColumn();
@@ -192,10 +192,10 @@ class " . $this->getUnqualifiedClassName() . ' extends ' . $this->getParentClass
      *
      * @return void
      */
-    protected function addClassClose(&$script)
+    protected function addClassClose(&$script): void
     {
         $script .= "
-} // " . $this->getUnqualifiedClassName() . "
+}
 ";
     }
 }

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -40,7 +40,7 @@ class ObjectBuilder extends AbstractObjectBuilder
      *
      * @return string
      */
-    public function getPackage()
+    public function getPackage(): string
     {
         return parent::getPackage() . '.Base';
     }
@@ -68,7 +68,7 @@ class ObjectBuilder extends AbstractObjectBuilder
      *
      * @return string
      */
-    public function getDefaultKeyType()
+    public function getDefaultKeyType(): string
     {
         $defaultKeyType = $this->getBuildProperty('generator.objectModel.defaultKeyType') ?: 'phpName';
 
@@ -80,7 +80,7 @@ class ObjectBuilder extends AbstractObjectBuilder
      *
      * @return string
      */
-    public function getUnprefixedClassName()
+    public function getUnprefixedClassName(): string
     {
         return $this->getStubObjectBuilder()->getUnprefixedClassName();
     }
@@ -97,7 +97,7 @@ class ObjectBuilder extends AbstractObjectBuilder
      *
      * @return void
      */
-    protected function validateModel()
+    protected function validateModel(): void
     {
         parent::validateModel();
 
@@ -141,7 +141,7 @@ class ObjectBuilder extends AbstractObjectBuilder
      *
      * @return string
      */
-    protected function getTemporalFormatter(Column $column)
+    protected function getTemporalFormatter(Column $column): string
     {
         $fmt = null;
         if ($column->getType() === PropelTypes::DATE) {
@@ -165,7 +165,7 @@ class ObjectBuilder extends AbstractObjectBuilder
      *
      * @return string
      */
-    protected function getDefaultValueString(Column $column)
+    protected function getDefaultValueString(Column $column): string
     {
         $defaultValue = var_export(null, true);
         $val = $column->getPhpDefaultValue();
@@ -235,7 +235,7 @@ class ObjectBuilder extends AbstractObjectBuilder
      *
      * @return void
      */
-    protected function addClassOpen(&$script)
+    protected function addClassOpen(&$script): void
     {
         $table = $this->getTable();
         $tableName = $table->getName();
@@ -292,7 +292,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addClassBody(&$script)
+    protected function addClassBody(&$script): void
     {
         $this->declareClassFromBuilder($this->getStubObjectBuilder());
         $this->declareClassFromBuilder($this->getStubQueryBuilder());
@@ -405,7 +405,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addClassClose(&$script)
+    protected function addClassClose(&$script): void
     {
         $script .= "
 }
@@ -420,7 +420,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addConstants(&$script)
+    protected function addConstants(&$script): void
     {
         $script .= "
     /**
@@ -437,7 +437,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addAttributes(&$script)
+    protected function addAttributes(&$script): void
     {
         $table = $this->getTable();
 
@@ -476,7 +476,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addColumnAttributes(&$script)
+    protected function addColumnAttributes(&$script): void
     {
         $table = $this->getTable();
 
@@ -505,7 +505,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addColumnAttributeComment(&$script, Column $column)
+    protected function addColumnAttributeComment(&$script, Column $column): void
     {
         if ($column->isTemporalType()) {
             $cptype = $this->getDateTimeClass($column);
@@ -542,7 +542,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addColumnAttributeDeclaration(&$script, Column $column)
+    protected function addColumnAttributeDeclaration(&$script, Column $column): void
     {
         $clo = $column->getLowercasedName();
         $script .= "
@@ -559,7 +559,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addColumnAttributeLoaderComment(&$script, Column $column)
+    protected function addColumnAttributeLoaderComment(&$script, Column $column): void
     {
         $clo = $column->getLowercasedName();
         $script .= "
@@ -579,7 +579,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addColumnAttributeLoaderDeclaration(&$script, Column $column)
+    protected function addColumnAttributeLoaderDeclaration(&$script, Column $column): void
     {
         $clo = $column->getLowercasedName();
         $script .= "
@@ -595,7 +595,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addColumnAttributeUnserializedComment(&$script, Column $column)
+    protected function addColumnAttributeUnserializedComment(&$script, Column $column): void
     {
         $clo = $column->getLowercasedName();
         $script .= "
@@ -614,7 +614,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addColumnAttributeUnserializedDeclaration(&$script, Column $column)
+    protected function addColumnAttributeUnserializedDeclaration(&$script, Column $column): void
     {
         $clo = $column->getLowercasedName() . '_unserialized';
         $script .= "
@@ -628,7 +628,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addColumnAttributeConvertedDeclaration(&$script, Column $column)
+    protected function addColumnAttributeConvertedDeclaration(&$script, Column $column): void
     {
         $clo = $column->getLowercasedName() . '_converted';
         $script .= "
@@ -643,7 +643,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addConstructor(&$script)
+    protected function addConstructor(&$script): void
     {
         $this->addConstructorComment($script);
         $this->addConstructorOpen($script);
@@ -658,7 +658,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addConstructorComment(&$script)
+    protected function addConstructorComment(&$script): void
     {
         $script .= "
     /**
@@ -678,7 +678,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addConstructorOpen(&$script)
+    protected function addConstructorOpen(&$script): void
     {
         $script .= "
     public function __construct()
@@ -692,7 +692,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addConstructorBody(&$script)
+    protected function addConstructorBody(&$script): void
     {
         if ($this->getParentClass() !== null) {
             $script .= "
@@ -711,7 +711,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addConstructorClose(&$script)
+    protected function addConstructorClose(&$script): void
     {
         $script .= "
     }
@@ -725,7 +725,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addBaseObjectMethods(&$script)
+    protected function addBaseObjectMethods(&$script): void
     {
         $script .= $this->renderTemplate('baseObjectMethods', ['className' => $this->getUnqualifiedClassName()]);
     }
@@ -737,7 +737,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addHookMethods(&$script)
+    protected function addHookMethods(&$script): void
     {
         $hooks = [];
         foreach (['pre', 'post'] as $hook) {
@@ -762,7 +762,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addApplyDefaultValues(&$script)
+    protected function addApplyDefaultValues(&$script): void
     {
         $this->addApplyDefaultValuesComment($script);
         $this->addApplyDefaultValuesOpen($script);
@@ -777,7 +777,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addApplyDefaultValuesComment(&$script)
+    protected function addApplyDefaultValuesComment(&$script): void
     {
         $script .= "
     /**
@@ -795,7 +795,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addApplyDefaultValuesOpen(&$script)
+    protected function addApplyDefaultValuesOpen(&$script): void
     {
         $script .= "
     public function applyDefaultValues()
@@ -809,7 +809,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addApplyDefaultValuesBody(&$script)
+    protected function addApplyDefaultValuesBody(&$script): void
     {
         $table = $this->getTable();
         // FIXME - Apply support for PHP default expressions here
@@ -845,7 +845,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addApplyDefaultValuesClose(&$script)
+    protected function addApplyDefaultValuesClose(&$script): void
     {
         $script .= "
     }
@@ -860,7 +860,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addTemporalAccessor(&$script, Column $column)
+    protected function addTemporalAccessor(&$script, Column $column): void
     {
         $this->addTemporalAccessorComment($script, $column);
         $this->addTemporalAccessorOpen($script, $column);
@@ -876,7 +876,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    public function addTemporalAccessorComment(&$script, Column $column)
+    public function addTemporalAccessorComment(&$script, Column $column): void
     {
         $clo = $column->getLowercasedName();
 
@@ -921,7 +921,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    public function addTemporalAccessorOpen(&$script, Column $column)
+    public function addTemporalAccessorOpen(&$script, Column $column): void
     {
         $cfc = $column->getPhpName();
 
@@ -962,7 +962,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return string
      */
-    protected function getAccessorLazyLoadSnippet(Column $column)
+    protected function getAccessorLazyLoadSnippet(Column $column): string
     {
         if ($column->isLazyLoad()) {
             $clo = $column->getLowercasedName();
@@ -990,7 +990,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addTemporalAccessorBody(&$script, Column $column)
+    protected function addTemporalAccessorBody(&$script, Column $column): void
     {
         $clo = $column->getLowercasedName();
 
@@ -1031,7 +1031,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addTemporalAccessorClose(&$script)
+    protected function addTemporalAccessorClose(&$script): void
     {
         $script .= "
     }
@@ -1046,7 +1046,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addObjectAccessor(&$script, Column $column)
+    protected function addObjectAccessor(&$script, Column $column): void
     {
         $this->addDefaultAccessorComment($script, $column);
         $this->addDefaultAccessorOpen($script, $column);
@@ -1062,7 +1062,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addObjectAccessorBody(&$script, Column $column)
+    protected function addObjectAccessorBody(&$script, Column $column): void
     {
         $clo = $column->getLowercasedName();
         $cloUnserialized = $clo . '_unserialized';
@@ -1086,7 +1086,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addJsonAccessor(&$script, Column $column)
+    protected function addJsonAccessor(&$script, Column $column): void
     {
         $this->addJsonAccessorComment($script, $column);
         $this->addJsonAccessorOpen($script, $column);
@@ -1102,7 +1102,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    public function addJsonAccessorComment(&$script, Column $column)
+    public function addJsonAccessorComment(&$script, Column $column): void
     {
         $clo = $column->getLowercasedName();
 
@@ -1131,7 +1131,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    public function addJsonAccessorOpen(&$script, Column $column)
+    public function addJsonAccessorOpen(&$script, Column $column): void
     {
         $cfc = $column->getPhpName();
         $visibility = $column->getAccessorVisibility();
@@ -1152,7 +1152,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addJsonAccessorBody(&$script, Column $column)
+    protected function addJsonAccessorBody(&$script, Column $column): void
     {
         $clo = $column->getLowercasedName();
         $script .= "
@@ -1167,7 +1167,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addArrayAccessor(&$script, Column $column)
+    protected function addArrayAccessor(&$script, Column $column): void
     {
         $this->addDefaultAccessorComment($script, $column);
         $this->addDefaultAccessorOpen($script, $column);
@@ -1183,7 +1183,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addArrayAccessorBody(&$script, Column $column)
+    protected function addArrayAccessorBody(&$script, Column $column): void
     {
         $clo = $column->getLowercasedName();
         $cloUnserialized = $clo . '_unserialized';
@@ -1211,7 +1211,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addBooleanAccessor(&$script, Column $column)
+    protected function addBooleanAccessor(&$script, Column $column): void
     {
         $name = self::getBooleanAccessorName($column);
         if (in_array($name, ClassTools::getPropelReservedMethods(), true)) {
@@ -1231,7 +1231,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return string
      */
-    protected static function getBooleanAccessorName(Column $column)
+    protected static function getBooleanAccessorName(Column $column): string
     {
         $name = $column->getCamelCaseName();
         if (!preg_match('/^(?:is|has)(?=[A-Z])/', $name)) {
@@ -1249,7 +1249,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    public function addBooleanAccessorOpen(&$script, Column $column)
+    public function addBooleanAccessorOpen(&$script, Column $column): void
     {
         $name = self::getBooleanAccessorName($column);
         $visibility = $column->getAccessorVisibility();
@@ -1272,7 +1272,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addBooleanAccessorBody(&$script, Column $column)
+    protected function addBooleanAccessorBody(&$script, Column $column): void
     {
         $cfc = $column->getPhpName();
 
@@ -1294,7 +1294,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addEnumAccessor(&$script, Column $column)
+    protected function addEnumAccessor(&$script, Column $column): void
     {
         $this->addEnumAccessorComment($script, $column);
         $this->addDefaultAccessorOpen($script, $column);
@@ -1310,7 +1310,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    public function addEnumAccessorComment(&$script, Column $column)
+    public function addEnumAccessorComment(&$script, Column $column): void
     {
         $clo = $column->getLowercasedName();
 
@@ -1338,7 +1338,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addEnumAccessorBody(&$script, Column $column)
+    protected function addEnumAccessorBody(&$script, Column $column): void
     {
         $clo = $column->getLowercasedName();
         if ($column->isLazyLoad()) {
@@ -1365,7 +1365,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addSetAccessor(&$script, Column $column)
+    protected function addSetAccessor(&$script, Column $column): void
     {
         $this->addSetAccessorComment($script, $column);
         $this->addDefaultAccessorOpen($script, $column);
@@ -1381,7 +1381,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    public function addSetAccessorComment(&$script, Column $column)
+    public function addSetAccessorComment(&$script, Column $column): void
     {
         $clo = $column->getLowercasedName();
 
@@ -1407,7 +1407,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addSetAccessorBody(&$script, Column $column)
+    protected function addSetAccessorBody(&$script, Column $column): void
     {
         $clo = $column->getLowercasedName();
         $cloConverted = $clo . '_converted';
@@ -1443,7 +1443,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addHasArrayElement(&$script, Column $column)
+    protected function addHasArrayElement(&$script, Column $column): void
     {
         $clo = $column->getLowercasedName();
         $cfc = $column->getPhpName();
@@ -1460,14 +1460,14 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * @param      ConnectionInterface \$con An optional ConnectionInterface connection to use for fetching this lazy-loaded column.";
         }
         $script .= "
-     * @return boolean
+     * @return bool
      */
     $visibility function has$singularPhpName(\$value";
         if ($column->isLazyLoad()) {
             $script .= ', ConnectionInterface $con = null';
         }
 
-        $script .= ")
+        $script .= "): bool
     {
         return in_array(\$value, \$this->get$cfc(";
         if ($column->isLazyLoad()) {
@@ -1475,7 +1475,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
         }
 
         $script .= "));
-    } // has$singularPhpName()
+    }
 ";
     }
 
@@ -1487,7 +1487,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addDefaultAccessor(&$script, Column $column)
+    protected function addDefaultAccessor(&$script, Column $column): void
     {
         $this->addDefaultAccessorComment($script, $column);
         $this->addDefaultAccessorOpen($script, $column);
@@ -1503,7 +1503,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    public function addDefaultAccessorComment(&$script, Column $column)
+    public function addDefaultAccessorComment(&$script, Column $column): void
     {
         $clo = $column->getLowercasedName();
 
@@ -1530,7 +1530,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    public function addDefaultAccessorOpen(&$script, Column $column)
+    public function addDefaultAccessorOpen(&$script, Column $column): void
     {
         $cfc = $column->getPhpName();
         $visibility = $column->getAccessorVisibility();
@@ -1553,7 +1553,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addDefaultAccessorBody(&$script, Column $column)
+    protected function addDefaultAccessorBody(&$script, Column $column): void
     {
         $clo = $column->getLowercasedName();
         if ($column->isLazyLoad()) {
@@ -1571,7 +1571,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addDefaultAccessorClose(&$script)
+    protected function addDefaultAccessorClose(&$script): void
     {
         $script .= "
     }
@@ -1586,7 +1586,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addLazyLoader(&$script, Column $column)
+    protected function addLazyLoader(&$script, Column $column): void
     {
         $this->addLazyLoaderComment($script, $column);
         $this->addLazyLoaderOpen($script, $column);
@@ -1602,7 +1602,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addLazyLoaderComment(&$script, Column $column)
+    protected function addLazyLoaderComment(&$script, Column $column): void
     {
         $clo = $column->getLowercasedName();
 
@@ -1628,7 +1628,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addLazyLoaderOpen(&$script, Column $column)
+    protected function addLazyLoaderOpen(&$script, Column $column): void
     {
         $cfc = $column->getPhpName();
         $script .= "
@@ -1644,7 +1644,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addLazyLoaderBody(&$script, Column $column)
+    protected function addLazyLoaderBody(&$script, Column $column): void
     {
         $platform = $this->getPlatform();
         $clo = $column->getLowercasedName();
@@ -1717,7 +1717,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addLazyLoaderClose(&$script)
+    protected function addLazyLoaderClose(&$script): void
     {
         $script .= "
     }";
@@ -1731,7 +1731,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addMutatorOpen(&$script, Column $column)
+    protected function addMutatorOpen(&$script, Column $column): void
     {
         $this->addMutatorComment($script, $column);
         $this->addMutatorOpenOpen($script, $column);
@@ -1746,7 +1746,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addJsonMutatorOpen(&$script, Column $column)
+    protected function addJsonMutatorOpen(&$script, Column $column): void
     {
         $this->addJsonMutatorComment($script, $column);
         $this->addMutatorOpenOpen($script, $column);
@@ -1761,7 +1761,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    public function addJsonMutatorComment(&$script, Column $column)
+    public function addJsonMutatorComment(&$script, Column $column): void
     {
         $clo = $column->getLowercasedName();
 
@@ -1784,7 +1784,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    public function addMutatorComment(&$script, Column $column)
+    public function addMutatorComment(&$script, Column $column): void
     {
         $clo = $column->getLowercasedName();
         $type = $column->getPhpType();
@@ -1809,7 +1809,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    public function addMutatorOpenOpen(&$script, Column $column)
+    public function addMutatorOpenOpen(&$script, Column $column): void
     {
         $cfc = $column->getPhpName();
         $visibility = $this->getTable()->isReadOnly() ? 'protected' : $column->getMutatorVisibility();
@@ -1843,7 +1843,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addMutatorOpenBody(&$script, Column $column)
+    protected function addMutatorOpenBody(&$script, Column $column): void
     {
         $clo = $column->getLowercasedName();
         $cfc = $column->getPhpName();
@@ -1866,7 +1866,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addMutatorClose(&$script, Column $column)
+    protected function addMutatorClose(&$script, Column $column): void
     {
         $this->addMutatorCloseBody($script, $column);
         $this->addMutatorCloseClose($script, $column);
@@ -1880,7 +1880,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addMutatorCloseBody(&$script, Column $column)
+    protected function addMutatorCloseBody(&$script, Column $column): void
     {
         $table = $this->getTable();
 
@@ -1946,12 +1946,12 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addMutatorCloseClose(&$script, Column $col)
+    protected function addMutatorCloseClose(&$script, Column $col): void
     {
         $cfc = $col->getPhpName();
         $script .= "
         return \$this;
-    } // set$cfc()
+    }
 ";
     }
 
@@ -1965,7 +1965,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addLobMutator(&$script, Column $col)
+    protected function addLobMutator(&$script, Column $col): void
     {
         $this->addMutatorOpen($script, $col);
         $clo = $col->getLowercasedName();
@@ -1995,7 +1995,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addTemporalMutator(&$script, Column $col)
+    protected function addTemporalMutator(&$script, Column $col): void
     {
         $clo = $col->getLowercasedName();
 
@@ -2051,7 +2051,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    public function addTemporalMutatorComment(&$script, Column $col)
+    public function addTemporalMutatorComment(&$script, Column $col): void
     {
         $clo = $col->getLowercasedName();
 
@@ -2077,7 +2077,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addObjectMutator(&$script, Column $col)
+    protected function addObjectMutator(&$script, Column $col): void
     {
         $clo = $col->getLowercasedName();
         $cloUnserialized = $clo . '_unserialized';
@@ -2105,7 +2105,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addJsonMutator(&$script, Column $col)
+    protected function addJsonMutator(&$script, Column $col): void
     {
         $clo = $col->getLowercasedName();
 
@@ -2135,7 +2135,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addArrayMutator(&$script, Column $col)
+    protected function addArrayMutator(&$script, Column $col): void
     {
         $clo = $col->getLowercasedName();
         $cloUnserialized = $clo . '_unserialized';
@@ -2159,7 +2159,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addAddArrayElement(&$script, Column $col)
+    protected function addAddArrayElement(&$script, Column $col): void
     {
         $clo = $col->getLowercasedName();
         $cfc = $col->getPhpName();
@@ -2195,7 +2195,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
         \$this->set$cfc(\$currentArray);
 
         return \$this;
-    } // add$singularPhpName()
+    }
 ";
     }
 
@@ -2207,7 +2207,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addRemoveArrayElement(&$script, Column $col)
+    protected function addRemoveArrayElement(&$script, Column $col): void
     {
         $clo = $col->getLowercasedName();
         $cfc = $col->getPhpName();
@@ -2246,7 +2246,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
         \$this->set$cfc(\$targetArray);
 
         return \$this;
-    } // remove$singularPhpName()
+    }
 ";
     }
 
@@ -2260,7 +2260,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addEnumMutator(&$script, Column $col)
+    protected function addEnumMutator(&$script, Column $col): void
     {
         $clo = $col->getLowercasedName();
         $this->addEnumMutatorComment($script, $col);
@@ -2292,7 +2292,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    public function addEnumMutatorComment(&$script, Column $column)
+    public function addEnumMutatorComment(&$script, Column $column): void
     {
         $clo = $column->getLowercasedName();
 
@@ -2318,7 +2318,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addSetMutator(&$script, Column $col)
+    protected function addSetMutator(&$script, Column $col): void
     {
         $clo = $col->getLowercasedName();
         $this->addSetMutatorComment($script, $col);
@@ -2357,7 +2357,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    public function addSetMutatorComment(&$script, Column $column)
+    public function addSetMutatorComment(&$script, Column $column): void
     {
         $clo = $column->getLowercasedName();
 
@@ -2383,7 +2383,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addBooleanMutator(&$script, Column $col)
+    protected function addBooleanMutator(&$script, Column $col): void
     {
         $clo = $col->getLowercasedName();
 
@@ -2414,7 +2414,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    public function addBooleanMutatorComment(&$script, Column $col)
+    public function addBooleanMutatorComment(&$script, Column $col): void
     {
         $clo = $col->getLowercasedName();
 
@@ -2443,7 +2443,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addDefaultMutator(&$script, Column $col)
+    protected function addDefaultMutator(&$script, Column $col): void
     {
         $clo = $col->getLowercasedName();
 
@@ -2475,7 +2475,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addHasOnlyDefaultValues(&$script)
+    protected function addHasOnlyDefaultValues(&$script): void
     {
         $this->addHasOnlyDefaultValuesComment($script);
         $this->addHasOnlyDefaultValuesOpen($script);
@@ -2492,7 +2492,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addHasOnlyDefaultValuesComment(&$script)
+    protected function addHasOnlyDefaultValuesComment(&$script): void
     {
         $script .= "
     /**
@@ -2501,7 +2501,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * This method can be used in conjunction with isModified() to indicate whether an object is both
      * modified _and_ has some values set which are non-default.
      *
-     * @return boolean Whether the columns in this object are only been set with default values.
+     * @return bool Whether the columns in this object are only been set with default values.
      */";
     }
 
@@ -2514,10 +2514,10 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addHasOnlyDefaultValuesOpen(&$script)
+    protected function addHasOnlyDefaultValuesOpen(&$script): void
     {
         $script .= "
-    public function hasOnlyDefaultValues()
+    public function hasOnlyDefaultValues(): bool
     {";
     }
 
@@ -2530,7 +2530,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addHasOnlyDefaultValuesBody(&$script)
+    protected function addHasOnlyDefaultValuesBody(&$script): void
     {
         $table = $this->getTable();
         $colsWithDefaults = [];
@@ -2571,13 +2571,13 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addHasOnlyDefaultValuesClose(&$script)
+    protected function addHasOnlyDefaultValuesClose(&$script): void
     {
         $script .= "
         // otherwise, everything was equal, so return TRUE
         return true;";
         $script .= "
-    } // hasOnlyDefaultValues()
+    }
 ";
     }
 
@@ -2588,7 +2588,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addHydrate(&$script)
+    protected function addHydrate(&$script): void
     {
         $this->addHydrateComment($script);
         $this->addHydrateOpen($script);
@@ -2605,7 +2605,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addHydrateComment(&$script)
+    protected function addHydrateComment(&$script): void
     {
         $script .= "
     /**
@@ -2637,7 +2637,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addHydrateOpen(&$script)
+    protected function addHydrateOpen(&$script): void
     {
         $script .= "
     public function hydrate(\$row, \$startcol = 0, \$rehydrate = false, \$indexType = TableMap::TYPE_NUM)
@@ -2653,7 +2653,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addHydrateBody(&$script)
+    protected function addHydrateBody(&$script): void
     {
         $table = $this->getTable();
         $platform = $this->getPlatform();
@@ -2765,7 +2765,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addHydrateClose(&$script)
+    protected function addHydrateClose(&$script): void
     {
         $script .= "
     }
@@ -2779,7 +2779,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addBuildPkeyCriteria(&$script)
+    protected function addBuildPkeyCriteria(&$script): void
     {
         $this->declareClass('Propel\\Runtime\\Exception\\LogicException');
 
@@ -2798,7 +2798,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addBuildPkeyCriteriaComment(&$script)
+    protected function addBuildPkeyCriteriaComment(&$script): void
     {
         $script .= "
     /**
@@ -2822,7 +2822,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addBuildPkeyCriteriaOpen(&$script)
+    protected function addBuildPkeyCriteriaOpen(&$script): void
     {
         $script .= "
     public function buildPkeyCriteria()
@@ -2838,7 +2838,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addBuildPkeyCriteriaBody(&$script)
+    protected function addBuildPkeyCriteriaBody(&$script): void
     {
         if (!$this->getTable()->getPrimaryKey()) {
             $script .= "
@@ -2865,7 +2865,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addBuildPkeyCriteriaClose(&$script)
+    protected function addBuildPkeyCriteriaClose(&$script): void
     {
         $script .= "
 
@@ -2881,7 +2881,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addBuildCriteria(&$script)
+    protected function addBuildCriteria(&$script): void
     {
         $this->addBuildCriteriaComment($script);
         $this->addBuildCriteriaOpen($script);
@@ -2898,7 +2898,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addBuildCriteriaComment(&$script)
+    protected function addBuildCriteriaComment(&$script): void
     {
         $script .= "
     /**
@@ -2917,7 +2917,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addBuildCriteriaOpen(&$script)
+    protected function addBuildCriteriaOpen(&$script): void
     {
         $script .= "
     public function buildCriteria()
@@ -2933,7 +2933,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addBuildCriteriaBody(&$script)
+    protected function addBuildCriteriaBody(&$script): void
     {
         $script .= "
         \$criteria = new Criteria(" . $this->getTableMapClass() . "::DATABASE_NAME);
@@ -2956,7 +2956,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addBuildCriteriaClose(&$script)
+    protected function addBuildCriteriaClose(&$script): void
     {
         $script .= "
 
@@ -2972,7 +2972,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addToArray(&$script)
+    protected function addToArray(&$script): void
     {
         $fks = $this->getTable()->getForeignKeys();
         $referrers = $this->getTable()->getReferrers();
@@ -3084,7 +3084,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return string
      */
-    protected function addToArrayKeyLookUp($phpName, Table $table, $plural)
+    protected function addToArrayKeyLookUp($phpName, Table $table, $plural): string
     {
         if ($phpName == '') {
             $phpName = $table->getPhpName();
@@ -3120,7 +3120,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addGetByName(&$script)
+    protected function addGetByName(&$script): void
     {
         $this->addGetByNameComment($script);
         $this->addGetByNameOpen($script);
@@ -3137,7 +3137,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addGetByNameComment(&$script)
+    protected function addGetByNameComment(&$script): void
     {
         $defaultKeyType = $this->getDefaultKeyType();
         $script .= "
@@ -3162,7 +3162,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addGetByNameOpen(&$script)
+    protected function addGetByNameOpen(&$script): void
     {
         $defaultKeyType = $this->getDefaultKeyType();
         $script .= "
@@ -3179,7 +3179,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addGetByNameBody(&$script)
+    protected function addGetByNameBody(&$script): void
     {
         $script .= "
         \$pos = " . $this->getTableMapClassName() . "::translateFieldName(\$name, \$type, TableMap::TYPE_NUM);
@@ -3195,7 +3195,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addGetByNameClose(&$script)
+    protected function addGetByNameClose(&$script): void
     {
         $script .= "
 
@@ -3211,7 +3211,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addGetByPosition(&$script)
+    protected function addGetByPosition(&$script): void
     {
         $this->addGetByPositionComment($script);
         $this->addGetByPositionOpen($script);
@@ -3228,7 +3228,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addGetByPositionComment(&$script)
+    protected function addGetByPositionComment(&$script): void
     {
         $script .= "
     /**
@@ -3249,7 +3249,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addGetByPositionOpen(&$script)
+    protected function addGetByPositionOpen(&$script): void
     {
         $script .= "
     public function getByPosition(\$pos)
@@ -3265,7 +3265,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addGetByPositionBody(&$script)
+    protected function addGetByPositionBody(&$script): void
     {
         $table = $this->getTable();
         $script .= "
@@ -3295,7 +3295,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addGetByPositionClose(&$script)
+    protected function addGetByPositionClose(&$script): void
     {
         $script .= "
     }
@@ -3307,7 +3307,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addSetByName(&$script)
+    protected function addSetByName(&$script): void
     {
         $defaultKeyType = $this->getDefaultKeyType();
         $script .= "
@@ -3336,7 +3336,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addSetByPosition(&$script)
+    protected function addSetByPosition(&$script): void
     {
         $table = $this->getTable();
         $script .= "
@@ -3403,7 +3403,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addFromArray(&$script)
+    protected function addFromArray(&$script): void
     {
         $defaultKeyType = $this->getDefaultKeyType();
         $table = $this->getTable();
@@ -3448,7 +3448,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addImportFrom(&$script)
+    protected function addImportFrom(&$script): void
     {
         $defaultKeyType = $this->getDefaultKeyType();
         $script .= "
@@ -3491,7 +3491,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addDelete(&$script)
+    protected function addDelete(&$script): void
     {
         $this->addDeleteComment($script);
         $this->addDeleteOpen($script);
@@ -3508,7 +3508,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addDeleteComment(&$script)
+    protected function addDeleteComment(&$script): void
     {
         $className = $this->getUnqualifiedClassName();
         $script .= "
@@ -3532,10 +3532,10 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addDeleteOpen(&$script)
+    protected function addDeleteOpen(&$script): void
     {
         $script .= "
-    public function delete(ConnectionInterface \$con = null)
+    public function delete(ConnectionInterface \$con = null): void
     {";
     }
 
@@ -3548,7 +3548,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addDeleteBody(&$script)
+    protected function addDeleteBody(&$script): void
     {
         $script .= "
         if (\$this->isDeleted()) {
@@ -3600,7 +3600,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addDeleteClose(&$script)
+    protected function addDeleteClose(&$script): void
     {
         $script .= "
     }
@@ -3614,7 +3614,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addReload(&$script)
+    protected function addReload(&$script): void
     {
         $table = $this->getTable();
         $script .= "
@@ -3708,7 +3708,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addManipulationMethods(&$script)
+    protected function addManipulationMethods(&$script): void
     {
         $this->addReload($script);
         $this->addDelete($script);
@@ -3723,14 +3723,14 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addHashCode(&$script)
+    protected function addHashCode(&$script): void
     {
         $script .= "
     /**
      * If the primary key is not null, return the hashcode of the
      * primary key. Otherwise, return the hash code of the object.
      *
-     * @return int Hashcode
+     * @return int|string Hashcode
      */
     public function hashCode()
     {
@@ -3793,7 +3793,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addGetPrimaryKey(&$script)
+    protected function addGetPrimaryKey(&$script): void
     {
         $pkeys = $this->getTable()->getPrimaryKey();
         if (count($pkeys) == 1) {
@@ -3813,7 +3813,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addGetPrimaryKeySinglePK(&$script)
+    protected function addGetPrimaryKeySinglePK(&$script): void
     {
         $table = $this->getTable();
         $pkeys = $table->getPrimaryKey();
@@ -3838,7 +3838,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addGetPrimaryKeyMultiPK(&$script)
+    protected function addGetPrimaryKeyMultiPK(&$script): void
     {
         $script .= "
     /**
@@ -3874,7 +3874,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addGetPrimaryKeyNoPK(&$script)
+    protected function addGetPrimaryKeyNoPK(&$script): void
     {
         $script .= "
     /**
@@ -3896,7 +3896,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addSetPrimaryKey(&$script)
+    protected function addSetPrimaryKey(&$script): void
     {
         $pkeys = $this->getTable()->getPrimaryKey();
         if (count($pkeys) == 1) {
@@ -3916,7 +3916,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addSetPrimaryKeySinglePK(&$script)
+    protected function addSetPrimaryKeySinglePK(&$script): void
     {
         $pkeys = $this->getTable()->getPrimaryKey();
         $col = $pkeys[0];
@@ -3944,7 +3944,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addSetPrimaryKeyMultiPK(&$script)
+    protected function addSetPrimaryKeyMultiPK(&$script): void
     {
         $script .= "
     /**
@@ -3978,7 +3978,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addSetPrimaryKeyNoPK(&$script)
+    protected function addSetPrimaryKeyNoPK(&$script): void
     {
         $script .= "
     /**
@@ -4004,7 +4004,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addIsPrimaryKeyNull(&$script)
+    protected function addIsPrimaryKeyNull(&$script): void
     {
         $table = $this->getTable();
         $pkeys = $table->getPrimaryKey();
@@ -4039,7 +4039,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return string
      */
-    public function getFKVarName(ForeignKey $fk)
+    public function getFKVarName(ForeignKey $fk): string
     {
         return 'a' . $this->getFKPhpNameAffix($fk, false);
     }
@@ -4051,7 +4051,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return string
      */
-    public function getRefFKCollVarName(ForeignKey $fk)
+    public function getRefFKCollVarName(ForeignKey $fk): string
     {
         return 'coll' . $this->getRefFKPhpNameAffix($fk, true);
     }
@@ -4064,7 +4064,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return string
      */
-    public function getPKRefFKVarName(ForeignKey $fk)
+    public function getPKRefFKVarName(ForeignKey $fk): string
     {
         return 'single' . $this->getRefFKPhpNameAffix($fk, false);
     }
@@ -4076,7 +4076,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addFKMethods(&$script)
+    protected function addFKMethods(&$script): void
     {
         foreach ($this->getTable()->getForeignKeys() as $fk) {
             $this->declareClassFromBuilder($this->getNewStubObjectBuilder($fk->getForeignTable()), 'Child');
@@ -4094,7 +4094,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addFKAttributes(&$script, ForeignKey $fk)
+    protected function addFKAttributes(&$script, ForeignKey $fk): void
     {
         $className = $this->getClassNameFromTable($fk->getForeignTable());
         $varName = $this->getFKVarName($fk);
@@ -4115,7 +4115,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addFKMutator(&$script, ForeignKey $fk)
+    protected function addFKMutator(&$script, ForeignKey $fk): void
     {
         $table = $this->getTable();
         $fkTable = $fk->getForeignTable();
@@ -4203,7 +4203,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addFKAccessor(&$script, ForeignKey $fk)
+    protected function addFKAccessor(&$script, ForeignKey $fk): void
     {
         $table = $this->getTable();
 
@@ -4311,7 +4311,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addRefFKGetJoinMethods(&$script, ForeignKey $refFK)
+    protected function addRefFKGetJoinMethods(&$script, ForeignKey $refFK): void
     {
         $table = $this->getTable();
         $tblFK = $refFK->getTable();
@@ -4384,7 +4384,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addRefFKAttributes(&$script, ForeignKey $refFK)
+    protected function addRefFKAttributes(&$script, ForeignKey $refFK): void
     {
         $className = $this->getClassNameFromTable($refFK->getTable());
 
@@ -4414,7 +4414,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addRefFKMethods(&$script)
+    protected function addRefFKMethods(&$script): void
     {
         if (!$referrers = $this->getTable()->getReferrers()) {
             return;
@@ -4447,7 +4447,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addInitRelations(&$script, $referrers)
+    protected function addInitRelations(&$script, $referrers): void
     {
         $script .= "
 
@@ -4485,7 +4485,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addRefFKClear(&$script, ForeignKey $refFK)
+    protected function addRefFKClear(&$script, ForeignKey $refFK): void
     {
         $relCol = $this->getRefFKPhpNameAffix($refFK, true);
         $collName = $this->getRefFKCollVarName($refFK);
@@ -4515,7 +4515,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addRefFKInit(&$script, ForeignKey $refFK)
+    protected function addRefFKInit(&$script, ForeignKey $refFK): void
     {
         $relCol = $this->getRefFKPhpNameAffix($refFK, true);
         $collName = $this->getRefFKCollVarName($refFK);
@@ -4555,7 +4555,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addRefFKAdd(&$script, ForeignKey $refFK)
+    protected function addRefFKAdd(&$script, ForeignKey $refFK): void
     {
         $tblFK = $refFK->getTable();
 
@@ -4605,7 +4605,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addRefFKCount(&$script, ForeignKey $refFK)
+    protected function addRefFKCount(&$script, ForeignKey $refFK): void
     {
         $fkQueryClassName = $this->getClassNameFromBuilder($this->getNewStubQueryBuilder($refFK->getTable()));
         $relCol = $this->getRefFKPhpNameAffix($refFK, $plural = true);
@@ -4659,7 +4659,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addRefFKGet(&$script, ForeignKey $refFK)
+    protected function addRefFKGet(&$script, ForeignKey $refFK): void
     {
         $fkQueryClassName = $this->getClassNameFromBuilder($this->getNewStubQueryBuilder($refFK->getTable()));
         $relCol = $this->getRefFKPhpNameAffix($refFK, $plural = true);
@@ -4744,7 +4744,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addRefFKSet(&$script, ForeignKey $refFK)
+    protected function addRefFKSet(&$script, ForeignKey $refFK): void
     {
         $relatedName = $this->getRefFKPhpNameAffix($refFK, true);
         $relatedObjectClassName = $this->getRefFKPhpNameAffix($refFK, false);
@@ -4812,7 +4812,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addRefFKDoAdd(&$script, ForeignKey $refFK)
+    protected function addRefFKDoAdd(&$script, ForeignKey $refFK): void
     {
         $tblFK = $refFK->getTable();
 
@@ -4844,7 +4844,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addRefFKRemove(&$script, ForeignKey $refFK)
+    protected function addRefFKRemove(&$script, ForeignKey $refFK): void
     {
         $tblFK = $refFK->getTable();
 
@@ -4904,7 +4904,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addPKRefFKGet(&$script, ForeignKey $refFK)
+    protected function addPKRefFKGet(&$script, ForeignKey $refFK): void
     {
         $className = $this->getClassNameFromTable($refFK->getTable());
 
@@ -4942,7 +4942,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addPKRefFKSet(&$script, ForeignKey $refFK)
+    protected function addPKRefFKSet(&$script, ForeignKey $refFK): void
     {
         $className = $this->getClassNameFromTable($refFK->getTable());
 
@@ -4976,7 +4976,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addCrossFKAttributes(&$script, CrossForeignKeys $crossFKs)
+    protected function addCrossFKAttributes(&$script, CrossForeignKeys $crossFKs): void
     {
         if (1 < count($crossFKs->getCrossForeignKeys()) || $crossFKs->getUnclassifiedPrimaryKeys()) {
             [$names] = $this->getCrossFKInformation($crossFKs);
@@ -5017,7 +5017,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addCrossScheduledForDeletionAttribute(&$script, CrossForeignKeys $crossFKs)
+    protected function addCrossScheduledForDeletionAttribute(&$script, CrossForeignKeys $crossFKs): void
     {
         $name = $this->getCrossScheduledForDeletionVarName($crossFKs);
         if (1 < count($crossFKs->getCrossForeignKeys()) || $crossFKs->getUnclassifiedPrimaryKeys()) {
@@ -5050,7 +5050,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return string
      */
-    protected function getCrossScheduledForDeletionVarName(CrossForeignKeys $crossFKs)
+    protected function getCrossScheduledForDeletionVarName(CrossForeignKeys $crossFKs): string
     {
         if (1 < count($crossFKs->getCrossForeignKeys()) || $crossFKs->getUnclassifiedPrimaryKeys()) {
             return 'combination' . ucfirst($this->getCrossFKsVarName($crossFKs)) . 'ScheduledForDeletion';
@@ -5067,7 +5067,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addCrossFkScheduledForDeletionAttribute(&$script, ForeignKey $crossFK)
+    protected function addCrossFkScheduledForDeletionAttribute(&$script, ForeignKey $crossFK): void
     {
         $className = $this->getClassNameFromTable($crossFK->getForeignTable());
         $fkName = lcfirst($this->getFKPhpNameAffix($crossFK, true));
@@ -5088,7 +5088,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addRefFkScheduledForDeletionAttribute(&$script, ForeignKey $refFK)
+    protected function addRefFkScheduledForDeletionAttribute(&$script, ForeignKey $refFK): void
     {
         $className = $this->getClassNameFromTable($refFK->getTable());
         $fkName = lcfirst($this->getRefFKPhpNameAffix($refFK, true));
@@ -5109,7 +5109,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addCrossFkScheduledForDeletion(&$script, CrossForeignKeys $crossFKs)
+    protected function addCrossFkScheduledForDeletion(&$script, CrossForeignKeys $crossFKs): void
     {
         $multipleFks = 1 < count($crossFKs->getCrossForeignKeys()) || (bool)$crossFKs->getUnclassifiedPrimaryKeys();
         $scheduledForDeletionVarName = $this->getCrossScheduledForDeletionVarName($crossFKs);
@@ -5267,7 +5267,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addRefFkScheduledForDeletion(&$script, ForeignKey $refFK)
+    protected function addRefFkScheduledForDeletion(&$script, ForeignKey $refFK): void
     {
         $relatedName = $this->getRefFKPhpNameAffix($refFK, $plural = true);
         $lowerRelatedName = lcfirst($relatedName);
@@ -5303,7 +5303,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addCrossFKMethods(&$script)
+    protected function addCrossFKMethods(&$script): void
     {
         foreach ($this->getTable()->getCrossFks() as $crossFKs) {
             foreach ($crossFKs->getCrossForeignKeys() as $fk) {
@@ -5333,7 +5333,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addCrossFKClear(&$script, CrossForeignKeys $crossFKs)
+    protected function addCrossFKClear(&$script, CrossForeignKeys $crossFKs): void
     {
         $relCol = $this->getCrossFKsPhpNameAffix($crossFKs);
         $collName = $this->getCrossFKsVarName($crossFKs);
@@ -5363,7 +5363,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addRefFKPartial(&$script, ForeignKey $refFK)
+    protected function addRefFKPartial(&$script, ForeignKey $refFK): void
     {
         $relCol = $this->getRefFKPhpNameAffix($refFK, $plural = true);
         $collName = $this->getRefFKCollVarName($refFK);
@@ -5387,7 +5387,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addCrossFKInit(&$script, CrossForeignKeys $crossFKs)
+    protected function addCrossFKInit(&$script, CrossForeignKeys $crossFKs): void
     {
         $inits = [];
 
@@ -5469,7 +5469,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addCrossFKIsLoaded(&$script, CrossForeignKeys $crossFKs)
+    protected function addCrossFKIsLoaded(&$script, CrossForeignKeys $crossFKs): void
     {
         $inits = [];
 
@@ -5514,7 +5514,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addCrossFKCreateQuery(&$script, CrossForeignKeys $crossFKs)
+    protected function addCrossFKCreateQuery(&$script, CrossForeignKeys $crossFKs): void
     {
         if (1 <= count($crossFKs->getCrossForeignKeys()) && !$crossFKs->getUnclassifiedPrimaryKeys()) {
             return;
@@ -5594,7 +5594,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addCrossFKGet(&$script, CrossForeignKeys $crossFKs)
+    protected function addCrossFKGet(&$script, CrossForeignKeys $crossFKs): void
     {
         $refFK = $crossFKs->getIncomingForeignKey();
         $selfRelationName = $this->getFKPhpNameAffix($refFK, false);
@@ -5797,7 +5797,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addCrossFKSet(&$script, CrossForeignKeys $crossFKs)
+    protected function addCrossFKSet(&$script, CrossForeignKeys $crossFKs): void
     {
         $scheduledForDeletionVarName = $this->getCrossScheduledForDeletionVarName($crossFKs);
 
@@ -5876,7 +5876,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addCrossFKCount(&$script, CrossForeignKeys $crossFKs)
+    protected function addCrossFKCount(&$script, CrossForeignKeys $crossFKs): void
     {
         $refFK = $crossFKs->getIncomingForeignKey();
         $selfRelationName = $this->getFKPhpNameAffix($refFK, false);
@@ -5962,7 +5962,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return integer
      */
-    public function count{$firstFkName}($signature, Criteria \$criteria = null, ConnectionInterface \$con = null)
+    public function count{$firstFkName}($signature, Criteria \$criteria = null, ConnectionInterface \$con = null): int
     {
         return \$this->create{$firstFkName}Query($shortSignature, \$criteria)->count(\$con);
     }
@@ -5978,7 +5978,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addCrossFKAdd(&$script, CrossForeignKeys $crossFKs)
+    protected function addCrossFKAdd(&$script, CrossForeignKeys $crossFKs): void
     {
         $refFK = $crossFKs->getIncomingForeignKey();
 
@@ -6033,7 +6033,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return string
      */
-    protected function getCrossFKGetterSignature(CrossForeignKeys $crossFKs, $excludeSignatureItem)
+    protected function getCrossFKGetterSignature(CrossForeignKeys $crossFKs, $excludeSignatureItem): string
     {
         [, $getSignature] = $this->getCrossFKAddMethodInformation($crossFKs);
         $getSignature = explode(', ', $getSignature);
@@ -6051,7 +6051,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addCrossFKDoAdd(&$script, CrossForeignKeys $crossFKs)
+    protected function addCrossFKDoAdd(&$script, CrossForeignKeys $crossFKs): void
     {
         $selfRelationName = $this->getFKPhpNameAffix($crossFKs->getIncomingForeignKey(), false);
         $selfRelationNamePlural = $this->getFKPhpNameAffix($crossFKs->getIncomingForeignKey(), true);
@@ -6145,7 +6145,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return string
      */
-    protected function getCrossRefFKRemoveObjectNames(CrossForeignKeys $crossFKs, ForeignKey $excludeFK)
+    protected function getCrossRefFKRemoveObjectNames(CrossForeignKeys $crossFKs, ForeignKey $excludeFK): string
     {
         $names = [];
 
@@ -6176,7 +6176,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addCrossFKRemove(&$script, CrossForeignKeys $crossFKs)
+    protected function addCrossFKRemove(&$script, CrossForeignKeys $crossFKs): void
     {
         $relCol = $this->getCrossFKsPhpNameAffix($crossFKs, true);
         if (1 < count($crossFKs->getCrossForeignKeys()) || $crossFKs->getUnclassifiedPrimaryKeys()) {
@@ -6266,7 +6266,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addDoSave(&$script)
+    protected function addDoSave(&$script): void
     {
         $table = $this->getTable();
 
@@ -6411,7 +6411,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
         }
 
         return \$affectedRows;
-    } // doSave()
+    }
 ";
     }
 
@@ -6420,7 +6420,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return string the doInsert() method code
      */
-    protected function addDoInsert()
+    protected function addDoInsert(): string
     {
         $table = $this->getTable();
         $script = "
@@ -6460,7 +6460,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
     /**
      * @return string
      */
-    protected function addDoInsertBodyStandard()
+    protected function addDoInsertBodyStandard(): string
     {
         return "
         \$pk = \$criteria->doInsert(\$con);";
@@ -6469,7 +6469,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
     /**
      * @return string
      */
-    protected function addDoInsertBodyWithIdMethod()
+    protected function addDoInsertBodyWithIdMethod(): string
     {
         $table = $this->getTable();
         $script = '';
@@ -6524,7 +6524,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return string
      */
-    protected function addDoInsertBodyRaw()
+    protected function addDoInsertBodyRaw(): string
     {
         $this->declareClasses(
             '\Propel\Runtime\Propel',
@@ -6665,7 +6665,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return string the doUpdate() method code
      */
-    protected function addDoUpdate()
+    protected function addDoUpdate(): string
     {
         return "
     /**
@@ -6676,7 +6676,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * @return Integer Number of updated rows
      * @see doSave()
      */
-    protected function doUpdate(ConnectionInterface \$con)
+    protected function doUpdate(ConnectionInterface \$con): int
     {
         \$selectCriteria = \$this->buildPkeyCriteria();
         \$valuesCriteria = \$this->buildCriteria();
@@ -6693,7 +6693,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addAlreadyInSaveAttribute(&$script)
+    protected function addAlreadyInSaveAttribute(&$script): void
     {
         $script .= "
     /**
@@ -6713,7 +6713,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addSave(&$script)
+    protected function addSave(&$script): void
     {
         $this->addSaveComment($script);
         $this->addSaveOpen($script);
@@ -6730,7 +6730,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addSaveComment(&$script)
+    protected function addSaveComment(&$script): void
     {
         $table = $this->getTable();
         $reloadOnUpdate = $table->isReloadOnUpdate();
@@ -6781,7 +6781,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addSaveOpen(&$script)
+    protected function addSaveOpen(&$script): void
     {
         $table = $this->getTable();
         $reloadOnUpdate = $table->isReloadOnUpdate();
@@ -6800,7 +6800,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addSaveBody(&$script)
+    protected function addSaveBody(&$script): void
     {
         $table = $this->getTable();
         $reloadOnUpdate = $table->isReloadOnUpdate();
@@ -6912,7 +6912,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addSaveClose(&$script)
+    protected function addSaveClose(&$script): void
     {
         $script .= "
     }
@@ -6926,7 +6926,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addEnsureConsistency(&$script)
+    protected function addEnsureConsistency(&$script): void
     {
         $table = $this->getTable();
 
@@ -6968,7 +6968,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
         }
 
         $script .= "
-    } // ensureConsistency
+    }
 ";
     }
 
@@ -6979,7 +6979,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addCopy(&$script)
+    protected function addCopy(&$script): void
     {
         $this->addCopyInto($script);
 
@@ -7016,7 +7016,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addCopyInto(&$script)
+    protected function addCopyInto(&$script): void
     {
         $table = $this->getTable();
 
@@ -7115,7 +7115,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addClear(&$script)
+    protected function addClear(&$script): void
     {
         $table = $this->getTable();
 
@@ -7184,7 +7184,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addClearAllReferences(&$script)
+    protected function addClearAllReferences(&$script): void
     {
         $table = $this->getTable();
         $script .= "
@@ -7261,7 +7261,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addPrimaryString(&$script)
+    protected function addPrimaryString(&$script): void
     {
         foreach ($this->getTable()->getColumns() as $column) {
             if ($column->isPrimaryString()) {
@@ -7301,7 +7301,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return void
      */
-    protected function addMagicCall(&$script)
+    protected function addMagicCall(&$script): void
     {
         $behaviorCallScript = '';
         $this->applyBehaviorModifier('objectCall', $behaviorCallScript, '    ');
@@ -7316,7 +7316,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return string
      */
-    protected function getDateTimeClass(Column $column)
+    protected function getDateTimeClass(Column $column): string
     {
         if (PropelTypes::isPhpObjectType($column->getPhpType())) {
             return $column->getPhpType();

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -566,7 +566,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
     /**
      * Whether the lazy-loaded \$$clo value has been loaded from database.
      * This is necessary to avoid repeated lookups if \$$clo column is NULL in the db.
-     * @var boolean
+     * @var bool
      */";
     }
 
@@ -2428,7 +2428,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *   * 0, '0', 'false', 'off', and 'no'  are converted to boolean false
      * Check on string values is case insensitive (so 'FaLsE' is seen as 'false').
      * " . $col->getDescription() . "
-     * @param  boolean|integer|string{$orNull} \$v The new value
+     * @param  bool|integer|string{$orNull} \$v The new value
      * @return \$this|" . $this->getObjectClassName(true) . " The current object (for fluent API support)
      */";
     }
@@ -2618,7 +2618,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @param array   \$row       The row returned by DataFetcher->fetch().
      * @param int     \$startcol  0-based offset column which indicates which restultset column to start with.
-     * @param boolean \$rehydrate Whether this object is being re-hydrated from the database.
+     * @param bool    \$rehydrate Whether this object is being re-hydrated from the database.
      * @param string  \$indexType The index type of \$row. Mostly DataFetcher->getIndexType().
                                   One of the class type constants TableMap::TYPE_PHPNAME, TableMap::TYPE_CAMELNAME
      *                            TableMap::TYPE_COLNAME, TableMap::TYPE_FIELDNAME, TableMap::TYPE_NUM.
@@ -2990,11 +2990,11 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * @param     string  \$keyType (optional) One of the class type constants TableMap::TYPE_PHPNAME, TableMap::TYPE_CAMELNAME,
      *                    TableMap::TYPE_COLNAME, TableMap::TYPE_FIELDNAME, TableMap::TYPE_NUM.
      *                    Defaults to TableMap::$defaultKeyType.
-     * @param     boolean \$includeLazyLoadColumns (optional) Whether to include lazy loaded columns. Defaults to TRUE.
+     * @param     bool \$includeLazyLoadColumns (optional) Whether to include lazy loaded columns. Defaults to TRUE.
      * @param     array \$alreadyDumpedObjects List of objects to skip to avoid recursion";
         if ($hasFks) {
             $script .= "
-     * @param     boolean \$includeForeignObjects (optional) Whether to include hydrated related objects. Default to FALSE.";
+     * @param     bool \$includeForeignObjects (optional) Whether to include hydrated related objects. Default to FALSE.";
         }
         $script .= "
      *
@@ -3623,7 +3623,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * This will only work if the object has been saved and has a valid primary key set.
      *
-     * @param      boolean \$deep (optional) Whether to also de-associated any related objects.
+     * @param      bool \$deep (optional) Whether to also de-associated any related objects.
      * @param      ConnectionInterface \$con (optional) The ConnectionInterface connection to use.
      * @return void
      * @throws PropelException - if this object is deleted, unsaved or doesn't have pk match in db
@@ -4012,7 +4012,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
         $script .= "
     /**
      * Returns true if the primary key for this object is null.
-     * @return boolean
+     * @return bool
      */
     public function isPrimaryKeyNull()
     {";
@@ -4528,7 +4528,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * however, you may wish to override this method in your stub class to provide setting appropriate
      * to your application -- for example, setting the initial array to the values stored in database.
      *
-     * @param      boolean \$overrideExisting If set to true, the method call initializes
+     * @param      bool \$overrideExisting If set to true, the method call initializes
      *                                        the collection even if it is not empty
      *
      * @return void
@@ -4619,7 +4619,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * Returns the number of related $className objects.
      *
      * @param      Criteria \$criteria
-     * @param      boolean \$distinct
+     * @param      bool \$distinct
      * @param      ConnectionInterface \$con
      * @return int             Count of related $className objects.
      * @throws PropelException
@@ -5903,7 +5903,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * to the current object by way of the $crossRefTableName cross-reference table.
      *
      * @param      Criteria \$criteria Optional query object to filter the query
-     * @param      boolean \$distinct Set to true to force count distinct
+     * @param      bool \$distinct Set to true to force count distinct
      * @param      ConnectionInterface \$con Optional connection object
      *
      * @return int the number of related $relatedObjectClassName objects
@@ -6283,7 +6283,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * @param      ConnectionInterface \$con";
         if ($reloadOnUpdate || $reloadOnInsert) {
             $script .= "
-     * @param      boolean \$skipReload Whether to skip the reload for this object from database.";
+     * @param      bool \$skipReload Whether to skip the reload for this object from database.";
         }
         $script .= "
      * @return int             The number of rows affected by this insert/update and any referring fk objects' save() operations.
@@ -6700,7 +6700,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * Flag to prevent endless save loop, if this object is referenced
      * by another object which falls in this transaction.
      *
-     * @var boolean
+     * @var bool
      */
     protected \$alreadyInSave = false;
 ";
@@ -6992,7 +6992,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * If desired, this method can also make copies of all associated (fkey referrers)
      * objects.
      *
-     * @param  boolean \$deepCopy Whether to also copy all rows that refer (by fkey) to the current row.
+     * @param  bool \$deepCopy Whether to also copy all rows that refer (by fkey) to the current row.
      * @return " . $this->getObjectClassName(true) . " Clone of current object.
      * @throws PropelException
      */
@@ -7028,8 +7028,8 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * objects.
      *
      * @param      object \$copyObj An object of " . $this->getObjectClassName(true) . " (or compatible) type.
-     * @param      boolean \$deepCopy Whether to also copy all rows that refer (by fkey) to the current row.
-     * @param      boolean \$makeNew Whether to reset autoincrement PKs and make the object new.
+     * @param      bool \$deepCopy Whether to also copy all rows that refer (by fkey) to the current row.
+     * @param      bool \$makeNew Whether to reset autoincrement PKs and make the object new.
      * @throws PropelException
      */
     public function copyInto(\$copyObj, \$deepCopy = false, \$makeNew = true)
@@ -7194,7 +7194,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * This method is used to reset all php object references (not the actual reference in the database).
      * Necessary for object serialisation.
      *
-     * @param      boolean \$deep Whether to also clear the references on all referrer objects.
+     * @param      bool \$deep Whether to also clear the references on all referrer objects.
      */
     public function clearAllReferences(\$deep = false)
     {

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -139,9 +139,9 @@ class ObjectBuilder extends AbstractObjectBuilder
      *
      * @param \Propel\Generator\Model\Column $column
      *
-     * @return string
+     * @return string|null
      */
-    protected function getTemporalFormatter(Column $column): string
+    protected function getTemporalFormatter(Column $column): ?string
     {
         $fmt = null;
         if ($column->getType() === PropelTypes::DATE) {

--- a/src/Propel/Generator/Builder/Om/QueryBuilder.php
+++ b/src/Propel/Generator/Builder/Om/QueryBuilder.php
@@ -1088,7 +1088,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
      * \$query->filterBy$colPhpName('yes'); // WHERE $colName = true
      * </code>
      *
-     * @param     boolean|string \$$variableName The value to use as filter.
+     * @param     bool|string \$$variableName The value to use as filter.
      *              Non-boolean arguments are converted using the following rules:
      *                * 1, '1', 'true',  'on',  and 'yes' are converted to boolean true
      *                * 0, '0', 'false', 'off', and 'no'  are converted to boolean false
@@ -1930,7 +1930,7 @@ EOT;
      *
      * @param     array \$values The associative array of columns and values for the update
      * @param     ConnectionInterface \$con The connection object used by the query
-     * @param     boolean \$forceIndividualSaves If false (default), the resulting call is a Criteria::doUpdate(), otherwise it is a series of save() calls on all the found objects
+     * @param     bool \$forceIndividualSaves If false (default), the resulting call is a Criteria::doUpdate(), otherwise it is a series of save() calls on all the found objects
      *
      * @return int|null
      */

--- a/src/Propel/Generator/Builder/Om/QueryBuilder.php
+++ b/src/Propel/Generator/Builder/Om/QueryBuilder.php
@@ -30,7 +30,7 @@ class QueryBuilder extends AbstractOMBuilder
      *
      * @return string
      */
-    public function getPackage()
+    public function getPackage(): string
     {
         return parent::getPackage() . '.Base';
     }
@@ -54,7 +54,7 @@ class QueryBuilder extends AbstractOMBuilder
      *
      * @return string
      */
-    public function getUnprefixedClassName()
+    public function getUnprefixedClassName(): string
     {
         return $this->getStubQueryBuilder()->getUnprefixedClassName();
     }
@@ -64,7 +64,7 @@ class QueryBuilder extends AbstractOMBuilder
      *
      * @return string
      */
-    public function getParentClass()
+    public function getParentClass(): string
     {
         $parentClass = $this->getBehaviorContent('parentClass');
         if ($parentClass) {
@@ -86,7 +86,7 @@ class QueryBuilder extends AbstractOMBuilder
      *
      * @return void
      */
-    protected function addClassOpen(&$script)
+    protected function addClassOpen(&$script): void
     {
         $table = $this->getTable();
         $tableName = $table->getName();
@@ -248,7 +248,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
      *
      * @return void
      */
-    protected function addClassBody(&$script)
+    protected function addClassBody(&$script): void
     {
         $table = $this->getTable();
 
@@ -325,7 +325,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
      *
      * @return void
      */
-    protected function addEntityNotFoundExceptionClass(&$script)
+    protected function addEntityNotFoundExceptionClass(&$script): void
     {
         $script .= "protected \$entityNotFoundExceptionClass = '" . addslashes($this->getEntityNotFoundExceptionClass()) . "';\n";
     }
@@ -333,7 +333,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
     /**
      * @return string|null
      */
-    private function getEntityNotFoundExceptionClass()
+    private function getEntityNotFoundExceptionClass(): ?string
     {
         return $this->getBuildProperty('generator.objectModel.entityNotFoundExceptionClass');
     }
@@ -345,7 +345,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
      *
      * @return void
      */
-    protected function addDeleteMethods(&$script)
+    protected function addDeleteMethods(&$script): void
     {
         $this->addDoDeleteAll($script);
         $this->addDelete($script);
@@ -364,7 +364,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
      *
      * @return bool
      */
-    protected function isDeleteCascadeEmulationNeeded()
+    protected function isDeleteCascadeEmulationNeeded(): bool
     {
         $table = $this->getTable();
         if ((!$this->getPlatform()->supportsNativeDeleteTrigger() || $this->getBuildProperty('generator.objectModel.emulateForeignKeyConstraints')) && count($table->getReferrers()) > 0) {
@@ -383,7 +383,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
      *
      * @return bool
      */
-    protected function isDeleteSetNullEmulationNeeded()
+    protected function isDeleteSetNullEmulationNeeded(): bool
     {
         $table = $this->getTable();
         if ((!$this->getPlatform()->supportsNativeDeleteTrigger() || $this->getBuildProperty('generator.objectModel.emulateForeignKeyConstraints')) && count($table->getReferrers()) > 0) {
@@ -404,10 +404,10 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
      *
      * @return void
      */
-    protected function addClassClose(&$script)
+    protected function addClassClose(&$script): void
     {
         $script .= "
-} // " . $this->getUnqualifiedClassName() . "
+}
 ";
         $this->applyBehaviorModifier('queryFilter', $script, '');
     }
@@ -421,7 +421,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
      *
      * @return void
      */
-    protected function addConstructor(&$script)
+    protected function addConstructor(&$script): void
     {
         $this->addConstructorComment($script);
         $this->addConstructorOpen($script);
@@ -436,7 +436,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
      *
      * @return void
      */
-    protected function addConstructorComment(&$script)
+    protected function addConstructorComment(&$script): void
     {
         $script .= "
     /**
@@ -455,7 +455,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
      *
      * @return void
      */
-    protected function addConstructorOpen(&$script)
+    protected function addConstructorOpen(&$script): void
     {
         $table = $this->getTable();
         $script .= "
@@ -470,7 +470,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
      *
      * @return void
      */
-    protected function addConstructorBody(&$script)
+    protected function addConstructorBody(&$script): void
     {
         $script .= "
         parent::__construct(\$dbName, \$modelName, \$modelAlias);";
@@ -483,7 +483,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
      *
      * @return void
      */
-    protected function addConstructorClose(&$script)
+    protected function addConstructorClose(&$script): void
     {
         $script .= "
     }
@@ -497,7 +497,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
      *
      * @return void
      */
-    protected function addFactory(&$script)
+    protected function addFactory(&$script): void
     {
         $this->addFactoryComment($script);
         $this->addFactoryOpen($script);
@@ -512,7 +512,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
      *
      * @return void
      */
-    protected function addFactoryComment(&$script)
+    protected function addFactoryComment(&$script): void
     {
         $classname = $this->getClassNameFromBuilder($this->getNewStubQueryBuilder($this->getTable()));
         $script .= "
@@ -533,7 +533,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
      *
      * @return void
      */
-    protected function addFactoryOpen(&$script)
+    protected function addFactoryOpen(&$script): void
     {
         $script .= "
     public static function create(\$modelAlias = null, Criteria \$criteria = null)
@@ -547,7 +547,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
      *
      * @return void
      */
-    protected function addFactoryBody(&$script)
+    protected function addFactoryBody(&$script): void
     {
         $classname = $this->getClassNameFromBuilder($this->getNewStubQueryBuilder($this->getTable()));
         $script .= "
@@ -572,7 +572,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
      *
      * @return void
      */
-    protected function addFactoryClose(&$script)
+    protected function addFactoryClose(&$script): void
     {
         $script .= "
     }
@@ -584,7 +584,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
      *
      * @return void
      */
-    protected function addFindPk(&$script)
+    protected function addFindPk(&$script): void
     {
         $class = $this->getObjectClassName();
         $tableMapClassName = $this->getTableMapClassName();
@@ -676,7 +676,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
      *
      * @return void
      */
-    protected function addFindPkSimple(&$script)
+    protected function addFindPkSimple(&$script): void
     {
         $table = $this->getTable();
 
@@ -792,7 +792,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
      *
      * @return void
      */
-    protected function addFindPkComplex(&$script)
+    protected function addFindPkComplex(&$script): void
     {
         $class = $this->getObjectClassName();
         $table = $this->getTable();
@@ -832,7 +832,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
      *
      * @return void
      */
-    protected function addFindPks(&$script)
+    protected function addFindPks(&$script): void
     {
         $this->declareClasses(
             '\Propel\Runtime\Collection\ObjectCollection',
@@ -894,7 +894,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
      *
      * @return void
      */
-    protected function addFilterByPrimaryKey(&$script)
+    protected function addFilterByPrimaryKey(&$script): void
     {
         $script .= "
     /**
@@ -951,7 +951,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
      *
      * @return void
      */
-    protected function addFilterByPrimaryKeys(&$script)
+    protected function addFilterByPrimaryKeys(&$script): void
     {
         $script .= "
     /**
@@ -1021,7 +1021,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
      *
      * @return void
      */
-    protected function addFilterByCol(&$script, Column $col)
+    protected function addFilterByCol(&$script, Column $col): void
     {
         $colPhpName = $col->getPhpName();
         $colName = $col->getName();
@@ -1246,7 +1246,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
      *
      * @return void
      */
-    protected function addFilterByArrayCol(&$script, Column $col)
+    protected function addFilterByArrayCol(&$script, Column $col): void
     {
         $singularPhpName = $col->getPhpSingularName();
         $colName = $col->getName();
@@ -1294,7 +1294,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
      *
      * @return void
      */
-    protected function addFilterBySetCol(&$script, Column $col)
+    protected function addFilterBySetCol(&$script, Column $col): void
     {
         $colPhpName = $col->getPhpName();
         $singularPhpName = $col->getPhpSingularName();
@@ -1323,7 +1323,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
      *
      * @return void
      */
-    protected function addFilterByFk(&$script, $fk)
+    protected function addFilterByFk(&$script, $fk): void
     {
         $this->declareClasses(
             '\Propel\Runtime\Collection\ObjectCollection',
@@ -1408,7 +1408,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
      *
      * @return void
      */
-    protected function addFilterByRefFk(&$script, ForeignKey $fk)
+    protected function addFilterByRefFk(&$script, ForeignKey $fk): void
     {
         $this->declareClasses(
             '\Propel\Runtime\Collection\ObjectCollection',
@@ -1481,7 +1481,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
      *
      * @return void
      */
-    protected function addJoinFk(&$script, $fk)
+    protected function addJoinFk(&$script, $fk): void
     {
         $queryClass = $this->getQueryClassName();
         $fkTable = $fk->getForeignTable();
@@ -1498,7 +1498,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
      *
      * @return void
      */
-    protected function addJoinRefFk(&$script, ForeignKey $fk)
+    protected function addJoinRefFk(&$script, ForeignKey $fk): void
     {
         $queryClass = $this->getQueryClassName();
         $fkTable = $this->getTable()->getDatabase()->getTable($fk->getTableName());
@@ -1518,7 +1518,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
      *
      * @return void
      */
-    protected function addJoinRelated(&$script, $fkTable, $queryClass, $relationName, $joinType)
+    protected function addJoinRelated(&$script, $fkTable, $queryClass, $relationName, $joinType): void
     {
         $script .= "
     /**
@@ -1563,7 +1563,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
      *
      * @return void
      */
-    protected function addUseFkQuery(&$script, $fk)
+    protected function addUseFkQuery(&$script, $fk): void
     {
         $fkTable = $fk->getForeignTable();
         $fkQueryBuilder = $this->getNewStubQueryBuilder($fkTable);
@@ -1584,7 +1584,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
      *
      * @return void
      */
-    protected function addUseRefFkQuery(&$script, ForeignKey $fk)
+    protected function addUseRefFkQuery(&$script, ForeignKey $fk): void
     {
         $fkTable = $this->getTable()->getDatabase()->getTable($fk->getTableName());
         $fkQueryBuilder = $this->getNewStubQueryBuilder($fkTable);
@@ -1608,7 +1608,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
      *
      * @return void
      */
-    protected function addUseRelatedQuery(&$script, Table $fkTable, $queryClass, $relationName, $joinType)
+    protected function addUseRelatedQuery(&$script, Table $fkTable, $queryClass, $relationName, $joinType): void
     {
         $script .= "
     /**
@@ -1641,7 +1641,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
      *
      * @return void
      */
-    protected function addUseRelatedExistsQuery(&$script, Table $fkTable, $queryClass, $relationName)
+    protected function addUseRelatedExistsQuery(&$script, Table $fkTable, $queryClass, $relationName): void
     {
         $relationDescription = ($relationName === $fkTable->getPhpName()) ?
             "relation to $relationName table" :
@@ -1695,7 +1695,7 @@ EOT;
      *
      * @return void
      */
-    protected function addWithRelatedQuery(&$script, Table $fkTable, $queryClass, $relationName, $joinType)
+    protected function addWithRelatedQuery(&$script, Table $fkTable, $queryClass, $relationName, $joinType): void
     {
         $script .= "
     /**
@@ -1732,7 +1732,7 @@ EOT;
      *
      * @return void
      */
-    protected function addFilterByCrossFK(&$script, CrossForeignKeys $crossFKs)
+    protected function addFilterByCrossFK(&$script, CrossForeignKeys $crossFKs): void
     {
         $relationName = $this->getRefFKPhpNameAffix($crossFKs->getIncomingForeignKey(), false);
 
@@ -1772,7 +1772,7 @@ EOT;
      *
      * @return void
      */
-    protected function addPrune(&$script)
+    protected function addPrune(&$script): void
     {
         $table = $this->getTable();
         $class = $this->getObjectClassName();
@@ -1830,7 +1830,7 @@ EOT;
      *
      * @return void
      */
-    protected function addBasePreSelect(&$script)
+    protected function addBasePreSelect(&$script): void
     {
         $behaviorCode = '';
         $this->applyBehaviorModifier('preSelectQuery', $behaviorCode, '        ');
@@ -1843,10 +1843,10 @@ EOT;
      *
      * @param     ConnectionInterface \$con The connection object used by the query
      */
-    protected function basePreSelect(ConnectionInterface \$con)
+    protected function basePreSelect(ConnectionInterface \$con): void
     {" . $behaviorCode . "
 
-        return \$this->preSelect(\$con);
+        \$this->preSelect(\$con);
     }
 ";
     }
@@ -1858,7 +1858,7 @@ EOT;
      *
      * @return void
      */
-    protected function addBasePreDelete(&$script)
+    protected function addBasePreDelete(&$script): void
     {
         $behaviorCode = '';
         $this->applyBehaviorModifier('preDeleteQuery', $behaviorCode, '        ');
@@ -1870,8 +1870,9 @@ EOT;
      * Code to execute before every DELETE statement
      *
      * @param     ConnectionInterface \$con The connection object used by the query
+     * @return int|null
      */
-    protected function basePreDelete(ConnectionInterface \$con)
+    protected function basePreDelete(ConnectionInterface \$con): ?int
     {" . $behaviorCode . "
 
         return \$this->preDelete(\$con);
@@ -1886,7 +1887,7 @@ EOT;
      *
      * @return void
      */
-    protected function addBasePostDelete(&$script)
+    protected function addBasePostDelete(&$script): void
     {
         $behaviorCode = '';
         $this->applyBehaviorModifier('postDeleteQuery', $behaviorCode, '        ');
@@ -1899,8 +1900,9 @@ EOT;
      *
      * @param     int \$affectedRows the number of deleted rows
      * @param     ConnectionInterface \$con The connection object used by the query
+     * @return int|null
      */
-    protected function basePostDelete(\$affectedRows, ConnectionInterface \$con)
+    protected function basePostDelete(\$affectedRows, ConnectionInterface \$con): ?int
     {" . $behaviorCode . "
 
         return \$this->postDelete(\$affectedRows, \$con);
@@ -1915,7 +1917,7 @@ EOT;
      *
      * @return void
      */
-    protected function addBasePreUpdate(&$script)
+    protected function addBasePreUpdate(&$script): void
     {
         $behaviorCode = '';
         $this->applyBehaviorModifier('preUpdateQuery', $behaviorCode, '        ');
@@ -1929,8 +1931,10 @@ EOT;
      * @param     array \$values The associative array of columns and values for the update
      * @param     ConnectionInterface \$con The connection object used by the query
      * @param     boolean \$forceIndividualSaves If false (default), the resulting call is a Criteria::doUpdate(), otherwise it is a series of save() calls on all the found objects
+     *
+     * @return int|null
      */
-    protected function basePreUpdate(&\$values, ConnectionInterface \$con, \$forceIndividualSaves = false)
+    protected function basePreUpdate(&\$values, ConnectionInterface \$con, \$forceIndividualSaves = false): ?int
     {" . $behaviorCode . "
 
         return \$this->preUpdate(\$values, \$con, \$forceIndividualSaves);
@@ -1945,7 +1949,7 @@ EOT;
      *
      * @return void
      */
-    protected function addBasePostUpdate(&$script)
+    protected function addBasePostUpdate(&$script): void
     {
         $behaviorCode = '';
         $this->applyBehaviorModifier('postUpdateQuery', $behaviorCode, '        ');
@@ -1958,8 +1962,10 @@ EOT;
      *
      * @param     int \$affectedRows the number of updated rows
      * @param     ConnectionInterface \$con The connection object used by the query
+     *
+     * @return int|null
      */
-    protected function basePostUpdate(\$affectedRows, ConnectionInterface \$con)
+    protected function basePostUpdate(\$affectedRows, ConnectionInterface \$con): ?int
     {" . $behaviorCode . "
 
         return \$this->postUpdate(\$affectedRows, \$con);
@@ -1975,7 +1981,7 @@ EOT;
      *
      * @return bool
      */
-    public function hasBehaviorModifier($hookName, $modifier = '')
+    public function hasBehaviorModifier($hookName, $modifier = ''): bool
     {
         return parent::hasBehaviorModifier($hookName, 'QueryBuilderModifier');
     }
@@ -1989,7 +1995,7 @@ EOT;
      *
      * @return string
      */
-    public function applyBehaviorModifier($hookName, &$script, $tab = '        ')
+    public function applyBehaviorModifier($hookName, &$script, $tab = '        '): string
     {
         $this->applyBehaviorModifierBase($hookName, 'QueryBuilderModifier', $script, $tab);
 
@@ -2003,7 +2009,7 @@ EOT;
      *
      * @return string|null
      */
-    public function getBehaviorContent($contentName)
+    public function getBehaviorContent($contentName): ?string
     {
         return $this->getBehaviorContentBase($contentName, 'QueryBuilderModifier');
     }
@@ -2015,7 +2021,7 @@ EOT;
      *
      * @return void
      */
-    protected function addDelete(&$script)
+    protected function addDelete(&$script): void
     {
         $script .= "
     /**
@@ -2027,7 +2033,7 @@ EOT;
      * @throws PropelException Any exceptions caught during processing will be
      *                         rethrown wrapped into a PropelException.
      */
-    public function delete(ConnectionInterface \$con = null)
+    public function delete(ConnectionInterface \$con = null): int
     {
         if (null === \$con) {
             \$con = Propel::getServiceContainer()->getWriteConnection(" . $this->getTableMapClass() . "::DATABASE_NAME);
@@ -2081,7 +2087,7 @@ EOT;
      *
      * @return void
      */
-    protected function addDoOnDeleteCascade(&$script)
+    protected function addDoOnDeleteCascade(&$script): void
     {
         $table = $this->getTable();
         $script .= "
@@ -2097,7 +2103,7 @@ EOT;
      * @param ConnectionInterface \$con
      * @return int The number of affected rows (if supported by underlying database driver).
      */
-    protected function doOnDeleteCascade(ConnectionInterface \$con)
+    protected function doOnDeleteCascade(ConnectionInterface \$con): int
     {
         // initialize var to track total num of affected rows
         \$affectedRows = 0;
@@ -2163,7 +2169,7 @@ EOT;
      *
      * @return void
      */
-    protected function addDoOnDeleteSetNull(&$script)
+    protected function addDoOnDeleteSetNull(&$script): void
     {
         $table = $this->getTable();
         $script .= "
@@ -2179,7 +2185,7 @@ EOT;
      * @param ConnectionInterface \$con
      * @return void
      */
-    protected function doOnDeleteSetNull(ConnectionInterface \$con)
+    protected function doOnDeleteSetNull(ConnectionInterface \$con): void
     {
         // first find the objects that are implicated by the \$this
         \$objects = {$this->getQueryClassName()}::create(null, \$this)->find(\$con);
@@ -2241,7 +2247,7 @@ EOT;
      *
      * @return void
      */
-    protected function addDoDeleteAll(&$script)
+    protected function addDoDeleteAll(&$script): void
     {
         $table = $this->getTable();
         $script .= "
@@ -2251,7 +2257,7 @@ EOT;
      * @param ConnectionInterface \$con the connection to use
      * @return int The number of affected rows (if supported by underlying database driver).
      */
-    public function doDeleteAll(ConnectionInterface \$con = null)
+    public function doDeleteAll(ConnectionInterface \$con = null): int
     {
         if (null === \$con) {
             \$con = Propel::getServiceContainer()->getWriteConnection(" . $this->getTableMapClass() . "::DATABASE_NAME);

--- a/src/Propel/Generator/Builder/Om/QueryInheritanceBuilder.php
+++ b/src/Propel/Generator/Builder/Om/QueryInheritanceBuilder.php
@@ -34,7 +34,7 @@ class QueryInheritanceBuilder extends AbstractOMBuilder
      *
      * @return string
      */
-    public function getUnprefixedClassName()
+    public function getUnprefixedClassName(): string
     {
         return $this->getNewStubQueryInheritanceBuilder($this->getChild())->getUnprefixedClassName();
     }
@@ -44,7 +44,7 @@ class QueryInheritanceBuilder extends AbstractOMBuilder
      *
      * @return string
      */
-    public function getPackage()
+    public function getPackage(): string
     {
         return ($this->getChild()->getPackage() ?: parent::getPackage()) . '.Base';
     }
@@ -70,7 +70,7 @@ class QueryInheritanceBuilder extends AbstractOMBuilder
      *
      * @return void
      */
-    public function setChild(Inheritance $child)
+    public function setChild(Inheritance $child): void
     {
         $this->child = $child;
     }
@@ -82,7 +82,7 @@ class QueryInheritanceBuilder extends AbstractOMBuilder
      *
      * @return \Propel\Generator\Model\Inheritance
      */
-    public function getChild()
+    public function getChild(): Inheritance
     {
         if (!$this->child) {
             throw new BuildException('The MultiExtendObjectBuilder needs to be told which child class to build (via setChild() method) before it can build the stub class.');
@@ -96,7 +96,7 @@ class QueryInheritanceBuilder extends AbstractOMBuilder
      *
      * @return string|null
      */
-    protected function getParentClassName()
+    protected function getParentClassName(): ?string
     {
         if ($this->getChild()->getAncestor() === null) {
             return $this->getNewStubQueryBuilder($this->getTable())->getUnqualifiedClassName();
@@ -124,7 +124,7 @@ class QueryInheritanceBuilder extends AbstractOMBuilder
      *
      * @return void
      */
-    protected function addClassOpen(&$script)
+    protected function addClassOpen(&$script): void
     {
         $table = $this->getTable();
         $tableName = $table->getName();
@@ -170,7 +170,7 @@ class " . $this->getUnqualifiedClassName() . ' extends ' . $baseClassName . "
      *
      * @return void
      */
-    protected function addClassBody(&$script)
+    protected function addClassBody(&$script): void
     {
         $this->declareClassFromBuilder($this->getTableMapBuilder());
         $this->declareClasses(
@@ -191,7 +191,7 @@ class " . $this->getUnqualifiedClassName() . ' extends ' . $baseClassName . "
      *
      * @return void
      */
-    protected function addFactory(&$script)
+    protected function addFactory(&$script): void
     {
         $builder = $this->getNewStubQueryInheritanceBuilder($this->getChild());
         $this->declareClassFromBuilder($builder, 'Child');
@@ -228,7 +228,7 @@ class " . $this->getUnqualifiedClassName() . ' extends ' . $baseClassName . "
      *
      * @return void
      */
-    protected function addPreSelect(&$script)
+    protected function addPreSelect(&$script): void
     {
         $child = $this->getChild();
 
@@ -236,7 +236,7 @@ class " . $this->getUnqualifiedClassName() . ' extends ' . $baseClassName . "
     /**
      * Filters the query to target only " . $child->getClassName() . " objects.
      */
-    public function preSelect(ConnectionInterface \$con)
+    public function preSelect(ConnectionInterface \$con): void
     {
         " . $this->getClassKeyCondition() . "
     }
@@ -248,15 +248,17 @@ class " . $this->getUnqualifiedClassName() . ' extends ' . $baseClassName . "
      *
      * @return void
      */
-    protected function addPreUpdate(&$script)
+    protected function addPreUpdate(&$script): void
     {
         $child = $this->getChild();
 
         $script .= "
     /**
      * Filters the query to target only " . $child->getClassName() . " objects.
+     *
+     * @return int|null
      */
-    public function preUpdate(&\$values, ConnectionInterface \$con, \$forceIndividualSaves = false)
+    public function preUpdate(&\$values, ConnectionInterface \$con, \$forceIndividualSaves = false): ?int
     {
         " . $this->getClassKeyCondition() . "
     }
@@ -268,15 +270,17 @@ class " . $this->getUnqualifiedClassName() . ' extends ' . $baseClassName . "
      *
      * @return void
      */
-    protected function addPreDelete(&$script)
+    protected function addPreDelete(&$script): void
     {
         $child = $this->getChild();
 
         $script .= "
     /**
      * Filters the query to target only " . $child->getClassName() . " objects.
+     *
+     * @return int|null
      */
-    public function preDelete(ConnectionInterface \$con)
+    public function preDelete(ConnectionInterface \$con): ?int
     {
         " . $this->getClassKeyCondition() . "
     }
@@ -286,7 +290,7 @@ class " . $this->getUnqualifiedClassName() . ' extends ' . $baseClassName . "
     /**
      * @return string
      */
-    protected function getClassKeyCondition()
+    protected function getClassKeyCondition(): string
     {
         $child = $this->getChild();
         $col = $child->getColumn();
@@ -299,7 +303,7 @@ class " . $this->getUnqualifiedClassName() . ' extends ' . $baseClassName . "
      *
      * @return void
      */
-    protected function addDoDeleteAll(&$script)
+    protected function addDoDeleteAll(&$script): void
     {
         $child = $this->getChild();
 
@@ -313,7 +317,7 @@ class " . $this->getUnqualifiedClassName() . ' extends ' . $baseClassName . "
      *
      * @return integer the number of deleted rows
      */
-    public function doDeleteAll(ConnectionInterface \$con = null)
+    public function doDeleteAll(ConnectionInterface \$con = null): int
     {
         // condition on class key is already added in preDelete()
         return parent::delete(\$con);
@@ -328,10 +332,10 @@ class " . $this->getUnqualifiedClassName() . ' extends ' . $baseClassName . "
      *
      * @return void
      */
-    protected function addClassClose(&$script)
+    protected function addClassClose(&$script): void
     {
         $script .= "
-} // " . $this->getUnqualifiedClassName() . "
+}
 ";
     }
 }

--- a/src/Propel/Generator/Builder/Om/QueryInheritanceBuilder.php
+++ b/src/Propel/Generator/Builder/Om/QueryInheritanceBuilder.php
@@ -261,6 +261,8 @@ class " . $this->getUnqualifiedClassName() . ' extends ' . $baseClassName . "
     public function preUpdate(&\$values, ConnectionInterface \$con, \$forceIndividualSaves = false): ?int
     {
         " . $this->getClassKeyCondition() . "
+
+        return null;
     }
 ";
     }
@@ -283,6 +285,8 @@ class " . $this->getUnqualifiedClassName() . ' extends ' . $baseClassName . "
     public function preDelete(ConnectionInterface \$con): ?int
     {
         " . $this->getClassKeyCondition() . "
+
+        return null;
     }
 ";
     }

--- a/src/Propel/Generator/Builder/Om/TableMapBuilder.php
+++ b/src/Propel/Generator/Builder/Om/TableMapBuilder.php
@@ -24,7 +24,7 @@ class TableMapBuilder extends AbstractOMBuilder
      *
      * @return string
      */
-    public function getPackage()
+    public function getPackage(): string
     {
         return parent::getPackage() . '.Map';
     }
@@ -51,7 +51,7 @@ class TableMapBuilder extends AbstractOMBuilder
     /**
      * @return string
      */
-    public function getBaseTableMapClassName()
+    public function getBaseTableMapClassName(): string
     {
         return 'TableMap';
     }
@@ -61,7 +61,7 @@ class TableMapBuilder extends AbstractOMBuilder
      *
      * @return string
      */
-    public function getUnprefixedClassName()
+    public function getUnprefixedClassName(): string
     {
         return $this->getTable()->getPhpName() . 'TableMap';
     }
@@ -73,7 +73,7 @@ class TableMapBuilder extends AbstractOMBuilder
      *
      * @return void
      */
-    protected function addClassOpen(&$script)
+    protected function addClassOpen(&$script): void
     {
         $table = $this->getTable();
         $script .= "
@@ -115,7 +115,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @return void
      */
-    protected function addClassBody(&$script)
+    protected function addClassBody(&$script): void
     {
         $table = $this->getTable();
 
@@ -186,7 +186,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @return void
      */
-    protected function addSelectMethods(&$script)
+    protected function addSelectMethods(&$script): void
     {
         $this->addAddSelectColumns($script);
         $this->addRemoveSelectColumns($script);
@@ -197,7 +197,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @return string
      */
-    protected function addConstants()
+    protected function addConstants(): string
     {
         return $this->renderTemplate('tableMapConstants', [
             'className' => $this->getClasspath(),
@@ -220,7 +220,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @return void
      */
-    protected function addColumnNameConstants(&$script)
+    protected function addColumnNameConstants(&$script): void
     {
         foreach ($this->getTable()->getColumns() as $col) {
             $script .= "
@@ -239,7 +239,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @return void
      */
-    protected function addValueSetColumnConstants(&$script)
+    protected function addValueSetColumnConstants(&$script): void
     {
         foreach ($this->getTable()->getColumns() as $col) {
             if ($col->isValueSetType()) {
@@ -262,7 +262,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @return void
      */
-    protected function addValueSetColumnAttributes(&$script)
+    protected function addValueSetColumnAttributes(&$script): void
     {
         $script .= "
     /** The enumerated values for this table */
@@ -291,7 +291,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @return void
      */
-    protected function addGetValueSets(&$script)
+    protected function addGetValueSets(&$script): void
     {
         $script .= "
     /**
@@ -312,7 +312,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @return void
      */
-    protected function addGetValueSet(&$script)
+    protected function addGetValueSet(&$script): void
     {
         $script .= "
     /**
@@ -336,7 +336,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @return void
      */
-    public function addInheritanceColumnConstants(&$script)
+    public function addInheritanceColumnConstants(&$script): void
     {
         if (!$col = $this->getTable()->getChildrenColumn()) {
             return;
@@ -375,7 +375,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @return string
      */
-    protected function getValueSetConstant($value)
+    protected function getValueSetConstant($value): string
     {
         return strtoupper(preg_replace('/[^a-zA-Z0-9_\x7f-\xff]/', '_', $value));
     }
@@ -387,14 +387,14 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @return void
      */
-    protected function addAttributes(&$script)
+    protected function addAttributes(&$script): void
     {
     }
 
     /**
      * @return string
      */
-    protected function addFieldsAttributes()
+    protected function addFieldsAttributes(): string
     {
         $tableColumns = $this->getTable()->getColumns();
 
@@ -470,7 +470,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
             $variants = array_unique($variants);
 
             $normalizedName = strtoupper($column->getName());
-            array_walk($variants, static function ($variant) use (&$arrayString, $normalizedName) {
+            array_walk($variants, static function ($variant) use (&$arrayString, $normalizedName): void {
                 $arrayString .= PHP_EOL . "        '{$variant}' => '{$normalizedName}',";
             });
         }
@@ -492,11 +492,10 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @return void
      */
-    protected function addClassClose(&$script)
+    protected function addClassClose(&$script): void
     {
-        $unqualifiedClassName = $this->getUnqualifiedClassName();
         $script .= "
-} // $unqualifiedClassName
+}
 ";
         $this->applyBehaviorModifier('tableMapFilter', $script, '');
     }
@@ -508,7 +507,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @return void
      */
-    protected function addInitialize(&$script)
+    protected function addInitialize(&$script): void
     {
         $table = $this->getTable();
         /** @var \Propel\Generator\Platform\DefaultPlatform $platform */
@@ -522,7 +521,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      * @return void
      * @throws PropelException
      */
-    public function initialize()
+    public function initialize(): void
     {
         // attributes
         \$this->setName('" . $table->getName() . "');
@@ -602,7 +601,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
         }
 
         $script .= "
-    } // initialize()
+    }
 ";
     }
 
@@ -613,7 +612,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @return void
      */
-    protected function addBuildRelations(&$script)
+    protected function addBuildRelations(&$script): void
     {
         $script .= "
     /**
@@ -621,7 +620,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @return void
      */
-    public function buildRelations()
+    public function buildRelations(): void
     {";
         foreach ($this->getTable()->getForeignKeys() as $fkey) {
             $joinCondition = var_export($fkey->getNormalizedMap($fkey->getMapping()), true);
@@ -660,7 +659,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
             }
         }
         $script .= "
-    } // buildRelations()
+    }
 ";
     }
 
@@ -671,7 +670,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @return void
      */
-    protected function addGetBehaviors(&$script)
+    protected function addGetBehaviors(&$script): void
     {
         $behaviors = $this->getTable()->getBehaviors();
         if (!$behaviors) {
@@ -691,14 +690,14 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * Gets the list of behaviors registered for this table
      *
-     * @return array Associative array (name => parameters) of behaviors
+     * @return array<string, array> Associative array (name => parameters) of behaviors
      */
-    public function getBehaviors()
+    public function getBehaviors(): array
     {
-        return array(
+        return [
             $itemsString
-        );
-    } // getBehaviors()
+        ];
+    }
 ";
     }
 
@@ -731,7 +730,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @return string
      */
-    public function getInstancePoolKeySnippet($pkphp)
+    public function getInstancePoolKeySnippet($pkphp): string
     {
         $pkphp = (array)$pkphp; // make it an array if it is not.
         $script = '';
@@ -752,7 +751,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
     /**
      * @return string
      */
-    public function addInstancePool()
+    public function addInstancePool(): string
     {
         // No need to override instancePool if the PK is not composite
         if (!$this->getTable()->hasCompositePrimaryKey()) {
@@ -793,7 +792,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
     /**
      * @return string
      */
-    public function addClearRelatedInstancePool()
+    public function addClearRelatedInstancePool(): string
     {
         $table = $this->getTable();
         $relatedClassNames = [];
@@ -835,7 +834,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @return bool
      */
-    public function hasBehaviorModifier($hookName, $modifier = '')
+    public function hasBehaviorModifier($hookName, $modifier = ''): bool
     {
         return parent::hasBehaviorModifier($hookName, 'TableMapBuilderModifier');
     }
@@ -849,7 +848,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @return void
      */
-    public function applyBehaviorModifier($hookName, &$script, $tab = '        ')
+    public function applyBehaviorModifier($hookName, &$script, $tab = '        '): void
     {
         $this->applyBehaviorModifierBase($hookName, 'TableMapBuilderModifier', $script, $tab);
     }
@@ -861,7 +860,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @return void
      */
-    protected function addGetPrimaryKeyHash(&$script)
+    protected function addGetPrimaryKeyHash(&$script): void
     {
         // We have to iterate through all the columns so that we know the offset of the primary
         // key columns.
@@ -920,7 +919,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @return void
      */
-    protected function addGetPrimaryKeyFromRow(&$script)
+    protected function addGetPrimaryKeyFromRow(&$script): void
     {
         $script .= "
     /**
@@ -996,7 +995,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @return void
      */
-    protected function addGetOMClassMethod(&$script)
+    protected function addGetOMClassMethod(&$script): void
     {
         $table = $this->getTable();
         if ($table->getChildrenColumn()) {
@@ -1017,7 +1016,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @return void
      */
-    protected function addGetOMClassInheritance(&$script)
+    protected function addGetOMClassInheritance(&$script): void
     {
         $col = $this->getTable()->getChildrenColumn();
         $script .= "
@@ -1086,7 +1085,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @return void
      */
-    protected function addGetOMClassNoInheritance(&$script)
+    protected function addGetOMClassNoInheritance(&$script): void
     {
         $script .= "
     /**
@@ -1114,7 +1113,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @return void
      */
-    protected function addGetOMClassNoInheritanceAbstract(&$script)
+    protected function addGetOMClassNoInheritanceAbstract(&$script): void
     {
         $objectClassName = $this->getObjectClassName();
 
@@ -1141,7 +1140,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @return void
      */
-    protected function addPopulateObject(&$script)
+    protected function addPopulateObject(&$script): void
     {
         $table = $this->getTable();
         $script .= "
@@ -1202,7 +1201,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @return void
      */
-    protected function addPopulateObjects(&$script)
+    protected function addPopulateObjects(&$script): void
     {
         $table = $this->getTable();
         $script .= "
@@ -1269,7 +1268,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @return void
      */
-    protected function addAddSelectColumns(&$script)
+    protected function addAddSelectColumns(&$script): void
     {
         $script .= "
     /**
@@ -1317,7 +1316,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @return void
      */
-    protected function addRemoveSelectColumns(&$script)
+    protected function addRemoveSelectColumns(&$script): void
     {
         $script .= "
     /**
@@ -1364,7 +1363,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @return void
      */
-    protected function addGetTableMap(&$script)
+    protected function addGetTableMap(&$script): void
     {
         $script .= "
     /**
@@ -1388,7 +1387,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @return void
      */
-    protected function addDoDeleteAll(&$script)
+    protected function addDoDeleteAll(&$script): void
     {
         $table = $this->getTable();
         $script .= "
@@ -1398,7 +1397,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      * @param ConnectionInterface \$con the connection to use
      * @return int The number of affected rows (if supported by underlying database driver).
      */
-    public static function doDeleteAll(ConnectionInterface \$con = null)
+    public static function doDeleteAll(ConnectionInterface \$con = null): int
     {
         return " . $this->getQueryClassName() . "::create()->doDeleteAll(\$con);
     }
@@ -1412,7 +1411,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @return void
      */
-    protected function addDoDelete(&$script)
+    protected function addDoDelete(&$script): void
     {
         $table = $this->getTable();
         $script .= "
@@ -1427,7 +1426,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      * @throws PropelException Any exceptions caught during processing will be
      *                         rethrown wrapped into a PropelException.
      */
-     public static function doDelete(\$values, ConnectionInterface \$con = null)
+     public static function doDelete(\$values, ConnectionInterface \$con = null): int
      {
         if (null === \$con) {
             \$con = Propel::getServiceContainer()->getWriteConnection(" . $this->getTableMapClass() . "::DATABASE_NAME);
@@ -1517,7 +1516,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @return void
      */
-    protected function addDoInsert(&$script)
+    protected function addDoInsert(&$script): void
     {
         $table = $this->getTable();
         $tableMapClass = $this->getTableMapClass();

--- a/src/Propel/Generator/Builder/Om/TableMapBuilder.php
+++ b/src/Propel/Generator/Builder/Om/TableMapBuilder.php
@@ -1026,7 +1026,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @param array   \$row ConnectionInterface result row.
      * @param int     \$colnum Column to examine for OM class information (first is 0).
-     * @param boolean \$withPrefix Whether to return the path with the class name
+     * @param bool \$withPrefix Whether to return the path with the class name
      * @throws PropelException Any exceptions caught during processing will be
      *                         rethrown wrapped into a PropelException.
      *
@@ -1096,7 +1096,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      * relative to a location on the PHP include_path.
      * (e.g. path.to.MyClass -> 'path/to/MyClass.php')
      *
-     * @param boolean \$withPrefix Whether to return the path with the class name
+     * @param bool \$withPrefix Whether to return the path with the class name
      * @return string path.to.ClassName
      */
     public static function getOMClass(\$withPrefix = true)
@@ -1124,7 +1124,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      * This method must be overridden by the stub subclass, because
      * $objectClassName is declared abstract in the schema.
      *
-     * @param boolean \$withPrefix
+     * @param bool \$withPrefix
      */
     public static function getOMClass(\$withPrefix = true)
     {

--- a/src/Propel/Generator/Builder/Om/templates/baseObjectAttributes.php
+++ b/src/Propel/Generator/Builder/Om/templates/baseObjectAttributes.php
@@ -1,13 +1,13 @@
 
     /**
      * attribute to determine if this object has previously been saved.
-     * @var boolean
+     * @var bool
      */
     protected $new = true;
 
     /**
      * attribute to determine whether this object has been deleted.
-     * @var boolean
+     * @var bool
      */
     protected $deleted = false;
 

--- a/src/Propel/Generator/Builder/Om/templates/baseObjectMethodHook.php
+++ b/src/Propel/Generator/Builder/Om/templates/baseObjectMethodHook.php
@@ -3,7 +3,7 @@
     /**
      * Code to be run before persisting the object
      * @param  ConnectionInterface $con
-     * @return boolean
+     * @return bool
      */
     public function preSave(ConnectionInterface $con = null)
     {
@@ -20,6 +20,7 @@
     /**
      * Code to be run after persisting the object
      * @param ConnectionInterface $con
+     * @return void
      */
     public function postSave(ConnectionInterface $con = null): void
     {
@@ -35,7 +36,7 @@
     /**
      * Code to be run before inserting to database
      * @param  ConnectionInterface $con
-     * @return boolean
+     * @return bool
      */
     public function preInsert(ConnectionInterface $con = null)
     {
@@ -52,6 +53,7 @@
     /**
      * Code to be run after inserting to database
      * @param ConnectionInterface $con
+     * @return void
      */
     public function postInsert(ConnectionInterface $con = null): void
     {
@@ -67,7 +69,7 @@
     /**
      * Code to be run before updating the object in database
      * @param  ConnectionInterface $con
-     * @return boolean
+     * @return bool
      */
     public function preUpdate(ConnectionInterface $con = null)
     {
@@ -84,6 +86,7 @@
     /**
      * Code to be run after updating the object in database
      * @param ConnectionInterface $con
+     * @return void
      */
     public function postUpdate(ConnectionInterface $con = null): void
     {
@@ -101,7 +104,7 @@
      * @param  ConnectionInterface $con
      * @return bool
      */
-    public function preDelete(ConnectionInterface $con = null): ?int
+    public function preDelete(ConnectionInterface $con = null)
     {
         <?php if ($hasBaseClass) : ?>
         if (is_callable('parent::preDelete')) {
@@ -116,6 +119,7 @@
     /**
      * Code to be run after deleting the object in database
      * @param ConnectionInterface $con
+     * @return void
      */
     public function postDelete(ConnectionInterface $con = null): void
     {

--- a/src/Propel/Generator/Builder/Om/templates/baseObjectMethodHook.php
+++ b/src/Propel/Generator/Builder/Om/templates/baseObjectMethodHook.php
@@ -21,7 +21,7 @@
      * Code to be run after persisting the object
      * @param ConnectionInterface $con
      */
-    public function postSave(ConnectionInterface $con = null)
+    public function postSave(ConnectionInterface $con = null): ?int
     {
         <?php if ($hasBaseClass) : ?>
         if (is_callable('parent::postSave')) {
@@ -53,7 +53,7 @@
      * Code to be run after inserting to database
      * @param ConnectionInterface $con
      */
-    public function postInsert(ConnectionInterface $con = null)
+    public function postInsert(ConnectionInterface $con = null): ?int
     {
         <?php if ($hasBaseClass) : ?>
         if (is_callable('parent::postInsert')) {
@@ -85,7 +85,7 @@
      * Code to be run after updating the object in database
      * @param ConnectionInterface $con
      */
-    public function postUpdate(ConnectionInterface $con = null)
+    public function postUpdate(ConnectionInterface $con = null): ?int
     {
         <?php if ($hasBaseClass) : ?>
         if (is_callable('parent::postUpdate')) {
@@ -99,9 +99,9 @@
     /**
      * Code to be run before deleting the object in database
      * @param  ConnectionInterface $con
-     * @return boolean
+     * @return bool
      */
-    public function preDelete(ConnectionInterface $con = null)
+    public function preDelete(ConnectionInterface $con = null): ?int
     {
         <?php if ($hasBaseClass) : ?>
         if (is_callable('parent::preDelete')) {
@@ -117,7 +117,7 @@
      * Code to be run after deleting the object in database
      * @param ConnectionInterface $con
      */
-    public function postDelete(ConnectionInterface $con = null)
+    public function postDelete(ConnectionInterface $con = null): ?int
     {
         <?php if ($hasBaseClass) : ?>
         if (is_callable('parent::postDelete')) {

--- a/src/Propel/Generator/Builder/Om/templates/baseObjectMethods.php
+++ b/src/Propel/Generator/Builder/Om/templates/baseObjectMethods.php
@@ -2,7 +2,7 @@
     /**
      * Returns whether the object has been modified.
      *
-     * @return boolean True if the object has been modified.
+     * @return bool True if the object has been modified.
      */
     public function isModified()
     {
@@ -12,8 +12,8 @@
     /**
      * Has specified column been modified?
      *
-     * @param  string  $col column fully qualified name (TableMap::TYPE_COLNAME), e.g. Book::AUTHOR_ID
-     * @return boolean True if $col has been modified.
+     * @param string $col column fully qualified name (TableMap::TYPE_COLNAME), e.g. Book::AUTHOR_ID
+     * @return bool True if $col has been modified.
      */
     public function isColumnModified($col)
     {
@@ -34,7 +34,7 @@
      * be false, if the object was retrieved from storage or was created
      * and then saved.
      *
-     * @return boolean true, if the object has never been persisted.
+     * @return bool True, if the object has never been persisted.
      */
     public function isNew()
     {
@@ -45,7 +45,7 @@
      * Setter for the isNew attribute.  This method will be called
      * by Propel-generated children and objects.
      *
-     * @param boolean $b the state of the object.
+     * @param bool $b the state of the object.
      */
     public function setNew($b)
     {
@@ -54,7 +54,7 @@
 
     /**
      * Whether this object has been deleted.
-     * @return boolean The deleted state of this object.
+     * @return bool The deleted state of this object.
      */
     public function isDeleted()
     {
@@ -63,7 +63,7 @@
 
     /**
      * Specify whether this object has been deleted.
-     * @param  boolean $b The deleted state of this object.
+     * @param  bool $b The deleted state of this object.
      * @return void
      */
     public function setDeleted($b)
@@ -90,8 +90,8 @@
      * <code>obj</code> is an instance of <code><?php echo $className ?></code>, delegates to
      * <code>equals(<?php echo $className ?>)</code>.  Otherwise, returns <code>false</code>.
      *
-     * @param  mixed   $obj The object to compare to.
-     * @return boolean Whether equal to the object specified.
+     * @param mixed $obj The object to compare to.
+     * @return bool Whether equal to the object specified.
      */
     public function equals($obj)
     {
@@ -124,7 +124,7 @@
      * Checks the existence of a virtual column in this object
      *
      * @param  string  $name The virtual column name
-     * @return boolean
+     * @return bool
      */
     public function hasVirtualColumn($name)
     {
@@ -184,7 +184,7 @@
      * </code>
      *
      * @param  mixed   $parser                 A AbstractParser instance, or a format name ('XML', 'YAML', 'JSON', 'CSV')
-     * @param  boolean $includeLazyLoadColumns (optional) Whether to include lazy load(ed) columns. Defaults to TRUE.
+     * @param  bool    $includeLazyLoadColumns (optional) Whether to include lazy load(ed) columns. Defaults to TRUE.
      * @param  string  $keyType                (optional) One of the class type constants TableMap::TYPE_PHPNAME, TableMap::TYPE_CAMELNAME, TableMap::TYPE_COLNAME, TableMap::TYPE_FIELDNAME, TableMap::TYPE_NUM. Defaults to TableMap::TYPE_PHPNAME.
      * @return string  The exported data
      */

--- a/src/Propel/Generator/Builder/Om/templates/tableMapClearRelatedInstancePool.php
+++ b/src/Propel/Generator/Builder/Om/templates/tableMapClearRelatedInstancePool.php
@@ -3,7 +3,7 @@
      * Method to invalidate the instance pool of all tables related to <?= $tableName ?>
      * by a foreign key with ON DELETE CASCADE
      */
-    public static function clearRelatedInstancePool()
+    public static function clearRelatedInstancePool(): void
     {
         // Invalidate objects in related instance pools,
         // since one or more of them may be deleted by ON DELETE CASCADE/SETNULL rule.

--- a/src/Propel/Generator/Builder/Util/PropelTemplate.php
+++ b/src/Propel/Generator/Builder/Util/PropelTemplate.php
@@ -40,7 +40,7 @@ class PropelTemplate
      *
      * @return void
      */
-    public function setTemplate($template)
+    public function setTemplate($template): void
     {
         $this->template = $template;
     }
@@ -56,7 +56,7 @@ class PropelTemplate
      *
      * @return void
      */
-    public function setTemplateFile($filePath)
+    public function setTemplateFile($filePath): void
     {
         $this->templateFile = $filePath;
     }
@@ -77,7 +77,7 @@ class PropelTemplate
      *
      * @return string The rendered template
      */
-    public function render($vars = [])
+    public function render($vars = []): string
     {
         if ($this->templateFile === null && $this->template === null) {
             throw new InvalidArgumentException('You must set a template or a template file before rendering');

--- a/src/Propel/Generator/Builder/Util/SchemaReader.php
+++ b/src/Propel/Generator/Builder/Util/SchemaReader.php
@@ -249,7 +249,7 @@ class SchemaReader
                     if ($xmlFile[0] !== '/') {
                         $xmlFile = realpath(dirname($this->currentXmlFile) . DIRECTORY_SEPARATOR . $xmlFile);
                         if (!file_exists($xmlFile)) {
-                            throw new SchemaException(sprintf('Unknown include external "%s"', $xmlFile));
+                            throw new SchemaException(sprintf('Unknown include external `%s`', $xmlFile));
                         }
                     }
 

--- a/src/Propel/Generator/Builder/Util/SchemaReader.php
+++ b/src/Propel/Generator/Builder/Util/SchemaReader.php
@@ -138,7 +138,7 @@ class SchemaReader
      *
      * @return void
      */
-    public function setGeneratorConfig(GeneratorConfigInterface $generatorConfig)
+    public function setGeneratorConfig(GeneratorConfigInterface $generatorConfig): void
     {
         $this->schema->setGeneratorConfig($generatorConfig);
     }
@@ -151,7 +151,7 @@ class SchemaReader
      *
      * @return \Propel\Generator\Model\Schema|null
      */
-    public function parseFile($xmlFile)
+    public function parseFile($xmlFile): ?Schema
     {
         // we don't want infinite recursion
         if ($this->isAlreadyParsed($xmlFile)) {
@@ -172,7 +172,7 @@ class SchemaReader
      *
      * @return \Propel\Generator\Model\Schema|null
      */
-    public function parseString($xmlString, $xmlFile = null)
+    public function parseString($xmlString, $xmlFile = null): ?Schema
     {
         // we don't want infinite recursion
         if ($this->isAlreadyParsed($xmlFile)) {
@@ -215,7 +215,7 @@ class SchemaReader
      *
      * @return void
      */
-    public function startElement($parser, $tagName, $attributes)
+    public function startElement($parser, $tagName, $attributes): void
     {
         $parentTag = $this->peekCurrentSchemaTag();
         if ($parentTag === false) {
@@ -429,7 +429,7 @@ class SchemaReader
      *
      * @return void
      */
-    protected function throwInvalidTagException($tag_name)
+    protected function throwInvalidTagException($tag_name): void
     {
         $this->throwSchemaExceptionWithLocation('Unexpected tag <%s>', $tag_name);
     }
@@ -442,7 +442,7 @@ class SchemaReader
      *
      * @return void
      */
-    private function throwSchemaExceptionWithLocation($format, ...$args)
+    private function throwSchemaExceptionWithLocation($format, ...$args): void
     {
         $format .= ' in %s';
         $args[] = $this->getLocationDescription();
@@ -456,7 +456,7 @@ class SchemaReader
      *
      * @return string
      */
-    private function getLocationDescription()
+    private function getLocationDescription(): string
     {
         $location = '';
         if ($this->currentXmlFile !== null) {
@@ -477,7 +477,7 @@ class SchemaReader
      *
      * @return void
      */
-    public function endElement($parser, $tagName)
+    public function endElement($parser, $tagName): void
     {
         if ($tagName === 'index') {
             $this->currTable->addIndex($this->currIndex);
@@ -521,7 +521,7 @@ class SchemaReader
      *
      * @return void
      */
-    protected function pushCurrentSchemaTag($tag)
+    protected function pushCurrentSchemaTag($tag): void
     {
         $keys = array_keys($this->schemasTagsStack);
         $this->schemasTagsStack[end($keys)][] = $tag;
@@ -530,7 +530,7 @@ class SchemaReader
     /**
      * @return bool
      */
-    protected function isExternalSchema()
+    protected function isExternalSchema(): bool
     {
         return count($this->schemasTagsStack) > 1;
     }
@@ -540,7 +540,7 @@ class SchemaReader
      *
      * @return bool
      */
-    protected function isAlreadyParsed($filePath)
+    protected function isAlreadyParsed($filePath): bool
     {
         return isset($this->schemasTagsStack[$filePath]);
     }
@@ -577,7 +577,7 @@ class SchemaReader
      *
      * @return void
      */
-    private function addAttributeToParameterListItem(array $attributes)
+    private function addAttributeToParameterListItem(array $attributes): void
     {
         $name = $this->getExpectedValue($attributes, 'name');
         $value = $this->getExpectedValue($attributes, 'value');

--- a/src/Propel/Generator/Command/AbstractCommand.php
+++ b/src/Propel/Generator/Command/AbstractCommand.php
@@ -64,7 +64,7 @@ abstract class AbstractCommand extends Command
      *
      * @return \Propel\Generator\Config\GeneratorConfig
      */
-    protected function getGeneratorConfig(?array $properties = null, ?InputInterface $input = null)
+    protected function getGeneratorConfig(?array $properties = null, ?InputInterface $input = null): GeneratorConfig
     {
         if ($input === null) {
             return new GeneratorConfig(null, $properties);
@@ -89,7 +89,7 @@ abstract class AbstractCommand extends Command
      *
      * @return array List of schema files
      */
-    protected function getSchemas($directory, $recursive = false)
+    protected function getSchemas($directory, $recursive = false): array
     {
         $finder = new Finder();
         $finder
@@ -108,7 +108,7 @@ abstract class AbstractCommand extends Command
      *
      * @return \Symfony\Component\Filesystem\Filesystem
      */
-    protected function getFilesystem()
+    protected function getFilesystem(): Filesystem
     {
         if ($this->filesystem === null) {
             $this->filesystem = new Filesystem();
@@ -124,7 +124,7 @@ abstract class AbstractCommand extends Command
      *
      * @return void
      */
-    protected function createDirectory($directory)
+    protected function createDirectory($directory): void
     {
         $filesystem = $this->getFilesystem();
 
@@ -142,7 +142,7 @@ abstract class AbstractCommand extends Command
      *
      * @return array
      */
-    protected function parseConnection($connection)
+    protected function parseConnection($connection): array
     {
         $pos = strpos($connection, '=');
         $name = substr($connection, 0, $pos);
@@ -174,7 +174,7 @@ abstract class AbstractCommand extends Command
      *
      * @return array
      */
-    protected function connectionToProperties($connection, $section = null)
+    protected function connectionToProperties($connection, $section = null): array
     {
         [$name, $dsn, $infos] = $this->parseConnection($connection);
         $config['propel']['database']['connections'][$name]['classname'] = '\Propel\Runtime\Connection\ConnectionWrapper';
@@ -204,7 +204,7 @@ abstract class AbstractCommand extends Command
      *
      * @return bool
      */
-    protected function hasInputOption($option, $input)
+    protected function hasInputOption($option, $input): bool
     {
         return $input->hasOption($option) && $input->getOption($option) !== null;
     }
@@ -217,7 +217,7 @@ abstract class AbstractCommand extends Command
      *
      * @return bool
      */
-    protected function hasInputArgument($argument, $input)
+    protected function hasInputArgument($argument, $input): bool
     {
         return $input->hasArgument($argument) && $input->getArgument($argument) !== null;
     }

--- a/src/Propel/Generator/Command/DataDictionaryExportCommand.php
+++ b/src/Propel/Generator/Command/DataDictionaryExportCommand.php
@@ -79,7 +79,7 @@ class DataDictionaryExportCommand extends AbstractCommand
         $recursive = $generatorConfig->getConfigProperty('generator.recursive');
         $schemas = $this->getSchemas($schemaDir, $recursive);
         $manager->setSchemas($schemas);
-        $manager->setLoggerClosure(function ($message) use ($input, $output) {
+        $manager->setLoggerClosure(function ($message) use ($input, $output): void {
             if ($input->getOption('verbose')) {
                 $output->writeln($message);
             }

--- a/src/Propel/Generator/Command/DatabaseReverseCommand.php
+++ b/src/Propel/Generator/Command/DatabaseReverseCommand.php
@@ -90,7 +90,7 @@ class DatabaseReverseCommand extends AbstractCommand
 
         $manager = new ReverseManager(new XmlDumper());
         $manager->setGeneratorConfig($generatorConfig);
-        $manager->setLoggerClosure(function ($message) use ($input, $output) {
+        $manager->setLoggerClosure(function ($message) use ($input, $output): void {
             if ($input->getOption('verbose')) {
                 $output->writeln($message);
             }

--- a/src/Propel/Generator/Command/GraphvizGenerateCommand.php
+++ b/src/Propel/Generator/Command/GraphvizGenerateCommand.php
@@ -54,7 +54,7 @@ class GraphvizGenerateCommand extends AbstractCommand
         $manager = new GraphvizManager();
         $manager->setGeneratorConfig($generatorConfig);
         $manager->setSchemas($this->getSchemas($generatorConfig->getSection('paths')['schemaDir'], $generatorConfig->getSection('generator')['recursive']));
-        $manager->setLoggerClosure(function ($message) use ($input, $output) {
+        $manager->setLoggerClosure(function ($message) use ($input, $output): void {
             if ($input->getOption('verbose')) {
                 $output->writeln($message);
             }

--- a/src/Propel/Generator/Command/Helper/ConsoleHelper.php
+++ b/src/Propel/Generator/Command/Helper/ConsoleHelper.php
@@ -38,22 +38,29 @@ class ConsoleHelper extends QuestionHelper
     }
 
     /**
-     * @inheritDoc
+     * @param string $questionText
+     * @param string|null $default
+     * @param array|null $autocomplete
+     *
+     * @return mixed
      */
-    public function askQuestion($question, $default = null, ?array $autocomplete = null)
+    public function askQuestion(string $questionText, ?string $default = null, ?array $autocomplete = null)
     {
-        $question = new Question($this->formatQuestion($question, $default), $default);
+        $question = new Question($this->formatQuestion($questionText, $default), $default);
         $question->setAutocompleterValues($autocomplete);
 
         return parent::ask($this->input, $this->output, $question);
     }
 
     /**
-     * @inheritDoc
+     * @param string $questionText
+     * @param bool $fallback
+     *
+     * @return mixed
      */
-    public function askHiddenResponse($question, $fallback = true)
+    public function askHiddenResponse(string $questionText, bool $fallback = true)
     {
-        $question = new Question($this->formatQuestion($question));
+        $question = new Question($this->formatQuestion($questionText));
         $question->setHidden(true);
         $question->setHiddenFallback($fallback);
 
@@ -61,9 +68,11 @@ class ConsoleHelper extends QuestionHelper
     }
 
     /**
-     * @inheritDoc
+     * @param string $text
+     *
+     * @return void
      */
-    public function writeSection($text)
+    public function writeSection(string $text): void
     {
         $this->output->writeln([
             '',
@@ -72,9 +81,12 @@ class ConsoleHelper extends QuestionHelper
     }
 
     /**
-     * @inheritDoc
+     * @param string $text
+     * @param string $style
+     *
+     * @return void
      */
-    public function writeBlock($text, $style = 'bg=blue;fg=white')
+    public function writeBlock(string $text, string $style = 'bg=blue;fg=white'): void
     {
         /** @var \Symfony\Component\Console\Helper\FormatterHelper $formatter */
         $formatter = $this->getHelperSet()->get('formatter');
@@ -84,9 +96,11 @@ class ConsoleHelper extends QuestionHelper
     }
 
     /**
-     * @inheritDoc
+     * @param array<string, string> $items
+     *
+     * @return void
      */
-    public function writeSummary($items)
+    public function writeSummary(array $items): void
     {
         $this->output->writeln('');
         foreach ($items as $name => $value) {
@@ -95,10 +109,23 @@ class ConsoleHelper extends QuestionHelper
     }
 
     /**
-     * @inheritDoc
+     * @param string $question
+     * @param array $choices
+     * @param string|null $default
+     * @param int|null $attempts
+     * @param string $errorMessage
+     * @param bool $multiselect
+     *
+     * @return mixed
      */
-    public function select($question, $choices, $default = null, $attempts = null, $errorMessage = 'Value "%s" is invalid', $multiselect = false)
-    {
+    public function select(
+        string $question,
+        array $choices,
+        ?string $default = null,
+        ?int $attempts = null,
+        string $errorMessage = 'Value "%s" is invalid',
+        bool $multiselect = false
+    ) {
         $choiceQuestion = new ChoiceQuestion($this->formatQuestion($question, $default), $choices, $default);
 
         if ($attempts) {
@@ -112,51 +139,61 @@ class ConsoleHelper extends QuestionHelper
     }
 
     /**
-     * @inheritDoc
+     * @param string $questionText
+     * @param bool $default
+     *
+     * @return mixed
      */
-    public function askConfirmation($question, $default = true)
+    public function askConfirmation(string $questionText, bool $default = true)
     {
-        $question = new ConfirmationQuestion($this->formatQuestion($question, $default ? 'yes' : 'no'), $default);
+        $question = new ConfirmationQuestion($this->formatQuestion($questionText, $default ? 'yes' : 'no'), $default);
 
         return parent::ask($this->input, $this->output, $question);
     }
 
     /**
-     * @inheritDoc
+     * @return \Symfony\Component\Console\Input\InputInterface
      */
-    public function getInput()
+    public function getInput(): InputInterface
     {
         return $this->input;
     }
 
     /**
-     * @inheritDoc
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     *
+     * @return void
      */
-    public function setInput(InputInterface $input)
+    public function setInput(InputInterface $input): void
     {
         $this->input = $input;
     }
 
     /**
-     * @inheritDoc
+     * @return \Symfony\Component\Console\Output\OutputInterface
      */
-    public function getOutput()
+    public function getOutput(): OutputInterface
     {
         return $this->output;
     }
 
     /**
-     * @inheritDoc
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     *
+     * @return void
      */
-    public function setOutput(OutputInterface $output)
+    public function setOutput(OutputInterface $output): void
     {
         $this->output = $output;
     }
 
     /**
-     * @inheritDoc
+     * @param iterable|string $messages
+     * @param int $options
+     *
+     * @return void
      */
-    public function writeln($messages, $options = 0)
+    public function writeln($messages, int $options = 0): void
     {
         $this->output->writeln($messages, $options);
     }
@@ -167,12 +204,12 @@ class ConsoleHelper extends QuestionHelper
      *
      * @return string
      */
-    private function formatQuestion($question, $default = null)
+    protected function formatQuestion(string $question, ?string $default = null): string
     {
         if ($default) {
             return sprintf('<info>%s</info> [<comment>%s</comment>]: ', $question, $default);
-        } else {
-            return sprintf('<info>%s</info>: ', $question);
         }
+
+        return sprintf('<info>%s</info>: ', $question);
     }
 }

--- a/src/Propel/Generator/Command/InitCommand.php
+++ b/src/Propel/Generator/Command/InitCommand.php
@@ -46,7 +46,7 @@ class InitCommand extends AbstractCommand
     /**
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         parent::configure();
 
@@ -181,7 +181,7 @@ class InitCommand extends AbstractCommand
     /**
      * @return string
      */
-    private function detectDefaultPhpDir()
+    private function detectDefaultPhpDir(): string
     {
         if (file_exists(getcwd() . '/src/')) {
             $vendors = Finder::create()->directories()->in(getcwd() . '/src/')->depth(1);
@@ -202,7 +202,7 @@ class InitCommand extends AbstractCommand
      *
      * @return string
      */
-    private function initMysql(ConsoleHelper $consoleHelper)
+    private function initMysql(ConsoleHelper $consoleHelper): string
     {
         $host = $consoleHelper->askQuestion('Please enter your database host', 'localhost');
         $port = $consoleHelper->askQuestion('Please enter your database port', '3306');
@@ -216,7 +216,7 @@ class InitCommand extends AbstractCommand
      *
      * @return string
      */
-    private function initSqlite(ConsoleHelper $consoleHelper)
+    private function initSqlite(ConsoleHelper $consoleHelper): string
     {
         $path = $consoleHelper->askQuestion('Where should the sqlite database be stored?', getcwd() . '/my.app.sq3');
 
@@ -228,7 +228,7 @@ class InitCommand extends AbstractCommand
      *
      * @return string
      */
-    private function initPgsql(ConsoleHelper $consoleHelper)
+    private function initPgsql(ConsoleHelper $consoleHelper): string
     {
         $host = $consoleHelper->askQuestion('Please enter your database host (without port)', 'localhost');
         $port = $consoleHelper->askQuestion('Please enter your database port', '5432');
@@ -267,11 +267,11 @@ class InitCommand extends AbstractCommand
 
     /**
      * @param \Symfony\Component\Console\Output\OutputInterface $output
-     * @param array $options
+     * @param array<string, mixed> $options
      *
      * @return void
      */
-    private function generateProject(OutputInterface $output, array $options)
+    private function generateProject(OutputInterface $output, array $options): void
     {
         $schema = new PropelTemplate();
         $schema->setTemplateFile(__DIR__ . '/templates/schema.xml.php');
@@ -298,7 +298,7 @@ class InitCommand extends AbstractCommand
      *
      * @return void
      */
-    private function buildSqlAndModelsAndConvertConfig(?OutputInterface $output = null)
+    private function buildSqlAndModelsAndConvertConfig(?OutputInterface $output = null): void
     {
         $this->getApplication()->setAutoExit(false);
 
@@ -325,7 +325,7 @@ class InitCommand extends AbstractCommand
      *
      * @return void
      */
-    private function writeFile(OutputInterface $output, $filename, $content)
+    private function writeFile(OutputInterface $output, $filename, $content): void
     {
         $this->getFilesystem()->dumpFile($filename, $content);
 
@@ -338,7 +338,7 @@ class InitCommand extends AbstractCommand
      *
      * @return bool
      */
-    private function testConnection(ConsoleHelper $consoleHelper, array $options)
+    private function testConnection(ConsoleHelper $consoleHelper, array $options): bool
     {
         $adapter = AdapterFactory::create($options['rdbms']);
 
@@ -359,7 +359,7 @@ class InitCommand extends AbstractCommand
             $consoleHelper->writeln('');
 
             if ($consoleHelper->getOutput()->getVerbosity() === OutputInterface::VERBOSITY_DEBUG) {
-                $consoleHelper->writeln($e);
+                $consoleHelper->writeln('Exception: ' . print_r($e, true));
             }
 
             return false;
@@ -372,7 +372,7 @@ class InitCommand extends AbstractCommand
      *
      * @return string
      */
-    private function reverseEngineerSchema(OutputInterface $output, array $options)
+    private function reverseEngineerSchema(OutputInterface $output, array $options): string
     {
         $outputDir = sys_get_temp_dir();
 

--- a/src/Propel/Generator/Command/ModelBuildCommand.php
+++ b/src/Propel/Generator/Command/ModelBuildCommand.php
@@ -140,7 +140,7 @@ class ModelBuildCommand extends AbstractCommand
         $manager->setFilesystem($this->getFilesystem());
         $manager->setGeneratorConfig($generatorConfig);
         $manager->setSchemas($this->getSchemas($generatorConfig->getSection('paths')['schemaDir'], $generatorConfig->getSection('generator')['recursive']));
-        $manager->setLoggerClosure(function ($message) use ($input, $output) {
+        $manager->setLoggerClosure(function ($message) use ($input, $output): void {
             if ($input->getOption('verbose')) {
                 $output->writeln($message);
             }

--- a/src/Propel/Generator/Command/SqlBuildCommand.php
+++ b/src/Propel/Generator/Command/SqlBuildCommand.php
@@ -101,7 +101,7 @@ class SqlBuildCommand extends AbstractCommand
         $manager->setValidate($input->getOption('validate'));
         $manager->setGeneratorConfig($generatorConfig);
         $manager->setSchemas($this->getSchemas($generatorConfig->getSection('paths')['schemaDir'], $generatorConfig->getSection('generator')['recursive']));
-        $manager->setLoggerClosure(function ($message) use ($input, $output) {
+        $manager->setLoggerClosure(function ($message) use ($input, $output): void {
             if ($input->getOption('verbose')) {
                 $output->writeln($message);
             }

--- a/src/Propel/Generator/Command/SqlInsertCommand.php
+++ b/src/Propel/Generator/Command/SqlInsertCommand.php
@@ -60,7 +60,7 @@ class SqlInsertCommand extends AbstractCommand
         }
 
         $manager->setConnections($connections);
-        $manager->setLoggerClosure(function ($message) use ($input, $output) {
+        $manager->setLoggerClosure(function ($message) use ($input, $output): void {
             if ($input->getOption('verbose')) {
                 $output->writeln($message);
             }

--- a/src/Propel/Generator/Config/ArrayToPhpConverter.php
+++ b/src/Propel/Generator/Config/ArrayToPhpConverter.php
@@ -54,7 +54,7 @@ class ArrayToPhpConverter
                     $conf[] = "\$manager->{$masterConfigurationSetter}(" . var_export($connection, true) . ');';
                 }
 
-                $conf[] = "\$serviceContainer->setConnectionManager(\$manager);";
+                $conf[] = '$serviceContainer->setConnectionManager($manager);';
             }
 
             // set default datasource

--- a/src/Propel/Generator/Config/ArrayToPhpConverter.php
+++ b/src/Propel/Generator/Config/ArrayToPhpConverter.php
@@ -17,11 +17,11 @@ class ArrayToPhpConverter
     /**
      * Create a PHP configuration from an array
      *
-     * @param array $c The array configuration
+     * @param array<string, mixed> $c The array configuration
      *
      * @return string
      */
-    public static function convert($c)
+    public static function convert($c): string
     {
         $conf = [];
         // set datasources

--- a/src/Propel/Generator/Config/GeneratorConfig.php
+++ b/src/Propel/Generator/Config/GeneratorConfig.php
@@ -10,10 +10,13 @@ namespace Propel\Generator\Config;
 
 use Propel\Common\Config\ConfigurationManager;
 use Propel\Common\Pluralizer\PluralizerInterface;
+use Propel\Generator\Builder\Om\AbstractOMBuilder;
 use Propel\Generator\Exception\BuildException;
 use Propel\Generator\Exception\ClassNotFoundException;
 use Propel\Generator\Exception\InvalidArgumentException;
 use Propel\Generator\Model\Table;
+use Propel\Generator\Platform\PlatformInterface;
+use Propel\Generator\Reverse\SchemaParserInterface;
 use Propel\Generator\Util\BehaviorLocator;
 use Propel\Runtime\Adapter\AdapterFactory;
 use Propel\Runtime\Connection\ConnectionFactory;
@@ -47,7 +50,7 @@ class GeneratorConfig extends ConfigurationManager implements GeneratorConfigInt
      *
      * @throws \Propel\Generator\Exception\ClassNotFoundException
      */
-    public function getConfiguredPlatform(?ConnectionInterface $con = null, $database = null)
+    public function getConfiguredPlatform(?ConnectionInterface $con = null, ?string $database = null): ?PlatformInterface
     {
         $platform = $this->get()['generator']['platformClass'];
 
@@ -95,7 +98,7 @@ class GeneratorConfig extends ConfigurationManager implements GeneratorConfigInt
      *
      * @throws \Propel\Generator\Exception\ClassNotFoundException
      */
-    public function getConfiguredSchemaParser(?ConnectionInterface $con = null, $database = null)
+    public function getConfiguredSchemaParser(?ConnectionInterface $con = null, $database = null): ?SchemaParserInterface
     {
         $reverse = $this->get()['migrations']['parserClass'];
 
@@ -153,9 +156,9 @@ class GeneratorConfig extends ConfigurationManager implements GeneratorConfigInt
      *
      * @throws \Propel\Generator\Exception\InvalidArgumentException
      *
-     * @return \Propel\Generator\Builder\DataModelBuilder
+     * @return \Propel\Generator\Builder\Om\AbstractOMBuilder
      */
-    public function getConfiguredBuilder(Table $table, $type)
+    public function getConfiguredBuilder(Table $table, string $type): AbstractOMBuilder
     {
         $configProperty = 'generator.objectModel.builders.' . $type;
         $classname = $this->getConfigProperty($configProperty);
@@ -163,7 +166,7 @@ class GeneratorConfig extends ConfigurationManager implements GeneratorConfigInt
             throw new InvalidArgumentException(sprintf('Unable to get config property: "%s"', $configProperty));
         }
 
-        /** @var \Propel\Generator\Builder\DataModelBuilder $builder */
+        /** @var \Propel\Generator\Builder\Om\AbstractOMBuilder $builder */
         $builder = $this->getInstance($classname, $table);
         $builder->setGeneratorConfig($this);
 
@@ -175,7 +178,7 @@ class GeneratorConfig extends ConfigurationManager implements GeneratorConfigInt
      *
      * @return \Propel\Common\Pluralizer\PluralizerInterface
      */
-    public function getConfiguredPluralizer()
+    public function getConfiguredPluralizer(): PluralizerInterface
     {
         $classname = $this->get()['generator']['objectModel']['pluralizerClass'];
 
@@ -191,7 +194,7 @@ class GeneratorConfig extends ConfigurationManager implements GeneratorConfigInt
      *
      * @return array
      */
-    public function getBuildConnections()
+    public function getBuildConnections(): array
     {
         if ($this->buildConnections === null) {
             $connectionNames = $this->get()['generator']['connections'];
@@ -221,7 +224,7 @@ class GeneratorConfig extends ConfigurationManager implements GeneratorConfigInt
      *
      * @return array
      */
-    public function getBuildConnection($databaseName = null)
+    public function getBuildConnection(?string $databaseName = null): array
     {
         if ($databaseName === null) {
             $databaseName = $this->get()['generator']['defaultConnection'];
@@ -241,7 +244,7 @@ class GeneratorConfig extends ConfigurationManager implements GeneratorConfigInt
      *
      * @return \Propel\Runtime\Connection\ConnectionInterface
      */
-    public function getConnection($database = null)
+    public function getConnection(?string $database = null): ConnectionInterface
     {
         $buildConnection = $this->getBuildConnection($database);
 
@@ -264,7 +267,7 @@ class GeneratorConfig extends ConfigurationManager implements GeneratorConfigInt
     /**
      * @return \Propel\Generator\Util\BehaviorLocator
      */
-    public function getBehaviorLocator()
+    public function getBehaviorLocator(): BehaviorLocator
     {
         if (!$this->behaviorLocator) {
             $this->behaviorLocator = new BehaviorLocator($this);
@@ -286,7 +289,7 @@ class GeneratorConfig extends ConfigurationManager implements GeneratorConfigInt
      *
      * @return object
      */
-    private function getInstance(string $className, $arguments = null, $interfaceName = null): object
+    private function getInstance(string $className, $arguments = null, ?string $interfaceName = null): object
     {
         if (!class_exists($className)) {
             throw new ClassNotFoundException("Class $className not found.");

--- a/src/Propel/Generator/Config/GeneratorConfigInterface.php
+++ b/src/Propel/Generator/Config/GeneratorConfigInterface.php
@@ -8,7 +8,12 @@
 
 namespace Propel\Generator\Config;
 
+use Propel\Common\Pluralizer\PluralizerInterface;
+use Propel\Generator\Builder\Om\AbstractOMBuilder;
 use Propel\Generator\Model\Table;
+use Propel\Generator\Platform\PlatformInterface;
+use Propel\Generator\Reverse\SchemaParserInterface;
+use Propel\Generator\Util\BehaviorLocator;
 use Propel\Runtime\Connection\ConnectionInterface;
 
 interface GeneratorConfigInterface
@@ -22,14 +27,14 @@ interface GeneratorConfigInterface
      *
      * @return \Propel\Generator\Builder\Om\AbstractOMBuilder
      */
-    public function getConfiguredBuilder(Table $table, $type);
+    public function getConfiguredBuilder(Table $table, string $type): AbstractOMBuilder;
 
     /**
      * Returns a configured Pluralizer class.
      *
      * @return \Propel\Common\Pluralizer\PluralizerInterface
      */
-    public function getConfiguredPluralizer();
+    public function getConfiguredPluralizer(): PluralizerInterface;
 
     /**
      * Creates and configures a new Platform class.
@@ -42,7 +47,7 @@ interface GeneratorConfigInterface
      *
      * @return \Propel\Generator\Platform\PlatformInterface|null
      */
-    public function getConfiguredPlatform(?ConnectionInterface $con = null, $database = null);
+    public function getConfiguredPlatform(?ConnectionInterface $con = null, ?string $database = null): ?PlatformInterface;
 
     /**
      * Creates and configures a new SchemaParser class for a specified platform.
@@ -55,14 +60,14 @@ interface GeneratorConfigInterface
      *
      * @return \Propel\Generator\Reverse\SchemaParserInterface|null
      */
-    public function getConfiguredSchemaParser(?ConnectionInterface $con = null, $database = null);
+    public function getConfiguredSchemaParser(?ConnectionInterface $con = null, ?string $database = null): ?SchemaParserInterface;
 
     /**
      * Returns the behavior locator.
      *
      * @return \Propel\Generator\Util\BehaviorLocator
      */
-    public function getBehaviorLocator();
+    public function getBehaviorLocator(): BehaviorLocator;
 
     /**
      * Return a specific configuration property.
@@ -78,5 +83,5 @@ interface GeneratorConfigInterface
      *
      * @return mixed The configuration property
      */
-    public function getConfigProperty($name);
+    public function getConfigProperty(string $name);
 }

--- a/src/Propel/Generator/Config/QuickGeneratorConfig.php
+++ b/src/Propel/Generator/Config/QuickGeneratorConfig.php
@@ -9,9 +9,13 @@
 namespace Propel\Generator\Config;
 
 use Propel\Common\Config\ConfigurationManager;
+use Propel\Common\Pluralizer\PluralizerInterface;
 use Propel\Common\Pluralizer\StandardEnglishPluralizer;
+use Propel\Generator\Builder\Om\AbstractOMBuilder;
 use Propel\Generator\Exception\InvalidArgumentException;
 use Propel\Generator\Model\Table;
+use Propel\Generator\Platform\PlatformInterface;
+use Propel\Generator\Reverse\SchemaParserInterface;
 use Propel\Generator\Util\BehaviorLocator;
 use Propel\Runtime\Connection\ConnectionInterface;
 
@@ -25,7 +29,7 @@ class QuickGeneratorConfig extends ConfigurationManager implements GeneratorConf
     /**
      * @param array|null $extraConf
      */
-    public function __construct($extraConf = [])
+    public function __construct(?array $extraConf = [])
     {
         if ($extraConf === null) {
             $extraConf = [];
@@ -69,9 +73,9 @@ class QuickGeneratorConfig extends ConfigurationManager implements GeneratorConf
      *
      * @throws \Propel\Generator\Exception\InvalidArgumentException
      *
-     * @return \Propel\Generator\Builder\DataModelBuilder
+     * @return \Propel\Generator\Builder\Om\AbstractOMBuilder
      */
-    public function getConfiguredBuilder(Table $table, $type)
+    public function getConfiguredBuilder(Table $table, string $type): AbstractOMBuilder
     {
         $class = $this->getConfigProperty('generator.objectModel.builders.' . $type);
 
@@ -79,6 +83,7 @@ class QuickGeneratorConfig extends ConfigurationManager implements GeneratorConf
             throw new InvalidArgumentException("Invalid data model builder type `$type`");
         }
 
+        /** @var \Propel\Generator\Builder\Om\AbstractOMBuilder $builder */
         $builder = new $class($table);
         $builder->setGeneratorConfig($this);
 
@@ -90,7 +95,7 @@ class QuickGeneratorConfig extends ConfigurationManager implements GeneratorConf
      *
      * @return \Propel\Common\Pluralizer\PluralizerInterface
      */
-    public function getConfiguredPluralizer()
+    public function getConfiguredPluralizer(): PluralizerInterface
     {
         return new StandardEnglishPluralizer();
     }
@@ -98,7 +103,7 @@ class QuickGeneratorConfig extends ConfigurationManager implements GeneratorConf
     /**
      * @inheritDoc
      */
-    public function getConfiguredPlatform(?ConnectionInterface $con = null, $database = null)
+    public function getConfiguredPlatform(?ConnectionInterface $con = null, ?string $database = null): ?PlatformInterface
     {
         return null;
     }
@@ -106,7 +111,7 @@ class QuickGeneratorConfig extends ConfigurationManager implements GeneratorConf
     /**
      * @inheritDoc
      */
-    public function getConfiguredSchemaParser(?ConnectionInterface $con = null, $database = null)
+    public function getConfiguredSchemaParser(?ConnectionInterface $con = null, ?string $database = null): ?SchemaParserInterface
     {
         return null;
     }
@@ -114,7 +119,7 @@ class QuickGeneratorConfig extends ConfigurationManager implements GeneratorConf
     /**
      * @return \Propel\Generator\Util\BehaviorLocator
      */
-    public function getBehaviorLocator()
+    public function getBehaviorLocator(): BehaviorLocator
     {
         if (!$this->behaviorLocator) {
             $this->behaviorLocator = new BehaviorLocator($this);

--- a/src/Propel/Generator/Manager/AbstractManager.php
+++ b/src/Propel/Generator/Manager/AbstractManager.php
@@ -15,6 +15,8 @@ use Propel\Generator\Builder\Util\SchemaReader;
 use Propel\Generator\Config\GeneratorConfigInterface;
 use Propel\Generator\Exception\BuildException;
 use Propel\Generator\Exception\EngineException;
+use Propel\Generator\Model\Database;
+use Propel\Generator\Model\Schema;
 use XsltProcessor;
 
 /**
@@ -116,7 +118,7 @@ abstract class AbstractManager
      *
      * @return array
      */
-    public function getSchemas()
+    public function getSchemas(): array
     {
         return $this->schemas;
     }
@@ -128,7 +130,7 @@ abstract class AbstractManager
      *
      * @return void
      */
-    public function setSchemas($schemas)
+    public function setSchemas($schemas): void
     {
         $this->schemas = $schemas;
     }
@@ -140,7 +142,7 @@ abstract class AbstractManager
      *
      * @return void
      */
-    public function setWorkingDirectory($workingDirectory)
+    public function setWorkingDirectory($workingDirectory): void
     {
         $this->workingDirectory = $workingDirectory;
     }
@@ -150,7 +152,7 @@ abstract class AbstractManager
      *
      * @return string
      */
-    public function getWorkingDirectory()
+    public function getWorkingDirectory(): string
     {
         return $this->workingDirectory;
     }
@@ -161,7 +163,7 @@ abstract class AbstractManager
      *
      * @return array<\Propel\Generator\Model\Schema>
      */
-    public function getDataModels()
+    public function getDataModels(): array
     {
         if (!$this->dataModelsLoaded) {
             $this->loadDataModels();
@@ -175,7 +177,7 @@ abstract class AbstractManager
      *
      * @return array
      */
-    public function getDataModelDbMap()
+    public function getDataModelDbMap(): array
     {
         if (!$this->dataModelsLoaded) {
             $this->loadDataModels();
@@ -187,7 +189,7 @@ abstract class AbstractManager
     /**
      * @return array<\Propel\Generator\Model\Database>
      */
-    public function getDatabases()
+    public function getDatabases(): array
     {
         if ($this->databases === null) {
             $databases = [];
@@ -217,7 +219,7 @@ abstract class AbstractManager
      *
      * @return \Propel\Generator\Model\Database|null
      */
-    public function getDatabase($name)
+    public function getDatabase($name): ?Database
     {
         $dbs = $this->getDatabases();
 
@@ -231,7 +233,7 @@ abstract class AbstractManager
      *
      * @return void
      */
-    public function setValidate($validate)
+    public function setValidate($validate): void
     {
         $this->validate = (bool)$validate;
     }
@@ -244,7 +246,7 @@ abstract class AbstractManager
      *
      * @return void
      */
-    public function setXsd($xsd)
+    public function setXsd($xsd): void
     {
         $this->xsd = $xsd;
     }
@@ -257,7 +259,7 @@ abstract class AbstractManager
      *
      * @return void
      */
-    public function setXsl($xsl)
+    public function setXsl($xsl): void
     {
         $this->xsl = $xsl;
     }
@@ -269,7 +271,7 @@ abstract class AbstractManager
      *
      * @return void
      */
-    public function setDbEncoding($encoding)
+    public function setDbEncoding($encoding): void
     {
         $this->dbEncoding = $encoding;
     }
@@ -281,7 +283,7 @@ abstract class AbstractManager
      *
      * @return void
      */
-    public function setLoggerClosure(Closure $logger)
+    public function setLoggerClosure(Closure $logger): void
     {
         $this->loggerClosure = $logger;
     }
@@ -295,7 +297,7 @@ abstract class AbstractManager
      *
      * @return void
      */
-    protected function loadDataModels()
+    protected function loadDataModels(): void
     {
         $schemas = [];
         $totalNbTables = 0;
@@ -388,7 +390,7 @@ abstract class AbstractManager
      *
      * @return int number of included external schemas
      */
-    protected function includeExternalSchemas(DOMDocument $dom, $srcDir)
+    protected function includeExternalSchemas(DOMDocument $dom, $srcDir): int
     {
         $databaseNode = $dom->getElementsByTagName('database')->item(0);
         $externalSchemaNodes = $dom->getElementsByTagName('external-schema');
@@ -435,7 +437,7 @@ abstract class AbstractManager
      *
      * @return \Propel\Generator\Model\Schema
      */
-    protected function joinDataModels(array $schemas)
+    protected function joinDataModels(array $schemas): Schema
     {
         $mainSchema = array_shift($schemas);
         $mainSchema->joinSchemas($schemas);
@@ -449,7 +451,7 @@ abstract class AbstractManager
      *
      * @return \Propel\Generator\Config\GeneratorConfigInterface
      */
-    protected function getGeneratorConfig()
+    protected function getGeneratorConfig(): GeneratorConfigInterface
     {
         return $this->generatorConfig;
     }
@@ -461,7 +463,7 @@ abstract class AbstractManager
      *
      * @return void
      */
-    public function setGeneratorConfig(GeneratorConfigInterface $generatorConfig)
+    public function setGeneratorConfig(GeneratorConfigInterface $generatorConfig): void
     {
         $this->generatorConfig = $generatorConfig;
     }
@@ -471,7 +473,7 @@ abstract class AbstractManager
      *
      * @return void
      */
-    protected function validate()
+    protected function validate(): void
     {
         if ($this->validate) {
             if (!$this->xsd) {
@@ -485,7 +487,7 @@ abstract class AbstractManager
      *
      * @return void
      */
-    protected function log($message)
+    protected function log($message): void
     {
         if ($this->loggerClosure !== null) {
             $closure = $this->loggerClosure;
@@ -502,7 +504,7 @@ abstract class AbstractManager
      *
      * @return array<string>
      */
-    protected function getProperties($file)
+    protected function getProperties($file): array
     {
         $properties = [];
 

--- a/src/Propel/Generator/Manager/AbstractManager.php
+++ b/src/Propel/Generator/Manager/AbstractManager.php
@@ -150,9 +150,9 @@ abstract class AbstractManager
     /**
      * Returns the working directory path.
      *
-     * @return string
+     * @return string|null
      */
-    public function getWorkingDirectory(): string
+    public function getWorkingDirectory(): ?string
     {
         return $this->workingDirectory;
     }

--- a/src/Propel/Generator/Manager/GraphvizManager.php
+++ b/src/Propel/Generator/Manager/GraphvizManager.php
@@ -20,7 +20,7 @@ class GraphvizManager extends AbstractManager
     /**
      * @return void
      */
-    public function build()
+    public function build(): void
     {
         foreach ($this->getDatabases() as $database) {
             $dotSyntax = "digraph G {\n";
@@ -80,7 +80,7 @@ class GraphvizManager extends AbstractManager
      *
      * @return void
      */
-    protected function writeDot($dotSyntax, $baseFilename)
+    protected function writeDot($dotSyntax, $baseFilename): void
     {
         $file = $this->getWorkingDirectory() . DIRECTORY_SEPARATOR . $baseFilename . '.schema.dot';
 

--- a/src/Propel/Generator/Manager/MigrationManager.php
+++ b/src/Propel/Generator/Manager/MigrationManager.php
@@ -16,9 +16,11 @@ use Propel\Generator\Exception\InvalidArgumentException;
 use Propel\Generator\Model\Column;
 use Propel\Generator\Model\Database;
 use Propel\Generator\Model\Table;
+use Propel\Generator\Platform\PlatformInterface;
 use Propel\Generator\Util\SqlParser;
 use Propel\Runtime\Adapter\AdapterFactory;
 use Propel\Runtime\Connection\ConnectionFactory;
+use Propel\Runtime\Connection\ConnectionInterface;
 
 /**
  * Service class for preparing and executing migrations
@@ -49,7 +51,7 @@ class MigrationManager extends AbstractManager
      *
      * @return void
      */
-    public function setConnections($connections)
+    public function setConnections($connections): void
     {
         $this->connections = $connections;
     }
@@ -59,7 +61,7 @@ class MigrationManager extends AbstractManager
      *
      * @return array
      */
-    public function getConnections()
+    public function getConnections(): array
     {
         return $this->connections;
     }
@@ -71,7 +73,7 @@ class MigrationManager extends AbstractManager
      *
      * @return array
      */
-    public function getConnection($datasource)
+    public function getConnection($datasource): array
     {
         if (!isset($this->connections[$datasource])) {
             throw new InvalidArgumentException(sprintf('Unknown datasource "%s"', $datasource));
@@ -85,7 +87,7 @@ class MigrationManager extends AbstractManager
      *
      * @return \Propel\Runtime\Connection\ConnectionInterface
      */
-    public function getAdapterConnection($datasource)
+    public function getAdapterConnection($datasource): ConnectionInterface
     {
         if (!isset($this->adapterConnections[$datasource])) {
             $buildConnection = $this->getConnection($datasource);
@@ -101,7 +103,7 @@ class MigrationManager extends AbstractManager
      *
      * @return \Propel\Generator\Platform\PlatformInterface
      */
-    public function getPlatform($datasource)
+    public function getPlatform($datasource): PlatformInterface
     {
         $params = $this->getConnection($datasource);
         $adapter = $params['adapter'];
@@ -118,7 +120,7 @@ class MigrationManager extends AbstractManager
      *
      * @return void
      */
-    public function setMigrationTable($migrationTable)
+    public function setMigrationTable($migrationTable): void
     {
         $this->migrationTable = $migrationTable;
     }
@@ -128,7 +130,7 @@ class MigrationManager extends AbstractManager
      *
      * @return string
      */
-    public function getMigrationTable()
+    public function getMigrationTable(): string
     {
         return $this->migrationTable;
     }
@@ -138,7 +140,7 @@ class MigrationManager extends AbstractManager
      *
      * @return array<int>
      */
-    public function getAllDatabaseVersions()
+    public function getAllDatabaseVersions(): array
     {
         $connections = $this->getConnections();
         if (!$connections) {
@@ -180,7 +182,7 @@ class MigrationManager extends AbstractManager
      *
      * @return bool
      */
-    public function migrationTableExists($datasource)
+    public function migrationTableExists($datasource): bool
     {
         $conn = $this->getAdapterConnection($datasource);
         $sql = sprintf('SELECT version FROM %s', $this->getMigrationTable());
@@ -201,7 +203,7 @@ class MigrationManager extends AbstractManager
      *
      * @return void
      */
-    public function createMigrationTable($datasource)
+    public function createMigrationTable($datasource): void
     {
         /** @var \Propel\Generator\Platform\DefaultPlatform $platform */
         $platform = $this->getPlatform($datasource);
@@ -233,11 +235,11 @@ class MigrationManager extends AbstractManager
      *
      * @return void
      */
-    public function removeMigrationTimestamp($datasource, $timestamp)
+    public function removeMigrationTimestamp($datasource, $timestamp): void
     {
         $platform = $this->getPlatform($datasource);
         $conn = $this->getAdapterConnection($datasource);
-        $conn->transaction(function () use ($conn, $platform, $timestamp) {
+        $conn->transaction(function () use ($conn, $platform, $timestamp): void {
             $sql = sprintf(
                 'DELETE FROM %s WHERE %s = ?',
                 $this->getMigrationTable(),
@@ -255,7 +257,7 @@ class MigrationManager extends AbstractManager
      *
      * @return void
      */
-    public function updateLatestMigrationTimestamp($datasource, $timestamp)
+    public function updateLatestMigrationTimestamp($datasource, $timestamp): void
     {
         $platform = $this->getPlatform($datasource);
         $conn = $this->getAdapterConnection($datasource);
@@ -272,7 +274,7 @@ class MigrationManager extends AbstractManager
     /**
      * @return array<int>
      */
-    public function getMigrationTimestamps()
+    public function getMigrationTimestamps(): array
     {
         $path = $this->getWorkingDirectory();
         $migrationTimestamps = [];
@@ -292,7 +294,7 @@ class MigrationManager extends AbstractManager
     /**
      * @return array<int>
      */
-    public function getValidMigrationTimestamps()
+    public function getValidMigrationTimestamps(): array
     {
         $migrationTimestamps = array_diff($this->getMigrationTimestamps(), $this->getAllDatabaseVersions());
         sort($migrationTimestamps);
@@ -303,7 +305,7 @@ class MigrationManager extends AbstractManager
     /**
      * @return bool
      */
-    public function hasPendingMigrations()
+    public function hasPendingMigrations(): bool
     {
         return $this->getValidMigrationTimestamps() !== [];
     }
@@ -311,7 +313,7 @@ class MigrationManager extends AbstractManager
     /**
      * @return array<int>
      */
-    public function getAlreadyExecutedMigrationTimestamps()
+    public function getAlreadyExecutedMigrationTimestamps(): array
     {
         $migrationTimestamps = array_intersect($this->getMigrationTimestamps(), $this->getAllDatabaseVersions());
         sort($migrationTimestamps);
@@ -322,7 +324,7 @@ class MigrationManager extends AbstractManager
     /**
      * @return int
      */
-    public function getFirstUpMigrationTimestamp()
+    public function getFirstUpMigrationTimestamp(): int
     {
         $validTimestamps = $this->getValidMigrationTimestamps();
 
@@ -332,7 +334,7 @@ class MigrationManager extends AbstractManager
     /**
      * @return int|null
      */
-    public function getFirstDownMigrationTimestamp()
+    public function getFirstDownMigrationTimestamp(): ?int
     {
         return $this->getOldestDatabaseVersion();
     }
@@ -343,7 +345,7 @@ class MigrationManager extends AbstractManager
      *
      * @return string
      */
-    public function getMigrationClassName($timestamp, $suffix = '')
+    public function getMigrationClassName($timestamp, $suffix = ''): string
     {
         $className = sprintf('PropelMigration_%d', $timestamp);
         if ($suffix === '') {
@@ -361,7 +363,7 @@ class MigrationManager extends AbstractManager
      *
      * @return string
      */
-    public function findMigrationClassNameSuffix($timestamp)
+    public function findMigrationClassNameSuffix($timestamp): string
     {
         $suffix = '';
         $path = $this->getWorkingDirectory();
@@ -382,7 +384,7 @@ class MigrationManager extends AbstractManager
      *
      * @return object
      */
-    public function getMigrationObject($timestamp)
+    public function getMigrationObject($timestamp): object
     {
         $className = $this->getMigrationClassName($timestamp);
         $filename = sprintf(
@@ -404,7 +406,7 @@ class MigrationManager extends AbstractManager
      *
      * @return string
      */
-    public function getMigrationClassBody($migrationsUp, $migrationsDown, $timestamp, $comment = '', $suffix = '')
+    public function getMigrationClassBody($migrationsUp, $migrationsDown, $timestamp, $comment = '', $suffix = ''): string
     {
         $connectionToVariableName = self::buildConnectionToVariableNameMap($migrationsUp, $migrationsDown);
 
@@ -465,7 +467,7 @@ class MigrationManager extends AbstractManager
      *
      * @return string
      */
-    public function getMigrationFileName($timestamp, $suffix = '')
+    public function getMigrationFileName($timestamp, $suffix = ''): string
     {
         return sprintf('%s.php', $this->getMigrationClassName($timestamp, $suffix));
     }
@@ -473,7 +475,7 @@ class MigrationManager extends AbstractManager
     /**
      * @return string
      */
-    public static function getUser()
+    public static function getUser(): string
     {
         if (function_exists('posix_getuid')) {
             $currentUser = posix_getpwuid(posix_getuid());
@@ -488,7 +490,7 @@ class MigrationManager extends AbstractManager
     /**
      * @return int|null
      */
-    public function getOldestDatabaseVersion()
+    public function getOldestDatabaseVersion(): ?int
     {
         $versions = $this->getAllDatabaseVersions();
         if (!$versions) {

--- a/src/Propel/Generator/Manager/ModelManager.php
+++ b/src/Propel/Generator/Manager/ModelManager.php
@@ -34,7 +34,7 @@ class ModelManager extends AbstractManager
      *
      * @return void
      */
-    public function setFilesystem(Filesystem $filesystem)
+    public function setFilesystem(Filesystem $filesystem): void
     {
         $this->filesystem = $filesystem;
     }
@@ -42,7 +42,7 @@ class ModelManager extends AbstractManager
     /**
      * @return void
      */
-    public function build()
+    public function build(): void
     {
         $this->validate();
 
@@ -163,7 +163,7 @@ class ModelManager extends AbstractManager
      *
      * @return int
      */
-    protected function doBuild(AbstractOMBuilder $builder, $overwrite = true)
+    protected function doBuild(AbstractOMBuilder $builder, $overwrite = true): int
     {
         $path = $builder->getClassFilePath();
         $file = new SplFileInfo($this->getWorkingDirectory() . DIRECTORY_SEPARATOR . $path);

--- a/src/Propel/Generator/Manager/ReverseManager.php
+++ b/src/Propel/Generator/Manager/ReverseManager.php
@@ -76,9 +76,9 @@ class ReverseManager extends AbstractManager
     /**
      * Gets the (optional) schema name to use.
      *
-     * @return string
+     * @return string|null
      */
-    public function getSchemaName(): string
+    public function getSchemaName(): ?string
     {
         return $this->schemaName;
     }

--- a/src/Propel/Generator/Manager/ReverseManager.php
+++ b/src/Propel/Generator/Manager/ReverseManager.php
@@ -13,6 +13,7 @@ use Propel\Generator\Exception\BuildException;
 use Propel\Generator\Model\Database;
 use Propel\Generator\Model\IdMethod;
 use Propel\Generator\Schema\Dumper\DumperInterface;
+use Propel\Runtime\Connection\ConnectionInterface;
 
 /**
  * @author William Durand <william.durand1@gmail.com>
@@ -77,7 +78,7 @@ class ReverseManager extends AbstractManager
      *
      * @return string
      */
-    public function getSchemaName()
+    public function getSchemaName(): string
     {
         return $this->schemaName;
     }
@@ -89,7 +90,7 @@ class ReverseManager extends AbstractManager
      *
      * @return void
      */
-    public function setSchemaName($schemaName)
+    public function setSchemaName($schemaName): void
     {
         $this->schemaName = $schemaName;
     }
@@ -111,7 +112,7 @@ class ReverseManager extends AbstractManager
      *
      * @return void
      */
-    public function setNamespace($namespace)
+    public function setNamespace($namespace): void
     {
         $this->namespace = $namespace;
     }
@@ -121,7 +122,7 @@ class ReverseManager extends AbstractManager
      *
      * @return string
      */
-    public function getDatabaseName()
+    public function getDatabaseName(): string
     {
         return $this->databaseName;
     }
@@ -135,7 +136,7 @@ class ReverseManager extends AbstractManager
      *
      * @return void
      */
-    public function setDatabaseName($databaseName)
+    public function setDatabaseName($databaseName): void
     {
         $this->databaseName = $databaseName;
     }
@@ -147,7 +148,7 @@ class ReverseManager extends AbstractManager
      *
      * @return void
      */
-    public function setSamePhpName($samePhpName)
+    public function setSamePhpName($samePhpName): void
     {
         $this->samePhpName = (bool)$samePhpName;
     }
@@ -159,7 +160,7 @@ class ReverseManager extends AbstractManager
      *
      * @return void
      */
-    public function setAddVendorInfo($addVendorInfo)
+    public function setAddVendorInfo($addVendorInfo): void
     {
         $this->addVendorInfo = (bool)$addVendorInfo;
     }
@@ -170,7 +171,7 @@ class ReverseManager extends AbstractManager
      *
      * @return bool
      */
-    public function isSamePhpName()
+    public function isSamePhpName(): bool
     {
         return $this->samePhpName;
     }
@@ -180,7 +181,7 @@ class ReverseManager extends AbstractManager
      *
      * @return bool
      */
-    public function reverse()
+    public function reverse(): bool
     {
         if (!$this->getDatabaseName()) {
             throw new BuildException('The databaseName attribute is required for schema reverse engineering');
@@ -208,7 +209,7 @@ class ReverseManager extends AbstractManager
      *
      * @return \Propel\Generator\Model\Database The built-out Database (with all tables, etc.)
      */
-    protected function buildModel()
+    protected function buildModel(): Database
     {
         /** @var \Propel\Generator\Config\GeneratorConfig $config */
         $config = $this->getGeneratorConfig();
@@ -270,7 +271,7 @@ class ReverseManager extends AbstractManager
      *
      * @return \Propel\Runtime\Connection\ConnectionInterface
      */
-    protected function getConnection()
+    protected function getConnection(): ConnectionInterface
     {
         /** @var \Propel\Generator\Config\GeneratorConfig $generatorConfig */
         $generatorConfig = $this->getGeneratorConfig();

--- a/src/Propel/Generator/Manager/SqlManager.php
+++ b/src/Propel/Generator/Manager/SqlManager.php
@@ -13,6 +13,7 @@ use Propel\Generator\Exception\InvalidArgumentException;
 use Propel\Generator\Util\SqlParser;
 use Propel\Runtime\Adapter\AdapterFactory;
 use Propel\Runtime\Connection\ConnectionFactory;
+use Propel\Runtime\Connection\ConnectionInterface;
 
 /**
  * Service class for managing SQL.
@@ -38,7 +39,7 @@ class SqlManager extends AbstractManager
      *
      * @return void
      */
-    public function setConnections($connections)
+    public function setConnections($connections): void
     {
         $this->connections = $connections;
     }
@@ -48,7 +49,7 @@ class SqlManager extends AbstractManager
      *
      * @return array
      */
-    public function getConnections()
+    public function getConnections(): array
     {
         return $this->connections;
     }
@@ -58,7 +59,7 @@ class SqlManager extends AbstractManager
      *
      * @return bool
      */
-    public function hasConnection($connection)
+    public function hasConnection($connection): bool
     {
         return isset($this->connections[$connection]);
     }
@@ -66,7 +67,7 @@ class SqlManager extends AbstractManager
     /**
      * @return bool
      */
-    public function isOverwriteSqlMap()
+    public function isOverwriteSqlMap(): bool
     {
         return $this->overwriteSqlMap;
     }
@@ -76,7 +77,7 @@ class SqlManager extends AbstractManager
      *
      * @return void
      */
-    public function setOverwriteSqlMap($overwriteSqlMap)
+    public function setOverwriteSqlMap($overwriteSqlMap): void
     {
         $this->overwriteSqlMap = (bool)$overwriteSqlMap;
     }
@@ -88,7 +89,7 @@ class SqlManager extends AbstractManager
      *
      * @return array
      */
-    public function getConnection($datasource)
+    public function getConnection($datasource): array
     {
         if (!$this->hasConnection($datasource)) {
             throw new InvalidArgumentException(sprintf('Unknown datasource "%s"', $datasource));
@@ -100,7 +101,7 @@ class SqlManager extends AbstractManager
     /**
      * @return string
      */
-    public function getSqlDbMapFilename()
+    public function getSqlDbMapFilename(): string
     {
         return $this->getWorkingDirectory() . DIRECTORY_SEPARATOR . 'sqldb.map';
     }
@@ -110,7 +111,7 @@ class SqlManager extends AbstractManager
      *
      * @return void
      */
-    public function buildSql()
+    public function buildSql(): void
     {
         $sqlDbMapContent = "# Sqlfile -> Database map\n";
         foreach ($this->getDatabases() as $datasource => $database) {
@@ -139,7 +140,7 @@ class SqlManager extends AbstractManager
      *
      * @return bool
      */
-    public function existSqlMap()
+    public function existSqlMap(): bool
     {
         return file_exists($this->getSqlDbMapFilename());
     }
@@ -149,7 +150,7 @@ class SqlManager extends AbstractManager
      *
      * @return bool
      */
-    public function insertSql($datasource = null)
+    public function insertSql($datasource = null): bool
     {
         $statementsToInsert = [];
         foreach ($this->getProperties($this->getSqlDbMapFilename()) as $sqlFile => $database) {
@@ -185,7 +186,7 @@ class SqlManager extends AbstractManager
             }
 
             $con = $this->getConnectionInstance($database);
-            $con->transaction(function () use ($con, $sqls) {
+            $con->transaction(function () use ($con, $sqls): void {
                 foreach ($sqls as $sql) {
                     try {
                         $stmt = $con->prepare($sql);
@@ -211,7 +212,7 @@ class SqlManager extends AbstractManager
      *
      * @return \Propel\Runtime\Connection\ConnectionInterface
      */
-    protected function getConnectionInstance($datasource)
+    protected function getConnectionInstance($datasource): ConnectionInterface
     {
         $buildConnection = $this->getConnection($datasource);
 

--- a/src/Propel/Generator/Model/Behavior.php
+++ b/src/Propel/Generator/Model/Behavior.php
@@ -394,9 +394,9 @@ class Behavior extends MappingModel
      *
      * @param string $name
      *
-     * @return \Propel\Generator\Model\Column
+     * @return \Propel\Generator\Model\Column|null
      */
-    public function getColumnForParameter($name): Column
+    public function getColumnForParameter($name): ?Column
     {
         return $this->table->getColumn($this->getParameter($name));
     }

--- a/src/Propel/Generator/Model/Behavior.php
+++ b/src/Propel/Generator/Model/Behavior.php
@@ -52,7 +52,7 @@ class Behavior extends MappingModel
     /**
      * A collection of parameters.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $parameters = [];
 
@@ -95,7 +95,7 @@ class Behavior extends MappingModel
      *
      * @return void
      */
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
 
@@ -111,7 +111,7 @@ class Behavior extends MappingModel
      *
      * @return void
      */
-    public function setId($id)
+    public function setId($id): void
     {
         $this->id = $id;
     }
@@ -122,7 +122,7 @@ class Behavior extends MappingModel
      *
      * @return bool
      */
-    public function allowMultiple()
+    public function allowMultiple(): bool
     {
         return false;
     }
@@ -132,7 +132,7 @@ class Behavior extends MappingModel
      *
      * @return string
      */
-    public function getId()
+    public function getId(): string
     {
         return $this->id;
     }
@@ -142,7 +142,7 @@ class Behavior extends MappingModel
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -154,7 +154,7 @@ class Behavior extends MappingModel
      *
      * @return void
      */
-    public function setTable(Table $table)
+    public function setTable(Table $table): void
     {
         $this->table = $table;
     }
@@ -164,7 +164,7 @@ class Behavior extends MappingModel
      *
      * @return \Propel\Generator\Model\Table
      */
-    public function getTable()
+    public function getTable(): Table
     {
         return $this->table;
     }
@@ -176,7 +176,7 @@ class Behavior extends MappingModel
      *
      * @return void
      */
-    public function setDatabase(Database $database)
+    public function setDatabase(Database $database): void
     {
         $this->database = $database;
     }
@@ -187,7 +187,7 @@ class Behavior extends MappingModel
      *
      * @return \Propel\Generator\Model\Database
      */
-    public function getDatabase()
+    public function getDatabase(): Database
     {
         return $this->database;
     }
@@ -202,7 +202,7 @@ class Behavior extends MappingModel
      *
      * @return void
      */
-    public function addParameter(array $parameter)
+    public function addParameter(array $parameter): void
     {
         $parameter = array_change_key_case($parameter, CASE_LOWER);
         $this->parameters[$parameter['name']] = $parameter['value'];
@@ -217,7 +217,7 @@ class Behavior extends MappingModel
      *
      * @return void
      */
-    public function setParameters(array $parameters)
+    public function setParameters(array $parameters): void
     {
         $this->parameters = $parameters;
     }
@@ -227,7 +227,7 @@ class Behavior extends MappingModel
      *
      * @return array
      */
-    public function getParameters()
+    public function getParameters(): array
     {
         return $this->parameters;
     }
@@ -255,7 +255,7 @@ class Behavior extends MappingModel
      *
      * @return void
      */
-    public function setTableModificationOrder($tableModificationOrder)
+    public function setTableModificationOrder($tableModificationOrder): void
     {
         $this->tableModificationOrder = (int)$tableModificationOrder;
     }
@@ -269,7 +269,7 @@ class Behavior extends MappingModel
      *
      * @return int
      */
-    public function getTableModificationOrder()
+    public function getTableModificationOrder(): int
     {
         return $this->tableModificationOrder;
     }
@@ -283,7 +283,7 @@ class Behavior extends MappingModel
      *
      * @return void
      */
-    public function modifyDatabase()
+    public function modifyDatabase(): void
     {
         foreach ($this->getTables() as $table) {
             if ($table->hasBehavior($this->getId())) {
@@ -300,7 +300,7 @@ class Behavior extends MappingModel
      *
      * @return array<\Propel\Generator\Model\Table> A collection of Table instance
      */
-    protected function getTables()
+    protected function getTables(): array
     {
         return $this->database->getTables();
     }
@@ -312,7 +312,7 @@ class Behavior extends MappingModel
      *
      * @return void
      */
-    public function modifyTable()
+    public function modifyTable(): void
     {
     }
 
@@ -323,7 +323,7 @@ class Behavior extends MappingModel
      *
      * @return void
      */
-    public function setTableModified($modified)
+    public function setTableModified($modified): void
     {
         $this->isTableModified = $modified;
     }
@@ -333,7 +333,7 @@ class Behavior extends MappingModel
      *
      * @return bool
      */
-    public function isTableModified()
+    public function isTableModified(): bool
     {
         return $this->isTableModified;
     }
@@ -351,7 +351,7 @@ class Behavior extends MappingModel
      *
      * @return string
      */
-    public function renderTemplate($filename, $vars = [], $templateDir = '/templates/')
+    public function renderTemplate($filename, $vars = [], $templateDir = '/templates/'): string
     {
         $filePath = $this->getDirname() . $templateDir . $filename;
         if (!file_exists($filePath)) {
@@ -378,7 +378,7 @@ class Behavior extends MappingModel
      *
      * @return string
      */
-    protected function getDirname()
+    protected function getDirname(): string
     {
         if ($this->dirname === null) {
             $r = new ReflectionObject($this);
@@ -396,7 +396,7 @@ class Behavior extends MappingModel
      *
      * @return \Propel\Generator\Model\Column
      */
-    public function getColumnForParameter($name)
+    public function getColumnForParameter($name): Column
     {
         return $this->table->getColumn($this->getParameter($name));
     }
@@ -406,7 +406,7 @@ class Behavior extends MappingModel
      *
      * @return void
      */
-    protected function setupObject()
+    protected function setupObject(): void
     {
         $this->setName($this->getAttribute('name'));
 
@@ -470,7 +470,7 @@ class Behavior extends MappingModel
      *
      * @return bool
      */
-    public function hasAdditionalBuilders()
+    public function hasAdditionalBuilders(): bool
     {
         return (bool)$this->additionalBuilders;
     }
@@ -480,7 +480,7 @@ class Behavior extends MappingModel
      *
      * @return array
      */
-    public function getAdditionalBuilders()
+    public function getAdditionalBuilders(): array
     {
         return $this->additionalBuilders;
     }

--- a/src/Propel/Generator/Model/Behavior.php
+++ b/src/Propel/Generator/Model/Behavior.php
@@ -140,9 +140,9 @@ class Behavior extends MappingModel
     /**
      * Returns the name of the Behavior
      *
-     * @return string
+     * @return string|null
      */
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }
@@ -162,9 +162,9 @@ class Behavior extends MappingModel
     /**
      * Returns the table this behavior is applied to
      *
-     * @return \Propel\Generator\Model\Table
+     * @return \Propel\Generator\Model\Table|null
      */
-    public function getTable(): Table
+    public function getTable(): ?Table
     {
         return $this->table;
     }

--- a/src/Propel/Generator/Model/BehaviorableTrait.php
+++ b/src/Propel/Generator/Model/BehaviorableTrait.php
@@ -8,6 +8,7 @@
 
 namespace Propel\Generator\Model;
 
+use Propel\Generator\Config\GeneratorConfigInterface;
 use Propel\Generator\Exception\BuildException;
 use Propel\Generator\Util\BehaviorLocator;
 
@@ -29,14 +30,14 @@ trait BehaviorableTrait
     /**
      * @return \Propel\Generator\Config\GeneratorConfigInterface|null
      */
-    abstract protected function getGeneratorConfig();
+    abstract protected function getGeneratorConfig(): ?GeneratorConfigInterface;
 
     /**
      * Returns the behavior locator.
      *
      * @return \Propel\Generator\Util\BehaviorLocator
      */
-    private function getBehaviorLocator()
+    private function getBehaviorLocator(): BehaviorLocator
     {
         if ($this->behaviorLocator === null) {
             $config = $this->getGeneratorConfig();
@@ -62,7 +63,7 @@ trait BehaviorableTrait
      *
      * @return \Propel\Generator\Model\Behavior
      */
-    public function addBehavior($bdata)
+    public function addBehavior($bdata): Behavior
     {
         if ($bdata instanceof Behavior) {
             $behavior = $bdata;
@@ -105,14 +106,14 @@ trait BehaviorableTrait
      *
      * @return void
      */
-    abstract protected function registerBehavior(Behavior $behavior);
+    abstract protected function registerBehavior(Behavior $behavior): void;
 
     /**
      * Returns the list of behaviors.
      *
      * @return array<\Propel\Generator\Model\Behavior>
      */
-    public function getBehaviors()
+    public function getBehaviors(): array
     {
         return $this->behaviors;
     }
@@ -124,7 +125,7 @@ trait BehaviorableTrait
      *
      * @return bool True if the behavior exists
      */
-    public function hasBehavior($id)
+    public function hasBehavior($id): bool
     {
         return isset($this->behaviors[$id]);
     }
@@ -136,7 +137,7 @@ trait BehaviorableTrait
      *
      * @return \Propel\Generator\Model\Behavior|null A behavior object or null if the behavior doesn't exist
      */
-    public function getBehavior($id)
+    public function getBehavior($id): ?Behavior
     {
         if ($this->hasBehavior($id)) {
             return $this->behaviors[$id];

--- a/src/Propel/Generator/Model/Column.php
+++ b/src/Propel/Generator/Model/Column.php
@@ -1417,9 +1417,9 @@ class Column extends MappingModel
     /**
      * Returns the column scale.
      *
-     * @return int
+     * @return int|null
      */
-    public function getScale(): int
+    public function getScale(): ?int
     {
         return $this->domain->getScale();
     }

--- a/src/Propel/Generator/Model/Column.php
+++ b/src/Propel/Generator/Model/Column.php
@@ -247,7 +247,7 @@ class Column extends MappingModel
     /**
      * @return string|null
      */
-    public function getTypeHint()
+    public function getTypeHint(): ?string
     {
         return $this->typeHint;
     }
@@ -257,7 +257,7 @@ class Column extends MappingModel
      *
      * @return void
      */
-    public function setTypeHint($typeHint)
+    public function setTypeHint($typeHint): void
     {
         $this->typeHint = $typeHint;
     }
@@ -267,7 +267,7 @@ class Column extends MappingModel
      *
      * @return void
      */
-    protected function setupObject()
+    protected function setupObject(): void
     {
         try {
             $database = $this->getDatabase();
@@ -400,7 +400,7 @@ class Column extends MappingModel
      *
      * @return string
      */
-    private function getMethodVisibility($attribute, $parentAttribute)
+    private function getMethodVisibility($attribute, $parentAttribute): string
     {
         $database = $this->getDatabase();
 
@@ -423,7 +423,7 @@ class Column extends MappingModel
      *
      * @return \Propel\Generator\Model\Database
      */
-    private function getDatabase()
+    private function getDatabase(): Database
     {
         return $this->parentTable->getDatabase();
     }
@@ -433,7 +433,7 @@ class Column extends MappingModel
      *
      * @return \Propel\Generator\Model\Domain
      */
-    public function getDomain()
+    public function getDomain(): Domain
     {
         $domain = $this->domain;
         if ($domain === null) {
@@ -451,7 +451,7 @@ class Column extends MappingModel
      *
      * @return void
      */
-    public function setDomain(Domain $domain)
+    public function setDomain(Domain $domain): void
     {
         $this->domain = $domain;
     }
@@ -461,7 +461,7 @@ class Column extends MappingModel
      *
      * @return string
      */
-    public function getFullyQualifiedName()
+    public function getFullyQualifiedName(): string
     {
         return $this->parentTable->getName() . '.' . strtoupper($this->getName());
     }
@@ -471,7 +471,7 @@ class Column extends MappingModel
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -481,7 +481,7 @@ class Column extends MappingModel
      *
      * @return string
      */
-    public function getLowercasedName()
+    public function getLowercasedName(): string
     {
         return strtolower($this->name);
     }
@@ -491,7 +491,7 @@ class Column extends MappingModel
      *
      * @return string
      */
-    public function getUppercasedName()
+    public function getUppercasedName(): string
     {
         return strtoupper($this->name);
     }
@@ -503,7 +503,7 @@ class Column extends MappingModel
      *
      * @return void
      */
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
@@ -513,7 +513,7 @@ class Column extends MappingModel
      *
      * @return bool
      */
-    public function isNamePlural()
+    public function isNamePlural(): bool
     {
         return $this->getSingularName() !== $this->name;
     }
@@ -523,7 +523,7 @@ class Column extends MappingModel
      *
      * @return string
      */
-    public function getSingularName()
+    public function getSingularName(): string
     {
         if ($this->getAttribute('phpSingularName')) {
             return $this->getAttribute('phpSingularName');
@@ -535,9 +535,9 @@ class Column extends MappingModel
     /**
      * Returns the column description.
      *
-     * @return string
+     * @return string|null
      */
-    public function getDescription()
+    public function getDescription(): ?string
     {
         return $this->description;
     }
@@ -549,7 +549,7 @@ class Column extends MappingModel
      *
      * @return void
      */
-    public function setDescription($description)
+    public function setDescription($description): void
     {
         $this->description = $description;
     }
@@ -560,7 +560,7 @@ class Column extends MappingModel
      *
      * @return string
      */
-    public function getPhpName()
+    public function getPhpName(): string
     {
         if ($this->phpName === null) {
             $this->setPhpName();
@@ -576,7 +576,7 @@ class Column extends MappingModel
      *
      * @return string
      */
-    public function getPhpSingularName()
+    public function getPhpSingularName(): string
     {
         if ($this->phpSingularName === null) {
             $this->setPhpSingularName();
@@ -595,7 +595,7 @@ class Column extends MappingModel
      *
      * @return void
      */
-    public function setPhpName($phpName = null)
+    public function setPhpName($phpName = null): void
     {
         if ($phpName === null) {
             $this->phpName = self::generatePhpName($this->name, $this->phpNamingMethod, $this->namePrefix);
@@ -615,7 +615,7 @@ class Column extends MappingModel
      *
      * @return void
      */
-    public function setPhpSingularName($phpSingularName = null)
+    public function setPhpSingularName($phpSingularName = null): void
     {
         if ($phpSingularName === null) {
             $this->phpSingularName = self::generatePhpSingularName($this->getPhpName());
@@ -631,7 +631,7 @@ class Column extends MappingModel
      *
      * @return string
      */
-    public function getCamelCaseName()
+    public function getCamelCaseName(): string
     {
         return lcfirst($this->getPhpName());
     }
@@ -641,7 +641,7 @@ class Column extends MappingModel
      *
      * @return string
      */
-    public function getAccessorVisibility()
+    public function getAccessorVisibility(): string
     {
         if ($this->accessorVisibility !== null) {
             return $this->accessorVisibility;
@@ -657,7 +657,7 @@ class Column extends MappingModel
      *
      * @return void
      */
-    public function setAccessorVisibility(string $visibility)
+    public function setAccessorVisibility(string $visibility): void
     {
         $visibility = strtolower($visibility);
         if (!in_array($visibility, self::$validVisibilities)) {
@@ -672,7 +672,7 @@ class Column extends MappingModel
      *
      * @return string
      */
-    public function getMutatorVisibility()
+    public function getMutatorVisibility(): string
     {
         if ($this->mutatorVisibility !== null) {
             return $this->mutatorVisibility;
@@ -688,7 +688,7 @@ class Column extends MappingModel
      *
      * @return void
      */
-    public function setMutatorVisibility(string $visibility)
+    public function setMutatorVisibility(string $visibility): void
     {
         $visibility = strtolower($visibility);
         if (!in_array($visibility, self::$validVisibilities)) {
@@ -703,7 +703,7 @@ class Column extends MappingModel
      *
      * @return string A column constant name for insertion into PHP code
      */
-    public function getFQConstantName()
+    public function getFQConstantName(): string
     {
         $classname = $this->parentTable->getPhpName() . 'TableMap';
         $const = $this->getConstantName();
@@ -716,7 +716,7 @@ class Column extends MappingModel
      *
      * @return string
      */
-    public function getConstantName()
+    public function getConstantName(): string
     {
         // was it overridden in schema.xml ?
         if ($this->getTableMapName()) {
@@ -729,9 +729,9 @@ class Column extends MappingModel
     /**
      * Returns the TableMap constant name that will identify this column.
      *
-     * @return string
+     * @return string|null
      */
-    public function getTableMapName()
+    public function getTableMapName(): ?string
     {
         return $this->tableMapName;
     }
@@ -743,7 +743,7 @@ class Column extends MappingModel
      *
      * @return void
      */
-    public function setTableMapName($name)
+    public function setTableMapName($name): void
     {
         $this->tableMapName = $name;
     }
@@ -755,7 +755,7 @@ class Column extends MappingModel
      *
      * @return string
      */
-    public function getPhpType()
+    public function getPhpType(): string
     {
         return $this->phpType ?: $this->getPhpNative();
     }
@@ -765,7 +765,7 @@ class Column extends MappingModel
      *
      * @return int|null
      */
-    public function getPosition()
+    public function getPosition(): ?int
     {
         return $this->position;
     }
@@ -777,7 +777,7 @@ class Column extends MappingModel
      *
      * @return void
      */
-    public function setPosition($position)
+    public function setPosition($position): void
     {
         $this->position = (int)$position;
     }
@@ -789,7 +789,7 @@ class Column extends MappingModel
      *
      * @return void
      */
-    public function setTable(Table $table)
+    public function setTable(Table $table): void
     {
         $this->parentTable = $table;
     }
@@ -799,7 +799,7 @@ class Column extends MappingModel
      *
      * @return \Propel\Generator\Model\Table
      */
-    public function getTable()
+    public function getTable(): Table
     {
         return $this->parentTable;
     }
@@ -809,7 +809,7 @@ class Column extends MappingModel
      *
      * @return string
      */
-    public function getTableName()
+    public function getTableName(): string
     {
         return $this->parentTable->getName();
     }
@@ -822,7 +822,7 @@ class Column extends MappingModel
      *
      * @return \Propel\Generator\Model\Inheritance
      */
-    public function addInheritance($inheritance)
+    public function addInheritance($inheritance): Inheritance
     {
         if ($inheritance instanceof Inheritance) {
             $inheritance->setColumn($this);
@@ -846,7 +846,7 @@ class Column extends MappingModel
      *
      * @return string|null
      */
-    public function getInheritanceType()
+    public function getInheritanceType(): ?string
     {
         return $this->inheritanceType;
     }
@@ -856,7 +856,7 @@ class Column extends MappingModel
      *
      * @return array<\Propel\Generator\Model\Inheritance>
      */
-    public function getInheritanceList()
+    public function getInheritanceList(): array
     {
         return $this->inheritanceList;
     }
@@ -866,7 +866,7 @@ class Column extends MappingModel
      *
      * @return array<\Propel\Generator\Model\Inheritance>
      */
-    public function getChildren()
+    public function getChildren(): array
     {
         return $this->inheritanceList;
     }
@@ -877,7 +877,7 @@ class Column extends MappingModel
      *
      * @return bool
      */
-    public function isInheritance()
+    public function isInheritance(): bool
     {
         return $this->isInheritance;
     }
@@ -888,7 +888,7 @@ class Column extends MappingModel
      *
      * @return bool
      */
-    public function isEnumeratedClasses()
+    public function isEnumeratedClasses(): bool
     {
         return $this->isEnumeratedClasses;
     }
@@ -898,7 +898,7 @@ class Column extends MappingModel
      *
      * @return bool
      */
-    public function isNotNull()
+    public function isNotNull(): bool
     {
         return $this->isNotNull;
     }
@@ -910,7 +910,7 @@ class Column extends MappingModel
      *
      * @return void
      */
-    public function setNotNull($flag = true)
+    public function setNotNull($flag = true): void
     {
         $this->isNotNull = (bool)$flag;
     }
@@ -920,7 +920,7 @@ class Column extends MappingModel
      *
      * @return string
      */
-    public function getNotNullString()
+    public function getNotNullString(): string
     {
         return $this->parentTable->getPlatform()->getNullString($this->isNotNull);
     }
@@ -935,7 +935,7 @@ class Column extends MappingModel
      *
      * @return void
      */
-    public function setPrimaryString($isPrimaryString)
+    public function setPrimaryString($isPrimaryString): void
     {
         $this->isPrimaryString = (bool)$isPrimaryString;
     }
@@ -946,7 +946,7 @@ class Column extends MappingModel
      *
      * @return bool
      */
-    public function isPrimaryString()
+    public function isPrimaryString(): bool
     {
         return $this->isPrimaryString;
     }
@@ -958,7 +958,7 @@ class Column extends MappingModel
      *
      * @return void
      */
-    public function setPrimaryKey($flag = true)
+    public function setPrimaryKey($flag = true): void
     {
         $this->isPrimaryKey = (bool)$flag;
     }
@@ -968,7 +968,7 @@ class Column extends MappingModel
      *
      * @return bool
      */
-    public function isPrimaryKey()
+    public function isPrimaryKey(): bool
     {
         return $this->isPrimaryKey;
     }
@@ -980,7 +980,7 @@ class Column extends MappingModel
      *
      * @return void
      */
-    public function setNodeKey($isNodeKey)
+    public function setNodeKey($isNodeKey): void
     {
         $this->isNodeKey = (bool)$isNodeKey;
     }
@@ -990,7 +990,7 @@ class Column extends MappingModel
      *
      * @return bool
      */
-    public function isNodeKey()
+    public function isNodeKey(): bool
     {
         return $this->isNodeKey;
     }
@@ -1002,7 +1002,7 @@ class Column extends MappingModel
      *
      * @return void
      */
-    public function setNodeKeySep($sep)
+    public function setNodeKeySep($sep): void
     {
         $this->nodeKeySep = (string)$sep;
     }
@@ -1012,7 +1012,7 @@ class Column extends MappingModel
      *
      * @return string
      */
-    public function getNodeKeySep()
+    public function getNodeKeySep(): string
     {
         return $this->nodeKeySep;
     }
@@ -1024,7 +1024,7 @@ class Column extends MappingModel
      *
      * @return void
      */
-    public function setNestedSetLeftKey($isNestedSetLeftKey)
+    public function setNestedSetLeftKey($isNestedSetLeftKey): void
     {
         $this->isNestedSetLeftKey = (bool)$isNestedSetLeftKey;
     }
@@ -1034,7 +1034,7 @@ class Column extends MappingModel
      *
      * @return bool
      */
-    public function isNestedSetLeftKey()
+    public function isNestedSetLeftKey(): bool
     {
         return $this->isNestedSetLeftKey;
     }
@@ -1046,7 +1046,7 @@ class Column extends MappingModel
      *
      * @return void
      */
-    public function setNestedSetRightKey($isNestedSetRightKey)
+    public function setNestedSetRightKey($isNestedSetRightKey): void
     {
         $this->isNestedSetRightKey = (bool)$isNestedSetRightKey;
     }
@@ -1056,7 +1056,7 @@ class Column extends MappingModel
      *
      * @return bool
      */
-    public function isNestedSetRightKey()
+    public function isNestedSetRightKey(): bool
     {
         return $this->isNestedSetRightKey;
     }
@@ -1068,7 +1068,7 @@ class Column extends MappingModel
      *
      * @return void
      */
-    public function setTreeScopeKey($isTreeScopeKey)
+    public function setTreeScopeKey($isTreeScopeKey): void
     {
         $this->isTreeScopeKey = (bool)$isTreeScopeKey;
     }
@@ -1078,7 +1078,7 @@ class Column extends MappingModel
      *
      * @return bool
      */
-    public function isTreeScopeKey()
+    public function isTreeScopeKey(): bool
     {
         return $this->isTreeScopeKey;
     }
@@ -1088,7 +1088,7 @@ class Column extends MappingModel
      *
      * @return bool
      */
-    public function isUnique()
+    public function isUnique(): bool
     {
         return $this->isUnique;
     }
@@ -1098,7 +1098,7 @@ class Column extends MappingModel
      *
      * @return bool
      */
-    public function requiresTransactionInPostgres()
+    public function requiresTransactionInPostgres(): bool
     {
         return $this->needsTransactionInPostgres;
     }
@@ -1108,7 +1108,7 @@ class Column extends MappingModel
      *
      * @return bool
      */
-    public function isForeignKey()
+    public function isForeignKey(): bool
     {
         return count($this->getForeignKeys()) > 0;
     }
@@ -1118,7 +1118,7 @@ class Column extends MappingModel
      *
      * @return bool
      */
-    public function hasMultipleFK()
+    public function hasMultipleFK(): bool
     {
         return count($this->getForeignKeys()) > 1;
     }
@@ -1130,7 +1130,7 @@ class Column extends MappingModel
      *
      * @return array<\Propel\Generator\Model\ForeignKey>
      */
-    public function getForeignKeys()
+    public function getForeignKeys(): array
     {
         return $this->parentTable->getColumnForeignKeys($this->name);
     }
@@ -1142,7 +1142,7 @@ class Column extends MappingModel
      *
      * @return void
      */
-    public function addReferrer(ForeignKey $fk)
+    public function addReferrer(ForeignKey $fk): void
     {
         $this->referrers[] = $fk;
     }
@@ -1152,7 +1152,7 @@ class Column extends MappingModel
      *
      * @return array<\Propel\Generator\Model\ForeignKey>
      */
-    public function getReferrers()
+    public function getReferrers(): array
     {
         return $this->referrers;
     }
@@ -1162,7 +1162,7 @@ class Column extends MappingModel
      *
      * @return bool
      */
-    public function hasReferrers()
+    public function hasReferrers(): bool
     {
         return count($this->referrers) > 0;
     }
@@ -1175,7 +1175,7 @@ class Column extends MappingModel
      *
      * @return bool
      */
-    public function hasReferrer(ForeignKey $fk)
+    public function hasReferrer(ForeignKey $fk): bool
     {
         return $this->referrers && in_array($fk, $this->referrers, true);
     }
@@ -1185,7 +1185,7 @@ class Column extends MappingModel
      *
      * @return void
      */
-    public function clearReferrers()
+    public function clearReferrers(): void
     {
         $this->referrers = [];
     }
@@ -1195,7 +1195,7 @@ class Column extends MappingModel
      *
      * @return void
      */
-    public function clearInheritanceList()
+    public function clearInheritanceList(): void
     {
         $this->inheritanceList = [];
     }
@@ -1210,7 +1210,7 @@ class Column extends MappingModel
      *
      * @return void
      */
-    public function setDomainForType($mappingType)
+    public function setDomainForType($mappingType): void
     {
         $this->getDomain()->copy($this->getPlatform()->getDomainForType($mappingType));
     }
@@ -1224,7 +1224,7 @@ class Column extends MappingModel
      *
      * @return void
      */
-    public function setType($mappingType)
+    public function setType($mappingType): void
     {
         $this->getDomain()->setType($mappingType);
 
@@ -1250,7 +1250,7 @@ class Column extends MappingModel
      *
      * @return int
      */
-    public function getPDOType()
+    public function getPDOType(): int
     {
         return PropelTypes::getPDOType($this->getType());
     }
@@ -1260,7 +1260,7 @@ class Column extends MappingModel
      *
      * @return bool
      */
-    public function isDefaultSqlType(?PlatformInterface $platform = null)
+    public function isDefaultSqlType(?PlatformInterface $platform = null): bool
     {
         if (
             $this->domain === null
@@ -1280,7 +1280,7 @@ class Column extends MappingModel
      *
      * @return bool
      */
-    public function isLobType()
+    public function isLobType(): bool
     {
         return PropelTypes::isLobType($this->getType());
     }
@@ -1290,7 +1290,7 @@ class Column extends MappingModel
      *
      * @return bool
      */
-    public function isTextType()
+    public function isTextType(): bool
     {
         return PropelTypes::isTextType($this->getType());
     }
@@ -1300,7 +1300,7 @@ class Column extends MappingModel
      *
      * @return bool
      */
-    public function isNumericType()
+    public function isNumericType(): bool
     {
         return PropelTypes::isNumericType($this->getType());
     }
@@ -1310,7 +1310,7 @@ class Column extends MappingModel
      *
      * @return bool
      */
-    public function isBooleanType()
+    public function isBooleanType(): bool
     {
         return PropelTypes::isBooleanType($this->getType());
     }
@@ -1320,7 +1320,7 @@ class Column extends MappingModel
      *
      * @return bool
      */
-    public function isTemporalType()
+    public function isTemporalType(): bool
     {
         return PropelTypes::isTemporalType($this->getType());
     }
@@ -1330,7 +1330,7 @@ class Column extends MappingModel
      *
      * @return bool
      */
-    public function isPhpArrayType()
+    public function isPhpArrayType(): bool
     {
         return PropelTypes::isPhpArrayType($this->getType());
     }
@@ -1340,7 +1340,7 @@ class Column extends MappingModel
      *
      * @return bool
      */
-    public function isValueSetType()
+    public function isValueSetType(): bool
     {
         return ($this->isEnumType() || $this->isSetType());
     }
@@ -1350,7 +1350,7 @@ class Column extends MappingModel
      *
      * @return bool
      */
-    public function isEnumType()
+    public function isEnumType(): bool
     {
         return $this->getType() === PropelTypes::ENUM;
     }
@@ -1360,7 +1360,7 @@ class Column extends MappingModel
      *
      * @return bool
      */
-    public function isSetType()
+    public function isSetType(): bool
     {
         return $this->getType() === PropelTypes::SET;
     }
@@ -1372,7 +1372,7 @@ class Column extends MappingModel
      *
      * @return void
      */
-    public function setValueSet($valueSet)
+    public function setValueSet($valueSet): void
     {
         if (is_string($valueSet)) {
             $valueSet = explode(',', $valueSet);
@@ -1387,7 +1387,7 @@ class Column extends MappingModel
      *
      * @return array<string>
      */
-    public function getValueSet()
+    public function getValueSet(): array
     {
         return $this->valueSet;
     }
@@ -1395,11 +1395,11 @@ class Column extends MappingModel
     /**
      * Returns the column size.
      *
-     * @return int
+     * @return int|null
      */
-    public function getSize()
+    public function getSize(): ?int
     {
-        return $this->domain ? $this->domain->getSize() : false;
+        return $this->domain ? $this->domain->getSize() : null;
     }
 
     /**
@@ -1409,7 +1409,7 @@ class Column extends MappingModel
      *
      * @return void
      */
-    public function setSize($size)
+    public function setSize($size): void
     {
         $this->domain->setSize($size);
     }
@@ -1419,7 +1419,7 @@ class Column extends MappingModel
      *
      * @return int
      */
-    public function getScale()
+    public function getScale(): int
     {
         return $this->domain->getScale();
     }
@@ -1431,7 +1431,7 @@ class Column extends MappingModel
      *
      * @return void
      */
-    public function setScale($scale)
+    public function setScale($scale): void
     {
         $this->domain->setScale($scale);
     }
@@ -1443,7 +1443,7 @@ class Column extends MappingModel
      *
      * @return string
      */
-    public function getSizeDefinition()
+    public function getSizeDefinition(): string
     {
         return $this->domain->getSizeDefinition();
     }
@@ -1453,7 +1453,7 @@ class Column extends MappingModel
      *
      * @return bool
      */
-    public function hasDefaultValue()
+    public function hasDefaultValue(): bool
     {
         return $this->getDefaultValue() !== null;
     }
@@ -1463,7 +1463,7 @@ class Column extends MappingModel
      *
      * @return string
      */
-    public function getDefaultValueString()
+    public function getDefaultValueString(): string
     {
         $defaultValue = $this->getDefaultValue();
 
@@ -1493,7 +1493,7 @@ class Column extends MappingModel
      *
      * @return void
      */
-    public function setDefaultValue($defaultValue)
+    public function setDefaultValue($defaultValue): void
     {
         if (!$defaultValue instanceof ColumnDefaultValue) {
             $defaultValue = new ColumnDefaultValue($defaultValue, ColumnDefaultValue::TYPE_VALUE);
@@ -1509,7 +1509,7 @@ class Column extends MappingModel
      *
      * @return \Propel\Generator\Model\ColumnDefaultValue|null
      */
-    public function getDefaultValue()
+    public function getDefaultValue(): ?ColumnDefaultValue
     {
         return $this->domain->getDefaultValue();
     }
@@ -1533,7 +1533,7 @@ class Column extends MappingModel
      *
      * @return bool
      */
-    public function isAutoIncrement()
+    public function isAutoIncrement(): bool
     {
         return $this->isAutoIncrement;
     }
@@ -1546,7 +1546,7 @@ class Column extends MappingModel
      *
      * @return bool
      */
-    public function isLazyLoad()
+    public function isLazyLoad(): bool
     {
         return $this->isLazyLoad;
     }
@@ -1558,7 +1558,7 @@ class Column extends MappingModel
      *
      * @return string
      */
-    public function getAutoIncrementString()
+    public function getAutoIncrementString(): string
     {
         if ($this->isAutoIncrement() && $this->parentTable->getIdMethod() === IdMethod::NATIVE) {
             return $this->getPlatform()->getAutoIncrement();
@@ -1584,7 +1584,7 @@ class Column extends MappingModel
      *
      * @return void
      */
-    public function setAutoIncrement($flag = true)
+    public function setAutoIncrement($flag = true): void
     {
         $this->isAutoIncrement = (bool)$flag;
     }
@@ -1596,7 +1596,7 @@ class Column extends MappingModel
      *
      * @return string
      */
-    public function getPhpNative()
+    public function getPhpNative(): string
     {
         return PropelTypes::getPhpNative($this->getType());
     }
@@ -1609,7 +1609,7 @@ class Column extends MappingModel
      *
      * @return bool
      */
-    public function isPhpPrimitiveType()
+    public function isPhpPrimitiveType(): bool
     {
         return PropelTypes::isPhpPrimitiveType($this->getPhpType());
     }
@@ -1622,7 +1622,7 @@ class Column extends MappingModel
      *
      * @return bool
      */
-    public function isPhpPrimitiveNumericType()
+    public function isPhpPrimitiveNumericType(): bool
     {
         return PropelTypes::isPhpPrimitiveNumericType($this->getPhpType());
     }
@@ -1634,7 +1634,7 @@ class Column extends MappingModel
      *
      * @return bool
      */
-    public function isPhpObjectType()
+    public function isPhpObjectType(): bool
     {
         return PropelTypes::isPhpObjectType($this->getPhpType());
     }
@@ -1644,7 +1644,7 @@ class Column extends MappingModel
      *
      * @return \Propel\Generator\Platform\PlatformInterface|null
      */
-    public function getPlatform()
+    public function getPlatform(): ?PlatformInterface
     {
         return $this->parentTable->getPlatform();
     }
@@ -1654,7 +1654,7 @@ class Column extends MappingModel
      *
      * @return bool
      */
-    public function hasPlatform()
+    public function hasPlatform(): bool
     {
         if ($this->parentTable === null) {
             return false;
@@ -1685,7 +1685,7 @@ class Column extends MappingModel
      *
      * @return string
      */
-    public static function generatePhpName($name, $phpNamingMethod = PhpNameGenerator::CONV_METHOD_CLEAN, $namePrefix = null)
+    public static function generatePhpName($name, $phpNamingMethod = PhpNameGenerator::CONV_METHOD_CLEAN, $namePrefix = null): string
     {
         return NameFactory::generateName(NameFactory::PHP_GENERATOR, [$name, $phpNamingMethod, (string)$namePrefix]);
     }
@@ -1697,7 +1697,7 @@ class Column extends MappingModel
      *
      * @return string
      */
-    public static function generatePhpSingularName($phpname)
+    public static function generatePhpSingularName($phpname): string
     {
         return rtrim($phpname, 's');
     }

--- a/src/Propel/Generator/Model/Column.php
+++ b/src/Propel/Generator/Model/Column.php
@@ -398,9 +398,9 @@ class Column extends MappingModel
      * @param string $attribute Local column attribute
      * @param string $parentAttribute Parent (table or database) attribute
      *
-     * @return string
+     * @return string|null
      */
-    private function getMethodVisibility($attribute, $parentAttribute): string
+    private function getMethodVisibility($attribute, $parentAttribute): ?string
     {
         $database = $this->getDatabase();
 
@@ -797,9 +797,9 @@ class Column extends MappingModel
     /**
      * Returns the parent table.
      *
-     * @return \Propel\Generator\Model\Table
+     * @return \Propel\Generator\Model\Table|null
      */
-    public function getTable(): Table
+    public function getTable(): ?Table
     {
         return $this->parentTable;
     }

--- a/src/Propel/Generator/Model/Column.php
+++ b/src/Propel/Generator/Model/Column.php
@@ -421,9 +421,9 @@ class Column extends MappingModel
     /**
      * Returns the database object the current column is in.
      *
-     * @return \Propel\Generator\Model\Database
+     * @return \Propel\Generator\Model\Database|null
      */
-    private function getDatabase(): Database
+    private function getDatabase(): ?Database
     {
         return $this->parentTable->getDatabase();
     }
@@ -469,9 +469,9 @@ class Column extends MappingModel
     /**
      * Returns the column name.
      *
-     * @return string
+     * @return string|null
      */
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }
@@ -558,9 +558,9 @@ class Column extends MappingModel
      * Returns the name to use in PHP sources. It will set & return
      * a self-generated phpName from its name if its not already set.
      *
-     * @return string
+     * @return string|null
      */
-    public function getPhpName(): string
+    public function getPhpName(): ?string
     {
         if ($this->phpName === null) {
             $this->setPhpName();
@@ -574,9 +574,9 @@ class Column extends MappingModel
      * It will set & return a self-generated phpName from its name
      * if its not already set.
      *
-     * @return string
+     * @return string|null
      */
-    public function getPhpSingularName(): string
+    public function getPhpSingularName(): ?string
     {
         if ($this->phpSingularName === null) {
             $this->setPhpSingularName();
@@ -854,9 +854,9 @@ class Column extends MappingModel
     /**
      * Returns the inheritance list.
      *
-     * @return array<\Propel\Generator\Model\Inheritance>
+     * @return array|null
      */
-    public function getInheritanceList(): array
+    public function getInheritanceList(): ?array
     {
         return $this->inheritanceList;
     }
@@ -864,9 +864,9 @@ class Column extends MappingModel
     /**
      * Returns the inheritance definitions.
      *
-     * @return array<\Propel\Generator\Model\Inheritance>
+     * @return array|null
      */
-    public function getChildren(): array
+    public function getChildren(): ?array
     {
         return $this->inheritanceList;
     }

--- a/src/Propel/Generator/Model/ColumnDefaultValue.php
+++ b/src/Propel/Generator/Model/ColumnDefaultValue.php
@@ -54,7 +54,7 @@ class ColumnDefaultValue
     /**
      * @return string The type of default value (DefaultValue::TYPE_VALUE or DefaultValue::TYPE_EXPR)
      */
-    public function getType()
+    public function getType(): string
     {
         return $this->type;
     }
@@ -64,7 +64,7 @@ class ColumnDefaultValue
      *
      * @return void
      */
-    public function setType($type)
+    public function setType($type): void
     {
         $this->type = $type;
     }
@@ -74,7 +74,7 @@ class ColumnDefaultValue
      *
      * @return bool Whether value this object holds is an expression.
      */
-    public function isExpression()
+    public function isExpression(): bool
     {
         return $this->type === self::TYPE_EXPR;
     }
@@ -82,7 +82,7 @@ class ColumnDefaultValue
     /**
      * @return string|null The value, as specified in the schema.
      */
-    public function getValue()
+    public function getValue(): ?string
     {
         return $this->value;
     }
@@ -92,7 +92,7 @@ class ColumnDefaultValue
      *
      * @return void
      */
-    public function setValue($value)
+    public function setValue($value): void
     {
         $this->value = $value;
     }
@@ -106,7 +106,7 @@ class ColumnDefaultValue
      *
      * @return bool Whether this object represents same default value as $other
      */
-    public function equals(ColumnDefaultValue $other)
+    public function equals(ColumnDefaultValue $other): bool
     {
         if ($this->getType() !== $other->getType()) {
             return false;

--- a/src/Propel/Generator/Model/ColumnDefaultValue.php
+++ b/src/Propel/Generator/Model/ColumnDefaultValue.php
@@ -80,15 +80,15 @@ class ColumnDefaultValue
     }
 
     /**
-     * @return string|null The value, as specified in the schema.
+     * @return string|int|null The value, as specified in the schema.
      */
-    public function getValue(): ?string
+    public function getValue()
     {
         return $this->value;
     }
 
     /**
-     * @param string|null $value The value, as specified in the schema.
+     * @param string|int|null $value The value, as specified in the schema.
      *
      * @return void
      */

--- a/src/Propel/Generator/Model/ConstraintNameGenerator.php
+++ b/src/Propel/Generator/Model/ConstraintNameGenerator.php
@@ -43,7 +43,7 @@ class ConstraintNameGenerator implements NameGeneratorInterface
      *
      * @return string
      */
-    public function generateName($inputs)
+    public function generateName(array $inputs): string
     {
         $db = $inputs[0];
         $name = $inputs[1];

--- a/src/Propel/Generator/Model/CrossForeignKeys.php
+++ b/src/Propel/Generator/Model/CrossForeignKeys.php
@@ -84,7 +84,7 @@ class CrossForeignKeys
      *
      * @return void
      */
-    public function setIncomingForeignKey($foreignKey)
+    public function setIncomingForeignKey($foreignKey): void
     {
         $this->setMiddleTable($foreignKey ? $foreignKey->getTable() : null);
         $this->incomingForeignKey = $foreignKey;
@@ -95,7 +95,7 @@ class CrossForeignKeys
      *
      * @return \Propel\Generator\Model\ForeignKey|null
      */
-    public function getIncomingForeignKey()
+    public function getIncomingForeignKey(): ?ForeignKey
     {
         return $this->incomingForeignKey;
     }
@@ -130,7 +130,7 @@ class CrossForeignKeys
      *
      * @return bool
      */
-    public function isAtLeastOneLocalPrimaryKeyNotCovered(ForeignKey $fk)
+    public function isAtLeastOneLocalPrimaryKeyNotCovered(ForeignKey $fk): bool
     {
         $primaryKeys = $fk->getLocalPrimaryKeys();
         foreach ($primaryKeys as $primaryKey) {
@@ -156,7 +156,7 @@ class CrossForeignKeys
      *
      * @return array<\Propel\Generator\Model\Column>
      */
-    public function getUnclassifiedPrimaryKeys()
+    public function getUnclassifiedPrimaryKeys(): array
     {
         $pks = [];
         foreach ($this->getMiddleTable()->getPrimaryKey() as $pk) {
@@ -187,7 +187,7 @@ class CrossForeignKeys
      *
      * @return void
      */
-    public function addCrossForeignKey(ForeignKey $foreignKey)
+    public function addCrossForeignKey(ForeignKey $foreignKey): void
     {
         $this->crossForeignKeys[] = $foreignKey;
     }
@@ -195,7 +195,7 @@ class CrossForeignKeys
     /**
      * @return bool
      */
-    public function hasCrossForeignKeys()
+    public function hasCrossForeignKeys(): bool
     {
         return (bool)$this->crossForeignKeys;
     }
@@ -205,7 +205,7 @@ class CrossForeignKeys
      *
      * @return void
      */
-    public function setCrossForeignKeys(array $foreignKeys)
+    public function setCrossForeignKeys(array $foreignKeys): void
     {
         $this->crossForeignKeys = $foreignKeys;
     }
@@ -215,7 +215,7 @@ class CrossForeignKeys
      *
      * @return array<\Propel\Generator\Model\ForeignKey>
      */
-    public function getCrossForeignKeys()
+    public function getCrossForeignKeys(): array
     {
         return $this->crossForeignKeys;
     }
@@ -225,7 +225,7 @@ class CrossForeignKeys
      *
      * @return void
      */
-    public function setMiddleTable(Table $foreignTable)
+    public function setMiddleTable(Table $foreignTable): void
     {
         $this->middleTable = $foreignTable;
     }
@@ -235,7 +235,7 @@ class CrossForeignKeys
      *
      * @return \Propel\Generator\Model\Table
      */
-    public function getMiddleTable()
+    public function getMiddleTable(): Table
     {
         return $this->middleTable;
     }
@@ -245,7 +245,7 @@ class CrossForeignKeys
      *
      * @return void
      */
-    public function setTable(Table $table)
+    public function setTable(Table $table): void
     {
         $this->table = $table;
     }
@@ -255,7 +255,7 @@ class CrossForeignKeys
      *
      * @return \Propel\Generator\Model\Table
      */
-    public function getTable()
+    public function getTable(): Table
     {
         return $this->table;
     }

--- a/src/Propel/Generator/Model/Database.php
+++ b/src/Propel/Generator/Model/Database.php
@@ -139,7 +139,7 @@ class Database extends ScopedMappingModel
      * @param string|null $name The database's name
      * @param \Propel\Generator\Platform\PlatformInterface|null $platform The database's platform
      */
-    public function __construct($name = null, ?PlatformInterface $platform = null)
+    public function __construct(?string $name = null, ?PlatformInterface $platform = null)
     {
         parent::__construct();
 

--- a/src/Propel/Generator/Model/Database.php
+++ b/src/Propel/Generator/Model/Database.php
@@ -8,6 +8,7 @@
 
 namespace Propel\Generator\Model;
 
+use Propel\Generator\Config\GeneratorConfigInterface;
 use Propel\Generator\Exception\EngineException;
 use Propel\Generator\Exception\InvalidArgumentException;
 use Propel\Generator\Platform\PlatformInterface;
@@ -160,7 +161,7 @@ class Database extends ScopedMappingModel
     /**
      * @return void
      */
-    protected function setupObject()
+    protected function setupObject(): void
     {
         parent::setupObject();
 
@@ -180,7 +181,7 @@ class Database extends ScopedMappingModel
      *
      * @return \Propel\Generator\Platform\PlatformInterface|null
      */
-    public function getPlatform()
+    public function getPlatform(): ?PlatformInterface
     {
         return $this->platform;
     }
@@ -192,7 +193,7 @@ class Database extends ScopedMappingModel
      *
      * @return void
      */
-    public function setPlatform(?PlatformInterface $platform = null)
+    public function setPlatform(?PlatformInterface $platform = null): void
     {
         $this->platform = $platform;
     }
@@ -202,7 +203,7 @@ class Database extends ScopedMappingModel
      *
      * @return int
      */
-    public function getMaxColumnNameLength()
+    public function getMaxColumnNameLength(): int
     {
         return $this->platform->getMaxColumnNameLength();
     }
@@ -212,7 +213,7 @@ class Database extends ScopedMappingModel
      *
      * @return string|null
      */
-    public function getName()
+    public function getName(): ?string
     {
         return $this->name;
     }
@@ -224,7 +225,7 @@ class Database extends ScopedMappingModel
      *
      * @return void
      */
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
@@ -233,9 +234,9 @@ class Database extends ScopedMappingModel
      * Returns the name of the base super class inherited by active record
      * objects. This parameter is overridden at the table level.
      *
-     * @return string
+     * @return string|null
      */
-    public function getBaseClass()
+    public function getBaseClass(): ?string
     {
         return $this->baseClass;
     }
@@ -244,9 +245,9 @@ class Database extends ScopedMappingModel
      * Returns the name of the base super class inherited by query
      * objects. This parameter is overridden at the table level.
      *
-     * @return string
+     * @return string|null
      */
-    public function getBaseQueryClass()
+    public function getBaseQueryClass(): ?string
     {
         return $this->baseQueryClass;
     }
@@ -259,7 +260,7 @@ class Database extends ScopedMappingModel
      *
      * @return void
      */
-    public function setBaseClass($class)
+    public function setBaseClass($class): void
     {
         $this->baseClass = $this->makeNamespaceAbsolute($class);
     }
@@ -272,7 +273,7 @@ class Database extends ScopedMappingModel
      *
      * @return void
      */
-    public function setBaseQueryClass($class)
+    public function setBaseQueryClass($class): void
     {
         $this->baseQueryClass = $this->makeNamespaceAbsolute($class);
     }
@@ -283,7 +284,7 @@ class Database extends ScopedMappingModel
      *
      * @return string
      */
-    public function getDefaultIdMethod()
+    public function getDefaultIdMethod(): string
     {
         return $this->defaultIdMethod;
     }
@@ -296,7 +297,7 @@ class Database extends ScopedMappingModel
      *
      * @return void
      */
-    public function setDefaultIdMethod($strategy)
+    public function setDefaultIdMethod($strategy): void
     {
         $this->defaultIdMethod = $strategy;
     }
@@ -308,7 +309,7 @@ class Database extends ScopedMappingModel
      *
      * @return string
      */
-    public function getDefaultPhpNamingMethod()
+    public function getDefaultPhpNamingMethod(): string
     {
         return $this->defaultPhpNamingMethod;
     }
@@ -320,7 +321,7 @@ class Database extends ScopedMappingModel
      *
      * @return void
      */
-    public function setDefaultPhpNamingMethod($strategy)
+    public function setDefaultPhpNamingMethod($strategy): void
     {
         $this->defaultPhpNamingMethod = $strategy;
     }
@@ -330,7 +331,7 @@ class Database extends ScopedMappingModel
      *
      * @return array<string>
      */
-    public static function getSupportedStringFormats()
+    public static function getSupportedStringFormats(): array
     {
         return ['XML', 'YAML', 'JSON', 'CSV'];
     }
@@ -347,7 +348,7 @@ class Database extends ScopedMappingModel
      *
      * @return void
      */
-    public function setDefaultStringFormat($format)
+    public function setDefaultStringFormat($format): void
     {
         $formats = static::getSupportedStringFormats();
 
@@ -365,7 +366,7 @@ class Database extends ScopedMappingModel
      *
      * @return string
      */
-    public function getDefaultStringFormat()
+    public function getDefaultStringFormat(): string
     {
         return $this->defaultStringFormat;
     }
@@ -377,7 +378,7 @@ class Database extends ScopedMappingModel
      *
      * @return bool
      */
-    public function isHeavyIndexing()
+    public function isHeavyIndexing(): bool
     {
         return $this->getHeavyIndexing();
     }
@@ -389,7 +390,7 @@ class Database extends ScopedMappingModel
      *
      * @return bool
      */
-    public function getHeavyIndexing()
+    public function getHeavyIndexing(): bool
     {
         return $this->heavyIndexing;
     }
@@ -401,7 +402,7 @@ class Database extends ScopedMappingModel
      *
      * @return void
      */
-    public function setHeavyIndexing($flag = true)
+    public function setHeavyIndexing($flag = true): void
     {
         $this->heavyIndexing = (bool)$flag;
     }
@@ -411,7 +412,7 @@ class Database extends ScopedMappingModel
      *
      * @return array<\Propel\Generator\Model\Table>
      */
-    public function getTables()
+    public function getTables(): array
     {
         return $this->tables;
     }
@@ -423,7 +424,7 @@ class Database extends ScopedMappingModel
      *
      * @return int
      */
-    public function countTables()
+    public function countTables(): int
     {
         $count = 0;
         foreach ($this->tables as $table) {
@@ -440,7 +441,7 @@ class Database extends ScopedMappingModel
      *
      * @return array<\Propel\Generator\Model\Table>
      */
-    public function getTablesForSql()
+    public function getTablesForSql(): array
     {
         $tables = [];
         foreach ($this->tables as $table) {
@@ -460,7 +461,7 @@ class Database extends ScopedMappingModel
      *
      * @return bool
      */
-    public function hasTable($name, $caseInsensitive = false)
+    public function hasTable($name, $caseInsensitive = false): bool
     {
         if ($caseInsensitive) {
             return isset($this->tablesByLowercaseName[strtolower($name)]);
@@ -477,7 +478,7 @@ class Database extends ScopedMappingModel
      *
      * @return \Propel\Generator\Model\Table|null
      */
-    public function getTable($name, $caseInsensitive = false)
+    public function getTable($name, $caseInsensitive = false): ?Table
     {
         if (
             $this->getSchema() && $this->getPlatform()->supportsSchemas()
@@ -505,7 +506,7 @@ class Database extends ScopedMappingModel
      *
      * @return bool
      */
-    public function hasTableByPhpName($phpName)
+    public function hasTableByPhpName($phpName): bool
     {
         return isset($this->tablesByPhpName[$phpName]);
     }
@@ -517,7 +518,7 @@ class Database extends ScopedMappingModel
      *
      * @return \Propel\Generator\Model\Table|null
      */
-    public function getTableByPhpName($phpName)
+    public function getTableByPhpName($phpName): ?Table
     {
         if (isset($this->tablesByPhpName[$phpName])) {
             return $this->tablesByPhpName[$phpName];
@@ -533,7 +534,7 @@ class Database extends ScopedMappingModel
      *
      * @return void
      */
-    public function addTables(array $tables)
+    public function addTables(array $tables): void
     {
         foreach ($tables as $table) {
             $this->addTable($table);
@@ -545,7 +546,7 @@ class Database extends ScopedMappingModel
      *
      * @return void
      */
-    public function removeTable(Table $table)
+    public function removeTable(Table $table): void
     {
         if ($this->hasTable($table->getName(), true)) {
             foreach ($this->tables as $id => $tableExam) {
@@ -569,7 +570,7 @@ class Database extends ScopedMappingModel
      *
      * @return \Propel\Generator\Model\Table
      */
-    public function addTable($table)
+    public function addTable($table): Table
     {
         if (!$table instanceof Table) {
             $tbl = new Table();
@@ -607,7 +608,7 @@ class Database extends ScopedMappingModel
      *
      * @return void
      */
-    public function setSequences($sequences)
+    public function setSequences(array $sequences): void
     {
         $this->sequences = $sequences;
     }
@@ -615,7 +616,7 @@ class Database extends ScopedMappingModel
     /**
      * @return array<string>
      */
-    public function getSequences()
+    public function getSequences(): array
     {
         return $this->sequences;
     }
@@ -625,7 +626,7 @@ class Database extends ScopedMappingModel
      *
      * @return void
      */
-    public function addSequence($sequence)
+    public function addSequence($sequence): void
     {
         $this->sequences[] = $sequence;
     }
@@ -635,7 +636,7 @@ class Database extends ScopedMappingModel
      *
      * @return void
      */
-    public function removeSequence($sequence)
+    public function removeSequence($sequence): void
     {
         if ($this->sequences) {
             if (($idx = array_search($sequence, $this->sequences)) !== false) {
@@ -649,7 +650,7 @@ class Database extends ScopedMappingModel
      *
      * @return bool
      */
-    public function hasSequence($sequence)
+    public function hasSequence($sequence): bool
     {
         return $this->sequences && in_array($sequence, $this->sequences);
     }
@@ -662,7 +663,7 @@ class Database extends ScopedMappingModel
      *
      * @return string
      */
-    public function getSchemaDelimiter()
+    public function getSchemaDelimiter(): string
     {
         return $this->platform->getSchemaDelimiter();
     }
@@ -674,12 +675,12 @@ class Database extends ScopedMappingModel
      *
      * @return void
      */
-    public function setSchema($schema)
+    public function setSchema($schema): void
     {
         $oldSchema = $this->schema;
         if ($this->schema !== $schema && $this->getPlatform()) {
             $schemaDelimiter = $this->getPlatform()->getSchemaDelimiter();
-            $fixHash = function (&$array) use ($schema, $oldSchema, $schemaDelimiter) {
+            $fixHash = function (&$array) use ($schema, $oldSchema, $schemaDelimiter): void {
                 foreach ($array as $k => $v) {
                     if ($schema && $this->getPlatform()->supportsSchemas()) {
                         if (strpos($k, $schemaDelimiter) === false) {
@@ -739,7 +740,7 @@ class Database extends ScopedMappingModel
      *
      * @return void
      */
-    public function setParentSchema(Schema $parent)
+    public function setParentSchema(Schema $parent): void
     {
         $this->parentSchema = $parent;
     }
@@ -749,7 +750,7 @@ class Database extends ScopedMappingModel
      *
      * @return \Propel\Generator\Model\Schema
      */
-    public function getParentSchema()
+    public function getParentSchema(): Schema
     {
         return $this->parentSchema;
     }
@@ -761,7 +762,7 @@ class Database extends ScopedMappingModel
      *
      * @return \Propel\Generator\Model\Domain
      */
-    public function addDomain($data)
+    public function addDomain($data): Domain
     {
         if ($data instanceof Domain) {
             $domain = $data; // alias
@@ -785,7 +786,7 @@ class Database extends ScopedMappingModel
      *
      * @return \Propel\Generator\Model\Domain|null
      */
-    public function getDomain($name)
+    public function getDomain($name): ?Domain
     {
         if (isset($this->domainMap[$name])) {
             return $this->domainMap[$name];
@@ -799,7 +800,7 @@ class Database extends ScopedMappingModel
      *
      * @return \Propel\Generator\Config\GeneratorConfigInterface|null
      */
-    public function getGeneratorConfig()
+    public function getGeneratorConfig(): ?GeneratorConfigInterface
     {
         if ($this->parentSchema) {
             return $this->parentSchema->getGeneratorConfig();
@@ -817,11 +818,11 @@ class Database extends ScopedMappingModel
      *
      * @return string
      */
-    public function getBuildProperty($name)
+    public function getBuildProperty($name): string
     {
         $config = $this->getGeneratorConfig();
         if ($config) {
-            return $config->getConfigProperty($name);
+            return (string)$config->getConfigProperty($name);
         }
 
         return '';
@@ -832,7 +833,7 @@ class Database extends ScopedMappingModel
      *
      * @return string
      */
-    public function getTablePrefix()
+    public function getTablePrefix(): string
     {
         return $this->tablePrefix;
     }
@@ -844,7 +845,7 @@ class Database extends ScopedMappingModel
      *
      * @return void
      */
-    public function setTablePrefix($tablePrefix)
+    public function setTablePrefix($tablePrefix): void
     {
         $this->tablePrefix = $tablePrefix;
     }
@@ -855,7 +856,7 @@ class Database extends ScopedMappingModel
      *
      * @return \Propel\Generator\Model\Behavior|null
      */
-    public function getNextTableBehavior()
+    public function getNextTableBehavior(): ?Behavior
     {
         // order the behaviors according to Behavior::$tableModificationOrder
         $behaviors = [];
@@ -880,7 +881,7 @@ class Database extends ScopedMappingModel
      *
      * @return void
      */
-    public function doFinalInitialization()
+    public function doFinalInitialization(): void
     {
         // add the referrers for the foreign keys
         $this->setupTableReferrers();
@@ -909,7 +910,7 @@ class Database extends ScopedMappingModel
      *
      * @return void
      */
-    protected function registerBehavior(Behavior $behavior)
+    protected function registerBehavior(Behavior $behavior): void
     {
         $behavior->setDatabase($this);
     }
@@ -929,7 +930,7 @@ class Database extends ScopedMappingModel
     /**
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         $tables = [];
         foreach ($this->getTables() as $table) {
@@ -1017,7 +1018,7 @@ class Database extends ScopedMappingModel
      *
      * @return void
      */
-    public function setDefaultAccessorVisibility($defaultAccessorVisibility)
+    public function setDefaultAccessorVisibility($defaultAccessorVisibility): void
     {
         $this->defaultAccessorVisibility = $defaultAccessorVisibility;
     }
@@ -1027,7 +1028,7 @@ class Database extends ScopedMappingModel
      *
      * @return string
      */
-    public function getDefaultAccessorVisibility()
+    public function getDefaultAccessorVisibility(): string
     {
         return $this->defaultAccessorVisibility;
     }
@@ -1039,7 +1040,7 @@ class Database extends ScopedMappingModel
      *
      * @return void
      */
-    public function setDefaultMutatorVisibility($defaultMutatorVisibility)
+    public function setDefaultMutatorVisibility($defaultMutatorVisibility): void
     {
         $this->defaultMutatorVisibility = $defaultMutatorVisibility;
     }
@@ -1049,7 +1050,7 @@ class Database extends ScopedMappingModel
      *
      * @return string
      */
-    public function getDefaultMutatorVisibility()
+    public function getDefaultMutatorVisibility(): string
     {
         return $this->defaultMutatorVisibility;
     }
@@ -1073,7 +1074,7 @@ class Database extends ScopedMappingModel
     /**
      * @return bool
      */
-    public function isIdentifierQuotingEnabled()
+    public function isIdentifierQuotingEnabled(): bool
     {
         return $this->identifierQuoting;
     }
@@ -1083,7 +1084,7 @@ class Database extends ScopedMappingModel
      *
      * @return void
      */
-    public function setIdentifierQuoting($identifierQuoting)
+    public function setIdentifierQuoting($identifierQuoting): void
     {
         $this->identifierQuoting = $identifierQuoting;
     }

--- a/src/Propel/Generator/Model/Database.php
+++ b/src/Propel/Generator/Model/Database.php
@@ -748,9 +748,9 @@ class Database extends ScopedMappingModel
     /**
      * Returns the parent schema
      *
-     * @return \Propel\Generator\Model\Schema
+     * @return \Propel\Generator\Model\Schema|null
      */
-    public function getParentSchema(): Schema
+    public function getParentSchema(): ?Schema
     {
         return $this->parentSchema;
     }
@@ -831,9 +831,9 @@ class Database extends ScopedMappingModel
     /**
      * Returns the table prefix for this database.
      *
-     * @return string
+     * @return string|null
      */
-    public function getTablePrefix(): string
+    public function getTablePrefix(): ?string
     {
         return $this->tablePrefix;
     }

--- a/src/Propel/Generator/Model/Diff/ColumnComparator.php
+++ b/src/Propel/Generator/Model/Diff/ColumnComparator.php
@@ -49,7 +49,7 @@ class ColumnComparator
      *
      * @return array
      */
-    public static function compareColumns(Column $fromColumn, Column $toColumn)
+    public static function compareColumns(Column $fromColumn, Column $toColumn): array
     {
         $changedProperties = [];
 

--- a/src/Propel/Generator/Model/Diff/ColumnDiff.php
+++ b/src/Propel/Generator/Model/Diff/ColumnDiff.php
@@ -62,7 +62,7 @@ class ColumnDiff
      *
      * @return void
      */
-    public function setChangedProperties($properties)
+    public function setChangedProperties($properties): void
     {
         $this->changedProperties = $properties;
     }
@@ -72,7 +72,7 @@ class ColumnDiff
      *
      * @return array
      */
-    public function getChangedProperties()
+    public function getChangedProperties(): array
     {
         return $this->changedProperties;
     }
@@ -84,7 +84,7 @@ class ColumnDiff
      *
      * @return void
      */
-    public function setFromColumn(Column $fromColumn)
+    public function setFromColumn(Column $fromColumn): void
     {
         $this->fromColumn = $fromColumn;
     }
@@ -94,7 +94,7 @@ class ColumnDiff
      *
      * @return \Propel\Generator\Model\Column|null
      */
-    public function getFromColumn()
+    public function getFromColumn(): ?Column
     {
         return $this->fromColumn;
     }
@@ -106,7 +106,7 @@ class ColumnDiff
      *
      * @return void
      */
-    public function setToColumn(Column $toColumn)
+    public function setToColumn(Column $toColumn): void
     {
         $this->toColumn = $toColumn;
     }
@@ -116,7 +116,7 @@ class ColumnDiff
      *
      * @return \Propel\Generator\Model\Column|null
      */
-    public function getToColumn()
+    public function getToColumn(): ?Column
     {
         return $this->toColumn;
     }
@@ -124,9 +124,9 @@ class ColumnDiff
     /**
      * Returns the reverse diff for this diff.
      *
-     * @return \Propel\Generator\Model\Diff\ColumnDiff
+     * @return self
      */
-    public function getReverseDiff()
+    public function getReverseDiff(): self
     {
         $diff = new self();
 
@@ -149,7 +149,7 @@ class ColumnDiff
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         $ret = '';
         $ret .= sprintf("      %s:\n", $this->fromColumn->getFullyQualifiedName());

--- a/src/Propel/Generator/Model/Diff/DatabaseComparator.php
+++ b/src/Propel/Generator/Model/Diff/DatabaseComparator.php
@@ -62,7 +62,7 @@ class DatabaseComparator
     /**
      * @return \Propel\Generator\Model\Diff\DatabaseDiff
      */
-    public function getDatabaseDiff()
+    public function getDatabaseDiff(): DatabaseDiff
     {
         return $this->databaseDiff;
     }
@@ -74,7 +74,7 @@ class DatabaseComparator
      *
      * @return void
      */
-    public function setFromDatabase(Database $fromDatabase)
+    public function setFromDatabase(Database $fromDatabase): void
     {
         $this->fromDatabase = $fromDatabase;
     }
@@ -84,7 +84,7 @@ class DatabaseComparator
      *
      * @return \Propel\Generator\Model\Database
      */
-    public function getFromDatabase()
+    public function getFromDatabase(): Database
     {
         return $this->fromDatabase;
     }
@@ -96,7 +96,7 @@ class DatabaseComparator
      *
      * @return void
      */
-    public function setToDatabase(Database $toDatabase)
+    public function setToDatabase(Database $toDatabase): void
     {
         $this->toDatabase = $toDatabase;
     }
@@ -106,7 +106,7 @@ class DatabaseComparator
      *
      * @return \Propel\Generator\Model\Database
      */
-    public function getToDatabase()
+    public function getToDatabase(): Database
     {
         return $this->toDatabase;
     }
@@ -118,7 +118,7 @@ class DatabaseComparator
      *
      * @return void
      */
-    public function setRemoveTable($removeTable)
+    public function setRemoveTable($removeTable): void
     {
         $this->removeTable = $removeTable;
     }
@@ -126,7 +126,7 @@ class DatabaseComparator
     /**
      * @return bool
      */
-    public function getRemoveTable()
+    public function getRemoveTable(): bool
     {
         return $this->removeTable;
     }
@@ -138,7 +138,7 @@ class DatabaseComparator
      *
      * @return void
      */
-    public function setExcludedTables(array $excludedTables)
+    public function setExcludedTables(array $excludedTables): void
     {
         $this->excludedTables = $excludedTables;
     }
@@ -148,7 +148,7 @@ class DatabaseComparator
      *
      * @return array<string>
      */
-    public function getExcludedTables()
+    public function getExcludedTables(): array
     {
         return $this->excludedTables;
     }
@@ -202,7 +202,7 @@ class DatabaseComparator
      *
      * @return void
      */
-    public function setWithRenaming($withRenaming)
+    public function setWithRenaming($withRenaming): void
     {
         $this->withRenaming = $withRenaming;
     }
@@ -210,7 +210,7 @@ class DatabaseComparator
     /**
      * @return bool
      */
-    public function getWithRenaming()
+    public function getWithRenaming(): bool
     {
         return $this->withRenaming;
     }
@@ -225,7 +225,7 @@ class DatabaseComparator
      *
      * @return int
      */
-    public function compareTables($caseInsensitive = false)
+    public function compareTables($caseInsensitive = false): int
     {
         $fromDatabaseTables = $this->fromDatabase->getTables();
         $toDatabaseTables = $this->toDatabase->getTables();
@@ -302,7 +302,7 @@ class DatabaseComparator
      *
      * @return bool
      */
-    protected function isTableExcluded(Table $table)
+    protected function isTableExcluded(Table $table): bool
     {
         $tableName = $table->getName();
         if (in_array($tableName, $this->excludedTables, true)) {

--- a/src/Propel/Generator/Model/Diff/DatabaseDiff.php
+++ b/src/Propel/Generator/Model/Diff/DatabaseDiff.php
@@ -59,7 +59,7 @@ class DatabaseDiff
      *
      * @return void
      */
-    public function setAddedTables($tables)
+    public function setAddedTables($tables): void
     {
         $this->addedTables = $tables;
     }
@@ -72,7 +72,7 @@ class DatabaseDiff
      *
      * @return void
      */
-    public function addAddedTable($name, Table $table)
+    public function addAddedTable($name, Table $table): void
     {
         $this->addedTables[$name] = $table;
     }
@@ -84,7 +84,7 @@ class DatabaseDiff
      *
      * @return void
      */
-    public function removeAddedTable($name)
+    public function removeAddedTable($name): void
     {
         unset($this->addedTables[$name]);
     }
@@ -92,7 +92,7 @@ class DatabaseDiff
     /**
      * @return array<string>
      */
-    public function getPossibleRenamedTables()
+    public function getPossibleRenamedTables(): array
     {
         return $this->possibleRenamedTables;
     }
@@ -105,7 +105,7 @@ class DatabaseDiff
      *
      * @return void
      */
-    public function addPossibleRenamedTable($fromName, $toName)
+    public function addPossibleRenamedTable($fromName, $toName): void
     {
         $this->possibleRenamedTables[$fromName] = $toName;
     }
@@ -115,7 +115,7 @@ class DatabaseDiff
      *
      * @return array<\Propel\Generator\Model\Table>
      */
-    public function getAddedTables()
+    public function getAddedTables(): array
     {
         return $this->addedTables;
     }
@@ -125,7 +125,7 @@ class DatabaseDiff
      *
      * @return int
      */
-    public function countAddedTables()
+    public function countAddedTables(): int
     {
         return count($this->addedTables);
     }
@@ -137,7 +137,7 @@ class DatabaseDiff
      *
      * @return \Propel\Generator\Model\Table
      */
-    public function getAddedTable($name)
+    public function getAddedTable($name): Table
     {
         return $this->addedTables[$name];
     }
@@ -149,7 +149,7 @@ class DatabaseDiff
      *
      * @return void
      */
-    public function setRemovedTables($tables)
+    public function setRemovedTables($tables): void
     {
         $this->removedTables = $tables;
     }
@@ -162,7 +162,7 @@ class DatabaseDiff
      *
      * @return void
      */
-    public function addRemovedTable($name, Table $table)
+    public function addRemovedTable($name, Table $table): void
     {
         $this->removedTables[$name] = $table;
     }
@@ -174,7 +174,7 @@ class DatabaseDiff
      *
      * @return void
      */
-    public function removeRemovedTable($name)
+    public function removeRemovedTable($name): void
     {
         unset($this->removedTables[$name]);
     }
@@ -184,7 +184,7 @@ class DatabaseDiff
      *
      * @return array<\Propel\Generator\Model\Table>
      */
-    public function getRemovedTables()
+    public function getRemovedTables(): array
     {
         return $this->removedTables;
     }
@@ -194,7 +194,7 @@ class DatabaseDiff
      *
      * @return int
      */
-    public function countRemovedTables()
+    public function countRemovedTables(): int
     {
         return count($this->removedTables);
     }
@@ -206,7 +206,7 @@ class DatabaseDiff
      *
      * @return \Propel\Generator\Model\Table
      */
-    public function getRemovedTable($name)
+    public function getRemovedTable($name): Table
     {
         return $this->removedTables[$name];
     }
@@ -218,7 +218,7 @@ class DatabaseDiff
      *
      * @return void
      */
-    public function setModifiedTables($tables)
+    public function setModifiedTables($tables): void
     {
         $this->modifiedTables = $tables;
     }
@@ -231,7 +231,7 @@ class DatabaseDiff
      *
      * @return void
      */
-    public function addModifiedTable($name, TableDiff $difference)
+    public function addModifiedTable($name, TableDiff $difference): void
     {
         $this->modifiedTables[$name] = $difference;
     }
@@ -241,7 +241,7 @@ class DatabaseDiff
      *
      * @return int
      */
-    public function countModifiedTables()
+    public function countModifiedTables(): int
     {
         return count($this->modifiedTables);
     }
@@ -251,7 +251,7 @@ class DatabaseDiff
      *
      * @return array<\Propel\Generator\Model\Diff\TableDiff>
      */
-    public function getModifiedTables()
+    public function getModifiedTables(): array
     {
         return $this->modifiedTables;
     }
@@ -263,7 +263,7 @@ class DatabaseDiff
      *
      * @return void
      */
-    public function setRenamedTables($tables)
+    public function setRenamedTables($tables): void
     {
         $this->renamedTables = $tables;
     }
@@ -276,7 +276,7 @@ class DatabaseDiff
      *
      * @return void
      */
-    public function addRenamedTable($fromName, $toName)
+    public function addRenamedTable($fromName, $toName): void
     {
         $this->renamedTables[$fromName] = $toName;
     }
@@ -286,7 +286,7 @@ class DatabaseDiff
      *
      * @return array<string>
      */
-    public function getRenamedTables()
+    public function getRenamedTables(): array
     {
         return $this->renamedTables;
     }
@@ -296,7 +296,7 @@ class DatabaseDiff
      *
      * @return int
      */
-    public function countRenamedTables()
+    public function countRenamedTables(): int
     {
         return count($this->renamedTables);
     }
@@ -304,9 +304,9 @@ class DatabaseDiff
     /**
      * Returns the reverse diff for this diff.
      *
-     * @return \Propel\Generator\Model\Diff\DatabaseDiff
+     * @return self
      */
-    public function getReverseDiff()
+    public function getReverseDiff(): self
     {
         $diff = new self();
         $diff->setAddedTables($this->getRemovedTables());
@@ -333,7 +333,7 @@ class DatabaseDiff
      *
      * @return string
      */
-    public function getDescription()
+    public function getDescription(): string
     {
         $changes = [];
         if ($count = $this->countAddedTables()) {
@@ -355,7 +355,7 @@ class DatabaseDiff
     /**
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         $ret = '';
         if ($addedTables = $this->getAddedTables()) {

--- a/src/Propel/Generator/Model/Diff/ForeignKeyComparator.php
+++ b/src/Propel/Generator/Model/Diff/ForeignKeyComparator.php
@@ -27,7 +27,7 @@ class ForeignKeyComparator
      *
      * @return bool false if the two fks are similar, true if they have differences
      */
-    public static function computeDiff(ForeignKey $fromFk, ForeignKey $toFk, $caseInsensitive = false)
+    public static function computeDiff(ForeignKey $fromFk, ForeignKey $toFk, $caseInsensitive = false): bool
     {
         // Check for differences in local and remote table
         $test = $caseInsensitive ?

--- a/src/Propel/Generator/Model/Diff/IndexComparator.php
+++ b/src/Propel/Generator/Model/Diff/IndexComparator.php
@@ -26,7 +26,7 @@ class IndexComparator
      *
      * @return bool
      */
-    public static function computeDiff(Index $fromIndex, Index $toIndex, $caseInsensitive = false)
+    public static function computeDiff(Index $fromIndex, Index $toIndex, $caseInsensitive = false): bool
     {
         // Check for removed index columns in $toIndex
         $fromIndexColumns = $fromIndex->getColumns();

--- a/src/Propel/Generator/Model/Diff/TableComparator.php
+++ b/src/Propel/Generator/Model/Diff/TableComparator.php
@@ -39,7 +39,7 @@ class TableComparator
      *
      * @return \Propel\Generator\Model\Diff\TableDiff
      */
-    public function getTableDiff()
+    public function getTableDiff(): TableDiff
     {
         return $this->tableDiff;
     }
@@ -51,7 +51,7 @@ class TableComparator
      *
      * @return void
      */
-    public function setFromTable(Table $fromTable)
+    public function setFromTable(Table $fromTable): void
     {
         $this->tableDiff->setFromTable($fromTable);
     }
@@ -61,7 +61,7 @@ class TableComparator
      *
      * @return \Propel\Generator\Model\Table
      */
-    public function getFromTable()
+    public function getFromTable(): Table
     {
         return $this->tableDiff->getFromTable();
     }
@@ -73,7 +73,7 @@ class TableComparator
      *
      * @return void
      */
-    public function setToTable(Table $toTable)
+    public function setToTable(Table $toTable): void
     {
         $this->tableDiff->setToTable($toTable);
     }
@@ -83,7 +83,7 @@ class TableComparator
      *
      * @return \Propel\Generator\Model\Table
      */
-    public function getToTable()
+    public function getToTable(): Table
     {
         return $this->tableDiff->getToTable();
     }
@@ -123,7 +123,7 @@ class TableComparator
      *
      * @return int
      */
-    public function compareColumns($caseInsensitive = false)
+    public function compareColumns($caseInsensitive = false): int
     {
         $fromTableColumns = $this->getFromTable()->getColumns();
         $toTableColumns = $this->getToTable()->getColumns();
@@ -186,7 +186,7 @@ class TableComparator
      *
      * @return int
      */
-    public function comparePrimaryKeys($caseInsensitive = false)
+    public function comparePrimaryKeys($caseInsensitive = false): int
     {
         $pkDifferences = 0;
         $fromTablePk = $this->getFromTable()->getPrimaryKey();
@@ -243,7 +243,7 @@ class TableComparator
      *
      * @return int
      */
-    public function compareIndices($caseInsensitive = false)
+    public function compareIndices($caseInsensitive = false): int
     {
         $indexDifferences = 0;
         $fromTableIndices = array_merge($this->getFromTable()->getIndices(), $this->getFromTable()->getUnices());
@@ -293,7 +293,7 @@ class TableComparator
      *
      * @return int
      */
-    public function compareForeignKeys($caseInsensitive = false)
+    public function compareForeignKeys($caseInsensitive = false): int
     {
         $fkDifferences = 0;
         $fromTableFks = $this->getFromTable()->getForeignKeys();

--- a/src/Propel/Generator/Model/Diff/TableComparator.php
+++ b/src/Propel/Generator/Model/Diff/TableComparator.php
@@ -59,9 +59,9 @@ class TableComparator
     /**
      * Returns the table the comparator starts from.
      *
-     * @return \Propel\Generator\Model\Table
+     * @return \Propel\Generator\Model\Table|null
      */
-    public function getFromTable(): Table
+    public function getFromTable(): ?Table
     {
         return $this->tableDiff->getFromTable();
     }

--- a/src/Propel/Generator/Model/Diff/TableDiff.php
+++ b/src/Propel/Generator/Model/Diff/TableDiff.php
@@ -438,7 +438,7 @@ class TableDiff
     public function addAddedPkColumn($columnName, Column $addedPkColumn): void
     {
         if (!$addedPkColumn->isPrimaryKey()) {
-            throw new DiffException(sprintf('Column %s is not a valid primary key column.', $columnName));
+            throw new DiffException(sprintf('Column `%s` is not a valid primary key column.', $columnName));
         }
 
         $this->addedPkColumns[$columnName] = $addedPkColumn;

--- a/src/Propel/Generator/Model/Diff/TableDiff.php
+++ b/src/Propel/Generator/Model/Diff/TableDiff.php
@@ -164,7 +164,7 @@ class TableDiff
      *
      * @return void
      */
-    public function setFromTable(Table $fromTable)
+    public function setFromTable(Table $fromTable): void
     {
         $this->fromTable = $fromTable;
     }
@@ -174,7 +174,7 @@ class TableDiff
      *
      * @return \Propel\Generator\Model\Table|null
      */
-    public function getFromTable()
+    public function getFromTable(): ?Table
     {
         return $this->fromTable;
     }
@@ -186,7 +186,7 @@ class TableDiff
      *
      * @return void
      */
-    public function setToTable(Table $toTable)
+    public function setToTable(Table $toTable): void
     {
         $this->toTable = $toTable;
     }
@@ -196,7 +196,7 @@ class TableDiff
      *
      * @return \Propel\Generator\Model\Table
      */
-    public function getToTable()
+    public function getToTable(): Table
     {
         return $this->toTable;
     }
@@ -208,7 +208,7 @@ class TableDiff
      *
      * @return void
      */
-    public function setAddedColumns(array $columns)
+    public function setAddedColumns(array $columns): void
     {
         $this->addedColumns = [];
         foreach ($columns as $column) {
@@ -224,7 +224,7 @@ class TableDiff
      *
      * @return void
      */
-    public function addAddedColumn($name, Column $column)
+    public function addAddedColumn($name, Column $column): void
     {
         $this->addedColumns[$name] = $column;
     }
@@ -236,7 +236,7 @@ class TableDiff
      *
      * @return void
      */
-    public function removeAddedColumn($columnName)
+    public function removeAddedColumn($columnName): void
     {
         unset($this->addedColumns[$columnName]);
     }
@@ -246,7 +246,7 @@ class TableDiff
      *
      * @return array<\Propel\Generator\Model\Column>
      */
-    public function getAddedColumns()
+    public function getAddedColumns(): array
     {
         return $this->addedColumns;
     }
@@ -258,7 +258,7 @@ class TableDiff
      *
      * @return \Propel\Generator\Model\Column|null
      */
-    public function getAddedColumn($columnName)
+    public function getAddedColumn($columnName): ?Column
     {
         if (isset($this->addedColumns[$columnName])) {
             return $this->addedColumns[$columnName];
@@ -274,7 +274,7 @@ class TableDiff
      *
      * @return void
      */
-    public function setRemovedColumns(array $removedColumns)
+    public function setRemovedColumns(array $removedColumns): void
     {
         $this->removedColumns = [];
         foreach ($removedColumns as $removedColumn) {
@@ -290,7 +290,7 @@ class TableDiff
      *
      * @return void
      */
-    public function addRemovedColumn($columnName, Column $removedColumn)
+    public function addRemovedColumn($columnName, Column $removedColumn): void
     {
         $this->removedColumns[$columnName] = $removedColumn;
     }
@@ -302,7 +302,7 @@ class TableDiff
      *
      * @return void
      */
-    public function removeRemovedColumn($columnName)
+    public function removeRemovedColumn($columnName): void
     {
         unset($this->removedColumns[$columnName]);
     }
@@ -312,7 +312,7 @@ class TableDiff
      *
      * @return array<\Propel\Generator\Model\Column>
      */
-    public function getRemovedColumns()
+    public function getRemovedColumns(): array
     {
         return $this->removedColumns;
     }
@@ -324,7 +324,7 @@ class TableDiff
      *
      * @return \Propel\Generator\Model\Column|null
      */
-    public function getRemovedColumn($columnName)
+    public function getRemovedColumn($columnName): ?Column
     {
         if (isset($this->removedColumns[$columnName])) {
             return $this->removedColumns[$columnName];
@@ -340,7 +340,7 @@ class TableDiff
      *
      * @return void
      */
-    public function setModifiedColumns(array $modifiedColumns)
+    public function setModifiedColumns(array $modifiedColumns): void
     {
         $this->modifiedColumns = [];
         foreach ($modifiedColumns as $columnName => $modifiedColumn) {
@@ -356,7 +356,7 @@ class TableDiff
      *
      * @return void
      */
-    public function addModifiedColumn($columnName, ColumnDiff $modifiedColumn)
+    public function addModifiedColumn($columnName, ColumnDiff $modifiedColumn): void
     {
         $this->modifiedColumns[$columnName] = $modifiedColumn;
     }
@@ -366,7 +366,7 @@ class TableDiff
      *
      * @return array<\Propel\Generator\Model\Diff\ColumnDiff>
      */
-    public function getModifiedColumns()
+    public function getModifiedColumns(): array
     {
         return $this->modifiedColumns;
     }
@@ -378,7 +378,7 @@ class TableDiff
      *
      * @return void
      */
-    public function setRenamedColumns(array $renamedColumns)
+    public function setRenamedColumns(array $renamedColumns): void
     {
         $this->renamedColumns = [];
         foreach ($renamedColumns as $columns) {
@@ -395,7 +395,7 @@ class TableDiff
      *
      * @return void
      */
-    public function addRenamedColumn(Column $fromColumn, Column $toColumn)
+    public function addRenamedColumn(Column $fromColumn, Column $toColumn): void
     {
         $this->renamedColumns[] = [$fromColumn, $toColumn];
     }
@@ -405,7 +405,7 @@ class TableDiff
      *
      * @return array
      */
-    public function getRenamedColumns()
+    public function getRenamedColumns(): array
     {
         return $this->renamedColumns;
     }
@@ -417,7 +417,7 @@ class TableDiff
      *
      * @return void
      */
-    public function setAddedPkColumns(array $addedPkColumns)
+    public function setAddedPkColumns(array $addedPkColumns): void
     {
         $this->addedPkColumns = [];
         foreach ($addedPkColumns as $addedPkColumn) {
@@ -435,7 +435,7 @@ class TableDiff
      *
      * @return void
      */
-    public function addAddedPkColumn($columnName, Column $addedPkColumn)
+    public function addAddedPkColumn($columnName, Column $addedPkColumn): void
     {
         if (!$addedPkColumn->isPrimaryKey()) {
             throw new DiffException(sprintf('Column %s is not a valid primary key column.', $columnName));
@@ -451,7 +451,7 @@ class TableDiff
      *
      * @return void
      */
-    public function removeAddedPkColumn($columnName)
+    public function removeAddedPkColumn($columnName): void
     {
         unset($this->addedPkColumns[$columnName]);
     }
@@ -461,7 +461,7 @@ class TableDiff
      *
      * @return array
      */
-    public function getAddedPkColumns()
+    public function getAddedPkColumns(): array
     {
         return $this->addedPkColumns;
     }
@@ -473,7 +473,7 @@ class TableDiff
      *
      * @return void
      */
-    public function setRemovedPkColumns(array $removedPkColumns)
+    public function setRemovedPkColumns(array $removedPkColumns): void
     {
         $this->removedPkColumns = [];
         foreach ($removedPkColumns as $removedPkColumn) {
@@ -489,7 +489,7 @@ class TableDiff
      *
      * @return void
      */
-    public function addRemovedPkColumn($columnName, Column $removedPkColumn)
+    public function addRemovedPkColumn($columnName, Column $removedPkColumn): void
     {
         $this->removedPkColumns[$columnName] = $removedPkColumn;
     }
@@ -501,7 +501,7 @@ class TableDiff
      *
      * @return void
      */
-    public function removeRemovedPkColumn($columnName)
+    public function removeRemovedPkColumn($columnName): void
     {
         unset($this->removedPkColumns[$columnName]);
     }
@@ -511,7 +511,7 @@ class TableDiff
      *
      * @return array
      */
-    public function getRemovedPkColumns()
+    public function getRemovedPkColumns(): array
     {
         return $this->removedPkColumns;
     }
@@ -523,7 +523,7 @@ class TableDiff
      *
      * @return void
      */
-    public function setRenamedPkColumns(array $renamedPkColumns)
+    public function setRenamedPkColumns(array $renamedPkColumns): void
     {
         $this->renamedPkColumns = [];
         foreach ($renamedPkColumns as $columns) {
@@ -540,7 +540,7 @@ class TableDiff
      *
      * @return void
      */
-    public function addRenamedPkColumn(Column $fromColumn, Column $toColumn)
+    public function addRenamedPkColumn(Column $fromColumn, Column $toColumn): void
     {
         $this->renamedPkColumns[] = [$fromColumn, $toColumn];
     }
@@ -550,7 +550,7 @@ class TableDiff
      *
      * @return array
      */
-    public function getRenamedPkColumns()
+    public function getRenamedPkColumns(): array
     {
         return $this->renamedPkColumns;
     }
@@ -560,7 +560,7 @@ class TableDiff
      *
      * @return bool
      */
-    public function hasModifiedPk()
+    public function hasModifiedPk(): bool
     {
         return $this->renamedPkColumns || $this->removedPkColumns || $this->addedPkColumns;
     }
@@ -572,7 +572,7 @@ class TableDiff
      *
      * @return void
      */
-    public function setAddedIndices(array $addedIndices)
+    public function setAddedIndices(array $addedIndices): void
     {
         $this->addedIndices = [];
         foreach ($addedIndices as $addedIndex) {
@@ -588,7 +588,7 @@ class TableDiff
      *
      * @return void
      */
-    public function addAddedIndex($indexName, Index $addedIndex)
+    public function addAddedIndex($indexName, Index $addedIndex): void
     {
         $this->addedIndices[$indexName] = $addedIndex;
     }
@@ -598,7 +598,7 @@ class TableDiff
      *
      * @return array<\Propel\Generator\Model\Index>
      */
-    public function getAddedIndices()
+    public function getAddedIndices(): array
     {
         return $this->addedIndices;
     }
@@ -610,7 +610,7 @@ class TableDiff
      *
      * @return void
      */
-    public function setRemovedIndices(array $removedIndices)
+    public function setRemovedIndices(array $removedIndices): void
     {
         $this->removedIndices = [];
         foreach ($removedIndices as $removedIndex) {
@@ -626,7 +626,7 @@ class TableDiff
      *
      * @return void
      */
-    public function addRemovedIndex($indexName, Index $removedIndex)
+    public function addRemovedIndex($indexName, Index $removedIndex): void
     {
         $this->removedIndices[$indexName] = $removedIndex;
     }
@@ -636,7 +636,7 @@ class TableDiff
      *
      * @return array<\Propel\Generator\Model\Index>
      */
-    public function getRemovedIndices()
+    public function getRemovedIndices(): array
     {
         return $this->removedIndices;
     }
@@ -650,7 +650,7 @@ class TableDiff
      *
      * @return void
      */
-    public function setModifiedIndices(array $modifiedIndices)
+    public function setModifiedIndices(array $modifiedIndices): void
     {
         $this->modifiedIndices = [];
         foreach ($modifiedIndices as $indices) {
@@ -668,7 +668,7 @@ class TableDiff
      *
      * @return void
      */
-    public function addModifiedIndex($indexName, Index $fromIndex, Index $toIndex)
+    public function addModifiedIndex($indexName, Index $fromIndex, Index $toIndex): void
     {
         $this->modifiedIndices[$indexName] = [$fromIndex, $toIndex];
     }
@@ -678,7 +678,7 @@ class TableDiff
      *
      * @return array
      */
-    public function getModifiedIndices()
+    public function getModifiedIndices(): array
     {
         return $this->modifiedIndices;
     }
@@ -690,7 +690,7 @@ class TableDiff
      *
      * @return void
      */
-    public function setAddedFks(array $addedFks)
+    public function setAddedFks(array $addedFks): void
     {
         $this->addedFks = [];
         foreach ($addedFks as $addedFk) {
@@ -706,7 +706,7 @@ class TableDiff
      *
      * @return void
      */
-    public function addAddedFk($fkName, ForeignKey $addedFk)
+    public function addAddedFk($fkName, ForeignKey $addedFk): void
     {
         $this->addedFks[$fkName] = $addedFk;
     }
@@ -718,7 +718,7 @@ class TableDiff
      *
      * @return void
      */
-    public function removeAddedFk($fkName)
+    public function removeAddedFk($fkName): void
     {
         unset($this->addedFks[$fkName]);
     }
@@ -728,7 +728,7 @@ class TableDiff
      *
      * @return array<\Propel\Generator\Model\ForeignKey>
      */
-    public function getAddedFks()
+    public function getAddedFks(): array
     {
         return $this->addedFks;
     }
@@ -740,7 +740,7 @@ class TableDiff
      *
      * @return void
      */
-    public function setRemovedFks(array $removedFks)
+    public function setRemovedFks(array $removedFks): void
     {
         $this->removedFks = [];
         foreach ($removedFks as $removedFk) {
@@ -756,7 +756,7 @@ class TableDiff
      *
      * @return void
      */
-    public function addRemovedFk($fkName, ForeignKey $removedFk)
+    public function addRemovedFk($fkName, ForeignKey $removedFk): void
     {
         $this->removedFks[$fkName] = $removedFk;
     }
@@ -768,7 +768,7 @@ class TableDiff
      *
      * @return void
      */
-    public function removeRemovedFk($fkName)
+    public function removeRemovedFk($fkName): void
     {
         unset($this->removedFks[$fkName]);
     }
@@ -778,7 +778,7 @@ class TableDiff
      *
      * @return array<\Propel\Generator\Model\ForeignKey>
      */
-    public function getRemovedFks()
+    public function getRemovedFks(): array
     {
         return $this->removedFks;
     }
@@ -792,7 +792,7 @@ class TableDiff
      *
      * @return void
      */
-    public function setModifiedFks(array $modifiedFks)
+    public function setModifiedFks(array $modifiedFks): void
     {
         $this->modifiedFks = [];
         foreach ($modifiedFks as $foreignKeys) {
@@ -810,7 +810,7 @@ class TableDiff
      *
      * @return void
      */
-    public function addModifiedFk($fkName, ForeignKey $fromFk, ForeignKey $toFk)
+    public function addModifiedFk($fkName, ForeignKey $fromFk, ForeignKey $toFk): void
     {
         $this->modifiedFks[$fkName] = [$fromFk, $toFk];
     }
@@ -820,7 +820,7 @@ class TableDiff
      *
      * @return array
      */
-    public function getModifiedFks()
+    public function getModifiedFks(): array
     {
         return $this->modifiedFks;
     }
@@ -831,7 +831,7 @@ class TableDiff
      *
      * @return bool
      */
-    public function hasModifiedFks()
+    public function hasModifiedFks(): bool
     {
         return (bool)$this->modifiedFks;
     }
@@ -842,7 +842,7 @@ class TableDiff
      *
      * @return bool
      */
-    public function hasModifiedIndices()
+    public function hasModifiedIndices(): bool
     {
         return (bool)$this->modifiedIndices;
     }
@@ -853,7 +853,7 @@ class TableDiff
      *
      * @return bool
      */
-    public function hasModifiedColumns()
+    public function hasModifiedColumns(): bool
     {
         return (bool)$this->modifiedColumns;
     }
@@ -864,7 +864,7 @@ class TableDiff
      *
      * @return bool
      */
-    public function hasRemovedFks()
+    public function hasRemovedFks(): bool
     {
         return (bool)$this->removedFks;
     }
@@ -875,7 +875,7 @@ class TableDiff
      *
      * @return bool
      */
-    public function hasRemovedIndices()
+    public function hasRemovedIndices(): bool
     {
         return (bool)$this->removedIndices;
     }
@@ -886,7 +886,7 @@ class TableDiff
      *
      * @return bool
      */
-    public function hasRenamedColumns()
+    public function hasRenamedColumns(): bool
     {
         return (bool)$this->renamedColumns;
     }
@@ -897,7 +897,7 @@ class TableDiff
      *
      * @return bool
      */
-    public function hasRemovedColumns()
+    public function hasRemovedColumns(): bool
     {
         return (bool)$this->removedColumns;
     }
@@ -908,7 +908,7 @@ class TableDiff
      *
      * @return bool
      */
-    public function hasAddedColumns()
+    public function hasAddedColumns(): bool
     {
         return (bool)$this->addedColumns;
     }
@@ -919,7 +919,7 @@ class TableDiff
      *
      * @return bool
      */
-    public function hasAddedIndices()
+    public function hasAddedIndices(): bool
     {
         return (bool)$this->addedIndices;
     }
@@ -930,7 +930,7 @@ class TableDiff
      *
      * @return bool
      */
-    public function hasAddedFks()
+    public function hasAddedFks(): bool
     {
         return (bool)$this->addedFks;
     }
@@ -941,7 +941,7 @@ class TableDiff
      *
      * @return bool
      */
-    public function hasAddedPkColumns()
+    public function hasAddedPkColumns(): bool
     {
         return (bool)$this->addedPkColumns;
     }
@@ -952,7 +952,7 @@ class TableDiff
      *
      * @return bool
      */
-    public function hasRemovedPkColumns()
+    public function hasRemovedPkColumns(): bool
     {
         return (bool)$this->removedPkColumns;
     }
@@ -963,7 +963,7 @@ class TableDiff
      *
      * @return bool
      */
-    public function hasRenamedPkColumns()
+    public function hasRenamedPkColumns(): bool
     {
         return (bool)$this->renamedPkColumns;
     }
@@ -971,9 +971,9 @@ class TableDiff
     /**
      * Returns the reverse diff for this diff.
      *
-     * @return \Propel\Generator\Model\Diff\TableDiff
+     * @return self
      */
-    public function getReverseDiff()
+    public function getReverseDiff(): self
     {
         $diff = new self();
 
@@ -1080,7 +1080,7 @@ class TableDiff
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         $ret = '';
         $ret .= sprintf("  %s:\n", $this->fromTable->getName());

--- a/src/Propel/Generator/Model/Diff/TableDiff.php
+++ b/src/Propel/Generator/Model/Diff/TableDiff.php
@@ -194,9 +194,9 @@ class TableDiff
     /**
      * Returns the toTable property.
      *
-     * @return \Propel\Generator\Model\Table
+     * @return \Propel\Generator\Model\Table|null
      */
-    public function getToTable(): Table
+    public function getToTable(): ?Table
     {
         return $this->toTable;
     }

--- a/src/Propel/Generator/Model/Domain.php
+++ b/src/Propel/Generator/Model/Domain.php
@@ -22,7 +22,7 @@ use Propel\Generator\Exception\EngineException;
 class Domain extends MappingModel
 {
     /**
-     * @var string
+     * @var string|null
      */
     private $name;
 
@@ -95,7 +95,7 @@ class Domain extends MappingModel
      *
      * @return void
      */
-    public function copy(Domain $domain)
+    public function copy(Domain $domain): void
     {
         $this->defaultValue = $domain->getDefaultValue();
         $this->description = $domain->getDescription();
@@ -109,7 +109,7 @@ class Domain extends MappingModel
     /**
      * @return void
      */
-    protected function setupObject()
+    protected function setupObject(): void
     {
         $schemaType = !$this->getAttribute('type')
             ? ''
@@ -140,7 +140,7 @@ class Domain extends MappingModel
      *
      * @return void
      */
-    public function setDatabase(Database $database)
+    public function setDatabase(Database $database): void
     {
         $this->database = $database;
     }
@@ -150,7 +150,7 @@ class Domain extends MappingModel
      *
      * @return \Propel\Generator\Model\Database
      */
-    public function getDatabase()
+    public function getDatabase(): Database
     {
         return $this->database;
     }
@@ -158,9 +158,9 @@ class Domain extends MappingModel
     /**
      * Returns the domain description.
      *
-     * @return string
+     * @return string|null
      */
-    public function getDescription()
+    public function getDescription(): ?string
     {
         return $this->description;
     }
@@ -172,7 +172,7 @@ class Domain extends MappingModel
      *
      * @return void
      */
-    public function setDescription($description)
+    public function setDescription($description): void
     {
         $this->description = $description;
     }
@@ -180,9 +180,9 @@ class Domain extends MappingModel
     /**
      * Returns the domain description.
      *
-     * @return string
+     * @return string|null
      */
-    public function getName()
+    public function getName(): ?string
     {
         return $this->name;
     }
@@ -194,7 +194,7 @@ class Domain extends MappingModel
      *
      * @return void
      */
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
@@ -204,7 +204,7 @@ class Domain extends MappingModel
      *
      * @return int|null
      */
-    public function getScale()
+    public function getScale(): ?int
     {
         return $this->scale;
     }
@@ -216,7 +216,7 @@ class Domain extends MappingModel
      *
      * @return void
      */
-    public function setScale($scale)
+    public function setScale($scale): void
     {
         $this->scale = $scale === null ? null : (int)$scale;
     }
@@ -228,7 +228,7 @@ class Domain extends MappingModel
      *
      * @return void
      */
-    public function replaceScale($scale)
+    public function replaceScale($scale): void
     {
         if ($scale !== null) {
             $this->scale = (int)$scale;
@@ -238,9 +238,9 @@ class Domain extends MappingModel
     /**
      * Returns the size.
      *
-     * @return int
+     * @return int|null
      */
-    public function getSize()
+    public function getSize(): ?int
     {
         return $this->size;
     }
@@ -252,7 +252,7 @@ class Domain extends MappingModel
      *
      * @return void
      */
-    public function setSize($size)
+    public function setSize($size): void
     {
         $this->size = $size === null ? null : (int)$size;
     }
@@ -264,7 +264,7 @@ class Domain extends MappingModel
      *
      * @return void
      */
-    public function replaceSize($size)
+    public function replaceSize($size): void
     {
         if ($size !== null) {
             $this->size = (int)$size;
@@ -290,7 +290,7 @@ class Domain extends MappingModel
      *
      * @return void
      */
-    public function setType(?string $mappingType)
+    public function setType(?string $mappingType): void
     {
         $this->mappingType = $mappingType;
     }
@@ -302,7 +302,7 @@ class Domain extends MappingModel
      *
      * @return void
      */
-    public function replaceType($mappingType)
+    public function replaceType($mappingType): void
     {
         if ($mappingType !== null) {
             $this->mappingType = $mappingType;
@@ -314,7 +314,7 @@ class Domain extends MappingModel
      *
      * @return \Propel\Generator\Model\ColumnDefaultValue|null
      */
-    public function getDefaultValue()
+    public function getDefaultValue(): ?ColumnDefaultValue
     {
         return $this->defaultValue;
     }
@@ -357,7 +357,7 @@ class Domain extends MappingModel
      *
      * @return void
      */
-    public function setDefaultValue(ColumnDefaultValue $value)
+    public function setDefaultValue(ColumnDefaultValue $value): void
     {
         $this->defaultValue = $value;
     }
@@ -369,7 +369,7 @@ class Domain extends MappingModel
      *
      * @return void
      */
-    public function replaceDefaultValue(?ColumnDefaultValue $value = null)
+    public function replaceDefaultValue(?ColumnDefaultValue $value = null): void
     {
         if ($value !== null) {
             $this->defaultValue = $value;
@@ -381,7 +381,7 @@ class Domain extends MappingModel
      *
      * @return string|null
      */
-    public function getSqlType()
+    public function getSqlType(): ?string
     {
         return $this->sqlType;
     }
@@ -393,7 +393,7 @@ class Domain extends MappingModel
      *
      * @return void
      */
-    public function setSqlType($sqlType)
+    public function setSqlType($sqlType): void
     {
         $this->sqlType = $sqlType;
     }
@@ -405,7 +405,7 @@ class Domain extends MappingModel
      *
      * @return void
      */
-    public function replaceSqlType($sqlType)
+    public function replaceSqlType($sqlType): void
     {
         if ($sqlType !== null) {
             $this->sqlType = $sqlType;
@@ -417,7 +417,7 @@ class Domain extends MappingModel
      *
      * @return string
      */
-    public function getSizeDefinition()
+    public function getSizeDefinition(): string
     {
         if ($this->size === null) {
             return '';
@@ -447,7 +447,7 @@ class Domain extends MappingModel
      *
      * @return void
      */
-    public function appendXml(DOMNode $node)
+    public function appendXml(DOMNode $node): void
     {
         $doc = ($node instanceof DOMDocument) ? $node : $node->ownerDocument;
 

--- a/src/Propel/Generator/Model/Domain.php
+++ b/src/Propel/Generator/Model/Domain.php
@@ -148,9 +148,9 @@ class Domain extends MappingModel
     /**
      * Returns the owning database object (if this domain was setup via XML).
      *
-     * @return \Propel\Generator\Model\Database
+     * @return \Propel\Generator\Model\Database|null
      */
-    public function getDatabase(): Database
+    public function getDatabase(): ?Database
     {
         return $this->database;
     }
@@ -324,7 +324,7 @@ class Domain extends MappingModel
      *
      * @throws \Propel\Generator\Exception\EngineException
      *
-     * @return array|string|bool|null
+     * @return array|string|int|bool|null
      */
     public function getPhpDefaultValue()
     {

--- a/src/Propel/Generator/Model/ForeignKey.php
+++ b/src/Propel/Generator/Model/ForeignKey.php
@@ -454,9 +454,9 @@ class ForeignKey extends MappingModel
     /**
      * Returns the foreign table name of the FK.
      *
-     * @return string
+     * @return string|null
      */
-    public function getForeignTableName(): string
+    public function getForeignTableName(): ?string
     {
         $platform = $this->getPlatform();
         if ($this->foreignSchemaName && $platform && $platform->supportsSchemas()) {
@@ -478,9 +478,9 @@ class ForeignKey extends MappingModel
     /**
      * Returns the foreign table name without schema.
      *
-     * @return string
+     * @return string|null
      */
-    public function getForeignTableCommonName(): string
+    public function getForeignTableCommonName(): ?string
     {
         return $this->foreignTableCommonName;
     }
@@ -515,9 +515,9 @@ class ForeignKey extends MappingModel
     /**
      * Returns the foreign schema name of the FK.
      *
-     * @return string
+     * @return string|null
      */
-    public function getForeignSchemaName(): string
+    public function getForeignSchemaName(): ?string
     {
         return $this->foreignSchemaName;
     }

--- a/src/Propel/Generator/Model/ForeignKey.php
+++ b/src/Propel/Generator/Model/ForeignKey.php
@@ -569,9 +569,9 @@ class ForeignKey extends MappingModel
     /**
      * Returns the name of the schema the foreign key is in.
      *
-     * @return string
+     * @return string|null
      */
-    public function getSchemaName(): string
+    public function getSchemaName(): ?string
     {
         return $this->parentTable->getSchema();
     }
@@ -603,8 +603,8 @@ class ForeignKey extends MappingModel
         }
 
         $local = null;
-        $foreign = null;
         if ($ref1 instanceof Column) {
+            /** @var string $local */
             $local = $ref1->getName();
             $this->localColumns[] = $local;
         } else {
@@ -677,9 +677,9 @@ class ForeignKey extends MappingModel
      *
      * @param int $index
      *
-     * @return \Propel\Generator\Model\Column
+     * @return \Propel\Generator\Model\Column|null
      */
-    public function getLocalColumn($index = 0): Column
+    public function getLocalColumn($index = 0): ?Column
     {
         return $this->parentTable->getColumn($this->getLocalColumnName($index));
     }
@@ -800,9 +800,9 @@ class ForeignKey extends MappingModel
      *
      * @param int $index
      *
-     * @return string
+     * @return string|null
      */
-    public function getForeignColumnName($index = 0): string
+    public function getForeignColumnName($index = 0): ?string
     {
         return $this->foreignColumns[$index];
     }
@@ -812,9 +812,9 @@ class ForeignKey extends MappingModel
      *
      * @param int $index
      *
-     * @return \Propel\Generator\Model\Column
+     * @return \Propel\Generator\Model\Column|null
      */
-    public function getForeignColumn($index = 0): Column
+    public function getForeignColumn($index = 0): ?Column
     {
         return $this->getForeignTable()->getColumn($this->getForeignColumnName($index));
     }

--- a/src/Propel/Generator/Model/ForeignKey.php
+++ b/src/Propel/Generator/Model/ForeignKey.php
@@ -8,7 +8,8 @@
 
 namespace Propel\Generator\Model;
 
-use RuntimeException;
+use Propel\Generator\Platform\PlatformInterface;
+use Propel\Runtime\Exception\RuntimeException;
 
 /**
  * A class for information about table foreign keys.
@@ -70,12 +71,12 @@ class ForeignKey extends MappingModel
     private $name;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $phpName;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $refPhpName;
 
@@ -147,7 +148,7 @@ class ForeignKey extends MappingModel
     /**
      * @return void
      */
-    protected function setupObject()
+    protected function setupObject(): void
     {
         $this->foreignTableCommonName = $this->parentTable->getDatabase()->getTablePrefix() . $this->getAttribute('foreignTable');
         $this->foreignSchemaName = $this->getAttribute('foreignSchema');
@@ -165,7 +166,7 @@ class ForeignKey extends MappingModel
     /**
      * @return void
      */
-    protected function doNaming()
+    protected function doNaming(): void
     {
         if (!$this->name || $this->autoNaming) {
             $newName = 'fk_';
@@ -194,7 +195,7 @@ class ForeignKey extends MappingModel
      *
      * @return string
      */
-    public function normalizeFKey($behavior, ?string $default = null)
+    public function normalizeFKey($behavior, ?string $default = null): string
     {
         if ($behavior === null) {
             return $default ?: self::NONE;
@@ -222,7 +223,7 @@ class ForeignKey extends MappingModel
      *
      * @return bool
      */
-    public function hasOnUpdate()
+    public function hasOnUpdate(): bool
     {
         return $this->onUpdate !== self::NONE;
     }
@@ -232,7 +233,7 @@ class ForeignKey extends MappingModel
      *
      * @return bool
      */
-    public function hasOnDelete()
+    public function hasOnDelete(): bool
     {
         return $this->onDelete !== self::NONE;
     }
@@ -244,7 +245,7 @@ class ForeignKey extends MappingModel
      *
      * @return bool
      */
-    public function hasLocalColumn(Column $column)
+    public function hasLocalColumn(Column $column): bool
     {
         return in_array($column, $this->getLocalColumnObjects(), true);
     }
@@ -254,7 +255,7 @@ class ForeignKey extends MappingModel
      *
      * @return string
      */
-    public function getOnUpdate()
+    public function getOnUpdate(): string
     {
         return $this->onUpdate;
     }
@@ -278,7 +279,7 @@ class ForeignKey extends MappingModel
      *
      * @return string
      */
-    public function getOnDelete()
+    public function getOnDelete(): string
     {
         return $this->onDelete;
     }
@@ -304,7 +305,7 @@ class ForeignKey extends MappingModel
      *
      * @return void
      */
-    public function setOnDelete($behavior)
+    public function setOnDelete($behavior): void
     {
         $this->onDelete = $this->normalizeFKey($behavior);
     }
@@ -316,7 +317,7 @@ class ForeignKey extends MappingModel
      *
      * @return void
      */
-    public function setOnUpdate($behavior)
+    public function setOnUpdate($behavior): void
     {
         $this->onUpdate = $this->normalizeFKey($behavior);
     }
@@ -326,7 +327,7 @@ class ForeignKey extends MappingModel
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         $this->doNaming();
 
@@ -340,16 +341,16 @@ class ForeignKey extends MappingModel
      *
      * @return void
      */
-    public function setName($name)
+    public function setName($name): void
     {
         $this->autoNaming = !$name; //if no name we activate autoNaming
         $this->name = $name;
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getInterface()
+    public function getInterface(): ?string
     {
         return $this->interface;
     }
@@ -359,7 +360,7 @@ class ForeignKey extends MappingModel
      *
      * @return void
      */
-    public function setInterface($interface)
+    public function setInterface($interface): void
     {
         $this->interface = $interface;
     }
@@ -367,9 +368,9 @@ class ForeignKey extends MappingModel
     /**
      * Returns the phpName for this foreign key (if any).
      *
-     * @return string
+     * @return string|null
      */
-    public function getPhpName()
+    public function getPhpName(): ?string
     {
         return $this->phpName;
     }
@@ -381,7 +382,7 @@ class ForeignKey extends MappingModel
      *
      * @return void
      */
-    public function setPhpName($name)
+    public function setPhpName($name): void
     {
         $this->phpName = $name;
     }
@@ -389,9 +390,9 @@ class ForeignKey extends MappingModel
     /**
      * Returns the refPhpName for this foreign key (if any).
      *
-     * @return string
+     * @return string|null
      */
-    public function getRefPhpName()
+    public function getRefPhpName(): ?string
     {
         return $this->refPhpName;
     }
@@ -403,7 +404,7 @@ class ForeignKey extends MappingModel
      *
      * @return void
      */
-    public function setRefPhpName($name)
+    public function setRefPhpName($name): void
     {
         $this->refPhpName = $name;
     }
@@ -411,9 +412,9 @@ class ForeignKey extends MappingModel
     /**
      * Returns the default join strategy for this foreign key (if any).
      *
-     * @return string
+     * @return string|null
      */
-    public function getDefaultJoin()
+    public function getDefaultJoin(): ?string
     {
         return $this->defaultJoin;
     }
@@ -425,7 +426,7 @@ class ForeignKey extends MappingModel
      *
      * @return void
      */
-    public function setDefaultJoin($join)
+    public function setDefaultJoin($join): void
     {
         $this->defaultJoin = $join;
     }
@@ -435,7 +436,7 @@ class ForeignKey extends MappingModel
      *
      * @return \Propel\Generator\Platform\PlatformInterface|null
      */
-    private function getPlatform()
+    private function getPlatform(): ?PlatformInterface
     {
         return $this->parentTable->getPlatform();
     }
@@ -445,7 +446,7 @@ class ForeignKey extends MappingModel
      *
      * @return \Propel\Generator\Model\Database|null
      */
-    public function getDatabase()
+    public function getDatabase(): ?Database
     {
         return $this->parentTable->getDatabase();
     }
@@ -455,17 +456,17 @@ class ForeignKey extends MappingModel
      *
      * @return string
      */
-    public function getForeignTableName()
+    public function getForeignTableName(): string
     {
         $platform = $this->getPlatform();
-        if ($this->foreignSchemaName && $platform->supportsSchemas()) {
+        if ($this->foreignSchemaName && $platform && $platform->supportsSchemas()) {
             return $this->foreignSchemaName
                 . $platform->getSchemaDelimiter()
                 . $this->foreignTableCommonName;
         }
 
         $database = $this->getDatabase();
-        if ($database && ($schema = $this->parentTable->guessSchemaName()) && $platform->supportsSchemas()) {
+        if ($database && ($schema = $this->parentTable->guessSchemaName()) && $platform && $platform->supportsSchemas()) {
             return $schema
                 . $platform->getSchemaDelimiter()
                 . $this->foreignTableCommonName;
@@ -479,7 +480,7 @@ class ForeignKey extends MappingModel
      *
      * @return string
      */
-    public function getForeignTableCommonName()
+    public function getForeignTableCommonName(): string
     {
         return $this->foreignTableCommonName;
     }
@@ -491,7 +492,7 @@ class ForeignKey extends MappingModel
      *
      * @return void
      */
-    public function setForeignTableCommonName($tableName)
+    public function setForeignTableCommonName($tableName): void
     {
         $this->foreignTableCommonName = $tableName;
     }
@@ -501,7 +502,7 @@ class ForeignKey extends MappingModel
      *
      * @return \Propel\Generator\Model\Table|null
      */
-    public function getForeignTable()
+    public function getForeignTable(): ?Table
     {
         $database = $this->parentTable->getDatabase();
         if ($database) {
@@ -516,7 +517,7 @@ class ForeignKey extends MappingModel
      *
      * @return string
      */
-    public function getForeignSchemaName()
+    public function getForeignSchemaName(): string
     {
         return $this->foreignSchemaName;
     }
@@ -528,7 +529,7 @@ class ForeignKey extends MappingModel
      *
      * @return void
      */
-    public function setForeignSchemaName($schemaName)
+    public function setForeignSchemaName($schemaName): void
     {
         $this->foreignSchemaName = $schemaName;
     }
@@ -540,7 +541,7 @@ class ForeignKey extends MappingModel
      *
      * @return void
      */
-    public function setTable(Table $parent)
+    public function setTable(Table $parent): void
     {
         $this->parentTable = $parent;
     }
@@ -550,7 +551,7 @@ class ForeignKey extends MappingModel
      *
      * @return \Propel\Generator\Model\Table
      */
-    public function getTable()
+    public function getTable(): Table
     {
         return $this->parentTable;
     }
@@ -560,7 +561,7 @@ class ForeignKey extends MappingModel
      *
      * @return string
      */
-    public function getTableName()
+    public function getTableName(): string
     {
         return $this->parentTable->getName();
     }
@@ -570,7 +571,7 @@ class ForeignKey extends MappingModel
      *
      * @return string
      */
-    public function getSchemaName()
+    public function getSchemaName(): string
     {
         return $this->parentTable->getSchema();
     }
@@ -583,7 +584,7 @@ class ForeignKey extends MappingModel
      *
      * @return void
      */
-    public function addReference($ref1, $ref2 = null)
+    public function addReference($ref1, $ref2 = null): void
     {
         if (is_array($ref1)) {
             $this->localColumns[] = $ref1['local'] ?? null;
@@ -625,7 +626,7 @@ class ForeignKey extends MappingModel
      *
      * @return void
      */
-    public function clearReferences()
+    public function clearReferences(): void
     {
         $this->localColumns = [];
         $this->foreignColumns = [];
@@ -637,7 +638,7 @@ class ForeignKey extends MappingModel
      *
      * @return array
      */
-    public function getLocalColumns()
+    public function getLocalColumns(): array
     {
         return $this->localColumns;
     }
@@ -647,7 +648,7 @@ class ForeignKey extends MappingModel
      *
      * @return array<\Propel\Generator\Model\Column>
      */
-    public function getLocalColumnObjects()
+    public function getLocalColumnObjects(): array
     {
         $columns = [];
         foreach ($this->localColumns as $columnName) {
@@ -666,7 +667,7 @@ class ForeignKey extends MappingModel
      *
      * @return string
      */
-    public function getLocalColumnName($index = 0)
+    public function getLocalColumnName($index = 0): string
     {
         return $this->localColumns[$index];
     }
@@ -678,7 +679,7 @@ class ForeignKey extends MappingModel
      *
      * @return \Propel\Generator\Model\Column
      */
-    public function getLocalColumn($index = 0)
+    public function getLocalColumn($index = 0): Column
     {
         return $this->parentTable->getColumn($this->getLocalColumnName($index));
     }
@@ -686,7 +687,7 @@ class ForeignKey extends MappingModel
     /**
      * @return array [[Column $leftColumn, $rightValueOrColumn], ..., ...]
      */
-    public function getMapping()
+    public function getMapping(): array
     {
         $mapping = [];
         for ($i = 0, $size = count($this->localColumns); $i < $size; $i++) {
@@ -704,7 +705,7 @@ class ForeignKey extends MappingModel
     /**
      * @return array [[$leftValueOrColumn, Column $rightColumn], ..., ...]
      */
-    public function getInverseMapping()
+    public function getInverseMapping(): array
     {
         $mapping = $this->getMapping();
         foreach ($mapping as &$map) {
@@ -722,7 +723,7 @@ class ForeignKey extends MappingModel
      *
      * @return array
      */
-    public function getColumnObjectsMapping()
+    public function getColumnObjectsMapping(): array
     {
         $mapping = [];
         $foreignTable = $this->getForeignTable();
@@ -742,9 +743,9 @@ class ForeignKey extends MappingModel
      *
      * @param string $local
      *
-     * @return string
+     * @return string|null
      */
-    public function getMappedForeignColumn($local)
+    public function getMappedForeignColumn($local): ?string
     {
         $index = array_search($local, $this->localColumns);
 
@@ -756,9 +757,9 @@ class ForeignKey extends MappingModel
      *
      * @param string $foreign
      *
-     * @return string
+     * @return string|null
      */
-    public function getMappedLocalColumn($foreign)
+    public function getMappedLocalColumn($foreign): ?string
     {
         $index = array_search($foreign, $this->foreignColumns);
 
@@ -770,7 +771,7 @@ class ForeignKey extends MappingModel
      *
      * @return array
      */
-    public function getForeignColumns()
+    public function getForeignColumns(): array
     {
         return $this->foreignColumns;
     }
@@ -780,7 +781,7 @@ class ForeignKey extends MappingModel
      *
      * @return array
      */
-    public function getForeignColumnObjects()
+    public function getForeignColumnObjects(): array
     {
         $columns = [];
         $foreignTable = $this->getForeignTable();
@@ -801,7 +802,7 @@ class ForeignKey extends MappingModel
      *
      * @return string
      */
-    public function getForeignColumnName($index = 0)
+    public function getForeignColumnName($index = 0): string
     {
         return $this->foreignColumns[$index];
     }
@@ -813,7 +814,7 @@ class ForeignKey extends MappingModel
      *
      * @return \Propel\Generator\Model\Column
      */
-    public function getForeignColumn($index = 0)
+    public function getForeignColumn($index = 0): Column
     {
         return $this->getForeignTable()->getColumn($this->getForeignColumnName($index));
     }
@@ -823,7 +824,7 @@ class ForeignKey extends MappingModel
      *
      * @return bool
      */
-    public function isLocalColumnsRequired()
+    public function isLocalColumnsRequired(): bool
     {
         foreach ($this->localColumns as $columnName) {
             if (!$this->parentTable->getColumn($columnName)->isNotNull()) {
@@ -839,7 +840,7 @@ class ForeignKey extends MappingModel
      *
      * @return bool
      */
-    public function isAtLeastOneLocalColumnRequired()
+    public function isAtLeastOneLocalColumnRequired(): bool
     {
         foreach ($this->localColumns as $columnName) {
             if ($this->parentTable->getColumn($columnName)->isNotNull()) {
@@ -855,7 +856,7 @@ class ForeignKey extends MappingModel
      *
      * @return bool
      */
-    public function isAtLeastOneLocalPrimaryKeyIsRequired()
+    public function isAtLeastOneLocalPrimaryKeyIsRequired(): bool
     {
         foreach ($this->getLocalPrimaryKeys() as $pk) {
             if ($pk->isNotNull() && !$pk->hasDefaultValue()) {
@@ -872,7 +873,7 @@ class ForeignKey extends MappingModel
      *
      * @return bool Returns true if all columns inside this foreign key are primary keys of the foreign table
      */
-    public function isForeignPrimaryKey()
+    public function isForeignPrimaryKey(): bool
     {
         $foreignTable = $this->getForeignTable();
 
@@ -923,7 +924,7 @@ class ForeignKey extends MappingModel
      *
      * @return bool
      */
-    public function isComposite()
+    public function isComposite(): bool
     {
         return count($this->localColumns) > 1;
     }
@@ -933,7 +934,7 @@ class ForeignKey extends MappingModel
      *
      * @return array [[$localColumnName, $right, $compare], ...]
      */
-    public function getNormalizedMap($mapping)
+    public function getNormalizedMap($mapping): array
     {
         $result = [];
 
@@ -955,7 +956,7 @@ class ForeignKey extends MappingModel
      *
      * @return bool
      */
-    public function isPolymorphic()
+    public function isPolymorphic(): bool
     {
         foreach ($this->localValues as $value) {
             if ($value !== null) {
@@ -969,7 +970,7 @@ class ForeignKey extends MappingModel
     /**
      * @return array [[$localColumnName, $localValue], [.., ..], ...]
      */
-    public function getLocalValues()
+    public function getLocalValues(): array
     {
         $map = [];
 
@@ -988,7 +989,7 @@ class ForeignKey extends MappingModel
      *
      * @return bool True if all local columns are at the same time a primary key
      */
-    public function isLocalPrimaryKey()
+    public function isLocalPrimaryKey(): bool
     {
         $localPKCols = [];
         foreach ($this->parentTable->getPrimaryKey() as $lPKCol) {
@@ -1006,7 +1007,7 @@ class ForeignKey extends MappingModel
      *
      * @return void
      */
-    public function setSkipSql($skip)
+    public function setSkipSql($skip): void
     {
         $this->skipSql = (bool)$skip;
     }
@@ -1017,7 +1018,7 @@ class ForeignKey extends MappingModel
      *
      * @return bool
      */
-    public function isSkipSql()
+    public function isSkipSql(): bool
     {
         return $this->skipSql;
     }
@@ -1033,17 +1034,17 @@ class ForeignKey extends MappingModel
      *
      * @return bool
      */
-    public function isMatchedByInverseFK()
+    public function isMatchedByInverseFK(): bool
     {
         return (bool)$this->getInverseFK();
     }
 
     /**
-     * @throws \RuntimeException
+     * @throws \Propel\Runtime\Exception\RuntimeException
      *
      * @return \Propel\Generator\Model\ForeignKey|null
      */
-    public function getInverseFK()
+    public function getInverseFK(): ?self
     {
         $foreignTable = $this->getForeignTable();
         if (!$foreignTable) {
@@ -1069,7 +1070,7 @@ class ForeignKey extends MappingModel
      *
      * @return array<\Propel\Generator\Model\ForeignKey>
      */
-    public function getOtherFks()
+    public function getOtherFks(): array
     {
         $fks = [];
         foreach ($this->parentTable->getForeignKeys() as $fk) {
@@ -1086,7 +1087,7 @@ class ForeignKey extends MappingModel
      *
      * @return array<\Propel\Generator\Model\Column>
      */
-    public function getLocalPrimaryKeys()
+    public function getLocalPrimaryKeys(): array
     {
         $cols = [];
         $localCols = $this->getLocalColumnObjects();
@@ -1105,7 +1106,7 @@ class ForeignKey extends MappingModel
      *
      * @return bool True if there is at least one column that is a primary key
      */
-    public function isAtLeastOneLocalPrimaryKey()
+    public function isAtLeastOneLocalPrimaryKey(): bool
     {
         $cols = $this->getLocalPrimaryKeys();
 

--- a/src/Propel/Generator/Model/IdMethodParameter.php
+++ b/src/Propel/Generator/Model/IdMethodParameter.php
@@ -36,7 +36,7 @@ class IdMethodParameter extends MappingModel
     /**
      * @return void
      */
-    protected function setupObject()
+    protected function setupObject(): void
     {
         $this->name = $this->getAttribute('name');
         $this->value = $this->getAttribute('value');
@@ -47,7 +47,7 @@ class IdMethodParameter extends MappingModel
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -59,7 +59,7 @@ class IdMethodParameter extends MappingModel
      *
      * @return void
      */
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
@@ -81,7 +81,7 @@ class IdMethodParameter extends MappingModel
      *
      * @return void
      */
-    public function setValue($value)
+    public function setValue($value): void
     {
         $this->value = $value;
     }
@@ -93,7 +93,7 @@ class IdMethodParameter extends MappingModel
      *
      * @return void
      */
-    public function setTable(Table $parent)
+    public function setTable(Table $parent): void
     {
         $this->parentTable = $parent;
     }
@@ -103,7 +103,7 @@ class IdMethodParameter extends MappingModel
      *
      * @return \Propel\Generator\Model\Table
      */
-    public function getTable()
+    public function getTable(): Table
     {
         return $this->parentTable;
     }
@@ -113,7 +113,7 @@ class IdMethodParameter extends MappingModel
      *
      * @return string
      */
-    public function getTableName()
+    public function getTableName(): string
     {
         return $this->parentTable->getName();
     }

--- a/src/Propel/Generator/Model/Index.php
+++ b/src/Propel/Generator/Model/Index.php
@@ -189,9 +189,9 @@ class Index extends MappingModel
     {
         if ($data instanceof Column) {
             $column = $data;
-            $this->columns[] = $column->getName();
+            $this->columns[] = (string)$column->getName();
             if ($column->getSize()) {
-                $this->columnsSize[$column->getName()] = $column->getSize();
+                $this->columnsSize[$column->getName()] = (int)$column->getSize();
             }
             $this->columnObjects[] = $column;
         } else {

--- a/src/Propel/Generator/Model/Index.php
+++ b/src/Propel/Generator/Model/Index.php
@@ -66,7 +66,7 @@ class Index extends MappingModel
      *
      * @return bool
      */
-    public function isUnique()
+    public function isUnique(): bool
     {
         return false;
     }
@@ -78,7 +78,7 @@ class Index extends MappingModel
      *
      * @return void
      */
-    public function setName($name)
+    public function setName($name): void
     {
         $this->autoNaming = !$name; //if no name we activate autoNaming
         $this->name = $name;
@@ -89,7 +89,7 @@ class Index extends MappingModel
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         $this->doNaming();
 
@@ -103,7 +103,7 @@ class Index extends MappingModel
     /**
      * @return void
      */
-    protected function doNaming()
+    protected function doNaming(): void
     {
         if (!$this->name || $this->autoNaming) {
             $newName = sprintf('%s_', $this instanceof Unique ? 'u' : 'i');
@@ -130,7 +130,7 @@ class Index extends MappingModel
     /**
      * @return string
      */
-    public function getFQName()
+    public function getFQName(): string
     {
         $table = $this->getTable();
         if (
@@ -153,7 +153,7 @@ class Index extends MappingModel
      *
      * @return void
      */
-    public function setTable(Table $table)
+    public function setTable(Table $table): void
     {
         $this->table = $table;
     }
@@ -163,7 +163,7 @@ class Index extends MappingModel
      *
      * @return \Propel\Generator\Model\Table|null
      */
-    public function getTable()
+    public function getTable(): ?Table
     {
         return $this->table;
     }
@@ -173,7 +173,7 @@ class Index extends MappingModel
      *
      * @return string
      */
-    public function getTableName()
+    public function getTableName(): string
     {
         return $this->table->getName();
     }
@@ -185,7 +185,7 @@ class Index extends MappingModel
      *
      * @return void
      */
-    public function addColumn($data)
+    public function addColumn($data): void
     {
         if ($data instanceof Column) {
             $column = $data;
@@ -210,7 +210,7 @@ class Index extends MappingModel
      *
      * @return bool
      */
-    public function hasColumn($name)
+    public function hasColumn($name): bool
     {
         return in_array($name, $this->columns);
     }
@@ -222,7 +222,7 @@ class Index extends MappingModel
      *
      * @return void
      */
-    public function setColumns(array $columns)
+    public function setColumns(array $columns): void
     {
         $this->columns = [];
         $this->columnsSize = [];
@@ -238,7 +238,7 @@ class Index extends MappingModel
      *
      * @return bool
      */
-    public function hasColumnSize($name)
+    public function hasColumnSize($name): bool
     {
         return isset($this->columnsSize[$name]);
     }
@@ -251,7 +251,7 @@ class Index extends MappingModel
      *
      * @return int|null
      */
-    public function getColumnSize($name, $caseInsensitive = false)
+    public function getColumnSize($name, $caseInsensitive = false): ?int
     {
         if ($caseInsensitive) {
             foreach ($this->columnsSize as $forName => $size) {
@@ -273,7 +273,7 @@ class Index extends MappingModel
      *
      * @return void
      */
-    public function resetColumnsSize()
+    public function resetColumnsSize(): void
     {
         $this->columnsSize = [];
     }
@@ -288,7 +288,7 @@ class Index extends MappingModel
      *
      * @return bool
      */
-    public function hasColumnAtPosition($pos, $name, $size = null, $caseInsensitive = false)
+    public function hasColumnAtPosition($pos, $name, $size = null, $caseInsensitive = false): bool
     {
         if (!isset($this->columns[$pos])) {
             return false;
@@ -316,7 +316,7 @@ class Index extends MappingModel
      *
      * @return bool
      */
-    public function hasColumns()
+    public function hasColumns(): bool
     {
         return count($this->columns) > 0;
     }
@@ -328,7 +328,7 @@ class Index extends MappingModel
      *
      * @return array<string>
      */
-    public function getColumns()
+    public function getColumns(): array
     {
         return $this->columns;
     }
@@ -336,7 +336,7 @@ class Index extends MappingModel
     /**
      * @return void
      */
-    protected function setupObject()
+    protected function setupObject(): void
     {
         $this->setName($this->getAttribute('name'));
     }
@@ -344,7 +344,7 @@ class Index extends MappingModel
     /**
      * @return array<\Propel\Generator\Model\Column>
      */
-    public function getColumnObjects()
+    public function getColumnObjects(): array
     {
         return $this->columnObjects;
     }
@@ -354,7 +354,7 @@ class Index extends MappingModel
      *
      * @return void
      */
-    public function setColumnObjects($columnObjects)
+    public function setColumnObjects($columnObjects): void
     {
         $this->columnObjects = $columnObjects;
     }

--- a/src/Propel/Generator/Model/Inheritance.php
+++ b/src/Propel/Generator/Model/Inheritance.php
@@ -45,9 +45,9 @@ class Inheritance extends MappingModel
     /**
      * Returns a key name.
      *
-     * @return string
+     * @return string|null
      */
-    public function getKey(): string
+    public function getKey(): ?string
     {
         return $this->key;
     }
@@ -91,9 +91,9 @@ class Inheritance extends MappingModel
     /**
      * Returns the parent column.
      *
-     * @return \Propel\Generator\Model\Column
+     * @return \Propel\Generator\Model\Column|null
      */
-    public function getColumn(): Column
+    public function getColumn(): ?Column
     {
         return $this->column;
     }
@@ -101,9 +101,9 @@ class Inheritance extends MappingModel
     /**
      * Returns the class name.
      *
-     * @return string
+     * @return string|null
      */
-    public function getClassName(): string
+    public function getClassName(): ?string
     {
         return $this->className;
     }

--- a/src/Propel/Generator/Model/Inheritance.php
+++ b/src/Propel/Generator/Model/Inheritance.php
@@ -47,7 +47,7 @@ class Inheritance extends MappingModel
      *
      * @return string
      */
-    public function getKey()
+    public function getKey(): string
     {
         return $this->key;
     }
@@ -57,7 +57,7 @@ class Inheritance extends MappingModel
      *
      * @return string
      */
-    public function getConstantSuffix()
+    public function getConstantSuffix(): string
     {
         $separator = PhpNameGenerator::STD_SEPARATOR_CHAR;
 
@@ -71,7 +71,7 @@ class Inheritance extends MappingModel
      *
      * @return void
      */
-    public function setKey($key)
+    public function setKey($key): void
     {
         $this->key = $key;
     }
@@ -83,7 +83,7 @@ class Inheritance extends MappingModel
      *
      * @return void
      */
-    public function setColumn(Column $column)
+    public function setColumn(Column $column): void
     {
         $this->column = $column;
     }
@@ -93,7 +93,7 @@ class Inheritance extends MappingModel
      *
      * @return \Propel\Generator\Model\Column
      */
-    public function getColumn()
+    public function getColumn(): Column
     {
         return $this->column;
     }
@@ -103,7 +103,7 @@ class Inheritance extends MappingModel
      *
      * @return string
      */
-    public function getClassName()
+    public function getClassName(): string
     {
         return $this->className;
     }
@@ -115,7 +115,7 @@ class Inheritance extends MappingModel
      *
      * @return void
      */
-    public function setClassName($name)
+    public function setClassName($name): void
     {
         $this->className = $name;
     }
@@ -123,9 +123,9 @@ class Inheritance extends MappingModel
     /**
      * Returns the package.
      *
-     * @return string
+     * @return string|null
      */
-    public function getPackage()
+    public function getPackage(): ?string
     {
         return $this->package;
     }
@@ -137,7 +137,7 @@ class Inheritance extends MappingModel
      *
      * @return void
      */
-    public function setPackage($package)
+    public function setPackage($package): void
     {
         $this->package = $package;
     }
@@ -147,7 +147,7 @@ class Inheritance extends MappingModel
      *
      * @return string|null
      */
-    public function getAncestor()
+    public function getAncestor(): ?string
     {
         return $this->ancestor;
     }
@@ -159,7 +159,7 @@ class Inheritance extends MappingModel
      *
      * @return void
      */
-    public function setAncestor($ancestor)
+    public function setAncestor($ancestor): void
     {
         $this->ancestor = $ancestor;
     }
@@ -167,7 +167,7 @@ class Inheritance extends MappingModel
     /**
      * @return void
      */
-    protected function setupObject()
+    protected function setupObject(): void
     {
         $this->key = $this->getAttribute('key');
         $this->className = $this->getAttribute('class');

--- a/src/Propel/Generator/Model/MappingModel.php
+++ b/src/Propel/Generator/Model/MappingModel.php
@@ -38,7 +38,7 @@ abstract class MappingModel implements MappingModelInterface
      *
      * @return void
      */
-    public function loadMapping(array $attributes)
+    public function loadMapping(array $attributes): void
     {
         $this->attributes = array_change_key_case($attributes, CASE_LOWER);
         $this->setupObject();
@@ -51,7 +51,7 @@ abstract class MappingModel implements MappingModelInterface
      *
      * @return void
      */
-    abstract protected function setupObject();
+    abstract protected function setupObject(): void;
 
     /**
      * Returns all definition attributes.
@@ -60,7 +60,7 @@ abstract class MappingModel implements MappingModelInterface
      *
      * @return array
      */
-    public function getAttributes()
+    public function getAttributes(): array
     {
         return $this->attributes;
     }
@@ -95,7 +95,7 @@ abstract class MappingModel implements MappingModelInterface
      *
      * @return bool
      */
-    protected function booleanValue($value)
+    protected function booleanValue($value): bool
     {
         if (is_bool($value)) {
             return $value;
@@ -117,7 +117,7 @@ abstract class MappingModel implements MappingModelInterface
      *
      * @return string|null
      */
-    protected function getDefaultValueForArray(string $stringValue)
+    protected function getDefaultValueForArray(string $stringValue): ?string
     {
         $stringValue = trim($stringValue);
 
@@ -145,7 +145,7 @@ abstract class MappingModel implements MappingModelInterface
      *
      * @return array|null
      */
-    protected function getDefaultValueForSet($stringValue)
+    protected function getDefaultValueForSet($stringValue): ?array
     {
         $stringValue = trim($stringValue);
 
@@ -168,7 +168,7 @@ abstract class MappingModel implements MappingModelInterface
      *
      * @return \Propel\Generator\Model\VendorInfo
      */
-    public function addVendorInfo($vendor)
+    public function addVendorInfo($vendor): VendorInfo
     {
         if ($vendor instanceof VendorInfo) {
             $this->vendorInfos[$vendor->getType()] = $vendor;
@@ -189,7 +189,7 @@ abstract class MappingModel implements MappingModelInterface
      *
      * @return \Propel\Generator\Model\VendorInfo
      */
-    public function getVendorInfoForType($type)
+    public function getVendorInfoForType($type): VendorInfo
     {
         if (isset($this->vendorInfos[$type])) {
             return $this->vendorInfos[$type];
@@ -203,7 +203,7 @@ abstract class MappingModel implements MappingModelInterface
      *
      * @return array<\Propel\Generator\Model\VendorInfo>
      */
-    public function getVendorInformation()
+    public function getVendorInformation(): array
     {
         return $this->vendorInfos;
     }

--- a/src/Propel/Generator/Model/MappingModel.php
+++ b/src/Propel/Generator/Model/MappingModel.php
@@ -87,7 +87,7 @@ abstract class MappingModel implements MappingModelInterface
     }
 
     /**
-     * Converts a value (Boolean, string or numeric) into a Boolean value.
+     * Converts a value (Boolean, string or numeric) into a boolean value.
      *
      * This is to support the default value when used with a boolean column.
      *

--- a/src/Propel/Generator/Model/MappingModelInterface.php
+++ b/src/Propel/Generator/Model/MappingModelInterface.php
@@ -42,5 +42,5 @@ interface MappingModelInterface
      *
      * @return void
      */
-    public function loadMapping(array $attributes);
+    public function loadMapping(array $attributes): void;
 }

--- a/src/Propel/Generator/Model/NameFactory.php
+++ b/src/Propel/Generator/Model/NameFactory.php
@@ -47,7 +47,7 @@ class NameFactory
      *
      * @return \Propel\Generator\Model\NameGeneratorInterface
      */
-    protected static function getAlgorithm($name)
+    protected static function getAlgorithm($name): NameGeneratorInterface
     {
         if (!isset(self::$algorithms[$name])) {
             self::$algorithms[$name] = new $name();
@@ -66,7 +66,7 @@ class NameFactory
      *
      * @return string The generated name.
      */
-    public static function generateName($algorithmName, $inputs)
+    public static function generateName($algorithmName, $inputs): string
     {
         $algorithm = self::getAlgorithm($algorithmName);
 

--- a/src/Propel/Generator/Model/NameGeneratorInterface.php
+++ b/src/Propel/Generator/Model/NameGeneratorInterface.php
@@ -79,5 +79,5 @@ interface NameGeneratorInterface
      *
      * @return string The generated name.
      */
-    public function generateName($inputs);
+    public function generateName(array $inputs): string;
 }

--- a/src/Propel/Generator/Model/PhpNameGenerator.php
+++ b/src/Propel/Generator/Model/PhpNameGenerator.php
@@ -8,8 +8,6 @@
 
 namespace Propel\Generator\Model;
 
-use Propel\Generator\Exception\InvalidArgumentException;
-
 /**
  * A <code>NameGeneratorInterface</code> implementation for PHP-esque names.
  *
@@ -41,8 +39,6 @@ class PhpNameGenerator implements NameGeneratorInterface
      * @param array<string> $inputs List expected to contain two (optional: three) parameters,
      * element 0 contains name to convert, element 1 contains method for conversion,
      * optional element 2 contains prefix to be striped from name
-     *
-     * @throws \Propel\Generator\Exception\InvalidArgumentException
      *
      * @return string The generated name.
      */

--- a/src/Propel/Generator/Model/PhpNameGenerator.php
+++ b/src/Propel/Generator/Model/PhpNameGenerator.php
@@ -8,6 +8,8 @@
 
 namespace Propel\Generator\Model;
 
+use Propel\Generator\Exception\InvalidArgumentException;
+
 /**
  * A <code>NameGeneratorInterface</code> implementation for PHP-esque names.
  *
@@ -40,9 +42,11 @@ class PhpNameGenerator implements NameGeneratorInterface
      * element 0 contains name to convert, element 1 contains method for conversion,
      * optional element 2 contains prefix to be striped from name
      *
-     * @return string|null The generated name.
+     * @throws \Propel\Generator\Exception\InvalidArgumentException
+     *
+     * @return string The generated name.
      */
-    public function generateName($inputs): ?string
+    public function generateName(array $inputs): string
     {
         $schemaName = $inputs[0];
         $method = $inputs[1];
@@ -56,10 +60,8 @@ class PhpNameGenerator implements NameGeneratorInterface
 
         // We really shouldn't be getting null here, but we cannot pass a null value further
         if ($schemaName === null) {
-            return null;
+            throw new InvalidArgumentException('No schema name available');
         }
-
-        $phpName = null;
 
         switch ($method) {
             case self::CONV_METHOD_CLEAN:
@@ -99,7 +101,7 @@ class PhpNameGenerator implements NameGeneratorInterface
      *
      * @return string Converted name.
      */
-    protected function underscoreMethod(string $schemaName)
+    protected function underscoreMethod(string $schemaName): string
     {
         $name = '';
         $tok = strtok($schemaName, self::STD_SEPARATOR_CHAR);
@@ -126,7 +128,7 @@ class PhpNameGenerator implements NameGeneratorInterface
      *
      * @return string Converted name.
      */
-    protected function cleanMethod(string $schemaName)
+    protected function cleanMethod(string $schemaName): string
     {
         $name = '';
         $regexp = '/([a-z0-9]+)/i';
@@ -156,7 +158,7 @@ class PhpNameGenerator implements NameGeneratorInterface
      *
      * @return string Converted name.
      */
-    protected function phpnameMethod(string $schemaName)
+    protected function phpnameMethod(string $schemaName): string
     {
         $name = '';
         $tok = strtok($schemaName, self::STD_SEPARATOR_CHAR);
@@ -176,7 +178,7 @@ class PhpNameGenerator implements NameGeneratorInterface
      *
      * @return string
      */
-    protected function nochangeMethod(string $name)
+    protected function nochangeMethod(string $name): string
     {
         return $name;
     }

--- a/src/Propel/Generator/Model/PhpNameGenerator.php
+++ b/src/Propel/Generator/Model/PhpNameGenerator.php
@@ -38,7 +38,7 @@ class PhpNameGenerator implements NameGeneratorInterface
      *
      * @see NameGenerator
      *
-     * @param array<(string|null)> $inputs List expected to contain two (optional: three) parameters,
+     * @param array<string> $inputs List expected to contain two (optional: three) parameters,
      * element 0 contains name to convert, element 1 contains method for conversion,
      * optional element 2 contains prefix to be striped from name
      *
@@ -48,19 +48,14 @@ class PhpNameGenerator implements NameGeneratorInterface
      */
     public function generateName(array $inputs): string
     {
-        $schemaName = $inputs[0];
-        $method = $inputs[1];
+        $schemaName = (string)$inputs[0];
+        $method = (string)$inputs[1];
 
         if (count($inputs) > 2) {
-            $prefix = $inputs[2];
+            $prefix = (string)$inputs[2];
             if ($prefix && substr($schemaName, 0, strlen($prefix)) === $prefix) {
                 $schemaName = substr($schemaName, strlen($prefix));
             }
-        }
-
-        // We really shouldn't be getting null here, but we cannot pass a null value further
-        if ($schemaName === null) {
-            throw new InvalidArgumentException('No schema name available');
         }
 
         switch ($method) {

--- a/src/Propel/Generator/Model/PropelTypes.php
+++ b/src/Propel/Generator/Model/PropelTypes.php
@@ -474,7 +474,7 @@ class PropelTypes
      *
      * @return string
      */
-    public static function getPhpNative($mappingType)
+    public static function getPhpNative($mappingType): string
     {
         return self::$mappingToPHPNativeMap[$mappingType];
     }
@@ -486,7 +486,7 @@ class PropelTypes
      *
      * @return int
      */
-    public static function getPDOType($type)
+    public static function getPDOType($type): int
     {
         return self::$mappingTypeToPDOTypeMap[$type];
     }
@@ -498,7 +498,7 @@ class PropelTypes
      *
      * @return string
      */
-    public static function getPdoTypeString($type)
+    public static function getPdoTypeString($type): string
     {
         return self::$pdoTypeNames[self::$mappingTypeToPDOTypeMap[$type]];
     }
@@ -508,7 +508,7 @@ class PropelTypes
      *
      * @return array
      */
-    public static function getPropelTypes()
+    public static function getPropelTypes(): array
     {
         return self::$mappingTypes;
     }
@@ -520,7 +520,7 @@ class PropelTypes
      *
      * @return bool
      */
-    public static function isTemporalType($type)
+    public static function isTemporalType($type): bool
     {
         return in_array($type, [
             self::DATE,
@@ -538,7 +538,7 @@ class PropelTypes
      *
      * @return bool
      */
-    public static function isTextType($mappingType)
+    public static function isTextType($mappingType): bool
     {
         return in_array($mappingType, [
             self::CHAR,
@@ -561,7 +561,7 @@ class PropelTypes
      *
      * @return bool
      */
-    public static function isNumericType($mappingType)
+    public static function isNumericType($mappingType): bool
     {
         return in_array($mappingType, [
             self::SMALLINT,
@@ -583,7 +583,7 @@ class PropelTypes
      *
      * @return bool
      */
-    public static function isBooleanType($mappingType)
+    public static function isBooleanType($mappingType): bool
     {
         return in_array($mappingType, [self::BOOLEAN, self::BOOLEAN_EMU]);
     }
@@ -595,7 +595,7 @@ class PropelTypes
      *
      * @return bool
      */
-    public static function isLobType($mappingType)
+    public static function isLobType($mappingType): bool
     {
         return in_array($mappingType, [self::VARBINARY, self::LONGVARBINARY, self::BLOB, self::OBJECT, self::GEOMETRY]);
     }
@@ -607,7 +607,7 @@ class PropelTypes
      *
      * @return bool
      */
-    public static function isPhpPrimitiveType($phpType)
+    public static function isPhpPrimitiveType($phpType): bool
     {
         return in_array($phpType, ['boolean', 'int', 'double', 'float', 'string']);
     }
@@ -619,7 +619,7 @@ class PropelTypes
      *
      * @return bool
      */
-    public static function isPhpPrimitiveNumericType($phpType)
+    public static function isPhpPrimitiveNumericType($phpType): bool
     {
         return in_array($phpType, ['boolean', 'int', 'double', 'float']);
     }
@@ -631,7 +631,7 @@ class PropelTypes
      *
      * @return bool
      */
-    public static function isPhpObjectType($phpType)
+    public static function isPhpObjectType($phpType): bool
     {
         return !self::isPhpPrimitiveType($phpType) && !in_array($phpType, ['resource', 'array']);
     }

--- a/src/Propel/Generator/Model/Schema.php
+++ b/src/Propel/Generator/Model/Schema.php
@@ -103,9 +103,9 @@ class Schema
     /**
      * Returns the generator configuration
      *
-     * @return \Propel\Generator\Config\GeneratorConfigInterface
+     * @return \Propel\Generator\Config\GeneratorConfigInterface|null
      */
-    public function getGeneratorConfig(): GeneratorConfigInterface
+    public function getGeneratorConfig(): ?GeneratorConfigInterface
     {
         return $this->generatorConfig;
     }
@@ -179,9 +179,9 @@ class Schema
      * @param string|null $name
      * @param bool $doFinalInitialization
      *
-     * @return \Propel\Generator\Model\Database
+     * @return \Propel\Generator\Model\Database|null
      */
-    public function getDatabase($name = null, $doFinalInitialization = true): Database
+    public function getDatabase(?string $name = null, bool $doFinalInitialization = true): ?Database
     {
         // this is temporary until we'll have a clean solution
         // for packaging datamodels/requiring schemas

--- a/src/Propel/Generator/Model/Schema.php
+++ b/src/Propel/Generator/Model/Schema.php
@@ -72,7 +72,7 @@ class Schema
      *
      * @return void
      */
-    public function setPlatform(PlatformInterface $platform)
+    public function setPlatform(PlatformInterface $platform): void
     {
         $this->platform = $platform;
     }
@@ -83,7 +83,7 @@ class Schema
      *
      * @return \Propel\Generator\Platform\PlatformInterface
      */
-    public function getPlatform()
+    public function getPlatform(): PlatformInterface
     {
         return $this->platform;
     }
@@ -95,7 +95,7 @@ class Schema
      *
      * @return void
      */
-    public function setGeneratorConfig(GeneratorConfigInterface $generatorConfig)
+    public function setGeneratorConfig(GeneratorConfigInterface $generatorConfig): void
     {
         $this->generatorConfig = $generatorConfig;
     }
@@ -105,7 +105,7 @@ class Schema
      *
      * @return \Propel\Generator\Config\GeneratorConfigInterface
      */
-    public function getGeneratorConfig()
+    public function getGeneratorConfig(): GeneratorConfigInterface
     {
         return $this->generatorConfig;
     }
@@ -117,7 +117,7 @@ class Schema
      *
      * @return void
      */
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
@@ -127,7 +127,7 @@ class Schema
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -137,7 +137,7 @@ class Schema
      *
      * @return string
      */
-    public function getShortName()
+    public function getShortName(): string
     {
         return str_replace('-schema', '', $this->name);
     }
@@ -152,7 +152,7 @@ class Schema
      *
      * @return array<\Propel\Generator\Model\Database>
      */
-    public function getDatabases($doFinalInitialization = true)
+    public function getDatabases(bool $doFinalInitialization = true): array
     {
         // this is temporary until we'll have a clean solution
         // for packaging datamodels/requiring schemas
@@ -168,7 +168,7 @@ class Schema
      *
      * @return bool
      */
-    public function hasMultipleDatabases()
+    public function hasMultipleDatabases(): bool
     {
         return count($this->databases) > 1;
     }
@@ -181,7 +181,7 @@ class Schema
      *
      * @return \Propel\Generator\Model\Database
      */
-    public function getDatabase($name = null, $doFinalInitialization = true)
+    public function getDatabase($name = null, $doFinalInitialization = true): Database
     {
         // this is temporary until we'll have a clean solution
         // for packaging datamodels/requiring schemas
@@ -213,7 +213,7 @@ class Schema
      *
      * @return bool
      */
-    public function hasDatabase($name)
+    public function hasDatabase($name): bool
     {
         foreach ($this->databases as $database) {
             if ($database->getName() === $name) {
@@ -233,7 +233,7 @@ class Schema
      *
      * @return \Propel\Generator\Model\Database
      */
-    public function addDatabase($database)
+    public function addDatabase($database): Database
     {
         if ($database instanceof Database) {
             $platform = null;
@@ -263,7 +263,7 @@ class Schema
      *
      * @return void
      */
-    public function doFinalInitialization()
+    public function doFinalInitialization(): void
     {
         if (!$this->isInitialized) {
             foreach ($this->databases as $database) {
@@ -282,7 +282,7 @@ class Schema
      *
      * @return void
      */
-    public function joinSchemas(array $schemas)
+    public function joinSchemas(array $schemas): void
     {
         foreach ($schemas as $schema) {
             foreach ($schema->getDatabases(false) as $addDb) {
@@ -319,7 +319,7 @@ class Schema
      *
      * @return int
      */
-    public function countTables()
+    public function countTables(): int
     {
         $nb = 0;
         foreach ($this->getDatabases() as $database) {
@@ -335,7 +335,7 @@ class Schema
      *
      * @return string Representation in xml format
      */
-    public function toString()
+    public function toString(): string
     {
         $dumper = new XmlDumper();
 
@@ -349,7 +349,7 @@ class Schema
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->toString();
     }

--- a/src/Propel/Generator/Model/ScopedMappingModel.php
+++ b/src/Propel/Generator/Model/ScopedMappingModel.php
@@ -49,7 +49,7 @@ abstract class ScopedMappingModel extends MappingModel
      *
      * @return bool
      */
-    public function isPackageOverriden()
+    public function isPackageOverriden(): bool
     {
         return $this->packageOverridden;
     }
@@ -61,12 +61,12 @@ abstract class ScopedMappingModel extends MappingModel
      *
      * @return string
      */
-    abstract protected function getBuildProperty($name);
+    abstract protected function getBuildProperty($name): string;
 
     /**
      * @return void
      */
-    protected function setupObject()
+    protected function setupObject(): void
     {
         $this->setPackage($this->getAttribute('package', $this->package));
         $this->setSchema($this->getAttribute('schema', $this->schema));
@@ -96,7 +96,7 @@ abstract class ScopedMappingModel extends MappingModel
      *
      * @return void
      */
-    public function setNamespace(?string $namespace)
+    public function setNamespace(?string $namespace): void
     {
         $namespace = $namespace === null
             ? ''
@@ -122,7 +122,7 @@ abstract class ScopedMappingModel extends MappingModel
      *
      * @return bool
      */
-    public function isAbsoluteNamespace($namespace)
+    public function isAbsoluteNamespace($namespace): bool
     {
         return ($namespace && substr($namespace, 0, 1) === '\\');
     }
@@ -146,9 +146,9 @@ abstract class ScopedMappingModel extends MappingModel
     /**
      * Returns the package name.
      *
-     * @return string
+     * @return string|null
      */
-    public function getPackage()
+    public function getPackage(): ?string
     {
         return $this->package;
     }
@@ -160,7 +160,7 @@ abstract class ScopedMappingModel extends MappingModel
      *
      * @return void
      */
-    public function setPackage($package)
+    public function setPackage($package): void
     {
         if ($package === $this->package) {
             return;
@@ -187,7 +187,7 @@ abstract class ScopedMappingModel extends MappingModel
      *
      * @return void
      */
-    public function setSchema($schema)
+    public function setSchema($schema): void
     {
         if ($schema === $this->schema) {
             return;

--- a/src/Propel/Generator/Model/Table.php
+++ b/src/Propel/Generator/Model/Table.php
@@ -235,7 +235,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @param string|null $name table name
      */
-    public function __construct($name = null)
+    public function __construct(?string $name = null)
     {
         parent::__construct();
 
@@ -765,8 +765,10 @@ class Table extends ScopedMappingModel implements IdMethod
             $this->foreignKeys[] = $fk;
             $this->foreignKeysByName[$name] = $fk;
 
-            if (!in_array($fk->getForeignTableName(), $this->foreignTableNames)) {
-                $this->foreignTableNames[] = $fk->getForeignTableName();
+            if (!in_array($fk->getForeignTableName(), $this->foreignTableNames, true)) {
+                /** @var string $foreignTableName */
+                $foreignTableName = $fk->getForeignTableName();
+                $this->foreignTableNames[] = $foreignTableName;
             }
 
             return $fk;

--- a/src/Propel/Generator/Model/Table.php
+++ b/src/Propel/Generator/Model/Table.php
@@ -8,10 +8,12 @@
 
 namespace Propel\Generator\Model;
 
+use Propel\Generator\Config\GeneratorConfigInterface;
 use Propel\Generator\Exception\BuildException;
 use Propel\Generator\Exception\EngineException;
 use Propel\Generator\Exception\InvalidArgumentException;
 use Propel\Generator\Platform\MysqlPlatform;
+use Propel\Generator\Platform\PlatformInterface;
 use Propel\Runtime\Exception\RuntimeException;
 
 /**
@@ -76,12 +78,12 @@ class Table extends ScopedMappingModel implements IdMethod
     private $originCommonName;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $description;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $phpName;
 
@@ -254,7 +256,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return string
      */
-    private function getStdSeparatedName()
+    private function getStdSeparatedName(): string
     {
         if ($this->schema && $this->getBuildProperty('generator.schema.autoPrefix')) {
             return $this->schema . NameGeneratorInterface::STD_SEPARATOR_CHAR . $this->getCommonName();
@@ -266,7 +268,7 @@ class Table extends ScopedMappingModel implements IdMethod
     /**
      * @return void
      */
-    public function setupObject()
+    public function setupObject(): void
     {
         parent::setupObject();
 
@@ -322,7 +324,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return string
      */
-    public function getBuildProperty($name)
+    public function getBuildProperty($name): string
     {
         return $this->database ? $this->database->getBuildProperty($name) : '';
     }
@@ -332,7 +334,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return void
      */
-    public function applyBehaviors()
+    public function applyBehaviors(): void
     {
         foreach ($this->behaviors as $behavior) {
             if (!$behavior->isTableModified()) {
@@ -347,7 +349,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return void
      */
-    protected function registerBehavior(Behavior $behavior)
+    protected function registerBehavior(Behavior $behavior): void
     {
         $behavior->setTable($this);
     }
@@ -362,7 +364,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return void
      */
-    public function doFinalInitialization()
+    public function doFinalInitialization(): void
     {
         // Heavy indexing must wait until after all columns composing
         // a table's primary key have been parsed.
@@ -402,7 +404,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return void
      */
-    private function doHeavyIndexing()
+    private function doHeavyIndexing(): void
     {
         $pk = $this->getPrimaryKey();
         $size = count($pk);
@@ -424,7 +426,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return void
      */
-    public function addExtraIndices()
+    public function addExtraIndices(): void
     {
         /**
          * A collection of indexed columns. The key is the column name
@@ -503,7 +505,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return \Propel\Generator\Model\Index The created index
      */
-    protected function createIndex($name, array $columns)
+    protected function createIndex($name, array $columns): Index
     {
         $index = new Index($name);
         $index->setColumns($columns);
@@ -523,7 +525,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return void
      */
-    protected function collectIndexedColumns($indexName, $columns, &$collectedIndexes)
+    protected function collectIndexedColumns($indexName, $columns, &$collectedIndexes): void
     {
         /**
          * "If the table has a multiple-column index, any leftmost prefix of the
@@ -553,7 +555,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return string
      */
-    public function getColumnList($columns, $delimiter = ',')
+    public function getColumnList($columns, $delimiter = ','): string
     {
         $list = [];
         foreach ($columns as $col) {
@@ -570,9 +572,9 @@ class Table extends ScopedMappingModel implements IdMethod
      * Returns the name of the base class used for superclass of all objects
      * of this table.
      *
-     * @return string
+     * @return string|null
      */
-    public function getBaseClass()
+    public function getBaseClass(): ?string
     {
         if ($this->isAlias() && $this->baseClass === null) {
             return $this->alias;
@@ -589,9 +591,9 @@ class Table extends ScopedMappingModel implements IdMethod
      * Returns the name of the base query class used for superclass of all query objects
      * of this table.
      *
-     * @return string
+     * @return string|null
      */
-    public function getBaseQueryClass()
+    public function getBaseQueryClass(): ?string
     {
         if ($this->baseQueryClass === null) {
             return $this->database->getBaseQueryClass();
@@ -607,7 +609,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return void
      */
-    public function setBaseClass($class)
+    public function setBaseClass($class): void
     {
         $this->baseClass = $this->makeNamespaceAbsolute($class);
     }
@@ -619,7 +621,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return void
      */
-    public function setBaseQueryClass($class)
+    public function setBaseQueryClass($class): void
     {
         $this->baseQueryClass = $this->makeNamespaceAbsolute($class);
     }
@@ -633,7 +635,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return \Propel\Generator\Model\Column
      */
-    public function addColumn($col)
+    public function addColumn($col): Column
     {
         if ($col instanceof Column) {
             if (isset($this->columnsByName[$col->getName()])) {
@@ -673,7 +675,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return void
      */
-    public function addColumns(array $columns)
+    public function addColumns(array $columns): void
     {
         foreach ($columns as $column) {
             $this->addColumn($column);
@@ -689,7 +691,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return void
      */
-    public function removeColumn($column)
+    public function removeColumn($column): void
     {
         if (is_string($column)) {
             $column = $this->getColumn($column);
@@ -731,7 +733,7 @@ class Table extends ScopedMappingModel implements IdMethod
     /**
      * @return void
      */
-    public function adjustColumnPositions()
+    public function adjustColumnPositions(): void
     {
         $this->columns = array_values($this->columns);
         $nbColumns = $this->getNumColumns();
@@ -749,7 +751,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return \Propel\Generator\Model\ForeignKey
      */
-    public function addForeignKey($foreignKey)
+    public function addForeignKey($foreignKey): ForeignKey
     {
         if ($foreignKey instanceof ForeignKey) {
             $fk = $foreignKey;
@@ -784,7 +786,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return void
      */
-    public function addForeignKeys(array $foreignKeys)
+    public function addForeignKeys(array $foreignKeys): void
     {
         foreach ($foreignKeys as $foreignKey) {
             $this->addForeignKey($foreignKey);
@@ -797,7 +799,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return \Propel\Generator\Model\Column|null
      */
-    public function getChildrenColumn()
+    public function getChildrenColumn(): ?Column
     {
         return $this->inheritanceColumn;
     }
@@ -817,7 +819,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return array|null
      */
-    public function getChildrenNames()
+    public function getChildrenNames(): ?array
     {
         if (
             $this->inheritanceColumn === null
@@ -841,7 +843,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return void
      */
-    public function addReferrer(ForeignKey $fk)
+    public function addReferrer(ForeignKey $fk): void
     {
         $this->referrers[] = $fk;
     }
@@ -851,7 +853,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return array<\Propel\Generator\Model\ForeignKey>
      */
-    public function getReferrers()
+    public function getReferrers(): array
     {
         return $this->referrers;
     }
@@ -868,7 +870,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return void
      */
-    public function setupReferrers($throwErrors = false)
+    public function setupReferrers($throwErrors = false): void
     {
         foreach ($this->foreignKeys as $foreignKey) {
             // table referrers
@@ -960,7 +962,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return array<\Propel\Generator\Model\CrossForeignKeys>
      */
-    public function getCrossFks()
+    public function getCrossFks(): array
     {
         $crossFks = [];
         foreach ($this->referrers as $refFK) {
@@ -990,7 +992,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return array<\Propel\Generator\Model\Column>
      */
-    public function getOtherRequiredPrimaryKeys(array $primaryKeys)
+    public function getOtherRequiredPrimaryKeys(array $primaryKeys): array
     {
         /** @var array<\Propel\Generator\Model\Column> $pks */
         $pks = [];
@@ -1010,7 +1012,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return void
      */
-    public function setContainsForeignPK($containsForeignPK)
+    public function setContainsForeignPK($containsForeignPK): void
     {
         $this->containsForeignPK = (bool)$containsForeignPK;
     }
@@ -1020,7 +1022,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return bool
      */
-    public function getContainsForeignPK()
+    public function getContainsForeignPK(): bool
     {
         return $this->containsForeignPK;
     }
@@ -1030,7 +1032,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return array
      */
-    public function getForeignTableNames()
+    public function getForeignTableNames(): array
     {
         return $this->foreignTableNames;
     }
@@ -1040,7 +1042,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return bool
      */
-    public function requiresTransactionInPostgres()
+    public function requiresTransactionInPostgres(): bool
     {
         return $this->needsTransactionInPostgres;
     }
@@ -1052,7 +1054,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return \Propel\Generator\Model\IdMethodParameter
      */
-    public function addIdMethodParameter($idMethodParameter)
+    public function addIdMethodParameter($idMethodParameter): IdMethodParameter
     {
         if ($idMethodParameter instanceof IdMethodParameter) {
             $idMethodParameter->setTable($this);
@@ -1075,7 +1077,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return void
      */
-    public function removeIndex($name)
+    public function removeIndex($name): void
     {
         // check if we have a index with this name already, then delete it
         foreach ($this->indices as $n => $idx) {
@@ -1094,7 +1096,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return bool
      */
-    public function hasIndex($name)
+    public function hasIndex($name): bool
     {
         foreach ($this->indices as $idx) {
             if ($idx->getName() == $name) {
@@ -1115,7 +1117,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return \Propel\Generator\Model\Index
      */
-    public function addIndex($index)
+    public function addIndex($index): Index
     {
         if ($index instanceof Index) {
             if ($this->hasIndex($index->getName())) {
@@ -1149,7 +1151,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return \Propel\Generator\Model\Unique
      */
-    public function addUnique($unique)
+    public function addUnique($unique): Unique
     {
         if ($unique instanceof Unique) {
             $unique->setTable($this);
@@ -1170,7 +1172,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return \Propel\Generator\Config\GeneratorConfigInterface|null
      */
-    public function getGeneratorConfig()
+    public function getGeneratorConfig(): ?GeneratorConfigInterface
     {
         return $this->database->getGeneratorConfig();
     }
@@ -1180,7 +1182,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return bool
      */
-    public function hasAdditionalBuilders()
+    public function hasAdditionalBuilders(): bool
     {
         foreach ($this->behaviors as $behavior) {
             if ($behavior->hasAdditionalBuilders()) {
@@ -1198,7 +1200,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return array<\Propel\Generator\Model\Behavior> Array of Behavior objects
      */
-    public function getEarlyBehaviors()
+    public function getEarlyBehaviors(): array
     {
         $behaviors = [];
         foreach ($this->behaviors as $name => $behavior) {
@@ -1215,7 +1217,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return array
      */
-    public function getAdditionalBuilders()
+    public function getAdditionalBuilders(): array
     {
         $additionalBuilders = [];
         foreach ($this->behaviors as $behavior) {
@@ -1230,7 +1232,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         $tableName = '';
         if ($this->hasSchema()) {
@@ -1245,9 +1247,9 @@ class Table extends ScopedMappingModel implements IdMethod
     /**
      * Returns the schema name from this table or from its database.
      *
-     * @return string
+     * @return string|null
      */
-    public function guessSchemaName()
+    public function guessSchemaName(): ?string
     {
         return $this->schema ?: $this->database->getSchema();
     }
@@ -1257,7 +1259,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return bool
      */
-    private function hasSchema()
+    private function hasSchema(): bool
     {
         return $this->database
             && ($this->schema ?: $this->database->getSchema())
@@ -1268,9 +1270,9 @@ class Table extends ScopedMappingModel implements IdMethod
     /**
      * Returns the table description.
      *
-     * @return string
+     * @return string|null
      */
-    public function getDescription()
+    public function getDescription(): ?string
     {
         return $this->description;
     }
@@ -1280,7 +1282,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return bool
      */
-    public function hasDescription()
+    public function hasDescription(): bool
     {
         return (bool)$this->description;
     }
@@ -1292,7 +1294,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return void
      */
-    public function setDescription($description)
+    public function setDescription($description): void
     {
         $this->description = $description;
     }
@@ -1302,7 +1304,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return string
      */
-    public function getPhpName()
+    public function getPhpName(): string
     {
         if ($this->phpName === null) {
             $this->phpName = $this->buildPhpName($this->getStdSeparatedName());
@@ -1318,7 +1320,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return void
      */
-    public function setPhpName($phpName)
+    public function setPhpName($phpName): void
     {
         $this->phpName = $phpName;
     }
@@ -1330,7 +1332,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return string
      */
-    private function buildPhpName($name)
+    private function buildPhpName($name): string
     {
         return NameFactory::generateName(NameFactory::PHP_GENERATOR, [$name, (string)$this->phpNamingMethod]);
     }
@@ -1342,7 +1344,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return string
      */
-    public function getCamelCaseName()
+    public function getCamelCaseName(): string
     {
         return lcfirst($this->getPhpName());
     }
@@ -1352,7 +1354,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return string
      */
-    public function getCommonName()
+    public function getCommonName(): string
     {
         return $this->commonName;
     }
@@ -1364,7 +1366,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return void
      */
-    public function setCommonName($name)
+    public function setCommonName($name): void
     {
         $this->commonName = $this->originCommonName = $name;
     }
@@ -1374,7 +1376,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return string
      */
-    public function getOriginCommonName()
+    public function getOriginCommonName(): string
     {
         return $this->originCommonName;
     }
@@ -1390,7 +1392,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return void
      */
-    public function setDefaultStringFormat($format)
+    public function setDefaultStringFormat($format): void
     {
         $formats = Database::getSupportedStringFormats();
 
@@ -1408,7 +1410,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return string
      */
-    public function getDefaultStringFormat()
+    public function getDefaultStringFormat(): string
     {
         if ($this->defaultStringFormat !== null) {
             return $this->defaultStringFormat;
@@ -1425,7 +1427,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return string
      */
-    public function getIdMethod()
+    public function getIdMethod(): string
     {
         return $this->idMethod;
     }
@@ -1436,7 +1438,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return bool
      */
-    public function isAllowPkInsert()
+    public function isAllowPkInsert(): bool
     {
         return $this->allowPkInsert;
     }
@@ -1448,7 +1450,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return void
      */
-    public function setIdMethod($idMethod)
+    public function setIdMethod($idMethod): void
     {
         $this->idMethod = $idMethod;
     }
@@ -1459,7 +1461,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return bool
      */
-    public function isSkipSql()
+    public function isSkipSql(): bool
     {
         return ($this->skipSql || $this->isAlias() || $this->isForReferenceOnly());
     }
@@ -1471,7 +1473,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return void
      */
-    public function setSkipSql($skip)
+    public function setSkipSql($skip): void
     {
         $this->skipSql = (bool)$skip;
     }
@@ -1482,7 +1484,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return bool
      */
-    public function isReadOnly()
+    public function isReadOnly(): bool
     {
         return $this->readOnly;
     }
@@ -1494,7 +1496,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return void
      */
-    public function setReadOnly($flag = true)
+    public function setReadOnly($flag = true): void
     {
         $this->readOnly = (bool)$flag;
     }
@@ -1504,7 +1506,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return bool
      */
-    public function isReloadOnInsert()
+    public function isReloadOnInsert(): bool
     {
         return $this->reloadOnInsert;
     }
@@ -1516,7 +1518,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return void
      */
-    public function setReloadOnInsert($flag = true)
+    public function setReloadOnInsert($flag = true): void
     {
         $this->reloadOnInsert = (bool)$flag;
     }
@@ -1526,7 +1528,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return bool
      */
-    public function isReloadOnUpdate()
+    public function isReloadOnUpdate(): bool
     {
         return $this->reloadOnUpdate;
     }
@@ -1538,7 +1540,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return void
      */
-    public function setReloadOnUpdate($flag = true)
+    public function setReloadOnUpdate($flag = true): void
     {
         $this->reloadOnUpdate = (bool)$flag;
     }
@@ -1548,7 +1550,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return string
      */
-    public function getAlias()
+    public function getAlias(): string
     {
         return $this->alias;
     }
@@ -1559,7 +1561,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return bool
      */
-    public function isAlias()
+    public function isAlias(): bool
     {
         return $this->alias !== null;
     }
@@ -1572,7 +1574,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return void
      */
-    public function setAlias($alias)
+    public function setAlias($alias): void
     {
         $this->alias = $alias;
     }
@@ -1580,9 +1582,9 @@ class Table extends ScopedMappingModel implements IdMethod
     /**
      * Returns the interface objects of this table will implement.
      *
-     * @return string
+     * @return string|null
      */
-    public function getInterface()
+    public function getInterface(): ?string
     {
         return $this->interface;
     }
@@ -1594,7 +1596,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return void
      */
-    public function setInterface($interface)
+    public function setInterface($interface): void
     {
         $this->interface = $interface;
     }
@@ -1607,7 +1609,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return bool
      */
-    public function isAbstract()
+    public function isAbstract(): bool
     {
         return $this->isAbstract;
     }
@@ -1622,7 +1624,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return void
      */
-    public function setAbstract($flag = true)
+    public function setAbstract($flag = true): void
     {
         $this->isAbstract = (bool)$flag;
     }
@@ -1632,7 +1634,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return array<\Propel\Generator\Model\Column>
      */
-    public function getColumns()
+    public function getColumns(): array
     {
         return $this->columns;
     }
@@ -1642,7 +1644,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return int
      */
-    public function getNumColumns()
+    public function getNumColumns(): int
     {
         return count($this->columns);
     }
@@ -1652,7 +1654,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return int
      */
-    public function getNumLazyLoadColumns()
+    public function getNumLazyLoadColumns(): int
     {
         $count = 0;
         foreach ($this->columns as $col) {
@@ -1669,7 +1671,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return bool
      */
-    public function hasValueSetColumns()
+    public function hasValueSetColumns(): bool
     {
         foreach ($this->columns as $col) {
             if ($col->isValueSetType()) {
@@ -1685,7 +1687,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return array<\Propel\Generator\Model\ForeignKey>
      */
-    public function getForeignKeys()
+    public function getForeignKeys(): array
     {
         return $this->foreignKeys;
     }
@@ -1696,7 +1698,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return array<\Propel\Generator\Model\IdMethodParameter>
      */
-    public function getIdMethodParameters()
+    public function getIdMethodParameters(): array
     {
         return $this->idMethodParameters;
     }
@@ -1706,7 +1708,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return array<\Propel\Generator\Model\Index>
      */
-    public function getIndices()
+    public function getIndices(): array
     {
         return $this->indices;
     }
@@ -1716,7 +1718,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return array<\Propel\Generator\Model\Unique>
      */
-    public function getUnices()
+    public function getUnices(): array
     {
         return $this->unices;
     }
@@ -1729,7 +1731,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return bool
      */
-    public function isUnique(array $keys)
+    public function isUnique(array $keys): bool
     {
         if (count($keys) === 1) {
             $column = $keys[0] instanceof Column ? $keys[0] : $this->getColumn($keys[0]);
@@ -1800,7 +1802,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return bool
      */
-    public function isIndex(array $keys)
+    public function isIndex(array $keys): bool
     {
         if ($this->indices) {
             foreach ($this->indices as $index) {
@@ -1831,7 +1833,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return bool
      */
-    public function hasColumn($column, $caseInsensitive = false)
+    public function hasColumn($column, $caseInsensitive = false): bool
     {
         if ($column instanceof Column) {
             $column = $column->getName();
@@ -1852,7 +1854,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return \Propel\Generator\Model\Column|null
      */
-    public function getColumn($name, $caseInsensitive = false)
+    public function getColumn($name, $caseInsensitive = false): ?Column
     {
         if (!$this->hasColumn($name, $caseInsensitive)) {
             return null;
@@ -1872,7 +1874,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return \Propel\Generator\Model\Column|null
      */
-    public function getColumnByPhpName($phpName)
+    public function getColumnByPhpName($phpName): ?Column
     {
         if (isset($this->columnsByPhpName[$phpName])) {
             return $this->columnsByPhpName[$phpName];
@@ -1889,7 +1891,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return array<\Propel\Generator\Model\ForeignKey>
      */
-    public function getForeignKeysReferencingTable($tableName)
+    public function getForeignKeysReferencingTable($tableName): array
     {
         $matches = [];
         foreach ($this->foreignKeys as $fk) {
@@ -1912,7 +1914,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return array<\Propel\Generator\Model\ForeignKey>
      */
-    public function getColumnForeignKeys($column)
+    public function getColumnForeignKeys($column): array
     {
         $matches = [];
         foreach ($this->foreignKeys as $fk) {
@@ -1931,7 +1933,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return void
      */
-    public function setDatabase(Database $database)
+    public function setDatabase(Database $database): void
     {
         $this->database = $database;
     }
@@ -1941,7 +1943,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return \Propel\Generator\Model\Database|null
      */
-    public function getDatabase()
+    public function getDatabase(): ?Database
     {
         return $this->database;
     }
@@ -1951,7 +1953,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return \Propel\Generator\Platform\PlatformInterface|null
      */
-    public function getPlatform()
+    public function getPlatform(): ?PlatformInterface
     {
         return $this->database ? $this->database->getPlatform() : null;
     }
@@ -1967,7 +1969,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return string
      */
-    public function quoteIdentifier($text)
+    public function quoteIdentifier($text): string
     {
         if (!$this->getPlatform()) {
             throw new RuntimeException('No platform specified. Can not quote without knowing which platform this table\'s database is using.');
@@ -1987,7 +1989,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return bool|null
      */
-    public function isForReferenceOnly()
+    public function isForReferenceOnly(): ?bool
     {
         return $this->forReferenceOnly;
     }
@@ -2000,7 +2002,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return void
      */
-    public function setForReferenceOnly($flag = true)
+    public function setForReferenceOnly($flag = true): void
     {
         $this->forReferenceOnly = (bool)$flag;
     }
@@ -2011,7 +2013,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return array<\Propel\Generator\Model\Column>
      */
-    public function getPrimaryKey()
+    public function getPrimaryKey(): array
     {
         $pk = [];
         foreach ($this->columns as $col) {
@@ -2028,7 +2030,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return bool
      */
-    public function hasPrimaryKey()
+    public function hasPrimaryKey(): bool
     {
         return count($this->getPrimaryKey()) > 0;
     }
@@ -2038,7 +2040,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return bool
      */
-    public function hasCompositePrimaryKey()
+    public function hasCompositePrimaryKey(): bool
     {
         return count($this->getPrimaryKey()) > 1;
     }
@@ -2050,7 +2052,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return \Propel\Generator\Model\Column|null
      */
-    public function getFirstPrimaryKeyColumn()
+    public function getFirstPrimaryKeyColumn(): ?Column
     {
         foreach ($this->columns as $col) {
             if ($col->isPrimaryKey()) {
@@ -2082,7 +2084,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return bool
      */
-    public function hasAutoIncrementPrimaryKey()
+    public function hasAutoIncrementPrimaryKey(): bool
     {
         return $this->getAutoIncrementPrimaryKey() !== null;
     }
@@ -2092,7 +2094,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return \Propel\Generator\Model\Column|null
      */
-    public function getAutoIncrementPrimaryKey()
+    public function getAutoIncrementPrimaryKey(): ?Column
     {
         if ($this->getIdMethod() !== IdMethod::NO_ID_METHOD) {
             foreach ($this->getPrimaryKey() as $pk) {
@@ -2111,7 +2113,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return bool
      */
-    public function getIsCrossRef()
+    public function getIsCrossRef(): bool
     {
         return $this->isCrossRef;
     }
@@ -2121,7 +2123,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return bool
      */
-    public function isCrossRef()
+    public function isCrossRef(): bool
     {
         return $this->isCrossRef;
     }
@@ -2133,7 +2135,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return void
      */
-    public function setIsCrossRef($flag = true)
+    public function setIsCrossRef($flag = true): void
     {
         $this->setCrossRef($flag);
     }
@@ -2145,7 +2147,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return void
      */
-    public function setCrossRef($flag = true)
+    public function setCrossRef($flag = true): void
     {
         $this->isCrossRef = (bool)$flag;
     }
@@ -2155,7 +2157,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return bool
      */
-    public function hasForeignKeys()
+    public function hasForeignKeys(): bool
     {
         return count($this->foreignKeys) !== 0;
     }
@@ -2165,7 +2167,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return bool
      */
-    public function hasCrossForeignKeys()
+    public function hasCrossForeignKeys(): bool
     {
         return count($this->getCrossFks()) !== 0;
     }
@@ -2175,7 +2177,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return string
      */
-    public function getPhpNamingMethod()
+    public function getPhpNamingMethod(): string
     {
         return $this->phpNamingMethod;
     }
@@ -2187,7 +2189,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return void
      */
-    public function setPhpNamingMethod($phpNamingMethod)
+    public function setPhpNamingMethod($phpNamingMethod): void
     {
         $this->phpNamingMethod = $phpNamingMethod;
     }
@@ -2199,7 +2201,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return void
      */
-    public function setDefaultAccessorVisibility($defaultAccessorVisibility)
+    public function setDefaultAccessorVisibility($defaultAccessorVisibility): void
     {
         $this->defaultAccessorVisibility = $defaultAccessorVisibility;
     }
@@ -2209,7 +2211,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return string
      */
-    public function getDefaultAccessorVisibility()
+    public function getDefaultAccessorVisibility(): string
     {
         return $this->defaultAccessorVisibility;
     }
@@ -2221,7 +2223,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return void
      */
-    public function setDefaultMutatorVisibility($defaultMutatorVisibility)
+    public function setDefaultMutatorVisibility($defaultMutatorVisibility): void
     {
         $this->defaultMutatorVisibility = $defaultMutatorVisibility;
     }
@@ -2231,7 +2233,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return string
      */
-    public function getDefaultMutatorVisibility()
+    public function getDefaultMutatorVisibility(): string
     {
         return $this->defaultMutatorVisibility;
     }
@@ -2244,7 +2246,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return bool
      */
-    public function isIdentifierQuotingEnabled()
+    public function isIdentifierQuotingEnabled(): bool
     {
         return ($this->identifierQuoting !== null || !$this->database) ? $this->identifierQuoting : $this->database->isIdentifierQuotingEnabled();
     }
@@ -2252,7 +2254,7 @@ class Table extends ScopedMappingModel implements IdMethod
     /**
      * @return bool|null
      */
-    public function getIdentifierQuoting()
+    public function getIdentifierQuoting(): ?bool
     {
         return $this->identifierQuoting;
     }
@@ -2262,7 +2264,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return void
      */
-    public function setIdentifierQuoting($identifierQuoting)
+    public function setIdentifierQuoting($identifierQuoting): void
     {
         $this->identifierQuoting = $identifierQuoting;
     }

--- a/src/Propel/Generator/Model/Table.php
+++ b/src/Propel/Generator/Model/Table.php
@@ -254,9 +254,9 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * If autoPrefix is set. Otherwise get the common name.
      *
-     * @return string
+     * @return string|null
      */
-    private function getStdSeparatedName(): string
+    private function getStdSeparatedName(): ?string
     {
         if ($this->schema && $this->getBuildProperty('generator.schema.autoPrefix')) {
             return $this->schema . NameGeneratorInterface::STD_SEPARATOR_CHAR . $this->getCommonName();
@@ -1352,9 +1352,9 @@ class Table extends ScopedMappingModel implements IdMethod
     /**
      * Returns the common name (without schema name), but with table prefix if defined.
      *
-     * @return string
+     * @return string|null
      */
-    public function getCommonName(): string
+    public function getCommonName(): ?string
     {
         return $this->commonName;
     }
@@ -1374,9 +1374,9 @@ class Table extends ScopedMappingModel implements IdMethod
     /**
      * Returns the unmodified common name (not modified by table prefix).
      *
-     * @return string
+     * @return string|null
      */
-    public function getOriginCommonName(): string
+    public function getOriginCommonName(): ?string
     {
         return $this->originCommonName;
     }
@@ -1548,9 +1548,9 @@ class Table extends ScopedMappingModel implements IdMethod
     /**
      * Returns the PHP name of an active record object this entry references.
      *
-     * @return string
+     * @return string|null
      */
-    public function getAlias(): string
+    public function getAlias(): ?string
     {
         return $this->alias;
     }
@@ -2175,9 +2175,9 @@ class Table extends ScopedMappingModel implements IdMethod
     /**
      * Returns the PHP naming method.
      *
-     * @return string
+     * @return string|null
      */
-    public function getPhpNamingMethod(): string
+    public function getPhpNamingMethod(): ?string
     {
         return $this->phpNamingMethod;
     }
@@ -2248,7 +2248,7 @@ class Table extends ScopedMappingModel implements IdMethod
      */
     public function isIdentifierQuotingEnabled(): bool
     {
-        return ($this->identifierQuoting !== null || !$this->database) ? $this->identifierQuoting : $this->database->isIdentifierQuotingEnabled();
+        return ($this->identifierQuoting !== null || !$this->database) ? (bool)$this->identifierQuoting : $this->database->isIdentifierQuotingEnabled();
     }
 
     /**

--- a/src/Propel/Generator/Model/Unique.php
+++ b/src/Propel/Generator/Model/Unique.php
@@ -27,7 +27,7 @@ class Unique extends Index
      *
      * @return bool
      */
-    public function isUnique()
+    public function isUnique(): bool
     {
         return true;
     }

--- a/src/Propel/Generator/Model/VendorInfo.php
+++ b/src/Propel/Generator/Model/VendorInfo.php
@@ -52,7 +52,7 @@ class VendorInfo extends MappingModel
      *
      * @return void
      */
-    public function setType($type)
+    public function setType($type): void
     {
         $this->type = $type;
     }
@@ -62,7 +62,7 @@ class VendorInfo extends MappingModel
      *
      * @return string
      */
-    public function getType()
+    public function getType(): string
     {
         return $this->type;
     }
@@ -75,7 +75,7 @@ class VendorInfo extends MappingModel
      *
      * @return void
      */
-    public function setParameter($name, $value)
+    public function setParameter($name, $value): void
     {
         $this->parameters[$name] = $value;
     }
@@ -99,7 +99,7 @@ class VendorInfo extends MappingModel
      *
      * @return bool
      */
-    public function hasParameter($name)
+    public function hasParameter($name): bool
     {
         return isset($this->parameters[$name]);
     }
@@ -111,7 +111,7 @@ class VendorInfo extends MappingModel
      *
      * @return void
      */
-    public function setParameters(array $parameters = [])
+    public function setParameters(array $parameters = []): void
     {
         $this->parameters = $parameters;
     }
@@ -122,7 +122,7 @@ class VendorInfo extends MappingModel
      *
      * @return array
      */
-    public function getParameters()
+    public function getParameters(): array
     {
         return $this->parameters;
     }
@@ -132,7 +132,7 @@ class VendorInfo extends MappingModel
      *
      * @return bool
      */
-    public function isEmpty()
+    public function isEmpty(): bool
     {
         return !$this->parameters;
     }
@@ -142,9 +142,9 @@ class VendorInfo extends MappingModel
      *
      * @param \Propel\Generator\Model\VendorInfo $info
      *
-     * @return \Propel\Generator\Model\VendorInfo
+     * @return self
      */
-    public function getMergedVendorInfo(VendorInfo $info)
+    public function getMergedVendorInfo(VendorInfo $info): self
     {
         $params = array_merge($this->parameters, $info->getParameters());
 
@@ -157,7 +157,7 @@ class VendorInfo extends MappingModel
     /**
      * @return void
      */
-    protected function setupObject()
+    protected function setupObject(): void
     {
         $this->type = $this->getAttribute('type');
     }

--- a/src/Propel/Generator/Model/VendorInfo.php
+++ b/src/Propel/Generator/Model/VendorInfo.php
@@ -60,9 +60,9 @@ class VendorInfo extends MappingModel
     /**
      * Returns the RDBMS type for this vendor specific information.
      *
-     * @return string
+     * @return string|null
      */
-    public function getType(): string
+    public function getType(): ?string
     {
         return $this->type;
     }

--- a/src/Propel/Generator/Platform/DefaultPlatform.php
+++ b/src/Propel/Generator/Platform/DefaultPlatform.php
@@ -259,9 +259,9 @@ class DefaultPlatform implements PlatformInterface
      *
      * @param \Propel\Generator\Model\Table $table
      *
-     * @return string
+     * @return string|null
      */
-    public function getSequenceName(Table $table): string
+    public function getSequenceName(Table $table): ?string
     {
         static $longNamesMap = [];
         $result = null;
@@ -278,7 +278,7 @@ class DefaultPlatform implements PlatformInterface
                     $result = substr($table->getName(), 0, $maxIdentifierLength - 4) . '_SEQ';
                 }
             } else {
-                $result = substr($idMethodParams[0]->getValue(), 0, $maxIdentifierLength);
+                $result = (string)substr($idMethodParams[0]->getValue(), 0, $maxIdentifierLength);
             }
         }
 

--- a/src/Propel/Generator/Platform/DefaultPlatform.php
+++ b/src/Propel/Generator/Platform/DefaultPlatform.php
@@ -1358,9 +1358,9 @@ ALTER TABLE %s ADD
     }
 
     /**
-     * Returns the Boolean value for the RDBMS.
+     * Returns the boolean value for the RDBMS.
      *
-     * This value should match the Boolean value that is set
+     * This value should match the boolean value that is set
      * when using Propel's PreparedStatement::setBoolean().
      *
      * This function is used to set default column values when building

--- a/src/Propel/Generator/Platform/DefaultPlatform.php
+++ b/src/Propel/Generator/Platform/DefaultPlatform.php
@@ -71,7 +71,7 @@ class DefaultPlatform implements PlatformInterface
      *
      * @return string
      */
-    public function getObjectBuilderClass($type)
+    public function getObjectBuilderClass($type): string
     {
         return '';
     }
@@ -83,7 +83,7 @@ class DefaultPlatform implements PlatformInterface
      *
      * @return void
      */
-    public function setConnection(?ConnectionInterface $con = null)
+    public function setConnection(?ConnectionInterface $con = null): void
     {
         $this->con = $con;
     }
@@ -91,9 +91,9 @@ class DefaultPlatform implements PlatformInterface
     /**
      * Returns the database connection to use for this Platform class.
      *
-     * @return \Propel\Runtime\Connection\ConnectionInterface
+     * @return \Propel\Runtime\Connection\ConnectionInterface|null
      */
-    public function getConnection()
+    public function getConnection(): ?ConnectionInterface
     {
         return $this->con;
     }
@@ -101,7 +101,7 @@ class DefaultPlatform implements PlatformInterface
     /**
      * @return bool
      */
-    public function isIdentifierQuotingEnabled()
+    public function isIdentifierQuotingEnabled(): bool
     {
         return $this->identifierQuoting;
     }
@@ -111,7 +111,7 @@ class DefaultPlatform implements PlatformInterface
      *
      * @return void
      */
-    public function setIdentifierQuoting($enabled)
+    public function setIdentifierQuoting($enabled): void
     {
         $this->identifierQuoting = $enabled;
     }
@@ -123,7 +123,7 @@ class DefaultPlatform implements PlatformInterface
      *
      * @return void
      */
-    public function setGeneratorConfig(GeneratorConfigInterface $generatorConfig)
+    public function setGeneratorConfig(GeneratorConfigInterface $generatorConfig): void
     {
     }
 
@@ -132,7 +132,7 @@ class DefaultPlatform implements PlatformInterface
      *
      * @return void
      */
-    protected function initialize()
+    protected function initialize(): void
     {
         $this->schemaDomainMap = [];
         foreach (PropelTypes::getPropelTypes() as $type) {
@@ -153,7 +153,7 @@ class DefaultPlatform implements PlatformInterface
      *
      * @return void
      */
-    protected function setSchemaDomainMapping(Domain $domain)
+    protected function setSchemaDomainMapping(Domain $domain): void
     {
         $this->schemaDomainMap[$domain->getType()] = $domain;
     }
@@ -164,7 +164,7 @@ class DefaultPlatform implements PlatformInterface
      *
      * @return string
      */
-    public function getDatabaseType()
+    public function getDatabaseType(): string
     {
         $reflClass = new ReflectionClass($this);
         $clazz = $reflClass->getShortName();
@@ -178,7 +178,7 @@ class DefaultPlatform implements PlatformInterface
      *
      * @return int The max column length
      */
-    public function getMaxColumnNameLength()
+    public function getMaxColumnNameLength(): int
     {
         return 64;
     }
@@ -188,7 +188,7 @@ class DefaultPlatform implements PlatformInterface
      *
      * @return string
      */
-    public function getSchemaDelimiter()
+    public function getSchemaDelimiter(): string
     {
         return '.';
     }
@@ -198,7 +198,7 @@ class DefaultPlatform implements PlatformInterface
      *
      * @return string The native IdMethod (PlatformInterface:IDENTITY, PlatformInterface::SEQUENCE).
      */
-    public function getNativeIdMethod()
+    public function getNativeIdMethod(): string
     {
         return PlatformInterface::IDENTITY;
     }
@@ -206,7 +206,7 @@ class DefaultPlatform implements PlatformInterface
     /**
      * @return bool
      */
-    public function isNativeIdMethodAutoIncrement()
+    public function isNativeIdMethodAutoIncrement(): bool
     {
         return $this->getNativeIdMethod() === PlatformInterface::IDENTITY;
     }
@@ -220,7 +220,7 @@ class DefaultPlatform implements PlatformInterface
      *
      * @return \Propel\Generator\Model\Domain
      */
-    public function getDomainForType($propelType)
+    public function getDomainForType($propelType): Domain
     {
         if (!isset($this->schemaDomainMap[$propelType])) {
             throw new EngineException(sprintf('Cannot map unknown Propel type %s to native database type.', var_export($propelType, true)));
@@ -236,7 +236,7 @@ class DefaultPlatform implements PlatformInterface
      *
      * @return string
      */
-    public function getNullString($notNull)
+    public function getNullString(bool $notNull): string
     {
         return $notNull ? 'NOT NULL' : '';
     }
@@ -246,7 +246,7 @@ class DefaultPlatform implements PlatformInterface
      *
      * @return string
      */
-    public function getAutoIncrement()
+    public function getAutoIncrement(): string
     {
         return 'IDENTITY';
     }
@@ -261,7 +261,7 @@ class DefaultPlatform implements PlatformInterface
      *
      * @return string
      */
-    public function getSequenceName(Table $table)
+    public function getSequenceName(Table $table): string
     {
         static $longNamesMap = [];
         $result = null;
@@ -293,7 +293,7 @@ class DefaultPlatform implements PlatformInterface
      *
      * @return string
      */
-    public function getAddTablesDDL(Database $database)
+    public function getAddTablesDDL(Database $database): string
     {
         $ret = $this->getBeginDDL();
         foreach ($database->getTablesForSql() as $table) {
@@ -316,7 +316,7 @@ class DefaultPlatform implements PlatformInterface
      *
      * @return string
      */
-    public function getBeginDDL()
+    public function getBeginDDL(): string
     {
         return '';
     }
@@ -326,7 +326,7 @@ class DefaultPlatform implements PlatformInterface
      *
      * @return string
      */
-    public function getEndDDL()
+    public function getEndDDL(): string
     {
         return '';
     }
@@ -338,7 +338,7 @@ class DefaultPlatform implements PlatformInterface
      *
      * @return string
      */
-    public function getDropTableDDL(Table $table)
+    public function getDropTableDDL(Table $table): string
     {
         return "
 DROP TABLE IF EXISTS " . $this->quoteIdentifier($table->getName()) . ";
@@ -353,7 +353,7 @@ DROP TABLE IF EXISTS " . $this->quoteIdentifier($table->getName()) . ";
      *
      * @return string
      */
-    public function getAddTableDDL(Table $table)
+    public function getAddTableDDL(Table $table): string
     {
         $tableDescription = $table->hasDescription() ? $this->getCommentLineDDL($table->getDescription()) : '';
 
@@ -396,7 +396,7 @@ DROP TABLE IF EXISTS " . $this->quoteIdentifier($table->getName()) . ";
      *
      * @return string
      */
-    public function getColumnDDL(Column $col)
+    public function getColumnDDL(Column $col): string
     {
         $domain = $col->getDomain();
 
@@ -427,7 +427,7 @@ DROP TABLE IF EXISTS " . $this->quoteIdentifier($table->getName()) . ";
      *
      * @return string
      */
-    public function getColumnDefaultValueDDL(Column $col)
+    public function getColumnDefaultValueDDL(Column $col): string
     {
         $default = '';
         $defaultValue = $col->getDefaultValue();
@@ -479,7 +479,7 @@ DROP TABLE IF EXISTS " . $this->quoteIdentifier($table->getName()) . ";
      *
      * @return string
      */
-    public function getColumnListDDL($columns, $delimiter = ',')
+    public function getColumnListDDL($columns, $delimiter = ','): string
     {
         $list = [];
         foreach ($columns as $column) {
@@ -497,7 +497,7 @@ DROP TABLE IF EXISTS " . $this->quoteIdentifier($table->getName()) . ";
      *
      * @return string
      */
-    public function getPrimaryKeyName(Table $table)
+    public function getPrimaryKeyName(Table $table): string
     {
         $tableName = $table->getCommonName();
 
@@ -511,7 +511,7 @@ DROP TABLE IF EXISTS " . $this->quoteIdentifier($table->getName()) . ";
      *
      * @return string
      */
-    public function getPrimaryKeyDDL(Table $table)
+    public function getPrimaryKeyDDL(Table $table): string
     {
         if ($table->hasPrimaryKey()) {
             return 'PRIMARY KEY (' . $this->getColumnListDDL($table->getPrimaryKey()) . ')';
@@ -527,7 +527,7 @@ DROP TABLE IF EXISTS " . $this->quoteIdentifier($table->getName()) . ";
      *
      * @return string
      */
-    public function getDropPrimaryKeyDDL(Table $table)
+    public function getDropPrimaryKeyDDL(Table $table): string
     {
         if (!$table->hasPrimaryKey()) {
             return '';
@@ -551,7 +551,7 @@ ALTER TABLE %s DROP CONSTRAINT %s;
      *
      * @return string
      */
-    public function getAddPrimaryKeyDDL(Table $table)
+    public function getAddPrimaryKeyDDL(Table $table): string
     {
         if (!$table->hasPrimaryKey()) {
             return '';
@@ -575,7 +575,7 @@ ALTER TABLE %s ADD %s;
      *
      * @return string
      */
-    public function getAddIndicesDDL(Table $table)
+    public function getAddIndicesDDL(Table $table): string
     {
         $ret = '';
         foreach ($table->getIndices() as $fk) {
@@ -592,7 +592,7 @@ ALTER TABLE %s ADD %s;
      *
      * @return string
      */
-    public function getAddIndexDDL(Index $index)
+    public function getAddIndexDDL(Index $index): string
     {
         $pattern = "
 CREATE %sINDEX %s ON %s (%s);
@@ -614,7 +614,7 @@ CREATE %sINDEX %s ON %s (%s);
      *
      * @return string
      */
-    public function getDropIndexDDL(Index $index)
+    public function getDropIndexDDL(Index $index): string
     {
         $pattern = "
 DROP INDEX %s;
@@ -633,7 +633,7 @@ DROP INDEX %s;
      *
      * @return string
      */
-    public function getIndexDDL(Index $index)
+    public function getIndexDDL(Index $index): string
     {
         return sprintf(
             '%sINDEX %s (%s)',
@@ -650,7 +650,7 @@ DROP INDEX %s;
      *
      * @return string
      */
-    public function getUniqueDDL(Unique $unique)
+    public function getUniqueDDL(Unique $unique): string
     {
         return sprintf('UNIQUE (%s)', $this->getColumnListDDL($unique->getColumnObjects()));
     }
@@ -662,7 +662,7 @@ DROP INDEX %s;
      *
      * @return string
      */
-    public function getAddForeignKeysDDL(Table $table)
+    public function getAddForeignKeysDDL(Table $table): string
     {
         $ret = '';
         foreach ($table->getForeignKeys() as $fk) {
@@ -679,7 +679,7 @@ DROP INDEX %s;
      *
      * @return string
      */
-    public function getAddForeignKeyDDL(ForeignKey $fk)
+    public function getAddForeignKeyDDL(ForeignKey $fk): string
     {
         if ($fk->isSkipSql() || $fk->isPolymorphic()) {
             return '';
@@ -702,7 +702,7 @@ ALTER TABLE %s ADD %s;
      *
      * @return string|null
      */
-    public function getDropForeignKeyDDL(ForeignKey $fk)
+    public function getDropForeignKeyDDL(ForeignKey $fk): ?string
     {
         if ($fk->isSkipSql() || $fk->isPolymorphic()) {
             return null;
@@ -725,7 +725,7 @@ ALTER TABLE %s DROP CONSTRAINT %s;
      *
      * @return string
      */
-    public function getForeignKeyDDL(ForeignKey $fk)
+    public function getForeignKeyDDL(ForeignKey $fk): string
     {
         if ($fk->isSkipSql() || $fk->isPolymorphic()) {
             return '';
@@ -758,7 +758,7 @@ ALTER TABLE %s DROP CONSTRAINT %s;
      *
      * @return string
      */
-    public function getCommentLineDDL($comment)
+    public function getCommentLineDDL($comment): string
     {
         $pattern = "-- %s
 ";
@@ -771,7 +771,7 @@ ALTER TABLE %s DROP CONSTRAINT %s;
      *
      * @return string
      */
-    public function getCommentBlockDDL($comment)
+    public function getCommentBlockDDL($comment): string
     {
         $pattern = "
 -----------------------------------------------------------------------
@@ -790,7 +790,7 @@ ALTER TABLE %s DROP CONSTRAINT %s;
      *
      * @return string
      */
-    public function getModifyDatabaseDDL(DatabaseDiff $databaseDiff)
+    public function getModifyDatabaseDDL(DatabaseDiff $databaseDiff): string
     {
         $ret = '';
         foreach ($databaseDiff->getRemovedTables() as $table) {
@@ -829,7 +829,7 @@ ALTER TABLE %s DROP CONSTRAINT %s;
      *
      * @return string
      */
-    public function getRenameTableDDL($fromTableName, $toTableName)
+    public function getRenameTableDDL($fromTableName, $toTableName): string
     {
         $pattern = "
 ALTER TABLE %s RENAME TO %s;
@@ -850,7 +850,7 @@ ALTER TABLE %s RENAME TO %s;
      *
      * @return string
      */
-    public function getModifyTableDDL(TableDiff $tableDiff)
+    public function getModifyTableDDL(TableDiff $tableDiff): string
     {
         $ret = '';
 
@@ -959,7 +959,7 @@ ALTER TABLE %s%s;
      *
      * @return string
      */
-    public function getModifyTableColumnsDDL(TableDiff $tableDiff)
+    public function getModifyTableColumnsDDL(TableDiff $tableDiff): string
     {
         $ret = '';
 
@@ -990,7 +990,7 @@ ALTER TABLE %s%s;
      *
      * @return string
      */
-    public function getModifyTablePrimaryKeyDDL(TableDiff $tableDiff)
+    public function getModifyTablePrimaryKeyDDL(TableDiff $tableDiff): string
     {
         $ret = '';
 
@@ -1010,7 +1010,7 @@ ALTER TABLE %s%s;
      *
      * @return string
      */
-    public function getModifyTableIndicesDDL(TableDiff $tableDiff)
+    public function getModifyTableIndicesDDL(TableDiff $tableDiff): string
     {
         $ret = '';
 
@@ -1039,7 +1039,7 @@ ALTER TABLE %s%s;
      *
      * @return string
      */
-    public function getModifyTableForeignKeysDDL(TableDiff $tableDiff)
+    public function getModifyTableForeignKeysDDL(TableDiff $tableDiff): string
     {
         $ret = '';
 
@@ -1067,7 +1067,7 @@ ALTER TABLE %s%s;
      *
      * @return string
      */
-    public function getRemoveColumnDDL(Column $column)
+    public function getRemoveColumnDDL(Column $column): string
     {
         $pattern = "
 ALTER TABLE %s DROP COLUMN %s;
@@ -1088,7 +1088,7 @@ ALTER TABLE %s DROP COLUMN %s;
      *
      * @return string
      */
-    public function getRenameColumnDDL(Column $fromColumn, Column $toColumn)
+    public function getRenameColumnDDL(Column $fromColumn, Column $toColumn): string
     {
         $pattern = "
 ALTER TABLE %s RENAME COLUMN %s TO %s;
@@ -1109,7 +1109,7 @@ ALTER TABLE %s RENAME COLUMN %s TO %s;
      *
      * @return string
      */
-    public function getModifyColumnDDL(ColumnDiff $columnDiff)
+    public function getModifyColumnDDL(ColumnDiff $columnDiff): string
     {
         $toColumn = $columnDiff->getToColumn();
         $pattern = "
@@ -1130,7 +1130,7 @@ ALTER TABLE %s MODIFY %s;
      *
      * @return string
      */
-    public function getModifyColumnsDDL($columnDiffs)
+    public function getModifyColumnsDDL($columnDiffs): string
     {
         $lines = [];
         $table = null;
@@ -1166,7 +1166,7 @@ ALTER TABLE %s MODIFY
      *
      * @return string
      */
-    public function getAddColumnDDL(Column $column)
+    public function getAddColumnDDL(Column $column): string
     {
         $pattern = "
 ALTER TABLE %s ADD %s;
@@ -1186,7 +1186,7 @@ ALTER TABLE %s ADD %s;
      *
      * @return string
      */
-    public function getAddColumnsDDL($columns)
+    public function getAddColumnsDDL($columns): string
     {
         $lines = [];
         $table = null;
@@ -1221,7 +1221,7 @@ ALTER TABLE %s ADD
      *
      * @return bool True if the type has a size attribute
      */
-    public function hasSize($sqlType)
+    public function hasSize(string $sqlType): bool
     {
         return true;
     }
@@ -1233,7 +1233,7 @@ ALTER TABLE %s ADD
      *
      * @return bool True if the type has a scale attribute
      */
-    public function hasScale($sqlType)
+    public function hasScale(string $sqlType): bool
     {
         return true;
     }
@@ -1245,13 +1245,14 @@ ALTER TABLE %s ADD
      *
      * @return string
      */
-    public function quote($text)
+    public function quote($text): string
     {
-        if ($con = $this->getConnection()) {
+        $con = $this->getConnection();
+        if ($con) {
             return $con->quote($text);
-        } else {
-            return "'" . $this->disconnectedEscapeText($text) . "'";
         }
+
+        return "'" . $this->disconnectedEscapeText($text) . "'";
     }
 
     /**
@@ -1264,7 +1265,7 @@ ALTER TABLE %s ADD
      *
      * @return string
      */
-    protected function disconnectedEscapeText($text)
+    protected function disconnectedEscapeText($text): string
     {
         return str_replace("'", "''", $text);
     }
@@ -1277,7 +1278,7 @@ ALTER TABLE %s ADD
      *
      * @return string Quoted identifier.
      */
-    protected function quoteIdentifier($text)
+    protected function quoteIdentifier($text): string
     {
         return $this->isIdentifierQuotingEnabled() ? $this->doQuoting($text) : $text;
     }
@@ -1285,7 +1286,7 @@ ALTER TABLE %s ADD
     /**
      * @inheritDoc
      */
-    public function doQuoting($text)
+    public function doQuoting(string $text): string
     {
         return '"' . strtr($text, ['.' => '"."']) . '"';
     }
@@ -1295,7 +1296,7 @@ ALTER TABLE %s ADD
      *
      * @return bool
      */
-    public function supportsNativeDeleteTrigger()
+    public function supportsNativeDeleteTrigger(): bool
     {
         return false;
     }
@@ -1305,7 +1306,7 @@ ALTER TABLE %s ADD
      *
      * @return bool
      */
-    public function supportsInsertNullPk()
+    public function supportsInsertNullPk(): bool
     {
         return true;
     }
@@ -1313,7 +1314,7 @@ ALTER TABLE %s ADD
     /**
      * @return bool
      */
-    public function supportsIndexSize()
+    public function supportsIndexSize(): bool
     {
         return false;
     }
@@ -1323,7 +1324,7 @@ ALTER TABLE %s ADD
      *
      * @return bool
      */
-    public function hasStreamBlobImpl()
+    public function hasStreamBlobImpl(): bool
     {
         return false;
     }
@@ -1333,7 +1334,7 @@ ALTER TABLE %s ADD
      *
      * @return bool
      */
-    public function supportsSchemas()
+    public function supportsSchemas(): bool
     {
         return false;
     }
@@ -1343,7 +1344,7 @@ ALTER TABLE %s ADD
      *
      * @return bool
      */
-    public function supportsMigrations()
+    public function supportsMigrations(): bool
     {
         return true;
     }
@@ -1351,7 +1352,7 @@ ALTER TABLE %s ADD
     /**
      * @return bool
      */
-    public function supportsVarcharWithoutSize()
+    public function supportsVarcharWithoutSize(): bool
     {
         return false;
     }
@@ -1369,7 +1370,7 @@ ALTER TABLE %s ADD
      *
      * @return string
      */
-    public function getBooleanString($value)
+    public function getBooleanString($value): string
     {
         if (is_bool($value) && $value === true) {
             return '1';
@@ -1394,7 +1395,7 @@ ALTER TABLE %s ADD
      *
      * @return string|null
      */
-    public function getPhpArrayString($stringValue)
+    public function getPhpArrayString($stringValue): ?string
     {
         $stringValue = trim($stringValue);
         if (!$stringValue) {
@@ -1419,7 +1420,7 @@ ALTER TABLE %s ADD
      *
      * @return string
      */
-    public function getTimestampFormatter()
+    public function getTimestampFormatter(): string
     {
         return 'Y-m-d H:i:s.u';
     }
@@ -1429,7 +1430,7 @@ ALTER TABLE %s ADD
      *
      * @return string
      */
-    public function getTimeFormatter()
+    public function getTimeFormatter(): string
     {
         return 'H:i:s.u';
     }
@@ -1439,7 +1440,7 @@ ALTER TABLE %s ADD
      *
      * @return string
      */
-    public function getDateFormatter()
+    public function getDateFormatter(): string
     {
         return 'Y-m-d';
     }
@@ -1476,7 +1477,7 @@ ALTER TABLE %s ADD
      *
      * @return string
      */
-    public function getColumnBindingPHP(Column $column, $identifier, $columnValueAccessor, $tab = '            ')
+    public function getColumnBindingPHP(Column $column, $identifier, $columnValueAccessor, $tab = '            '): string
     {
         $script = '';
         if ($column->getType() === PropelTypes::DATE) {
@@ -1541,7 +1542,7 @@ if (is_resource($columnValueAccessor)) {
      *
      * @return array<int> type indexed array of integers
      */
-    public function getDefaultTypeSizes()
+    public function getDefaultTypeSizes(): array
     {
         return [];
     }
@@ -1553,11 +1554,11 @@ if (is_resource($columnValueAccessor)) {
      *
      * @return int
      */
-    public function getDefaultTypeSize($type)
+    public function getDefaultTypeSize($type): int
     {
         $sizes = $this->getDefaultTypeSizes();
 
-        return $sizes[strtolower($type)] ?? null;
+        return $sizes[strtolower($type)] ?? 0;
     }
 
     /**
@@ -1570,7 +1571,7 @@ if (is_resource($columnValueAccessor)) {
      *
      * @return void
      */
-    public function normalizeTable(Table $table)
+    public function normalizeTable(Table $table): void
     {
         if ($table->hasForeignKeys()) {
             foreach ($table->getForeignKeys() as $fk) {

--- a/src/Propel/Generator/Platform/MssqlPlatform.php
+++ b/src/Propel/Generator/Platform/MssqlPlatform.php
@@ -34,7 +34,7 @@ class MssqlPlatform extends DefaultPlatform
      *
      * @return void
      */
-    protected function initialize()
+    protected function initialize(): void
     {
         parent::initialize();
 
@@ -61,7 +61,7 @@ class MssqlPlatform extends DefaultPlatform
     /**
      * @return int
      */
-    public function getMaxColumnNameLength()
+    public function getMaxColumnNameLength(): int
     {
         return 128;
     }
@@ -71,7 +71,7 @@ class MssqlPlatform extends DefaultPlatform
      *
      * @return string
      */
-    public function getNullString($notNull)
+    public function getNullString(bool $notNull): string
     {
         return $notNull ? 'NOT NULL' : 'NULL';
     }
@@ -79,7 +79,7 @@ class MssqlPlatform extends DefaultPlatform
     /**
      * @return bool
      */
-    public function supportsNativeDeleteTrigger()
+    public function supportsNativeDeleteTrigger(): bool
     {
         return true;
     }
@@ -87,7 +87,7 @@ class MssqlPlatform extends DefaultPlatform
     /**
      * @return bool
      */
-    public function supportsInsertNullPk()
+    public function supportsInsertNullPk(): bool
     {
         return false;
     }
@@ -102,7 +102,7 @@ class MssqlPlatform extends DefaultPlatform
      *
      * @return string
      */
-    public function getAddTablesDDL(Database $database)
+    public function getAddTablesDDL(Database $database): string
     {
         $ret = $this->getBeginDDL();
         foreach ($database->getTablesForSql() as $table) {
@@ -127,7 +127,7 @@ class MssqlPlatform extends DefaultPlatform
      *
      * @return string
      */
-    public function getDropTableDDL(Table $table)
+    public function getDropTableDDL(Table $table): string
     {
         $ret = '';
         foreach ($table->getForeignKeys() as $fk) {
@@ -174,7 +174,7 @@ END
      *
      * @return string
      */
-    public function getPrimaryKeyDDL(Table $table)
+    public function getPrimaryKeyDDL(Table $table): string
     {
         if ($table->hasPrimaryKey()) {
             $pattern = 'CONSTRAINT %s PRIMARY KEY (%s)';
@@ -194,7 +194,7 @@ END
      *
      * @return string
      */
-    public function getAddForeignKeyDDL(ForeignKey $fk)
+    public function getAddForeignKeyDDL(ForeignKey $fk): string
     {
         if ($fk->isSkipSql() || $fk->isPolymorphic()) {
             return '';
@@ -221,7 +221,7 @@ END
      *
      * @return string
      */
-    public function getUniqueDDL(Unique $unique)
+    public function getUniqueDDL(Unique $unique): string
     {
         $pattern = 'CONSTRAINT %s UNIQUE NONCLUSTERED (%s) ON [PRIMARY]';
 
@@ -237,7 +237,7 @@ END
      *
      * @return string
      */
-    public function getForeignKeyDDL(ForeignKey $fk)
+    public function getForeignKeyDDL(ForeignKey $fk): string
     {
         if ($fk->isSkipSql() || $fk->isPolymorphic()) {
             return '';
@@ -266,7 +266,7 @@ END
      *
      * @return bool
      */
-    public function supportsSchemas()
+    public function supportsSchemas(): bool
     {
         return true;
     }
@@ -276,7 +276,7 @@ END
      *
      * @return bool
      */
-    public function hasSize($sqlType)
+    public function hasSize(string $sqlType): bool
     {
         $nosize = ['INT', 'TEXT', 'GEOMETRY', 'VARCHAR(MAX)', 'VARBINARY(MAX)', 'SMALLINT', 'DATETIME', 'TINYINT', 'REAL', 'BIGINT'];
 
@@ -286,7 +286,7 @@ END
     /**
      * @inheritDoc
      */
-    public function doQuoting($text)
+    public function doQuoting(string $text): string
     {
         return '[' . strtr($text, ['.' => '].[']) . ']';
     }
@@ -294,7 +294,7 @@ END
     /**
      * @return string
      */
-    public function getTimestampFormatter()
+    public function getTimestampFormatter(): string
     {
         return 'Y-m-d H:i:s';
     }

--- a/src/Propel/Generator/Platform/MysqlPlatform.php
+++ b/src/Propel/Generator/Platform/MysqlPlatform.php
@@ -50,7 +50,7 @@ class MysqlPlatform extends DefaultPlatform
      *
      * @return void
      */
-    protected function initialize()
+    protected function initialize(): void
     {
         parent::initialize();
         $this->setSchemaDomainMapping(new Domain(PropelTypes::BOOLEAN, 'TINYINT', 1));
@@ -73,7 +73,7 @@ class MysqlPlatform extends DefaultPlatform
      *
      * @return void
      */
-    public function setGeneratorConfig(GeneratorConfigInterface $generatorConfig)
+    public function setGeneratorConfig(GeneratorConfigInterface $generatorConfig): void
     {
         parent::setGeneratorConfig($generatorConfig);
         if ($defaultTableEngine = $generatorConfig->get()['database']['adapters']['mysql']['tableType']) {
@@ -91,7 +91,7 @@ class MysqlPlatform extends DefaultPlatform
      *
      * @return void
      */
-    public function setTableEngineKeyword($tableEngineKeyword)
+    public function setTableEngineKeyword($tableEngineKeyword): void
     {
         $this->tableEngineKeyword = $tableEngineKeyword;
     }
@@ -101,7 +101,7 @@ class MysqlPlatform extends DefaultPlatform
      *
      * @return string
      */
-    public function getTableEngineKeyword()
+    public function getTableEngineKeyword(): string
     {
         return $this->tableEngineKeyword;
     }
@@ -113,7 +113,7 @@ class MysqlPlatform extends DefaultPlatform
      *
      * @return void
      */
-    public function setDefaultTableEngine($defaultTableEngine)
+    public function setDefaultTableEngine($defaultTableEngine): void
     {
         $this->defaultTableEngine = $defaultTableEngine;
     }
@@ -123,7 +123,7 @@ class MysqlPlatform extends DefaultPlatform
      *
      * @return string
      */
-    public function getDefaultTableEngine()
+    public function getDefaultTableEngine(): string
     {
         return $this->defaultTableEngine;
     }
@@ -131,7 +131,7 @@ class MysqlPlatform extends DefaultPlatform
     /**
      * @return string
      */
-    public function getAutoIncrement()
+    public function getAutoIncrement(): string
     {
         return 'AUTO_INCREMENT';
     }
@@ -139,7 +139,7 @@ class MysqlPlatform extends DefaultPlatform
     /**
      * @return int
      */
-    public function getMaxColumnNameLength()
+    public function getMaxColumnNameLength(): int
     {
         return 64;
     }
@@ -147,7 +147,7 @@ class MysqlPlatform extends DefaultPlatform
     /**
      * @return bool
      */
-    public function supportsNativeDeleteTrigger()
+    public function supportsNativeDeleteTrigger(): bool
     {
         return strtolower($this->getDefaultTableEngine()) === 'innodb';
     }
@@ -155,7 +155,7 @@ class MysqlPlatform extends DefaultPlatform
     /**
      * @return bool
      */
-    public function supportsIndexSize()
+    public function supportsIndexSize(): bool
     {
         return true;
     }
@@ -165,7 +165,7 @@ class MysqlPlatform extends DefaultPlatform
      *
      * @return bool
      */
-    public function supportsForeignKeys(Table $table)
+    public function supportsForeignKeys(Table $table): bool
     {
         $vendorSpecific = $table->getVendorInfoForType('mysql');
         if ($vendorSpecific->hasParameter('Type')) {
@@ -184,7 +184,7 @@ class MysqlPlatform extends DefaultPlatform
      *
      * @return string
      */
-    public function getAddTablesDDL(Database $database)
+    public function getAddTablesDDL(Database $database): string
     {
         $ret = '';
         foreach ($database->getTablesForSql() as $table) {
@@ -202,7 +202,7 @@ class MysqlPlatform extends DefaultPlatform
     /**
      * @return string
      */
-    public function getBeginDDL()
+    public function getBeginDDL(): string
     {
         return "
 # This is a fix for InnoDB in MySQL >= 4.1.x
@@ -214,7 +214,7 @@ SET FOREIGN_KEY_CHECKS = 0;
     /**
      * @return string
      */
-    public function getEndDDL()
+    public function getEndDDL(): string
     {
         return "
 # This restores the fkey checks, after having unset them earlier
@@ -229,7 +229,7 @@ SET FOREIGN_KEY_CHECKS = 1;
      *
      * @return string
      */
-    public function getPrimaryKeyDDL(Table $table)
+    public function getPrimaryKeyDDL(Table $table): string
     {
         if ($table->hasPrimaryKey()) {
             $keys = $table->getPrimaryKey();
@@ -257,7 +257,7 @@ SET FOREIGN_KEY_CHECKS = 1;
      *
      * @return string
      */
-    public function getAddTableDDL(Table $table)
+    public function getAddTableDDL(Table $table): string
     {
         $lines = [];
 
@@ -329,7 +329,7 @@ CREATE TABLE %s
      *
      * @return array<string>
      */
-    protected function getTableOptions(Table $table)
+    protected function getTableOptions(Table $table): array
     {
         $dbVI = $table->getDatabase()->getVendorInfoForType('mysql');
         $tableVI = $table->getVendorInfoForType('mysql');
@@ -393,7 +393,7 @@ CREATE TABLE %s
      *
      * @return string
      */
-    public function getDropTableDDL(Table $table)
+    public function getDropTableDDL(Table $table): string
     {
         return "
 DROP TABLE IF EXISTS " . $this->quoteIdentifier($table->getName()) . ";
@@ -407,7 +407,7 @@ DROP TABLE IF EXISTS " . $this->quoteIdentifier($table->getName()) . ";
      *
      * @return string
      */
-    public function getColumnDDL(Column $col)
+    public function getColumnDDL(Column $col): string
     {
         $domain = $col->getDomain();
         $sqlType = $domain->getSqlType();
@@ -499,7 +499,7 @@ DROP TABLE IF EXISTS " . $this->quoteIdentifier($table->getName()) . ";
      *
      * @return string
      */
-    protected function getIndexColumnListDDL(Index $index)
+    protected function getIndexColumnListDDL(Index $index): string
     {
         $list = [];
         foreach ($index->getColumns() as $col) {
@@ -516,7 +516,7 @@ DROP TABLE IF EXISTS " . $this->quoteIdentifier($table->getName()) . ";
      *
      * @return string
      */
-    public function getDropPrimaryKeyDDL(Table $table)
+    public function getDropPrimaryKeyDDL(Table $table): string
     {
         if (!$table->hasPrimaryKey()) {
             return '';
@@ -539,7 +539,7 @@ ALTER TABLE %s DROP PRIMARY KEY;
      *
      * @return string
      */
-    public function getAddIndexDDL(Index $index)
+    public function getAddIndexDDL(Index $index): string
     {
         $pattern = "
 CREATE %sINDEX %s ON %s (%s);
@@ -561,7 +561,7 @@ CREATE %sINDEX %s ON %s (%s);
      *
      * @return string
      */
-    public function getDropIndexDDL(Index $index)
+    public function getDropIndexDDL(Index $index): string
     {
         $pattern = "
 DROP INDEX %s ON %s;
@@ -581,7 +581,7 @@ DROP INDEX %s ON %s;
      *
      * @return string
      */
-    public function getIndexDDL(Index $index)
+    public function getIndexDDL(Index $index): string
     {
         return sprintf(
             '%sINDEX %s (%s)',
@@ -596,7 +596,7 @@ DROP INDEX %s ON %s;
      *
      * @return string
      */
-    protected function getIndexType(Index $index)
+    protected function getIndexType(Index $index): string
     {
         $type = '';
         $vendorInfo = $index->getVendorInfoForType($this->getDatabaseType());
@@ -614,7 +614,7 @@ DROP INDEX %s ON %s;
      *
      * @return string
      */
-    public function getUniqueDDL(Unique $unique)
+    public function getUniqueDDL(Unique $unique): string
     {
         return sprintf(
             'UNIQUE INDEX %s (%s)',
@@ -628,7 +628,7 @@ DROP INDEX %s ON %s;
      *
      * @return string
      */
-    public function getAddForeignKeyDDL(ForeignKey $fk)
+    public function getAddForeignKeyDDL(ForeignKey $fk): string
     {
         if ($this->supportsForeignKeys($fk->getTable())) {
             return parent::getAddForeignKeyDDL($fk);
@@ -644,7 +644,7 @@ DROP INDEX %s ON %s;
      *
      * @return string
      */
-    public function getForeignKeyDDL(ForeignKey $fk)
+    public function getForeignKeyDDL(ForeignKey $fk): string
     {
         if ($this->supportsForeignKeys($fk->getTable())) {
             return parent::getForeignKeyDDL($fk);
@@ -658,7 +658,7 @@ DROP INDEX %s ON %s;
      *
      * @return string|null
      */
-    public function getDropForeignKeyDDL(ForeignKey $fk)
+    public function getDropForeignKeyDDL(ForeignKey $fk): ?string
     {
         if (!$this->supportsForeignKeys($fk->getTable())) {
             return '';
@@ -682,7 +682,7 @@ ALTER TABLE %s DROP FOREIGN KEY %s;
      *
      * @return string
      */
-    public function getCommentBlockDDL($comment)
+    public function getCommentBlockDDL($comment): string
     {
         $pattern = "
 -- ---------------------------------------------------------------------
@@ -701,7 +701,7 @@ ALTER TABLE %s DROP FOREIGN KEY %s;
      *
      * @return string
      */
-    public function getModifyDatabaseDDL(DatabaseDiff $databaseDiff)
+    public function getModifyDatabaseDDL(DatabaseDiff $databaseDiff): string
     {
         $ret = '';
 
@@ -736,7 +736,7 @@ ALTER TABLE %s DROP FOREIGN KEY %s;
      *
      * @return string
      */
-    public function getRenameTableDDL($fromTableName, $toTableName)
+    public function getRenameTableDDL($fromTableName, $toTableName): string
     {
         $pattern = "
 RENAME TABLE %s TO %s;
@@ -756,7 +756,7 @@ RENAME TABLE %s TO %s;
      *
      * @return string
      */
-    public function getRemoveColumnDDL(Column $column)
+    public function getRemoveColumnDDL(Column $column): string
     {
         $pattern = "
 ALTER TABLE %s DROP %s;
@@ -777,7 +777,7 @@ ALTER TABLE %s DROP %s;
      *
      * @return string
      */
-    public function getRenameColumnDDL(Column $fromColumn, Column $toColumn)
+    public function getRenameColumnDDL(Column $fromColumn, Column $toColumn): string
     {
         return $this->getChangeColumnDDL($fromColumn, $toColumn);
     }
@@ -789,7 +789,7 @@ ALTER TABLE %s DROP %s;
      *
      * @return string
      */
-    public function getModifyColumnDDL(ColumnDiff $columnDiff)
+    public function getModifyColumnDDL(ColumnDiff $columnDiff): string
     {
         return $this->getChangeColumnDDL($columnDiff->getFromColumn(), $columnDiff->getToColumn());
     }
@@ -802,7 +802,7 @@ ALTER TABLE %s DROP %s;
      *
      * @return string
      */
-    public function getChangeColumnDDL(Column $fromColumn, Column $toColumn)
+    public function getChangeColumnDDL(Column $fromColumn, Column $toColumn): string
     {
         $pattern = "
 ALTER TABLE %s CHANGE %s %s;
@@ -823,7 +823,7 @@ ALTER TABLE %s CHANGE %s %s;
      *
      * @return string
      */
-    public function getModifyColumnsDDL($columnDiffs)
+    public function getModifyColumnsDDL($columnDiffs): string
     {
         $ret = '';
         foreach ($columnDiffs as $columnDiff) {
@@ -840,7 +840,7 @@ ALTER TABLE %s CHANGE %s %s;
      *
      * @return string
      */
-    public function getAddColumnDDL(Column $column)
+    public function getAddColumnDDL(Column $column): string
     {
         $pattern = "
 ALTER TABLE %s ADD %s %s;
@@ -876,7 +876,7 @@ ALTER TABLE %s ADD %s %s;
      *
      * @return string
      */
-    public function getAddColumnsDDL($columns)
+    public function getAddColumnsDDL($columns): string
     {
         $lines = '';
         foreach ($columns as $column) {
@@ -891,7 +891,7 @@ ALTER TABLE %s ADD %s %s;
      *
      * @return bool
      */
-    public function supportsSchemas()
+    public function supportsSchemas(): bool
     {
         return true;
     }
@@ -901,7 +901,7 @@ ALTER TABLE %s ADD %s %s;
      *
      * @return bool
      */
-    public function hasSize($sqlType)
+    public function hasSize($sqlType): bool
     {
         return !in_array($sqlType, [
             'MEDIUMTEXT',
@@ -915,7 +915,7 @@ ALTER TABLE %s ADD %s %s;
     /**
      * @return array<int>
      */
-    public function getDefaultTypeSizes()
+    public function getDefaultTypeSizes(): array
     {
         return [
             'char' => 1,
@@ -934,7 +934,7 @@ ALTER TABLE %s ADD %s %s;
      *
      * @return string
      */
-    public function disconnectedEscapeText($text)
+    public function disconnectedEscapeText($text): string
     {
         return addslashes($text);
     }
@@ -950,7 +950,7 @@ ALTER TABLE %s ADD %s %s;
      *
      * @return string the quoted identifier
      */
-    public function doQuoting($text)
+    public function doQuoting(string $text): string
     {
         return '`' . strtr($text, ['.' => '`.`']) . '`';
     }
@@ -963,7 +963,7 @@ ALTER TABLE %s ADD %s %s;
      *
      * @return string
      */
-    public function getColumnBindingPHP(Column $column, $identifier, $columnValueAccessor, $tab = '            ')
+    public function getColumnBindingPHP(Column $column, $identifier, $columnValueAccessor, $tab = '            '): string
     {
         // FIXME - This is a temporary hack to get around apparent bugs w/ PDO+MYSQL
         // See http://pecl.php.net/bugs/bug.php?id=9919

--- a/src/Propel/Generator/Platform/OraclePlatform.php
+++ b/src/Propel/Generator/Platform/OraclePlatform.php
@@ -33,7 +33,7 @@ class OraclePlatform extends DefaultPlatform
      *
      * @return void
      */
-    protected function initialize()
+    protected function initialize(): void
     {
         parent::initialize();
         $this->schemaDomainMap[PropelTypes::BOOLEAN] = new Domain(PropelTypes::BOOLEAN_EMU, 'NUMBER', 1, 0);
@@ -64,7 +64,7 @@ class OraclePlatform extends DefaultPlatform
     /**
      * @return int
      */
-    public function getMaxColumnNameLength()
+    public function getMaxColumnNameLength(): int
     {
         return 30;
     }
@@ -72,7 +72,7 @@ class OraclePlatform extends DefaultPlatform
     /**
      * @return string
      */
-    public function getNativeIdMethod()
+    public function getNativeIdMethod(): string
     {
         return PlatformInterface::SEQUENCE;
     }
@@ -80,7 +80,7 @@ class OraclePlatform extends DefaultPlatform
     /**
      * @return string
      */
-    public function getAutoIncrement()
+    public function getAutoIncrement(): string
     {
         return '';
     }
@@ -88,7 +88,7 @@ class OraclePlatform extends DefaultPlatform
     /**
      * @return bool
      */
-    public function supportsNativeDeleteTrigger()
+    public function supportsNativeDeleteTrigger(): bool
     {
         return true;
     }
@@ -96,7 +96,7 @@ class OraclePlatform extends DefaultPlatform
     /**
      * @return string
      */
-    public function getBeginDDL()
+    public function getBeginDDL(): string
     {
         return "
 ALTER SESSION SET NLS_DATE_FORMAT='YYYY-MM-DD';
@@ -109,7 +109,7 @@ ALTER SESSION SET NLS_TIMESTAMP_FORMAT='YYYY-MM-DD HH24:MI:SS';
      *
      * @return string
      */
-    public function getAddTablesDDL(Database $database)
+    public function getAddTablesDDL(Database $database): string
     {
         $ret = $this->getBeginDDL();
         foreach ($database->getTablesForSql() as $table) {
@@ -135,7 +135,7 @@ ALTER SESSION SET NLS_TIMESTAMP_FORMAT='YYYY-MM-DD HH24:MI:SS';
      *
      * @return string
      */
-    public function getAddTableDDL(Table $table)
+    public function getAddTableDDL(Table $table): string
     {
         $tableDescription = $table->hasDescription() ? $this->getCommentLineDDL($table->getDescription()) : '';
 
@@ -177,7 +177,7 @@ ALTER SESSION SET NLS_TIMESTAMP_FORMAT='YYYY-MM-DD HH24:MI:SS';
      *
      * @return string
      */
-    public function getAddPrimaryKeyDDL(Table $table)
+    public function getAddPrimaryKeyDDL(Table $table): string
     {
         if (is_array($table->getPrimaryKey()) && count($table->getPrimaryKey())) {
             return parent::getAddPrimaryKeyDDL($table);
@@ -191,7 +191,7 @@ ALTER SESSION SET NLS_TIMESTAMP_FORMAT='YYYY-MM-DD HH24:MI:SS';
      *
      * @return string
      */
-    public function getAddSequencesDDL(Table $table)
+    public function getAddSequencesDDL(Table $table): string
     {
         if ($table->getIdMethod() === 'native') {
             $pattern = "
@@ -213,7 +213,7 @@ CREATE SEQUENCE %s
      *
      * @return string
      */
-    public function getDropTableDDL(Table $table)
+    public function getDropTableDDL(Table $table): string
     {
         $ret = "
 DROP TABLE " . $this->quoteIdentifier($table->getName()) . " CASCADE CONSTRAINTS;
@@ -232,7 +232,7 @@ DROP SEQUENCE " . $this->quoteIdentifier($this->getSequenceName($table)) . ";
      *
      * @return string
      */
-    public function getPrimaryKeyName(Table $table)
+    public function getPrimaryKeyName(Table $table): string
     {
         $tableName = $table->getName();
         // pk constraint name must be 30 chars at most
@@ -246,7 +246,7 @@ DROP SEQUENCE " . $this->quoteIdentifier($this->getSequenceName($table)) . ";
      *
      * @return string
      */
-    public function getPrimaryKeyDDL(Table $table)
+    public function getPrimaryKeyDDL(Table $table): string
     {
         if ($table->hasPrimaryKey()) {
             $pattern = 'CONSTRAINT %s PRIMARY KEY (%s)%s';
@@ -267,7 +267,7 @@ DROP SEQUENCE " . $this->quoteIdentifier($this->getSequenceName($table)) . ";
      *
      * @return string
      */
-    public function getUniqueDDL(Unique $unique)
+    public function getUniqueDDL(Unique $unique): string
     {
         return sprintf(
             'CONSTRAINT %s UNIQUE (%s)',
@@ -281,7 +281,7 @@ DROP SEQUENCE " . $this->quoteIdentifier($this->getSequenceName($table)) . ";
      *
      * @return string
      */
-    public function getForeignKeyDDL(ForeignKey $fk)
+    public function getForeignKeyDDL(ForeignKey $fk): string
     {
         if ($fk->isSkipSql() || $fk->isPolymorphic()) {
             return '';
@@ -309,7 +309,7 @@ DROP SEQUENCE " . $this->quoteIdentifier($this->getSequenceName($table)) . ";
      *
      * @return bool
      */
-    public function hasStreamBlobImpl()
+    public function hasStreamBlobImpl(): bool
     {
         return true;
     }
@@ -317,7 +317,7 @@ DROP SEQUENCE " . $this->quoteIdentifier($this->getSequenceName($table)) . ";
     /**
      * @inheritDoc
      */
-    public function doQuoting($text)
+    public function doQuoting(string $text): string
     {
         return $text;
     }
@@ -325,7 +325,7 @@ DROP SEQUENCE " . $this->quoteIdentifier($this->getSequenceName($table)) . ";
     /**
      * @return string
      */
-    public function getTimestampFormatter()
+    public function getTimestampFormatter(): string
     {
         return 'Y-m-d H:i:s';
     }
@@ -339,7 +339,7 @@ DROP SEQUENCE " . $this->quoteIdentifier($this->getSequenceName($table)) . ";
      *
      * @return bool
      */
-    public function supportsSchemas()
+    public function supportsSchemas(): bool
     {
         return false;
     }
@@ -352,7 +352,7 @@ DROP SEQUENCE " . $this->quoteIdentifier($this->getSequenceName($table)) . ";
      *
      * @return string oracle vendor sql part
      */
-    public function generateBlockStorage($object, $isPrimaryKey = false)
+    public function generateBlockStorage($object, $isPrimaryKey = false): string
     {
         $vendorSpecific = $object->getVendorInfoForType('oracle');
         if ($vendorSpecific->isEmpty()) {
@@ -410,7 +410,7 @@ USING INDEX
      *
      * @return string
      */
-    public function getAddIndexDDL(Index $index)
+    public function getAddIndexDDL(Index $index): string
     {
         // don't create index form primary key
         if ($this->getPrimaryKeyName($index->getTable()) == $this->quoteIdentifier($index->getName())) {
@@ -443,7 +443,7 @@ CREATE %sINDEX %s ON %s (%s)%s;
      *
      * @return string
      */
-    public function getColumnBindingPHP(Column $column, $identifier, $columnValueAccessor, $tab = '            ')
+    public function getColumnBindingPHP(Column $column, $identifier, $columnValueAccessor, $tab = '            '): string
     {
         if ($column->getType() === PropelTypes::CLOB_EMU) {
             return sprintf(

--- a/src/Propel/Generator/Platform/PgsqlPlatform.php
+++ b/src/Propel/Generator/Platform/PgsqlPlatform.php
@@ -40,7 +40,7 @@ class PgsqlPlatform extends DefaultPlatform
      *
      * @return void
      */
-    protected function initialize()
+    protected function initialize(): void
     {
         parent::initialize();
         $this->setSchemaDomainMapping(new Domain(PropelTypes::BOOLEAN, 'BOOLEAN'));
@@ -66,7 +66,7 @@ class PgsqlPlatform extends DefaultPlatform
     /**
      * @return string
      */
-    public function getNativeIdMethod()
+    public function getNativeIdMethod(): string
     {
         return PlatformInterface::SERIAL;
     }
@@ -74,7 +74,7 @@ class PgsqlPlatform extends DefaultPlatform
     /**
      * @return string
      */
-    public function getAutoIncrement()
+    public function getAutoIncrement(): string
     {
         return '';
     }
@@ -82,7 +82,7 @@ class PgsqlPlatform extends DefaultPlatform
     /**
      * @return array<int>
      */
-    public function getDefaultTypeSizes()
+    public function getDefaultTypeSizes(): array
     {
         return [
             'char' => 1,
@@ -97,7 +97,7 @@ class PgsqlPlatform extends DefaultPlatform
     /**
      * @return int
      */
-    public function getMaxColumnNameLength()
+    public function getMaxColumnNameLength(): int
     {
         return 63;
     }
@@ -107,7 +107,7 @@ class PgsqlPlatform extends DefaultPlatform
      *
      * @return string
      */
-    public function getBooleanString($value)
+    public function getBooleanString($value): string
     {
         // parent method does the checking for allows string
         // representations & returns integer
@@ -119,7 +119,7 @@ class PgsqlPlatform extends DefaultPlatform
     /**
      * @return bool
      */
-    public function supportsNativeDeleteTrigger()
+    public function supportsNativeDeleteTrigger(): bool
     {
         return true;
     }
@@ -132,7 +132,7 @@ class PgsqlPlatform extends DefaultPlatform
      *
      * @return string
      */
-    public function getSequenceName(Table $table)
+    public function getSequenceName(Table $table): string
     {
         $result = null;
         if ($table->getIdMethod() == IdMethod::NATIVE) {
@@ -161,7 +161,7 @@ class PgsqlPlatform extends DefaultPlatform
      *
      * @return string
      */
-    protected function getAddSequenceDDL(Table $table)
+    protected function getAddSequenceDDL(Table $table): string
     {
         if (
             $table->getIdMethod() == IdMethod::NATIVE
@@ -185,7 +185,7 @@ CREATE SEQUENCE %s;
      *
      * @return string
      */
-    protected function getDropSequenceDDL(Table $table)
+    protected function getDropSequenceDDL(Table $table): string
     {
         if (
             $table->getIdMethod() == IdMethod::NATIVE
@@ -209,7 +209,7 @@ DROP SEQUENCE %s;
      *
      * @return string
      */
-    public function getAddSchemasDDL(Database $database)
+    public function getAddSchemasDDL(Database $database): string
     {
         $ret = '';
         $schemas = [];
@@ -229,7 +229,7 @@ DROP SEQUENCE %s;
      *
      * @return string
      */
-    public function getAddSchemaDDL(Table $table)
+    public function getAddSchemaDDL(Table $table): string
     {
         $vi = $table->getVendorInfoForType('pgsql');
         if ($vi->hasParameter('schema')) {
@@ -248,7 +248,7 @@ CREATE SCHEMA %s;
      *
      * @return string
      */
-    public function getUseSchemaDDL(Table $table)
+    public function getUseSchemaDDL(Table $table): string
     {
         $vi = $table->getVendorInfoForType('pgsql');
         if ($vi->hasParameter('schema')) {
@@ -267,7 +267,7 @@ SET search_path TO %s;
      *
      * @return string
      */
-    public function getResetSchemaDDL(Table $table)
+    public function getResetSchemaDDL(Table $table): string
     {
         $vi = $table->getVendorInfoForType('pgsql');
         if ($vi->hasParameter('schema')) {
@@ -284,7 +284,7 @@ SET search_path TO public;
      *
      * @return string
      */
-    public function getAddTablesDDL(Database $database)
+    public function getAddTablesDDL(Database $database): string
     {
         $ret = $this->getAddSchemasDDL($database);
 
@@ -314,7 +314,7 @@ SET search_path TO public;
      *
      * @return string
      */
-    public function getForeignKeyDDL(ForeignKey $fk)
+    public function getForeignKeyDDL(ForeignKey $fk): string
     {
         $script = parent::getForeignKeyDDL($fk);
 
@@ -334,7 +334,7 @@ SET search_path TO public;
     /**
      * @return string
      */
-    public function getBeginDDL()
+    public function getBeginDDL(): string
     {
         return "
 BEGIN;
@@ -344,7 +344,7 @@ BEGIN;
     /**
      * @return string
      */
-    public function getEndDDL()
+    public function getEndDDL(): string
     {
         return "
 COMMIT;
@@ -354,7 +354,7 @@ COMMIT;
     /**
      * @inheritDoc
      */
-    public function getAddForeignKeysDDL(Table $table)
+    public function getAddForeignKeysDDL(Table $table): string
     {
         $ret = '';
         foreach ($table->getForeignKeys() as $fk) {
@@ -369,7 +369,7 @@ COMMIT;
      *
      * @return string
      */
-    public function getAddTableDDL(Table $table)
+    public function getAddTableDDL(Table $table): string
     {
         $ret = '';
         $ret .= $this->getUseSchemaDDL($table);
@@ -425,7 +425,7 @@ COMMENT ON TABLE %s IS %s;
      *
      * @return string
      */
-    protected function getAddColumnsComments(Table $table)
+    protected function getAddColumnsComments(Table $table): string
     {
         $ret = '';
         foreach ($table->getColumns() as $column) {
@@ -440,7 +440,7 @@ COMMENT ON TABLE %s IS %s;
      *
      * @return string
      */
-    protected function getAddColumnComment(Column $column)
+    protected function getAddColumnComment(Column $column): string
     {
         $pattern = "
 COMMENT ON COLUMN %s.%s IS %s;
@@ -462,7 +462,7 @@ COMMENT ON COLUMN %s.%s IS %s;
      *
      * @return string
      */
-    public function getDropTableDDL(Table $table)
+    public function getDropTableDDL(Table $table): string
     {
         $ret = '';
         $ret .= $this->getUseSchemaDDL($table);
@@ -481,7 +481,7 @@ DROP TABLE IF EXISTS %s CASCADE;
      *
      * @return string
      */
-    public function getPrimaryKeyName(Table $table)
+    public function getPrimaryKeyName(Table $table): string
     {
         $tableName = $table->getCommonName();
 
@@ -493,7 +493,7 @@ DROP TABLE IF EXISTS %s CASCADE;
      *
      * @return string
      */
-    public function getColumnDDL(Column $col)
+    public function getColumnDDL(Column $col): string
     {
         $domain = $col->getDomain();
 
@@ -534,7 +534,7 @@ DROP TABLE IF EXISTS %s CASCADE;
      *
      * @return string
      */
-    public function getUniqueDDL(Unique $unique)
+    public function getUniqueDDL(Unique $unique): string
     {
         return sprintf(
             'CONSTRAINT %s UNIQUE (%s)',
@@ -549,7 +549,7 @@ DROP TABLE IF EXISTS %s CASCADE;
      *
      * @return string
      */
-    public function getRenameTableDDL($fromTableName, $toTableName)
+    public function getRenameTableDDL($fromTableName, $toTableName): string
     {
         if (($pos = strpos($toTableName, '.')) !== false) {
             $toTableName = substr($toTableName, $pos + 1);
@@ -571,7 +571,7 @@ ALTER TABLE %s RENAME TO %s;
      *
      * @return bool
      */
-    public function supportsSchemas()
+    public function supportsSchemas(): bool
     {
         return true;
     }
@@ -581,7 +581,7 @@ ALTER TABLE %s RENAME TO %s;
      *
      * @return bool
      */
-    public function hasSize($sqlType)
+    public function hasSize($sqlType): bool
     {
         return !in_array($sqlType, ['BYTEA', 'TEXT', 'DOUBLE PRECISION']);
     }
@@ -589,7 +589,7 @@ ALTER TABLE %s RENAME TO %s;
     /**
      * @return bool
      */
-    public function hasStreamBlobImpl()
+    public function hasStreamBlobImpl(): bool
     {
         return true;
     }
@@ -597,7 +597,7 @@ ALTER TABLE %s RENAME TO %s;
     /**
      * @return bool
      */
-    public function supportsVarcharWithoutSize()
+    public function supportsVarcharWithoutSize(): bool
     {
         return true;
     }
@@ -607,7 +607,7 @@ ALTER TABLE %s RENAME TO %s;
      *
      * @return string
      */
-    public function getModifyTableDDL(TableDiff $tableDiff)
+    public function getModifyTableDDL(TableDiff $tableDiff): string
     {
         $ret = parent::getModifyTableDDL($tableDiff);
 
@@ -631,7 +631,7 @@ ALTER TABLE %s RENAME TO %s;
      *
      * @return string
      */
-    public function getModifyColumnDDL(ColumnDiff $columnDiff)
+    public function getModifyColumnDDL(ColumnDiff $columnDiff): string
     {
         $ret = '';
         $changedProperties = $columnDiff->getChangedProperties();
@@ -736,7 +736,7 @@ DROP SEQUENCE %s CASCADE;
      *
      * @return bool
      */
-    public function isString($type)
+    public function isString($type): bool
     {
         $strings = ['VARCHAR'];
 
@@ -748,7 +748,7 @@ DROP SEQUENCE %s CASCADE;
      *
      * @return bool
      */
-    public function isNumber($type)
+    public function isNumber($type): bool
     {
         $numbers = ['INTEGER', 'INT4', 'INT2', 'NUMBER', 'NUMERIC', 'SMALLINT', 'BIGINT', 'DECIMAL', 'REAL', 'DOUBLE PRECISION', 'SERIAL', 'BIGSERIAL'];
 
@@ -761,7 +761,7 @@ DROP SEQUENCE %s CASCADE;
      *
      * @return string
      */
-    public function getUsingCast(Column $fromColumn, Column $toColumn)
+    public function getUsingCast(Column $fromColumn, Column $toColumn): string
     {
         $fromSqlType = strtoupper($fromColumn->getDomain()->getSqlType());
         $toSqlType = strtoupper($toColumn->getDomain()->getSqlType());
@@ -809,7 +809,7 @@ DROP SEQUENCE %s CASCADE;
      *
      * @return string
      */
-    public function getModifyColumnsDDL($columnDiffs)
+    public function getModifyColumnsDDL($columnDiffs): string
     {
         $ret = '';
         foreach ($columnDiffs as $columnDiff) {
@@ -830,7 +830,7 @@ DROP SEQUENCE %s CASCADE;
      *
      * @return string
      */
-    public function getAddColumnsDDL($columns)
+    public function getAddColumnsDDL($columns): string
     {
         $ret = '';
         foreach ($columns as $column) {
@@ -851,7 +851,7 @@ DROP SEQUENCE %s CASCADE;
      *
      * @return string
      */
-    public function getDropIndexDDL(Index $index)
+    public function getDropIndexDDL(Index $index): string
     {
         if ($index instanceof Unique) {
             $pattern = "
@@ -907,7 +907,7 @@ ALTER TABLE %s DROP CONSTRAINT %s;
      *
      * @return string
      */
-    public function getAddIndexDDL(Index $index)
+    public function getAddIndexDDL(Index $index): string
     {
         if (!$index->isUnique()) {
             return parent::getAddIndexDDL($index);

--- a/src/Propel/Generator/Platform/PlatformInterface.php
+++ b/src/Propel/Generator/Platform/PlatformInterface.php
@@ -10,6 +10,7 @@ namespace Propel\Generator\Platform;
 
 use Propel\Generator\Config\GeneratorConfigInterface;
 use Propel\Generator\Model\Column;
+use Propel\Generator\Model\Domain;
 use Propel\Generator\Model\Table;
 use Propel\Runtime\Connection\ConnectionInterface;
 
@@ -49,14 +50,14 @@ interface PlatformInterface
      *
      * @return void
      */
-    public function setConnection(?ConnectionInterface $con = null);
+    public function setConnection(?ConnectionInterface $con = null): void;
 
     /**
      * Returns the database connection to use for this Platform class.
      *
-     * @return \Propel\Runtime\Connection\ConnectionInterface The database connection or NULL if none has been set.
+     * @return \Propel\Runtime\Connection\ConnectionInterface|null The database connection or NULL if none has been set.
      */
-    public function getConnection();
+    public function getConnection(): ?ConnectionInterface;
 
     /**
      * Sets the GeneratorConfigInterface which contains any generator build properties.
@@ -65,7 +66,7 @@ interface PlatformInterface
      *
      * @return void
      */
-    public function setGeneratorConfig(GeneratorConfigInterface $generatorConfig);
+    public function setGeneratorConfig(GeneratorConfigInterface $generatorConfig): void;
 
     /**
      * Returns the short name of the database type that this platform represents.
@@ -73,21 +74,21 @@ interface PlatformInterface
      *
      * @return string
      */
-    public function getDatabaseType();
+    public function getDatabaseType(): string;
 
     /**
      * Returns the native IdMethod (sequence|identity)
      *
      * @return string The native IdMethod (PlatformInterface:IDENTITY, PlatformInterface::SEQUENCE).
      */
-    public function getNativeIdMethod();
+    public function getNativeIdMethod(): string;
 
     /**
      * Returns the max column length supported by the db.
      *
      * @return int The max column length
      */
-    public function getMaxColumnNameLength();
+    public function getMaxColumnNameLength(): int;
 
     /**
      * Returns the db specific domain for a propelType.
@@ -96,7 +97,7 @@ interface PlatformInterface
      *
      * @return \Propel\Generator\Model\Domain The db specific domain.
      */
-    public function getDomainForType($propelType);
+    public function getDomainForType($propelType): Domain;
 
     /**
      * Returns the RDBMS-specific SQL fragment for <code>NULL</code>
@@ -106,14 +107,14 @@ interface PlatformInterface
      *
      * @return string
      */
-    public function getNullString($notNull);
+    public function getNullString(bool $notNull): string;
 
     /**
      * Returns the RDBMS-specific SQL fragment for autoincrement.
      *
      * @return string
      */
-    public function getAutoIncrement();
+    public function getAutoIncrement(): string;
 
     /**
      * Returns the DDL SQL for a Column object.
@@ -122,7 +123,7 @@ interface PlatformInterface
      *
      * @return string
      */
-    public function getColumnDDL(Column $col);
+    public function getColumnDDL(Column $col): string;
 
     /**
      * Returns the SQL for the default value of a Column object.
@@ -131,7 +132,7 @@ interface PlatformInterface
      *
      * @return string
      */
-    public function getColumnDefaultValueDDL(Column $col);
+    public function getColumnDefaultValueDDL(Column $col): string;
 
     /**
      * Creates a delimiter-delimited string list of column names, quoted using quoteIdentifier().
@@ -147,7 +148,7 @@ interface PlatformInterface
      *
      * @return string
      */
-    public function getColumnListDDL($columns, $delimiter = ',');
+    public function getColumnListDDL($columns, $delimiter = ','): string;
 
     /**
      * Returns the SQL for the primary key of a Table object
@@ -156,7 +157,7 @@ interface PlatformInterface
      *
      * @return string
      */
-    public function getPrimaryKeyDDL(Table $table);
+    public function getPrimaryKeyDDL(Table $table): string;
 
     /**
      * Returns if the RDBMS-specific SQL type has a size attribute.
@@ -165,7 +166,7 @@ interface PlatformInterface
      *
      * @return bool True if the type has a size attribute
      */
-    public function hasSize($sqlType);
+    public function hasSize(string $sqlType): bool;
 
     /**
      * Returns if the RDBMS-specific SQL type has a scale attribute.
@@ -174,7 +175,7 @@ interface PlatformInterface
      *
      * @return bool True if the type has a scale attribute
      */
-    public function hasScale($sqlType);
+    public function hasScale(string $sqlType): bool;
 
     /**
      * Quote and escape needed characters in the string for underlying RDBMS.
@@ -183,7 +184,7 @@ interface PlatformInterface
      *
      * @return string
      */
-    public function quote($text);
+    public function quote($text): string;
 
     /**
      * Quotes a identifier.
@@ -192,49 +193,49 @@ interface PlatformInterface
      *
      * @return string
      */
-    public function doQuoting($text);
+    public function doQuoting(string $text): string;
 
     /**
      * Whether RDBMS supports native index sizes.
      *
      * @return bool
      */
-    public function supportsIndexSize();
+    public function supportsIndexSize(): bool;
 
     /**
      * Whether RDBMS supports native ON DELETE triggers (e.g. ON DELETE CASCADE).
      *
      * @return bool
      */
-    public function supportsNativeDeleteTrigger();
+    public function supportsNativeDeleteTrigger(): bool;
 
     /**
      * Whether RDBMS supports INSERT null values in autoincremented primary keys
      *
      * @return bool
      */
-    public function supportsInsertNullPk();
+    public function supportsInsertNullPk(): bool;
 
     /**
      * Whether RDBMS supports native schemas for table layout.
      *
      * @return bool
      */
-    public function supportsSchemas();
+    public function supportsSchemas(): bool;
 
     /**
      * Whether RDBMS supports migrations.
      *
      * @return bool
      */
-    public function supportsMigrations();
+    public function supportsMigrations(): bool;
 
     /**
      * Whether RDBMS supports VARCHAR without explicit size
      *
      * @return bool
      */
-    public function supportsVarcharWithoutSize();
+    public function supportsVarcharWithoutSize(): bool;
 
     /**
      * Returns the boolean value for the RDBMS.
@@ -249,42 +250,42 @@ interface PlatformInterface
      *
      * @return string
      */
-    public function getBooleanString($value);
+    public function getBooleanString($value): string;
 
     /**
      * Whether the underlying PDO driver for this platform returns BLOB columns as streams (instead of strings).
      *
      * @return bool
      */
-    public function hasStreamBlobImpl();
+    public function hasStreamBlobImpl(): bool;
 
     /**
      * Gets the preferred timestamp formatter for setting date/time values.
      *
      * @return string
      */
-    public function getTimestampFormatter();
+    public function getTimestampFormatter(): string;
 
     /**
      * Gets the preferred date formatter for setting time values.
      *
      * @return string
      */
-    public function getDateFormatter();
+    public function getDateFormatter(): string;
 
     /**
      * Gets the preferred time formatter for setting time values.
      *
      * @return string
      */
-    public function getTimeFormatter();
+    public function getTimeFormatter(): string;
 
     /**
      * @phpstan-return non-empty-string
      *
      * @return string
      */
-    public function getSchemaDelimiter();
+    public function getSchemaDelimiter(): string;
 
     /**
      * Normalizes a table for the current platform. Very important for the TableComparator to not
@@ -296,7 +297,7 @@ interface PlatformInterface
      *
      * @return void
      */
-    public function normalizeTable(Table $table);
+    public function normalizeTable(Table $table): void;
 
     /**
      * Get the default On Delete behavior for foreign keys when not explicity set.
@@ -324,17 +325,17 @@ interface PlatformInterface
      *
      * @return string
      */
-    public function getColumnBindingPHP(Column $column, $identifier, $columnValueAccessor, $tab = '            ');
+    public function getColumnBindingPHP(Column $column, $identifier, $columnValueAccessor, $tab = '            '): string;
 
     /**
      * @return bool
      */
-    public function isIdentifierQuotingEnabled();
+    public function isIdentifierQuotingEnabled(): bool;
 
     /**
      * @param bool $enabled
      *
      * @return void
      */
-    public function setIdentifierQuoting($enabled);
+    public function setIdentifierQuoting($enabled): void;
 }

--- a/src/Propel/Generator/Platform/SqlitePlatform.php
+++ b/src/Propel/Generator/Platform/SqlitePlatform.php
@@ -51,7 +51,7 @@ class SqlitePlatform extends DefaultPlatform
      *
      * @return void
      */
-    protected function initialize()
+    protected function initialize(): void
     {
         parent::initialize();
 
@@ -78,7 +78,7 @@ class SqlitePlatform extends DefaultPlatform
      *
      * @return string
      */
-    public function getSchemaDelimiter()
+    public function getSchemaDelimiter(): string
     {
         return '§';
     }
@@ -86,7 +86,7 @@ class SqlitePlatform extends DefaultPlatform
     /**
      * @return array<int>
      */
-    public function getDefaultTypeSizes()
+    public function getDefaultTypeSizes(): array
     {
         return [
             'char' => 1,
@@ -101,7 +101,7 @@ class SqlitePlatform extends DefaultPlatform
     /**
      * @inheritDoc
      */
-    public function setGeneratorConfig(GeneratorConfigInterface $generatorConfig)
+    public function setGeneratorConfig(GeneratorConfigInterface $generatorConfig): void
     {
         parent::setGeneratorConfig($generatorConfig);
 
@@ -120,7 +120,7 @@ class SqlitePlatform extends DefaultPlatform
      *
      * @return string
      */
-    public function getAddColumnsDDL($columns)
+    public function getAddColumnsDDL($columns): string
     {
         $ret = '';
         $pattern = "
@@ -141,7 +141,7 @@ ALTER TABLE %s ADD %s;
     /**
      * @inheritDoc
      */
-    public function getModifyTableDDL(TableDiff $tableDiff)
+    public function getModifyTableDDL(TableDiff $tableDiff): string
     {
         $changedNotEditableThroughDirectDDL = $this->tableAlteringWorkaround && (
             $tableDiff->hasModifiedFks()
@@ -161,18 +161,18 @@ ALTER TABLE %s ADD %s;
         if ($this->tableAlteringWorkaround && !$changedNotEditableThroughDirectDDL && $tableDiff->hasAddedColumns()) {
             $addedCols = $tableDiff->getAddedColumns();
             foreach ($addedCols as $column) {
-                $sqlChangeNotSupported = false
-
+                $sqlChangeNotSupported =
                     //The column may not have a PRIMARY KEY or UNIQUE constraint.
-                    || $column->isPrimaryKey()
+                    $column->isPrimaryKey()
                     || $column->isUnique()
 
                     //The column may not have a default value of CURRENT_TIME, CURRENT_DATE, CURRENT_TIMESTAMP,
                     //or an expression in parentheses.
-                    || array_search(
-                        $column->getDefaultValue(),
+                    || ($column->getDefaultValue() && in_array(
+                        $column->getDefaultValue()->getValue(),
                         ['CURRENT_TIME', 'CURRENT_DATE', 'CURRENT_TIMESTAMP'],
-                    ) !== false
+                        true,
+                    ))
                     || substr(trim($column->getDefaultValue() ? $column->getDefaultValue()->getValue() : ''), 0, 1) === '('
 
                     //If a NOT NULL constraint is specified, then the column must have a default value other than NULL.
@@ -201,7 +201,7 @@ ALTER TABLE %s ADD %s;
      *
      * @return string
      */
-    public function getMigrationTableDDL(TableDiff $tableDiff)
+    public function getMigrationTableDDL(TableDiff $tableDiff): string
     {
         $pattern = "
 CREATE TEMPORARY TABLE %s AS SELECT %s FROM %s;
@@ -261,7 +261,7 @@ DROP TABLE %s;
     /**
      * @return string
      */
-    public function getBeginDDL()
+    public function getBeginDDL(): string
     {
         return '
 PRAGMA foreign_keys = OFF;
@@ -271,7 +271,7 @@ PRAGMA foreign_keys = OFF;
     /**
      * @return string
      */
-    public function getEndDDL()
+    public function getEndDDL(): string
     {
         return '
 PRAGMA foreign_keys = ON;
@@ -283,7 +283,7 @@ PRAGMA foreign_keys = ON;
      *
      * @return string
      */
-    public function getAddTablesDDL(Database $database)
+    public function getAddTablesDDL(Database $database): string
     {
         $ret = '';
         foreach ($database->getTablesForSql() as $table) {
@@ -308,7 +308,7 @@ PRAGMA foreign_keys = ON;
      *
      * @return void
      */
-    public function normalizeTable(Table $table)
+    public function normalizeTable(Table $table): void
     {
         if ($table->getPrimaryKey()) {
             //search if there is already a UNIQUE constraint over the primary keys
@@ -362,7 +362,7 @@ PRAGMA foreign_keys = ON;
      *
      * @return string
      */
-    public function getPrimaryKeyDDL(Table $table)
+    public function getPrimaryKeyDDL(Table $table): string
     {
         if ($table->hasPrimaryKey() && !$table->hasAutoIncrementPrimaryKey()) {
             return 'PRIMARY KEY (' . $this->getColumnListDDL($table->getPrimaryKey()) . ')';
@@ -374,7 +374,7 @@ PRAGMA foreign_keys = ON;
     /**
      * @inheritDoc
      */
-    public function getRemoveColumnDDL(Column $column)
+    public function getRemoveColumnDDL(Column $column): string
     {
         //not supported
         return '';
@@ -383,7 +383,7 @@ PRAGMA foreign_keys = ON;
     /**
      * @inheritDoc
      */
-    public function getRenameColumnDDL(Column $fromColumn, Column $toColumn)
+    public function getRenameColumnDDL(Column $fromColumn, Column $toColumn): string
     {
         //not supported
         return '';
@@ -392,7 +392,7 @@ PRAGMA foreign_keys = ON;
     /**
      * @inheritDoc
      */
-    public function getModifyColumnDDL(ColumnDiff $columnDiff)
+    public function getModifyColumnDDL(ColumnDiff $columnDiff): string
     {
         //not supported
         return '';
@@ -401,7 +401,7 @@ PRAGMA foreign_keys = ON;
     /**
      * @inheritDoc
      */
-    public function getModifyColumnsDDL($columnDiffs)
+    public function getModifyColumnsDDL($columnDiffs): string
     {
         //not supported
         return '';
@@ -410,7 +410,7 @@ PRAGMA foreign_keys = ON;
     /**
      * @inheritDoc
      */
-    public function getDropPrimaryKeyDDL(Table $table)
+    public function getDropPrimaryKeyDDL(Table $table): string
     {
         //not supported
         return '';
@@ -419,7 +419,7 @@ PRAGMA foreign_keys = ON;
     /**
      * @inheritDoc
      */
-    public function getAddPrimaryKeyDDL(Table $table)
+    public function getAddPrimaryKeyDDL(Table $table): string
     {
         //not supported
         return '';
@@ -428,7 +428,7 @@ PRAGMA foreign_keys = ON;
     /**
      * @inheritDoc
      */
-    public function getAddForeignKeyDDL(ForeignKey $fk)
+    public function getAddForeignKeyDDL(ForeignKey $fk): string
     {
         //not supported
         return '';
@@ -437,7 +437,7 @@ PRAGMA foreign_keys = ON;
     /**
      * @inheritDoc
      */
-    public function getDropForeignKeyDDL(ForeignKey $fk)
+    public function getDropForeignKeyDDL(ForeignKey $fk): string
     {
         //not supported
         return '';
@@ -448,7 +448,7 @@ PRAGMA foreign_keys = ON;
      *
      * @return string
      */
-    public function getAutoIncrement()
+    public function getAutoIncrement(): string
     {
         return 'PRIMARY KEY AUTOINCREMENT';
     }
@@ -456,7 +456,7 @@ PRAGMA foreign_keys = ON;
     /**
      * @return int
      */
-    public function getMaxColumnNameLength()
+    public function getMaxColumnNameLength(): int
     {
         return 1024;
     }
@@ -466,7 +466,7 @@ PRAGMA foreign_keys = ON;
      *
      * @return string
      */
-    public function getColumnDDL(Column $col)
+    public function getColumnDDL(Column $col): string
     {
         if ($col->isAutoIncrement()) {
             $col->setType('INTEGER');
@@ -493,7 +493,7 @@ PRAGMA foreign_keys = ON;
      *
      * @return string
      */
-    public function getAddTableDDL(Table $table)
+    public function getAddTableDDL(Table $table): string
     {
         $table = clone $table;
         $tableDescription = $table->hasDescription() ? $this->getCommentLineDDL($table->getDescription()) : '';
@@ -546,7 +546,7 @@ PRAGMA foreign_keys = ON;
      *
      * @return string
      */
-    public function getForeignKeyDDL(ForeignKey $fk)
+    public function getForeignKeyDDL(ForeignKey $fk): string
     {
         if ($fk->isSkipSql() || !$this->foreignKeySupport || $fk->isPolymorphic()) {
             return '';
@@ -578,7 +578,7 @@ PRAGMA foreign_keys = ON;
      *
      * @return bool
      */
-    public function hasSize($sqlType)
+    public function hasSize($sqlType): bool
     {
         return !in_array($sqlType, [
             'MEDIUMTEXT',
@@ -592,7 +592,7 @@ PRAGMA foreign_keys = ON;
     /**
      * @inheritDoc
      */
-    public function doQuoting($text)
+    public function doQuoting(string $text): string
     {
         return '[' . strtr($text, ['.' => '].[']) . ']';
     }
@@ -600,7 +600,7 @@ PRAGMA foreign_keys = ON;
     /**
      * @return bool
      */
-    public function supportsSchemas()
+    public function supportsSchemas(): bool
     {
         return true;
     }
@@ -608,7 +608,7 @@ PRAGMA foreign_keys = ON;
     /**
      * @return bool
      */
-    public function supportsNativeDeleteTrigger()
+    public function supportsNativeDeleteTrigger(): bool
     {
         return true;
     }

--- a/src/Propel/Generator/Platform/SqlsrvPlatform.php
+++ b/src/Propel/Generator/Platform/SqlsrvPlatform.php
@@ -20,7 +20,7 @@ class SqlsrvPlatform extends MssqlPlatform
      *
      * @return int
      */
-    public function getMaxColumnNameLength()
+    public function getMaxColumnNameLength(): int
     {
         return 128;
     }

--- a/src/Propel/Generator/Reverse/AbstractSchemaParser.php
+++ b/src/Propel/Generator/Reverse/AbstractSchemaParser.php
@@ -12,6 +12,7 @@ use Propel\Generator\Config\GeneratorConfigInterface;
 use Propel\Generator\Model\VendorInfo;
 use Propel\Generator\Platform\PlatformInterface;
 use Propel\Runtime\Connection\ConnectionInterface;
+use RuntimeException;
 
 /**
  * Base class for reverse engineering a database schema.
@@ -66,7 +67,7 @@ abstract class AbstractSchemaParser implements SchemaParserInterface
     /**
      * The database's platform.
      *
-     * @var \Propel\Generator\Platform\PlatformInterface
+     * @var \Propel\Generator\Platform\PlatformInterface|null
      */
     protected $platform;
 
@@ -241,7 +242,17 @@ abstract class AbstractSchemaParser implements SchemaParserInterface
     }
 
     /**
+     * @return bool
+     */
+    public function hasPlatform(): bool
+    {
+        return $this->platform !== null;
+    }
+
+    /**
      * Returns the database's platform.
+     *
+     * @throws \RuntimeException
      *
      * @return \Propel\Generator\Platform\PlatformInterface
      */
@@ -251,6 +262,11 @@ abstract class AbstractSchemaParser implements SchemaParserInterface
             $this->platform = $this->getGeneratorConfig()->getConfiguredPlatform();
         }
 
-        return $this->platform;
+        $platform = $this->platform;
+        if ($platform === null) {
+            throw new RuntimeException('No platform set, please use `hasPlatform()` to check for existance first.');
+        }
+
+        return $platform;
     }
 }

--- a/src/Propel/Generator/Reverse/AbstractSchemaParser.php
+++ b/src/Propel/Generator/Reverse/AbstractSchemaParser.php
@@ -163,9 +163,9 @@ abstract class AbstractSchemaParser implements SchemaParserInterface
     /**
      * Gets the GeneratorConfig option.
      *
-     * @return \Propel\Generator\Config\GeneratorConfigInterface
+     * @return \Propel\Generator\Config\GeneratorConfigInterface|null
      */
-    public function getGeneratorConfig(): GeneratorConfigInterface
+    public function getGeneratorConfig(): ?GeneratorConfigInterface
     {
         return $this->generatorConfig;
     }
@@ -202,9 +202,9 @@ abstract class AbstractSchemaParser implements SchemaParserInterface
      *
      * @param string $propelType
      *
-     * @return string The native SQL type that best matches the specified Propel type.
+     * @return string|null The native SQL type that best matches the specified Propel type.
      */
-    protected function getMappedNativeType($propelType): string
+    protected function getMappedNativeType($propelType): ?string
     {
         if ($this->reverseTypeMap === null) {
             $this->reverseTypeMap = array_flip($this->getTypeMapping());

--- a/src/Propel/Generator/Reverse/AbstractSchemaParser.php
+++ b/src/Propel/Generator/Reverse/AbstractSchemaParser.php
@@ -10,6 +10,7 @@ namespace Propel\Generator\Reverse;
 
 use Propel\Generator\Config\GeneratorConfigInterface;
 use Propel\Generator\Model\VendorInfo;
+use Propel\Generator\Platform\PlatformInterface;
 use Propel\Runtime\Connection\ConnectionInterface;
 
 /**
@@ -88,7 +89,7 @@ abstract class AbstractSchemaParser implements SchemaParserInterface
      *
      * @return void
      */
-    public function setConnection(ConnectionInterface $dbh)
+    public function setConnection(ConnectionInterface $dbh): void
     {
         $this->dbh = $dbh;
     }
@@ -98,7 +99,7 @@ abstract class AbstractSchemaParser implements SchemaParserInterface
      *
      * @return \Propel\Runtime\Connection\ConnectionInterface
      */
-    public function getConnection()
+    public function getConnection(): ConnectionInterface
     {
         return $this->dbh;
     }
@@ -110,7 +111,7 @@ abstract class AbstractSchemaParser implements SchemaParserInterface
      *
      * @return void
      */
-    public function setMigrationTable($migrationTable)
+    public function setMigrationTable($migrationTable): void
     {
         $this->migrationTable = $migrationTable;
     }
@@ -120,7 +121,7 @@ abstract class AbstractSchemaParser implements SchemaParserInterface
      *
      * @return string
      */
-    public function getMigrationTable()
+    public function getMigrationTable(): string
     {
         return $this->migrationTable;
     }
@@ -132,7 +133,7 @@ abstract class AbstractSchemaParser implements SchemaParserInterface
      *
      * @return void
      */
-    protected function warn($msg)
+    protected function warn($msg): void
     {
         $this->warnings[] = $msg;
     }
@@ -142,7 +143,7 @@ abstract class AbstractSchemaParser implements SchemaParserInterface
      *
      * @return array<string>
      */
-    public function getWarnings()
+    public function getWarnings(): array
     {
         return $this->warnings;
     }
@@ -154,7 +155,7 @@ abstract class AbstractSchemaParser implements SchemaParserInterface
      *
      * @return void
      */
-    public function setGeneratorConfig(GeneratorConfigInterface $config)
+    public function setGeneratorConfig(GeneratorConfigInterface $config): void
     {
         $this->generatorConfig = $config;
     }
@@ -164,7 +165,7 @@ abstract class AbstractSchemaParser implements SchemaParserInterface
      *
      * @return \Propel\Generator\Config\GeneratorConfigInterface
      */
-    public function getGeneratorConfig()
+    public function getGeneratorConfig(): GeneratorConfigInterface
     {
         return $this->generatorConfig;
     }
@@ -174,7 +175,7 @@ abstract class AbstractSchemaParser implements SchemaParserInterface
      *
      * @return array<string> The mapped Propel type.
      */
-    abstract protected function getTypeMapping();
+    abstract protected function getTypeMapping(): array;
 
     /**
      * Gets a mapped Propel type for specified native type.
@@ -183,7 +184,7 @@ abstract class AbstractSchemaParser implements SchemaParserInterface
      *
      * @return string|null The mapped Propel type.
      */
-    protected function getMappedPropelType($nativeType)
+    protected function getMappedPropelType($nativeType): ?string
     {
         if ($this->nativeToPropelTypeMap === null) {
             $this->nativeToPropelTypeMap = $this->getTypeMapping();
@@ -203,7 +204,7 @@ abstract class AbstractSchemaParser implements SchemaParserInterface
      *
      * @return string The native SQL type that best matches the specified Propel type.
      */
-    protected function getMappedNativeType($propelType)
+    protected function getMappedNativeType($propelType): string
     {
         if ($this->reverseTypeMap === null) {
             $this->reverseTypeMap = array_flip($this->getTypeMapping());
@@ -219,7 +220,7 @@ abstract class AbstractSchemaParser implements SchemaParserInterface
      *
      * @return \Propel\Generator\Model\VendorInfo
      */
-    protected function getNewVendorInfoObject(array $params)
+    protected function getNewVendorInfoObject(array $params): VendorInfo
     {
         $type = $this->getPlatform()->getDatabaseType();
 
@@ -234,7 +235,7 @@ abstract class AbstractSchemaParser implements SchemaParserInterface
      *
      * @return void
      */
-    public function setPlatform($platform)
+    public function setPlatform($platform): void
     {
         $this->platform = $platform;
     }
@@ -244,7 +245,7 @@ abstract class AbstractSchemaParser implements SchemaParserInterface
      *
      * @return \Propel\Generator\Platform\PlatformInterface
      */
-    public function getPlatform()
+    public function getPlatform(): PlatformInterface
     {
         if ($this->platform === null) {
             $this->platform = $this->getGeneratorConfig()->getConfiguredPlatform();

--- a/src/Propel/Generator/Reverse/MssqlSchemaParser.php
+++ b/src/Propel/Generator/Reverse/MssqlSchemaParser.php
@@ -77,7 +77,7 @@ class MssqlSchemaParser extends AbstractSchemaParser
      *
      * @return array<string>
      */
-    protected function getTypeMapping()
+    protected function getTypeMapping(): array
     {
         return self::$mssqlTypeMap;
     }
@@ -88,7 +88,7 @@ class MssqlSchemaParser extends AbstractSchemaParser
      *
      * @return int
      */
-    public function parse(Database $database, array $additionalTables = [])
+    public function parse(Database $database, array $additionalTables = []): int
     {
         $dataFetcher = $this->dbh->query("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE = 'BASE TABLE' AND TABLE_NAME <> 'dtproperties'");
 
@@ -127,7 +127,7 @@ class MssqlSchemaParser extends AbstractSchemaParser
      *
      * @return void
      */
-    protected function addColumns(Table $table)
+    protected function addColumns(Table $table): void
     {
         /** @var \Propel\Runtime\DataFetcher\PDODataFetcher $dataFetcher */
         $dataFetcher = $this->dbh->query("sp_columns '" . $table->getName() . "'");
@@ -175,7 +175,7 @@ class MssqlSchemaParser extends AbstractSchemaParser
      *
      * @return void
      */
-    protected function addForeignKeys(Table $table)
+    protected function addForeignKeys(Table $table): void
     {
         $database = $table->getDatabase();
 
@@ -220,7 +220,7 @@ class MssqlSchemaParser extends AbstractSchemaParser
      *
      * @return void
      */
-    protected function addIndexes(Table $table)
+    protected function addIndexes(Table $table): void
     {
         /** @var \Propel\Runtime\DataFetcher\PDODataFetcher $dataFetcher */
         $dataFetcher = $this->dbh->query("sp_indexes_rowset '" . $table->getName() . "'");
@@ -269,7 +269,7 @@ class MssqlSchemaParser extends AbstractSchemaParser
      *
      * @return void
      */
-    protected function addPrimaryKey(Table $table)
+    protected function addPrimaryKey(Table $table): void
     {
         $dataFetcher = $this->dbh->query("SELECT COLUMN_NAME
             FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
@@ -296,7 +296,7 @@ class MssqlSchemaParser extends AbstractSchemaParser
      *
      * @return string
      */
-    protected function cleanDelimitedIdentifiers($identifier)
+    protected function cleanDelimitedIdentifiers($identifier): string
     {
         return preg_replace('/^\'(.*)\'$/U', '$1', $identifier);
     }

--- a/src/Propel/Generator/Reverse/MysqlSchemaParser.php
+++ b/src/Propel/Generator/Reverse/MysqlSchemaParser.php
@@ -86,7 +86,7 @@ class MysqlSchemaParser extends AbstractSchemaParser
      *
      * @return array<string>
      */
-    protected function getTypeMapping()
+    protected function getTypeMapping(): array
     {
         return self::$mysqlTypeMap;
     }
@@ -107,7 +107,7 @@ class MysqlSchemaParser extends AbstractSchemaParser
      *
      * @return int
      */
-    public function parse(Database $database, array $additionalTables = [])
+    public function parse(Database $database, array $additionalTables = []): int
     {
         if ($this->getGeneratorConfig() !== null) {
             $this->addVendorInfo = $this->getGeneratorConfig()->get()['migrations']['addVendorInfo'];
@@ -143,7 +143,7 @@ class MysqlSchemaParser extends AbstractSchemaParser
      *
      * @return void
      */
-    protected function parseTables(Database $database, $filterTable = null)
+    protected function parseTables(Database $database, $filterTable = null): void
     {
         $sql = 'SHOW FULL TABLES';
 
@@ -183,7 +183,7 @@ class MysqlSchemaParser extends AbstractSchemaParser
      *
      * @return void
      */
-    protected function addColumns(Table $table)
+    protected function addColumns(Table $table): void
     {
         /** @var \PDOStatement $stmt */
         $stmt = $this->dbh->query(sprintf('SHOW COLUMNS FROM %s', $this->getPlatform()->doQuoting($table->getName())));
@@ -204,7 +204,7 @@ class MysqlSchemaParser extends AbstractSchemaParser
      *
      * @return \Propel\Generator\Model\Column
      */
-    public function getColumnFromRow($row, Table $table)
+    public function getColumnFromRow($row, Table $table): Column
     {
         $name = $row['Field'];
         $isNullable = ($row['Null'] === 'YES');
@@ -380,7 +380,7 @@ EOT;
      *
      * @return void
      */
-    protected function addForeignKeys(Table $table)
+    protected function addForeignKeys(Table $table): void
     {
         $database = $table->getDatabase();
 
@@ -478,7 +478,7 @@ EOT;
      *
      * @return void
      */
-    protected function addIndexes(Table $table)
+    protected function addIndexes(Table $table): void
     {
         /** @var \PDOStatement $stmt */
         $stmt = $this->dbh->query(sprintf('SHOW INDEX FROM %s', $this->getPlatform()->doQuoting($table->getName())));
@@ -533,7 +533,7 @@ EOT;
      *
      * @return void
      */
-    protected function addPrimaryKey(Table $table)
+    protected function addPrimaryKey(Table $table): void
     {
         /** @var \PDOStatement $stmt */
         $stmt = $this->dbh->query(sprintf('SHOW KEYS FROM %s', $this->getPlatform()->doQuoting($table->getName())));
@@ -560,7 +560,7 @@ EOT;
      *
      * @return void
      */
-    protected function addTableVendorInfo(Table $table)
+    protected function addTableVendorInfo(Table $table): void
     {
         /** @var \PDOStatement $stmt */
         $stmt = $this->dbh->query("SHOW TABLE STATUS LIKE '" . $table->getName() . "'");

--- a/src/Propel/Generator/Reverse/OracleSchemaParser.php
+++ b/src/Propel/Generator/Reverse/OracleSchemaParser.php
@@ -66,7 +66,7 @@ class OracleSchemaParser extends AbstractSchemaParser
      *
      * @return array<string>
      */
-    protected function getTypeMapping()
+    protected function getTypeMapping(): array
     {
         return self::$oracleTypeMap;
     }
@@ -79,7 +79,7 @@ class OracleSchemaParser extends AbstractSchemaParser
      *
      * @return int
      */
-    public function parse(Database $database, array $additionalTables = [])
+    public function parse(Database $database, array $additionalTables = []): int
     {
         $tables = [];
         /** @var \PDOStatement $stmt */
@@ -138,7 +138,7 @@ class OracleSchemaParser extends AbstractSchemaParser
      *
      * @return void
      */
-    protected function addColumns(Table $table)
+    protected function addColumns(Table $table): void
     {
         /** @var \PDOStatement $stmt */
         $stmt = $this->dbh->query("SELECT COLUMN_NAME, DATA_TYPE, NULLABLE, DATA_LENGTH, DATA_PRECISION, DATA_SCALE, DATA_DEFAULT FROM USER_TAB_COLS WHERE TABLE_NAME = '" . $table->getName() . "'");
@@ -201,7 +201,7 @@ class OracleSchemaParser extends AbstractSchemaParser
      *
      * @return void
      */
-    protected function addIndexes(Table $table)
+    protected function addIndexes(Table $table): void
     {
         /** @var \PDOStatement $stmt */
         $stmt = $this->dbh->query("SELECT INDEX_NAME, COLUMN_NAME FROM USER_IND_COLUMNS WHERE TABLE_NAME = '" . $table->getName() . "' ORDER BY COLUMN_NAME");
@@ -234,7 +234,7 @@ class OracleSchemaParser extends AbstractSchemaParser
      *
      * @return void
      */
-    protected function addForeignKeys(Table $table)
+    protected function addForeignKeys(Table $table): void
     {
         // local store to avoid duplicates
         $foreignKeys = [];
@@ -272,7 +272,7 @@ class OracleSchemaParser extends AbstractSchemaParser
      *
      * @return void
      */
-    protected function addPrimaryKey(Table $table)
+    protected function addPrimaryKey(Table $table): void
     {
         /** @var \PDOStatement $stmt */
         $stmt = $this->dbh->query("SELECT COLS.COLUMN_NAME FROM USER_CONSTRAINTS CONS, USER_CONS_COLUMNS COLS WHERE CONS.CONSTRAINT_NAME = COLS.CONSTRAINT_NAME AND CONS.TABLE_NAME = '" . $table->getName() . "' AND CONS.CONSTRAINT_TYPE = 'P'");

--- a/src/Propel/Generator/Reverse/PgsqlSchemaParser.php
+++ b/src/Propel/Generator/Reverse/PgsqlSchemaParser.php
@@ -92,7 +92,7 @@ class PgsqlSchemaParser extends AbstractSchemaParser
      *
      * @return array<string>
      */
-    protected function getTypeMapping()
+    protected function getTypeMapping(): array
     {
         return self::$pgsqlTypeMap;
     }
@@ -105,7 +105,7 @@ class PgsqlSchemaParser extends AbstractSchemaParser
      *
      * @return int
      */
-    public function parse(Database $database, array $additionalTables = [])
+    public function parse(Database $database, array $additionalTables = []): int
     {
         $tableWraps = [];
 
@@ -138,7 +138,7 @@ class PgsqlSchemaParser extends AbstractSchemaParser
      *
      * @return void
      */
-    protected function parseTables(&$tableWraps, Database $database, ?Table $filterTable = null)
+    protected function parseTables(&$tableWraps, Database $database, ?Table $filterTable = null): void
     {
         $stmt = null;
 
@@ -224,7 +224,7 @@ class PgsqlSchemaParser extends AbstractSchemaParser
      *
      * @return void
      */
-    protected function addColumns(Table $table, $oid)
+    protected function addColumns(Table $table, $oid): void
     {
         // Get the columns, types, etc.
         // Based on code from pgAdmin3 (http://www.pgadmin.org/)
@@ -344,7 +344,7 @@ class PgsqlSchemaParser extends AbstractSchemaParser
      *
      * @return bool
      */
-    protected function isColumnDefaultExpression($default)
+    protected function isColumnDefaultExpression($default): bool
     {
         $containsFunctionCall = substr($default, 0, 1) !== "'" && strpos($default, '(');
 
@@ -372,7 +372,7 @@ class PgsqlSchemaParser extends AbstractSchemaParser
      *
      * @return void
      */
-    protected function addForeignKeys(Table $table, $oid)
+    protected function addForeignKeys(Table $table, $oid): void
     {
         $database = $table->getDatabase();
         $stmt = $this->dbh->prepare("SELECT
@@ -496,7 +496,7 @@ class PgsqlSchemaParser extends AbstractSchemaParser
      *
      * @return void
      */
-    protected function addIndexes(Table $table, $oid)
+    protected function addIndexes(Table $table, $oid): void
     {
         $stmt = $this->dbh->prepare("SELECT
             DISTINCT ON(cls.relname)
@@ -562,7 +562,7 @@ class PgsqlSchemaParser extends AbstractSchemaParser
      *
      * @return void
      */
-    protected function addPrimaryKey(Table $table, $oid)
+    protected function addPrimaryKey(Table $table, $oid): void
     {
         $stmt = $this->dbh->prepare("SELECT
             DISTINCT ON(cls.relname)
@@ -605,7 +605,7 @@ class PgsqlSchemaParser extends AbstractSchemaParser
      *
      * @return void
      */
-    protected function addSequences(Database $database)
+    protected function addSequences(Database $database): void
     {
         $searchPath = '?';
         $params = [$database->getSchema()];

--- a/src/Propel/Generator/Reverse/SchemaParserInterface.php
+++ b/src/Propel/Generator/Reverse/SchemaParserInterface.php
@@ -10,6 +10,7 @@ namespace Propel\Generator\Reverse;
 
 use Propel\Generator\Config\GeneratorConfigInterface;
 use Propel\Generator\Model\Database;
+use Propel\Generator\Platform\PlatformInterface;
 use Propel\Runtime\Connection\ConnectionInterface;
 
 /**
@@ -24,7 +25,7 @@ interface SchemaParserInterface
      *
      * @return \Propel\Runtime\Connection\ConnectionInterface
      */
-    public function getConnection();
+    public function getConnection(): ConnectionInterface;
 
     /**
      * Sets the database connection.
@@ -33,7 +34,7 @@ interface SchemaParserInterface
      *
      * @return void
      */
-    public function setConnection(ConnectionInterface $dbh);
+    public function setConnection(ConnectionInterface $dbh): void;
 
     /**
      * Sets the GeneratorConfig to use in the parsing.
@@ -42,26 +43,26 @@ interface SchemaParserInterface
      *
      * @return void
      */
-    public function setGeneratorConfig(GeneratorConfigInterface $config);
+    public function setGeneratorConfig(GeneratorConfigInterface $config): void;
 
     /**
      * Gets array of warning messages.
      *
      * @return array<string>
      */
-    public function getWarnings();
+    public function getWarnings(): array;
 
     /**
      * @return \Propel\Generator\Platform\PlatformInterface
      */
-    public function getPlatform();
+    public function getPlatform(): PlatformInterface;
 
     /**
      * @param \Propel\Generator\Platform\PlatformInterface $platform
      *
      * @return void
      */
-    public function setPlatform($platform);
+    public function setPlatform($platform): void;
 
     /**
      * Parse the schema and populate passed-in Database model object.
@@ -71,5 +72,5 @@ interface SchemaParserInterface
      *
      * @return int Number of generated tables
      */
-    public function parse(Database $database, array $additionalTables = []);
+    public function parse(Database $database, array $additionalTables = []): int;
 }

--- a/src/Propel/Generator/Reverse/SqliteSchemaParser.php
+++ b/src/Propel/Generator/Reverse/SqliteSchemaParser.php
@@ -75,7 +75,7 @@ class SqliteSchemaParser extends AbstractSchemaParser
      *
      * @return array<string>
      */
-    protected function getTypeMapping()
+    protected function getTypeMapping(): array
     {
         return self::$sqliteTypeMap;
     }
@@ -86,7 +86,7 @@ class SqliteSchemaParser extends AbstractSchemaParser
      *
      * @return int
      */
-    public function parse(Database $database, array $additionalTables = [])
+    public function parse(Database $database, array $additionalTables = []): int
     {
         if ($this->getGeneratorConfig()) {
             $this->addVendorInfo = $this->getGeneratorConfig()->get()['migrations']['addVendorInfo'];
@@ -118,7 +118,7 @@ class SqliteSchemaParser extends AbstractSchemaParser
      *
      * @return void
      */
-    protected function parseTables(Database $database, ?Table $filterTable = null)
+    protected function parseTables(Database $database, ?Table $filterTable = null): void
     {
         $sql = "
         SELECT name
@@ -188,7 +188,7 @@ class SqliteSchemaParser extends AbstractSchemaParser
      *
      * @return void
      */
-    protected function addColumns(Table $table)
+    protected function addColumns(Table $table): void
     {
         $tableName = $table->getName();
 
@@ -276,7 +276,7 @@ class SqliteSchemaParser extends AbstractSchemaParser
      *
      * @return void
      */
-    protected function addForeignKeys(Table $table)
+    protected function addForeignKeys(Table $table): void
     {
         $database = $table->getDatabase();
 
@@ -327,7 +327,7 @@ class SqliteSchemaParser extends AbstractSchemaParser
      *
      * @return void
      */
-    protected function addIndexes(Table $table)
+    protected function addIndexes(Table $table): void
     {
         /** @var \PDOStatement $stmt */
         $stmt = $this->dbh->query('PRAGMA index_list("' . $table->getName() . '")');

--- a/src/Propel/Generator/Schema/Dumper/DumperInterface.php
+++ b/src/Propel/Generator/Schema/Dumper/DumperInterface.php
@@ -20,7 +20,7 @@ interface DumperInterface
      *
      * @return string The dumped formatted output (XML, YAML, CSV...)
      */
-    public function dump(Database $database);
+    public function dump(Database $database): string;
 
     /**
      * Dumps a single Schema model into an XML formatted version.
@@ -30,5 +30,5 @@ interface DumperInterface
      *
      * @return string The dumped formatted output (XML, YAML, CSV...)
      */
-    public function dumpSchema(Schema $schema, $doFinalInitialization = true);
+    public function dumpSchema(Schema $schema, bool $doFinalInitialization = true): string;
 }

--- a/src/Propel/Generator/Schema/Dumper/XmlDumper.php
+++ b/src/Propel/Generator/Schema/Dumper/XmlDumper.php
@@ -60,7 +60,7 @@ class XmlDumper implements DumperInterface
      *
      * @return string The dumped XML formatted output
      */
-    public function dump(Database $database)
+    public function dump(Database $database): string
     {
         $this->appendDatabaseNode($database, $this->document);
 
@@ -75,7 +75,7 @@ class XmlDumper implements DumperInterface
      *
      * @return string
      */
-    public function dumpSchema(Schema $schema, $doFinalInitialization = true)
+    public function dumpSchema(Schema $schema, bool $doFinalInitialization = true): string
     {
         $rootNode = $this->document->createElement('app-data');
         $this->document->appendChild($rootNode);
@@ -94,7 +94,7 @@ class XmlDumper implements DumperInterface
      *
      * @return void
      */
-    private function appendDatabaseNode(Database $database, DOMNode $parentNode)
+    private function appendDatabaseNode(Database $database, DOMNode $parentNode): void
     {
         /** @var \DOMElement $databaseNode */
         $databaseNode = $parentNode->appendChild($this->document->createElement('database'));
@@ -179,7 +179,7 @@ class XmlDumper implements DumperInterface
      *
      * @return void
      */
-    private function appendVendorInformationNode(VendorInfo $vendorInfo, DOMNode $parentNode)
+    private function appendVendorInformationNode(VendorInfo $vendorInfo, DOMNode $parentNode): void
     {
         /** @var \DOMElement $vendorNode */
         $vendorNode = $parentNode->appendChild($this->document->createElement('vendor'));
@@ -201,7 +201,7 @@ class XmlDumper implements DumperInterface
      *
      * @return void
      */
-    private function appendTableNode(Table $table, DOMNode $parentNode)
+    private function appendTableNode(Table $table, DOMNode $parentNode): void
     {
         /** @var \DOMElement $tableNode */
         $tableNode = $parentNode->appendChild($this->document->createElement('table'));
@@ -336,7 +336,7 @@ class XmlDumper implements DumperInterface
      *
      * @return void
      */
-    private function appendBehaviorNode(Behavior $behavior, DOMNode $parentNode)
+    private function appendBehaviorNode(Behavior $behavior, DOMNode $parentNode): void
     {
         /** @var \DOMElement $behaviorNode */
         $behaviorNode = $parentNode->appendChild($this->document->createElement('behavior'));
@@ -361,7 +361,7 @@ class XmlDumper implements DumperInterface
      *
      * @return void
      */
-    private function appendColumnNode(Column $column, DOMNode $parentNode)
+    private function appendColumnNode(Column $column, DOMNode $parentNode): void
     {
         /** @var \DOMElement $columnNode */
         $columnNode = $parentNode->appendChild($this->document->createElement('column'));
@@ -436,7 +436,7 @@ class XmlDumper implements DumperInterface
      *
      * @return void
      */
-    private function appendInheritanceNode(Inheritance $inheritance, DOMNode $parentNode)
+    private function appendInheritanceNode(Inheritance $inheritance, DOMNode $parentNode): void
     {
         /** @var \DOMElement $inheritanceNode */
         $inheritanceNode = $parentNode->appendChild($this->document->createElement('inheritance'));
@@ -456,7 +456,7 @@ class XmlDumper implements DumperInterface
      *
      * @return void
      */
-    private function appendForeignKeyNode(ForeignKey $foreignKey, DOMNode $parentNode)
+    private function appendForeignKeyNode(ForeignKey $foreignKey, DOMNode $parentNode): void
     {
         /** @var \DOMElement $foreignKeyNode */
         $foreignKeyNode = $parentNode->appendChild($this->document->createElement('foreign-key'));
@@ -507,7 +507,7 @@ class XmlDumper implements DumperInterface
      *
      * @return void
      */
-    private function appendIdMethodParameterNode(IdMethodParameter $parameter, DOMNode $parentNode)
+    private function appendIdMethodParameterNode(IdMethodParameter $parameter, DOMNode $parentNode): void
     {
         /** @var \DOMElement $idMethodParameterNode */
         $idMethodParameterNode = $parentNode->appendChild($this->document->createElement('id-method-parameter'));
@@ -525,7 +525,7 @@ class XmlDumper implements DumperInterface
      *
      * @return void
      */
-    private function appendIndexNode(Index $index, DOMNode $parentNode)
+    private function appendIndexNode(Index $index, DOMNode $parentNode): void
     {
         $this->appendGenericIndexNode('index', $index, $parentNode);
     }
@@ -538,7 +538,7 @@ class XmlDumper implements DumperInterface
      *
      * @return void
      */
-    private function appendUniqueIndexNode(Unique $index, DOMNode $parentNode)
+    private function appendUniqueIndexNode(Unique $index, DOMNode $parentNode): void
     {
         $this->appendGenericIndexNode('unique', $index, $parentNode);
     }
@@ -552,7 +552,7 @@ class XmlDumper implements DumperInterface
      *
      * @return void
      */
-    private function appendGenericIndexNode($nodeType, Index $index, DOMNode $parentNode)
+    private function appendGenericIndexNode($nodeType, Index $index, DOMNode $parentNode): void
     {
         /** @var \DOMElement $indexNode */
         $indexNode = $parentNode->appendChild($this->document->createElement($nodeType));

--- a/src/Propel/Generator/Util/BehaviorLocator.php
+++ b/src/Propel/Generator/Util/BehaviorLocator.php
@@ -56,7 +56,7 @@ class BehaviorLocator
      *
      * @return \Symfony\Component\Finder\SplFileInfo|null The found composer file or null if composer file isn't found
      */
-    private function findComposerFile($fileName)
+    private function findComposerFile($fileName): ?SplFileInfo
     {
         if ($this->composerDir !== null) {
             $filePath = $this->composerDir . '/' . $fileName;
@@ -83,7 +83,7 @@ class BehaviorLocator
      *
      * @return \Symfony\Component\Finder\SplFileInfo|null The found composer.lock or null if composer.lock isn't found
      */
-    private function findComposerLock()
+    private function findComposerLock(): ?SplFileInfo
     {
         return $this->findComposerFile('composer.lock');
     }
@@ -93,7 +93,7 @@ class BehaviorLocator
      *
      * @return \Symfony\Component\Finder\SplFileInfo|null the found composer.json or null if composer.json isn't found
      */
-    private function findComposerJson()
+    private function findComposerJson(): ?SplFileInfo
     {
         return $this->findComposerFile('composer.json');
     }
@@ -118,7 +118,7 @@ class BehaviorLocator
      *
      * @return array behaviors
      */
-    public function getBehaviors()
+    public function getBehaviors(): array
     {
         if ($this->behaviors === null) {
             // find behaviors in composer.lock file
@@ -154,7 +154,7 @@ class BehaviorLocator
      *
      * @return string the class name
      */
-    public function getBehavior($name)
+    public function getBehavior($name): string
     {
         if (strpos($name, '\\') !== false) {
             $class = $name;
@@ -184,7 +184,7 @@ class BehaviorLocator
      *
      * @return string The behavior fully qualified class name
      */
-    private function getCoreBehavior($name)
+    private function getCoreBehavior($name): string
     {
         $generator = new PhpNameGenerator();
         $phpName = $generator->generateName([$name, PhpNameGenerator::CONV_METHOD_PHPNAME]);
@@ -230,7 +230,7 @@ class BehaviorLocator
      *
      * @return array|null Behavior data
      */
-    private function loadBehavior($package)
+    private function loadBehavior($package): ?array
     {
         if (isset($package['type']) && $package['type'] == self::BEHAVIOR_PACKAGE_TYPE) {
             // find propel behavior information

--- a/src/Propel/Generator/Util/PhpParser.php
+++ b/src/Propel/Generator/Util/PhpParser.php
@@ -65,7 +65,7 @@ class PhpParser
      *
      * @return string PHP code
      */
-    public function getCode()
+    public function getCode(): string
     {
         return $this->isAddPhp ? $this->removePhp($this->code) : $this->code;
     }
@@ -75,7 +75,7 @@ class PhpParser
      *
      * @return string
      */
-    protected function addPhp($code)
+    protected function addPhp($code): string
     {
         return '<?php ' . $code;
     }
@@ -85,7 +85,7 @@ class PhpParser
      *
      * @return string
      */
-    protected function removePhp($code)
+    protected function removePhp($code): string
     {
         return substr($code, 6);
     }

--- a/src/Propel/Generator/Util/QuickBuilder.php
+++ b/src/Propel/Generator/Util/QuickBuilder.php
@@ -186,7 +186,7 @@ class QuickBuilder
      *
      * @return \Propel\Generator\Config\GeneratorConfigInterface
      */
-    public function getConfig()
+    public function getConfig(): GeneratorConfigInterface
     {
         if ($this->config === null) {
             $this->config = new QuickGeneratorConfig();

--- a/src/Propel/Generator/Util/QuickBuilder.php
+++ b/src/Propel/Generator/Util/QuickBuilder.php
@@ -265,7 +265,7 @@ class QuickBuilder
         $adapter->initConnection($con, []);
         $this->buildSQL($con);
         $this->buildClasses($classTargets);
-        $name = $this->getDatabase()->getName();
+        $name = (string)$this->getDatabase()->getName();
         Propel::getServiceContainer()->setAdapter($name, $adapter);
         Propel::getServiceContainer()->setConnection($name, $con);
 

--- a/src/Propel/Generator/Util/SchemaValidator.php
+++ b/src/Propel/Generator/Util/SchemaValidator.php
@@ -49,7 +49,7 @@ class SchemaValidator
     /**
      * @return bool true if valid, false otherwise
      */
-    public function validate()
+    public function validate(): bool
     {
         foreach ($this->schema->getDatabases() as $database) {
             $this->validateDatabaseTables($database);
@@ -63,7 +63,7 @@ class SchemaValidator
      *
      * @return void
      */
-    protected function validateDatabaseTables(Database $database)
+    protected function validateDatabaseTables(Database $database): void
     {
         $phpNames = [];
         $namespaces = [];
@@ -90,7 +90,7 @@ class SchemaValidator
      *
      * @return void
      */
-    protected function validateTableAttributes(Table $table)
+    protected function validateTableAttributes(Table $table): void
     {
         $reservedTableNames = ['table_name'];
         $tableName = strtolower($table->getName());
@@ -104,7 +104,7 @@ class SchemaValidator
      *
      * @return void
      */
-    protected function validateTableColumns(Table $table)
+    protected function validateTableColumns(Table $table): void
     {
         if (!$table->hasPrimaryKey() && !$table->isSkipSql()) {
             $this->errors[] = sprintf('Table "%s" does not have a primary key defined. Propel requires all tables to have a primary key.', $table->getName());
@@ -123,7 +123,7 @@ class SchemaValidator
      *
      * @return array
      */
-    public function getErrors()
+    public function getErrors(): array
     {
         return $this->errors;
     }

--- a/src/Propel/Generator/Util/SqlParser.php
+++ b/src/Propel/Generator/Util/SqlParser.php
@@ -51,7 +51,7 @@ class SqlParser
      *
      * @return void
      */
-    public function setSQL($sql)
+    public function setSQL($sql): void
     {
         $this->sql = $sql;
         $this->pos = 0;
@@ -63,7 +63,7 @@ class SqlParser
      *
      * @return string The SQL string to parse
      */
-    public function getSQL()
+    public function getSQL(): string
     {
         return $this->sql;
     }
@@ -77,7 +77,7 @@ class SqlParser
      *
      * @return int the number of executed statements
      */
-    public static function executeString($input, ConnectionInterface $connection)
+    public static function executeString($input, ConnectionInterface $connection): int
     {
         return self::executeStatements(self::parseString($input), $connection);
     }
@@ -91,7 +91,7 @@ class SqlParser
      *
      * @return int the number of executed statements
      */
-    public static function executeFile($file, ConnectionInterface $connection)
+    public static function executeFile($file, ConnectionInterface $connection): int
     {
         return self::executeStatements(self::parseFile($file), $connection);
     }
@@ -105,7 +105,7 @@ class SqlParser
      *
      * @return int the number of executed statements
      */
-    protected static function executeStatements($statements, ConnectionInterface $connection)
+    protected static function executeStatements($statements, ConnectionInterface $connection): int
     {
         $executed = 0;
 
@@ -148,7 +148,7 @@ class SqlParser
      *
      * @return array A list of SQL statement strings
      */
-    public static function parseString($input)
+    public static function parseString($input): array
     {
         $parser = new self();
         $parser->setSQL($input);
@@ -179,7 +179,7 @@ class SqlParser
      *
      * @return array A list of SQL statement strings
      */
-    public static function parseFile($file)
+    public static function parseFile($file): array
     {
         if (!file_exists($file)) {
             return [];
@@ -191,7 +191,7 @@ class SqlParser
     /**
      * @return void
      */
-    public function convertLineFeedsToUnixStyle()
+    public function convertLineFeedsToUnixStyle(): void
     {
         $this->setSQL(str_replace(["\r\n", "\r"], "\n", $this->sql));
     }
@@ -199,7 +199,7 @@ class SqlParser
     /**
      * @return void
      */
-    public function stripSQLCommentLines()
+    public function stripSQLCommentLines(): void
     {
         $this->setSQL(preg_replace([
             '#^\s*(//|--|\#).*(\n|$)#m', // //, --, or # style comments
@@ -212,7 +212,7 @@ class SqlParser
      *
      * @return array A list of SQL statement strings
      */
-    public function explodeIntoStatements()
+    public function explodeIntoStatements(): array
     {
         $this->pos = 0;
         $sqlStatements = [];
@@ -229,7 +229,7 @@ class SqlParser
      *
      * @return string A SQL statement
      */
-    public function getNextStatement()
+    public function getNextStatement(): string
     {
         $isAfterBackslash = false;
         $isInString = false;

--- a/src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
@@ -221,9 +221,9 @@ class BaseModelCriteria extends Criteria implements IteratorAggregate
     /**
      * Returns the alias of the main class for this model criteria
      *
-     * @return string The model alias
+     * @return string|null The model alias
      */
-    public function getModelAlias(): string
+    public function getModelAlias(): ?string
     {
         return $this->modelAlias;
     }
@@ -231,9 +231,9 @@ class BaseModelCriteria extends Criteria implements IteratorAggregate
     /**
      * Return the string to use in a clause as a model prefix for the main model
      *
-     * @return string The model alias if it exists, the model name if not
+     * @return string|null The model alias if it exists, the model name if not
      */
-    public function getModelAliasOrName(): string
+    public function getModelAliasOrName(): ?string
     {
         return $this->modelAlias ?: $this->modelName;
     }

--- a/src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
@@ -153,9 +153,9 @@ class BaseModelCriteria extends Criteria implements IteratorAggregate
     /**
      * Returns the name of the class for this model criteria
      *
-     * @return string
+     * @return string|null
      */
-    public function getModelName(): string
+    public function getModelName(): ?string
     {
         return $this->modelName;
     }
@@ -277,9 +277,9 @@ class BaseModelCriteria extends Criteria implements IteratorAggregate
      *
      * Either the SQL name or an alias.
      *
-     * @return string
+     * @return string|null
      */
-    public function getTableNameInQuery(): string
+    public function getTableNameInQuery(): ?string
     {
         if ($this->useAliasInSQL && $this->modelAlias) {
             return $this->modelAlias;

--- a/src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
@@ -13,6 +13,7 @@ use IteratorAggregate;
 use Propel\Runtime\Exception\InvalidArgumentException;
 use Propel\Runtime\Exception\LogicException;
 use Propel\Runtime\Formatter\AbstractFormatter;
+use Propel\Runtime\Map\TableMap;
 use Propel\Runtime\Propel;
 use Traversable;
 
@@ -84,7 +85,7 @@ class BaseModelCriteria extends Criteria implements IteratorAggregate
      *
      * @return array<\Propel\Runtime\ActiveQuery\ModelWith>
      */
-    public function getWith()
+    public function getWith(): array
     {
         return $this->with;
     }
@@ -139,7 +140,7 @@ class BaseModelCriteria extends Criteria implements IteratorAggregate
      *
      * @return \Propel\Runtime\Formatter\AbstractFormatter
      */
-    public function getFormatter()
+    public function getFormatter(): AbstractFormatter
     {
         if ($this->formatter === null) {
             $formatterClass = $this->defaultFormatterClass;
@@ -154,7 +155,7 @@ class BaseModelCriteria extends Criteria implements IteratorAggregate
      *
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return $this->modelName;
     }
@@ -192,7 +193,7 @@ class BaseModelCriteria extends Criteria implements IteratorAggregate
     /**
      * @return string
      */
-    public function getFullyQualifiedModelName()
+    public function getFullyQualifiedModelName(): string
     {
         return '\\' . $this->getModelName();
     }
@@ -222,7 +223,7 @@ class BaseModelCriteria extends Criteria implements IteratorAggregate
      *
      * @return string The model alias
      */
-    public function getModelAlias()
+    public function getModelAlias(): string
     {
         return $this->modelAlias;
     }
@@ -232,7 +233,7 @@ class BaseModelCriteria extends Criteria implements IteratorAggregate
      *
      * @return string The model alias if it exists, the model name if not
      */
-    public function getModelAliasOrName()
+    public function getModelAliasOrName(): string
     {
         return $this->modelAlias ?: $this->modelName;
     }
@@ -242,7 +243,7 @@ class BaseModelCriteria extends Criteria implements IteratorAggregate
      *
      * @return string The short model name
      */
-    public function getModelShortName()
+    public function getModelShortName(): string
     {
         return static::getShortName($this->modelName ?: '');
     }
@@ -254,7 +255,7 @@ class BaseModelCriteria extends Criteria implements IteratorAggregate
      *
      * @return string The short class name
      */
-    public static function getShortName(string $fullyQualifiedClassName)
+    public static function getShortName(string $fullyQualifiedClassName): string
     {
         $namespaceParts = explode('\\', $fullyQualifiedClassName);
 
@@ -266,7 +267,7 @@ class BaseModelCriteria extends Criteria implements IteratorAggregate
      *
      * @return \Propel\Runtime\Map\TableMap
      */
-    public function getTableMap()
+    public function getTableMap(): TableMap
     {
         return $this->tableMap;
     }
@@ -278,7 +279,7 @@ class BaseModelCriteria extends Criteria implements IteratorAggregate
      *
      * @return string
      */
-    public function getTableNameInQuery()
+    public function getTableNameInQuery(): string
     {
         if ($this->useAliasInSQL && $this->modelAlias) {
             return $this->modelAlias;

--- a/src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
@@ -265,9 +265,9 @@ class BaseModelCriteria extends Criteria implements IteratorAggregate
     /**
      * Returns the TableMap object for this Criteria
      *
-     * @return \Propel\Runtime\Map\TableMap
+     * @return \Propel\Runtime\Map\TableMap|null
      */
-    public function getTableMap(): TableMap
+    public function getTableMap(): ?TableMap
     {
         return $this->tableMap;
     }

--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -833,9 +833,9 @@ class Criteria
      * any SELECT columns or WHERE columns. This must be explicitly
      * set, of course, in order to be useful.
      *
-     * @return string
+     * @return string|null
      */
-    public function getPrimaryTableName(): string
+    public function getPrimaryTableName(): ?string
     {
         return $this->primaryTableName;
     }

--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -24,7 +24,9 @@ use Propel\Runtime\ActiveQuery\QueryExecutor\SelectQueryExecutor;
 use Propel\Runtime\ActiveQuery\QueryExecutor\UpdateQueryExecutor;
 use Propel\Runtime\ActiveQuery\SqlBuilder\SelectQuerySqlBuilder;
 use Propel\Runtime\Connection\ConnectionInterface;
+use Propel\Runtime\DataFetcher\DataFetcherInterface;
 use Propel\Runtime\Exception\LogicException;
+use Propel\Runtime\Map\ColumnMap;
 use Propel\Runtime\Propel;
 use Propel\Runtime\Util\PropelConditionalProxy;
 
@@ -426,7 +428,7 @@ class Criteria
      *
      * @return array<\Propel\Runtime\ActiveQuery\Criterion\AbstractCriterion>
      */
-    public function getMap()
+    public function getMap(): array
     {
         return $this->map;
     }
@@ -438,7 +440,7 @@ class Criteria
      *
      * @return void
      */
-    public function clear()
+    public function clear(): void
     {
         $this->map = [];
         $this->namedCriterions = [];
@@ -488,7 +490,7 @@ class Criteria
      * @return array An assoc array which map the column alias names
      *               to the alias clauses.
      */
-    public function getAsColumns()
+    public function getAsColumns(): array
     {
         return $this->asColumns;
     }
@@ -500,7 +502,7 @@ class Criteria
      *
      * @return string|null
      */
-    public function getColumnForAs($as)
+    public function getColumnForAs($as): ?string
     {
         if (isset($this->asColumns[$as])) {
             return $this->asColumns[$as];
@@ -544,7 +546,7 @@ class Criteria
      *
      * @return array
      */
-    public function getAliases()
+    public function getAliases(): array
     {
         return $this->aliases;
     }
@@ -556,7 +558,7 @@ class Criteria
      *
      * @return string|null
      */
-    public function getTableForAlias($alias)
+    public function getTableForAlias($alias): ?string
     {
         if (isset($this->aliases[$alias])) {
             return $this->aliases[$alias];
@@ -576,7 +578,7 @@ class Criteria
      *
      * @return array
      */
-    public function getTableNameAndAlias($tableAliasOrName)
+    public function getTableNameAndAlias($tableAliasOrName): array
     {
         if (isset($this->aliases[$tableAliasOrName])) {
             return [$this->aliases[$tableAliasOrName], $tableAliasOrName];
@@ -594,7 +596,7 @@ class Criteria
      *
      * @return array
      */
-    public function keys()
+    public function keys(): array
     {
         return array_keys($this->map);
     }
@@ -606,7 +608,7 @@ class Criteria
      *
      * @return bool True if this Criteria object contain the specified key.
      */
-    public function containsKey($column)
+    public function containsKey($column): bool
     {
         // must use array_key_exists() because the key could
         // exist but have a NULL value (that'd be valid).
@@ -620,7 +622,7 @@ class Criteria
      *
      * @return bool True if this Criteria object contain the specified key and a value for that key
      */
-    public function keyContainsValue($column)
+    public function keyContainsValue($column): bool
     {
         // must use array_key_exists() because the key could
         // exist but have a NULL value (that'd be valid).
@@ -636,7 +638,7 @@ class Criteria
      *
      * @return bool
      */
-    public function hasWhereClause()
+    public function hasWhereClause(): bool
     {
         return (bool)$this->map;
     }
@@ -651,7 +653,7 @@ class Criteria
      *
      * @return void
      */
-    public function setUseTransaction($v)
+    public function setUseTransaction($v): void
     {
         $this->useTransaction = (bool)$v;
     }
@@ -662,7 +664,7 @@ class Criteria
      *
      * @return bool
      */
-    public function isUseTransaction()
+    public function isUseTransaction(): bool
     {
         return $this->useTransaction;
     }
@@ -677,7 +679,7 @@ class Criteria
      *
      * @return \Propel\Runtime\ActiveQuery\Criterion\AbstractCriterion A Criterion object.
      */
-    public function getCriterion($column)
+    public function getCriterion($column): AbstractCriterion
     {
         return $this->map[$column];
     }
@@ -687,7 +689,7 @@ class Criteria
      *
      * @return \Propel\Runtime\ActiveQuery\Criterion\AbstractCriterion|null A Criterion or null no Criterion is added.
      */
-    public function getLastCriterion()
+    public function getLastCriterion(): ?AbstractCriterion
     {
         $count = count($this->map);
         if ($count) {
@@ -710,7 +712,7 @@ class Criteria
      *
      * @return \Propel\Runtime\ActiveQuery\Criterion\AbstractCriterion
      */
-    public function getNewCriterion($column, $value = null, $comparison = self::EQUAL)
+    public function getNewCriterion($column, $value = null, $comparison = self::EQUAL): AbstractCriterion
     {
         if (is_int($comparison)) {
             // $comparison is a PDO::PARAM_* constant value
@@ -753,7 +755,7 @@ class Criteria
      *
      * @return string|null The value of the object at key.
      */
-    public function getColumnName($name)
+    public function getColumnName($name): ?string
     {
         if (isset($this->map[$name])) {
             return $this->map[$name]->getColumn();
@@ -774,7 +776,7 @@ class Criteria
      *
      * @return array array(table => array(table.column1, table.column2))
      */
-    public function getTablesColumns()
+    public function getTablesColumns(): array
     {
         $tables = [];
         foreach ($this->keys() as $key) {
@@ -792,7 +794,7 @@ class Criteria
      *
      * @return string|null A String with the value of the object at key.
      */
-    public function getComparison($key)
+    public function getComparison($key): ?string
     {
         if (isset($this->map[$key])) {
             return $this->map[$key]->getComparison();
@@ -806,7 +808,7 @@ class Criteria
      *
      * @return string A String with the Database(Map) name.
      */
-    public function getDbName()
+    public function getDbName(): string
     {
         return $this->dbName;
     }
@@ -819,7 +821,7 @@ class Criteria
      *
      * @return void
      */
-    public function setDbName($dbName = null)
+    public function setDbName($dbName = null): void
     {
         $this->dbName = ($dbName ?? Propel::getServiceContainer()->getDefaultDatasource());
     }
@@ -833,7 +835,7 @@ class Criteria
      *
      * @return string
      */
-    public function getPrimaryTableName()
+    public function getPrimaryTableName(): string
     {
         return $this->primaryTableName;
     }
@@ -849,7 +851,7 @@ class Criteria
      *
      * @return void
      */
-    public function setPrimaryTableName($tableName)
+    public function setPrimaryTableName($tableName): void
     {
         $this->primaryTableName = $tableName;
     }
@@ -861,7 +863,7 @@ class Criteria
      *
      * @return string|null The value of table for criterion at key.
      */
-    public function getTableName($name)
+    public function getTableName($name): ?string
     {
         if (isset($this->map[$name])) {
             return $this->map[$name]->getTable();
@@ -932,7 +934,7 @@ class Criteria
      *
      * @return void
      */
-    public function putAll($t)
+    public function putAll($t): void
     {
         if (is_array($t)) {
             foreach ($t as $key => $value) {
@@ -982,7 +984,7 @@ class Criteria
     /**
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return implode(', ', $this->map) . "\n";
     }
@@ -1214,7 +1216,7 @@ class Criteria
      *
      * @return array<\Propel\Runtime\ActiveQuery\Join>
      */
-    public function getJoins()
+    public function getJoins(): array
     {
         return $this->joins;
     }
@@ -1226,7 +1228,7 @@ class Criteria
      *
      * @return \Propel\Runtime\ActiveQuery\Join A join object
      */
-    public function getJoin($name)
+    public function getJoin($name): Join
     {
         return $this->joins[$name];
     }
@@ -1236,7 +1238,7 @@ class Criteria
      *
      * @return bool
      */
-    public function hasJoin($name)
+    public function hasJoin($name): bool
     {
         return isset($this->joins[$name]);
     }
@@ -1264,7 +1266,7 @@ class Criteria
      *
      * @return bool
      */
-    public function hasSelectQueries()
+    public function hasSelectQueries(): bool
     {
         return (bool)$this->selectQueries;
     }
@@ -1274,7 +1276,7 @@ class Criteria
      *
      * @return array<\Propel\Runtime\ActiveQuery\Criteria>
      */
-    public function getSelectQueries()
+    public function getSelectQueries(): array
     {
         return $this->selectQueries;
     }
@@ -1286,7 +1288,7 @@ class Criteria
      *
      * @return self
      */
-    public function getSelectQuery($alias)
+    public function getSelectQuery($alias): self
     {
         return $this->selectQueries[$alias];
     }
@@ -1298,7 +1300,7 @@ class Criteria
      *
      * @return bool
      */
-    public function hasSelectQuery($alias)
+    public function hasSelectQuery($alias): bool
     {
         return isset($this->selectQueries[$alias]);
     }
@@ -1306,7 +1308,7 @@ class Criteria
     /**
      * @return int
      */
-    public function forgeSelectQueryAlias()
+    public function forgeSelectQueryAlias(): int
     {
         $aliasNumber = 0;
         foreach ($this->getSelectQueries() as $c1) {
@@ -1382,7 +1384,7 @@ class Criteria
      *
      * @return bool
      */
-    public function hasSelectModifier($modifier)
+    public function hasSelectModifier($modifier): bool
     {
         return in_array($modifier, $this->selectModifiers);
     }
@@ -1475,7 +1477,7 @@ class Criteria
      *
      * @return bool True if case is ignored.
      */
-    public function isIgnoreCase()
+    public function isIgnoreCase(): bool
     {
         return $this->ignoreCase;
     }
@@ -1505,7 +1507,7 @@ class Criteria
      *
      * @return bool True if a single record is being returned.
      */
-    public function isSingleRecord()
+    public function isSingleRecord(): bool
     {
         return $this->singleRecord;
     }
@@ -1529,7 +1531,7 @@ class Criteria
      *
      * @return int An int with the value for limit.
      */
-    public function getLimit()
+    public function getLimit(): int
     {
         return $this->limit;
     }
@@ -1553,7 +1555,7 @@ class Criteria
      *
      * @return int An int with the value for offset.
      */
-    public function getOffset()
+    public function getOffset(): int
     {
         return $this->offset;
     }
@@ -1605,9 +1607,9 @@ class Criteria
     /**
      * Get the query comment, that appears after the first verb in the SQL query
      *
-     * @return string The comment to add to the query, without comment sign
+     * @return string|null The comment to add to the query, without comment sign
      */
-    public function getComment()
+    public function getComment(): ?string
     {
         return $this->queryComment;
     }
@@ -1622,7 +1624,7 @@ class Criteria
      *
      * @return bool
      */
-    public function hasSelectClause()
+    public function hasSelectClause(): bool
     {
         return (bool)$this->selectColumns || (bool)$this->asColumns;
     }
@@ -1632,7 +1634,7 @@ class Criteria
      *
      * @return array An array with the name of the select columns.
      */
-    public function getSelectColumns()
+    public function getSelectColumns(): array
     {
         return $this->selectColumns;
     }
@@ -1654,7 +1656,7 @@ class Criteria
      *
      * @return array An array with the select modifiers.
      */
-    public function getSelectModifiers()
+    public function getSelectModifiers(): array
     {
         return $this->selectModifiers;
     }
@@ -1706,7 +1708,7 @@ class Criteria
      *
      * @return array<string> An array with the name of the order columns.
      */
-    public function getOrderByColumns()
+    public function getOrderByColumns(): array
     {
         return $this->orderByColumns;
     }
@@ -1740,7 +1742,7 @@ class Criteria
      *
      * @return array<string>
      */
-    public function getGroupByColumns()
+    public function getGroupByColumns(): array
     {
         return $this->groupByColumns;
     }
@@ -1750,7 +1752,7 @@ class Criteria
      *
      * @return \Propel\Runtime\ActiveQuery\Criterion\AbstractCriterion|null A Criterion object that is the having clause.
      */
-    public function getHaving()
+    public function getHaving(): ?AbstractCriterion
     {
         return $this->having;
     }
@@ -1783,7 +1785,7 @@ class Criteria
      *
      * @return string A String with the representation of the Criteria.
      */
-    public function toString()
+    public function toString(): string
     {
         $sb = 'Criteria:';
         try {
@@ -1810,7 +1812,7 @@ class Criteria
      *
      * @return int
      */
-    public function size()
+    public function size(): int
     {
         return count($this->map);
     }
@@ -1823,7 +1825,7 @@ class Criteria
      *
      * @return bool
      */
-    public function equals($crit)
+    public function equals($crit): bool
     {
         if ($crit === null || !($crit instanceof Criteria)) {
             return false;
@@ -2034,7 +2036,7 @@ class Criteria
      *
      * @return \Propel\Runtime\ActiveQuery\Criterion\AbstractCriterion
      */
-    protected function getCriterionForCondition($p1, $value = null, $comparison = null)
+    protected function getCriterionForCondition($p1, $value = null, $comparison = null): AbstractCriterion
     {
         if ($p1 instanceof AbstractCriterion) {
             // it's already a Criterion, so ignore $value and $comparison
@@ -2158,7 +2160,7 @@ class Criteria
      *
      * @return string
      */
-    public function createSelectSql(&$params)
+    public function createSelectSql(&$params): string
     {
         $preparedStatementDto = SelectQuerySqlBuilder::createSelectSql($this, $params);
         $params = $preparedStatementDto->getParameters();
@@ -2173,7 +2175,7 @@ class Criteria
      *
      * @return string the column name replacement
      */
-    protected function doReplaceNameInExpression($matches)
+    protected function doReplaceNameInExpression($matches): string
     {
         return $this->quoteIdentifier($matches[0]);
     }
@@ -2186,7 +2188,7 @@ class Criteria
      *
      * @return string
      */
-    public function quoteIdentifier($string, $tableName = '')
+    public function quoteIdentifier($string, $tableName = ''): string
     {
         if ($this->isIdentifierQuotingEnabled()) {
             $adapter = Propel::getServiceContainer()->getAdapter($this->getDbName());
@@ -2227,7 +2229,7 @@ class Criteria
      *
      * @return bool Whether the method managed to find and replace at least one column name
      */
-    public function replaceNames(&$sql)
+    public function replaceNames(&$sql): bool
     {
         $this->replacedColumns = [];
         $this->currentAlias = '';
@@ -2316,7 +2318,7 @@ class Criteria
      *
      * @return \Propel\Runtime\Map\ColumnMap|null
      */
-    public function getPrimaryKey(?Criteria $criteria = null)
+    public function getPrimaryKey(?Criteria $criteria = null): ?ColumnMap
     {
         if (!$criteria) {
             $criteria = $this;
@@ -2358,7 +2360,7 @@ class Criteria
      *             Note that the return value does require that this information is returned
      *             (supported) by the Propel db driver.
      */
-    public function doUpdate($updateValues, ConnectionInterface $con)
+    public function doUpdate($updateValues, ConnectionInterface $con): int
     {
         return UpdateQueryExecutor::execute($this, $updateValues, $con);
     }
@@ -2368,7 +2370,7 @@ class Criteria
      *
      * @return \Propel\Runtime\DataFetcher\DataFetcherInterface
      */
-    public function doCount(?ConnectionInterface $con = null)
+    public function doCount(?ConnectionInterface $con = null): DataFetcherInterface
     {
         return CountQueryExecutor::execute($this, $con);
     }
@@ -2380,7 +2382,7 @@ class Criteria
      *
      * @return bool
      */
-    public function needsSelectAliases()
+    public function needsSelectAliases(): bool
     {
         $columnNames = [];
         foreach ($this->getSelectColumns() as $fullyQualifiedColumnName) {
@@ -2406,7 +2408,7 @@ class Criteria
      *
      * @return int the number of deleted rows
      */
-    public function doDelete(?ConnectionInterface $con = null)
+    public function doDelete(?ConnectionInterface $con = null): int
     {
         return DeleteQueryExecutor::execute($this, $con);
     }
@@ -2419,7 +2421,7 @@ class Criteria
      *
      * @return int the number of deleted rows
      */
-    public function doDeleteAll(?ConnectionInterface $con = null)
+    public function doDeleteAll(?ConnectionInterface $con = null): int
     {
         return DeleteAllQueryExecutor::execute($this, $con);
     }
@@ -2431,7 +2433,7 @@ class Criteria
      *
      * @return \Propel\Runtime\DataFetcher\DataFetcherInterface A dataFetcher using the connection, ready to be fetched
      */
-    public function doSelect(?ConnectionInterface $con = null)
+    public function doSelect(?ConnectionInterface $con = null): DataFetcherInterface
     {
         return SelectQueryExecutor::execute($this, $con);
     }
@@ -2559,7 +2561,7 @@ class Criteria
     /**
      * @return bool
      */
-    public function isIdentifierQuotingEnabled()
+    public function isIdentifierQuotingEnabled(): bool
     {
         return $this->identifierQuoting;
     }
@@ -2569,7 +2571,7 @@ class Criteria
      *
      * @return void
      */
-    public function setIdentifierQuoting($identifierQuoting)
+    public function setIdentifierQuoting($identifierQuoting): void
     {
         $this->identifierQuoting = $identifierQuoting;
     }

--- a/src/Propel/Runtime/ActiveQuery/Criterion/AbstractCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/AbstractCriterion.php
@@ -156,9 +156,9 @@ abstract class AbstractCriterion
     /**
      * Get the column name.
      *
-     * @return string A String with the column name.
+     * @return string|null A String with the column name.
      */
-    public function getColumn(): string
+    public function getColumn(): ?string
     {
         return $this->column;
     }

--- a/src/Propel/Runtime/ActiveQuery/Criterion/AbstractCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/AbstractCriterion.php
@@ -112,7 +112,7 @@ abstract class AbstractCriterion
      *
      * @return void
      */
-    public function init(Criteria $criteria)
+    public function init(Criteria $criteria): void
     {
         try {
             $db = Propel::getServiceContainer()->getAdapter($criteria->getDbName());
@@ -135,7 +135,7 @@ abstract class AbstractCriterion
      *
      * @return void
      */
-    protected function setColumn($column)
+    protected function setColumn($column): void
     {
         if ($column instanceof ColumnMap) {
             $this->column = $column->getName();
@@ -158,7 +158,7 @@ abstract class AbstractCriterion
      *
      * @return string A String with the column name.
      */
-    public function getColumn()
+    public function getColumn(): string
     {
         return $this->column;
     }
@@ -170,7 +170,7 @@ abstract class AbstractCriterion
      *
      * @return void
      */
-    public function setTable($name)
+    public function setTable($name): void
     {
         $this->table = $name;
     }
@@ -180,7 +180,7 @@ abstract class AbstractCriterion
      *
      * @return string|null A String with the table name.
      */
-    public function getTable()
+    public function getTable(): ?string
     {
         return $this->table;
     }
@@ -190,7 +190,7 @@ abstract class AbstractCriterion
      *
      * @return string A String with the comparison.
      */
-    public function getComparison()
+    public function getComparison(): string
     {
         return $this->comparison;
     }
@@ -213,7 +213,7 @@ abstract class AbstractCriterion
      *
      * @return \Propel\Runtime\Adapter\AdapterInterface value of db.
      */
-    public function getAdapter()
+    public function getAdapter(): AdapterInterface
     {
         return $this->db;
     }
@@ -227,7 +227,7 @@ abstract class AbstractCriterion
      *
      * @return void
      */
-    public function setAdapter(AdapterInterface $v)
+    public function setAdapter(AdapterInterface $v): void
     {
         $this->db = $v;
         foreach ($this->clauses as $clause) {
@@ -240,7 +240,7 @@ abstract class AbstractCriterion
      *
      * @return array<self>
      */
-    public function getClauses()
+    public function getClauses(): array
     {
         return $this->clauses;
     }
@@ -250,7 +250,7 @@ abstract class AbstractCriterion
      *
      * @return array
      */
-    public function getConjunctions()
+    public function getConjunctions(): array
     {
         return $this->conjunctions;
     }
@@ -296,7 +296,7 @@ abstract class AbstractCriterion
      *
      *                                expression into proper SQL.
      */
-    public function appendPsTo(&$sb, array &$params)
+    public function appendPsTo(&$sb, array &$params): void
     {
         if (!$this->clauses) {
             $this->appendPsForUniqueClauseTo($sb, $params);
@@ -317,7 +317,7 @@ abstract class AbstractCriterion
     /**
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         $sb = '';
         $params = [];
@@ -334,7 +334,7 @@ abstract class AbstractCriterion
      *
      * @return void
      */
-    abstract protected function appendPsForUniqueClauseTo(&$sb, array &$params);
+    abstract protected function appendPsForUniqueClauseTo(&$sb, array &$params): void;
 
     /**
      * This method checks another Criteria to see if they contain
@@ -344,7 +344,7 @@ abstract class AbstractCriterion
      *
      * @return bool
      */
-    public function equals($obj)
+    public function equals($obj): bool
     {
         // TODO: optimize me with early outs
         if ($this === $obj) {
@@ -388,7 +388,7 @@ abstract class AbstractCriterion
      *
      * @return array
      */
-    public function getAllTables()
+    public function getAllTables(): array
     {
         $tables = [];
         $this->addCriterionTable($this, $tables);
@@ -405,7 +405,7 @@ abstract class AbstractCriterion
      *
      * @return void
      */
-    private function addCriterionTable(AbstractCriterion $c, array &$s)
+    private function addCriterionTable(AbstractCriterion $c, array &$s): void
     {
         $s[] = $c->getTable();
         foreach ($c->getClauses() as $clause) {
@@ -419,7 +419,7 @@ abstract class AbstractCriterion
      *
      * @return array<\Propel\Runtime\ActiveQuery\Criterion\AbstractCriterion>
      */
-    public function getAttachedCriterion()
+    public function getAttachedCriterion(): array
     {
         $criterions = [$this];
         foreach ($this->getClauses() as $criterion) {

--- a/src/Propel/Runtime/ActiveQuery/Criterion/AbstractModelCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/AbstractModelCriterion.php
@@ -45,7 +45,7 @@ abstract class AbstractModelCriterion extends AbstractCriterion
     /**
      * @return string
      */
-    public function getClause()
+    public function getClause(): string
     {
         return $this->clause;
     }
@@ -58,7 +58,7 @@ abstract class AbstractModelCriterion extends AbstractCriterion
      *
      * @return bool
      */
-    public function equals($obj)
+    public function equals($obj): bool
     {
         // TODO: optimize me with early outs
         if ($this === $obj) {

--- a/src/Propel/Runtime/ActiveQuery/Criterion/BasicCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/BasicCriterion.php
@@ -100,7 +100,7 @@ class BasicCriterion extends AbstractCriterion
                 $sb .= $field . Criteria::ISNOTNULL;
             } else {
                 // for now throw an exception, because not sure how to interpret this
-                throw new InvalidValueException(sprintf('Could not build SQL for expression: %s %s NULL', $field, $this->comparison));
+                throw new InvalidValueException(sprintf('Could not build SQL for expression: `%s %s NULL`', $field, $this->comparison));
             }
         }
     }

--- a/src/Propel/Runtime/ActiveQuery/Criterion/BasicCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/BasicCriterion.php
@@ -54,7 +54,7 @@ class BasicCriterion extends AbstractCriterion
      *
      * @return bool True if case is ignored.
      */
-    public function isIgnoreCase()
+    public function isIgnoreCase(): bool
     {
         return $this->ignoreStringCase;
     }
@@ -69,7 +69,7 @@ class BasicCriterion extends AbstractCriterion
      *
      * @return void
      */
-    protected function appendPsForUniqueClauseTo(&$sb, array &$params)
+    protected function appendPsForUniqueClauseTo(&$sb, array &$params): void
     {
         $field = ($this->table === null) ? $this->column : $this->table . '.' . $this->column;
         // NULL VALUES need special treatment because the SQL syntax is different

--- a/src/Propel/Runtime/ActiveQuery/Criterion/BasicModelCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/BasicModelCriterion.php
@@ -26,7 +26,7 @@ class BasicModelCriterion extends AbstractModelCriterion
      *
      * @return void
      */
-    protected function appendPsForUniqueClauseTo(&$sb, array &$params)
+    protected function appendPsForUniqueClauseTo(&$sb, array &$params): void
     {
         if ($this->value !== null) {
             if (strpos($this->clause, '?') === false) {

--- a/src/Propel/Runtime/ActiveQuery/Criterion/BinaryCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/BinaryCriterion.php
@@ -36,7 +36,7 @@ class BinaryCriterion extends AbstractCriterion
      *
      * @return void
      */
-    protected function appendPsForUniqueClauseTo(&$sb, array &$params)
+    protected function appendPsForUniqueClauseTo(&$sb, array &$params): void
     {
         if ($this->value !== null) {
             $params[] = ['table' => $this->realtable, 'column' => $this->column, 'value' => $this->value];

--- a/src/Propel/Runtime/ActiveQuery/Criterion/BinaryModelCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/BinaryModelCriterion.php
@@ -22,7 +22,7 @@ class BinaryModelCriterion extends AbstractModelCriterion
      *
      * @return void
      */
-    protected function appendPsForUniqueClauseTo(&$sb, array &$params)
+    protected function appendPsForUniqueClauseTo(&$sb, array &$params): void
     {
         if ($this->value !== null) {
             $params[] = ['table' => $this->realtable, 'column' => $this->column, 'value' => $this->value];

--- a/src/Propel/Runtime/ActiveQuery/Criterion/CustomCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/CustomCriterion.php
@@ -35,7 +35,7 @@ class CustomCriterion extends AbstractCriterion
      *
      * @return void
      */
-    protected function appendPsForUniqueClauseTo(&$sb, array &$params)
+    protected function appendPsForUniqueClauseTo(&$sb, array &$params): void
     {
         if ($this->value !== '') {
             $sb .= (string)$this->value;

--- a/src/Propel/Runtime/ActiveQuery/Criterion/ExistsCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/ExistsCriterion.php
@@ -70,7 +70,7 @@ class ExistsCriterion extends AbstractCriterion
      *
      * @return void
      */
-    protected function appendPsForUniqueClauseTo(&$sb, array &$params)
+    protected function appendPsForUniqueClauseTo(&$sb, array &$params): void
     {
         $existsQuery = $this->existsQuery
             ->clearSelectColumns()
@@ -85,7 +85,7 @@ class ExistsCriterion extends AbstractCriterion
      *
      * @return \Propel\Runtime\ActiveQuery\Criterion\AbstractCriterion
      */
-    protected function buildJoinCondition($outerQuery, RelationMap $relationMap)
+    protected function buildJoinCondition($outerQuery, RelationMap $relationMap): AbstractCriterion
     {
         $join = new ModelJoin();
         $outerAlias = $outerQuery->getModelAlias();

--- a/src/Propel/Runtime/ActiveQuery/Criterion/InCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/InCriterion.php
@@ -37,7 +37,7 @@ class InCriterion extends AbstractCriterion
      *
      * @return void
      */
-    protected function appendPsForUniqueClauseTo(&$sb, array &$params)
+    protected function appendPsForUniqueClauseTo(&$sb, array &$params): void
     {
         $bindParams = [];
         $index = count($params); // to avoid counting the number of parameters for each element in the array

--- a/src/Propel/Runtime/ActiveQuery/Criterion/InModelCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/InModelCriterion.php
@@ -24,7 +24,7 @@ class InModelCriterion extends AbstractModelCriterion
      *
      * @return void
      */
-    protected function appendPsForUniqueClauseTo(&$sb, array &$params)
+    protected function appendPsForUniqueClauseTo(&$sb, array &$params): void
     {
         $bindParams = []; // the param names used in query building
         $index = count($params);

--- a/src/Propel/Runtime/ActiveQuery/Criterion/LikeCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/LikeCriterion.php
@@ -54,7 +54,7 @@ class LikeCriterion extends AbstractCriterion
      *
      * @return bool True if case is ignored.
      */
-    public function isIgnoreCase()
+    public function isIgnoreCase(): bool
     {
         return $this->ignoreStringCase;
     }
@@ -67,7 +67,7 @@ class LikeCriterion extends AbstractCriterion
      *
      * @return void
      */
-    protected function appendPsForUniqueClauseTo(&$sb, array &$params)
+    protected function appendPsForUniqueClauseTo(&$sb, array &$params): void
     {
         $field = ($this->table === null) ? $this->column : $this->table . '.' . $this->column;
         $db = $this->getAdapter();

--- a/src/Propel/Runtime/ActiveQuery/Criterion/LikeModelCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/LikeModelCriterion.php
@@ -41,7 +41,7 @@ class LikeModelCriterion extends BasicModelCriterion
      *
      * @return bool True if case is ignored.
      */
-    public function isIgnoreCase()
+    public function isIgnoreCase(): bool
     {
         return $this->ignoreStringCase;
     }
@@ -57,7 +57,7 @@ class LikeModelCriterion extends BasicModelCriterion
      *
      * @return void
      */
-    protected function appendPsForUniqueClauseTo(&$sb, array &$params)
+    protected function appendPsForUniqueClauseTo(&$sb, array &$params): void
     {
         // LIKE is case insensitive in mySQL and SQLite, but not in PostGres
         // If the column is case insensitive, use ILIKE / NOT ILIKE instead of LIKE / NOT LIKE

--- a/src/Propel/Runtime/ActiveQuery/Criterion/RawCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/RawCriterion.php
@@ -53,7 +53,7 @@ class RawCriterion extends AbstractCriterion
     protected function appendPsForUniqueClauseTo(&$sb, array &$params): void
     {
         if (substr_count($this->column, '?') !== 1) {
-            throw new InvalidClauseException(sprintf('Could not build SQL for expression "%s" because Criteria::RAW works only with a clause containing a single question mark placeholder', $this->column));
+            throw new InvalidClauseException(sprintf('Could not build SQL for expression `%s` because Criteria::RAW works only with a clause containing a single question mark placeholder', $this->column));
         }
         $params[] = ['table' => null, 'type' => $this->type, 'value' => $this->value];
         $sb .= str_replace('?', ':p' . count($params), $this->column);

--- a/src/Propel/Runtime/ActiveQuery/Criterion/RawCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/RawCriterion.php
@@ -50,7 +50,7 @@ class RawCriterion extends AbstractCriterion
      *
      * @return void
      */
-    protected function appendPsForUniqueClauseTo(&$sb, array &$params)
+    protected function appendPsForUniqueClauseTo(&$sb, array &$params): void
     {
         if (substr_count($this->column, '?') !== 1) {
             throw new InvalidClauseException(sprintf('Could not build SQL for expression "%s" because Criteria::RAW works only with a clause containing a single question mark placeholder', $this->column));

--- a/src/Propel/Runtime/ActiveQuery/Criterion/RawModelCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/RawModelCriterion.php
@@ -51,7 +51,7 @@ class RawModelCriterion extends AbstractModelCriterion
      *
      * @return void
      */
-    protected function appendPsForUniqueClauseTo(&$sb, array &$params)
+    protected function appendPsForUniqueClauseTo(&$sb, array &$params): void
     {
         if (substr_count($this->clause, '?') !== 1) {
             throw new InvalidClauseException(sprintf('Could not build SQL for expression "%s" because Criteria::MODEL_CLAUSE_RAW works only with a clause containing a single question mark placeholder', $this->column));

--- a/src/Propel/Runtime/ActiveQuery/Criterion/RawModelCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/RawModelCriterion.php
@@ -54,7 +54,7 @@ class RawModelCriterion extends AbstractModelCriterion
     protected function appendPsForUniqueClauseTo(&$sb, array &$params): void
     {
         if (substr_count($this->clause, '?') !== 1) {
-            throw new InvalidClauseException(sprintf('Could not build SQL for expression "%s" because Criteria::MODEL_CLAUSE_RAW works only with a clause containing a single question mark placeholder', $this->column));
+            throw new InvalidClauseException(sprintf('Could not build SQL for expression `%s` because Criteria::MODEL_CLAUSE_RAW works only with a clause containing a single question mark placeholder', $this->column));
         }
         $params[] = [
             'table' => null,

--- a/src/Propel/Runtime/ActiveQuery/Criterion/SeveralModelCriterion.php
+++ b/src/Propel/Runtime/ActiveQuery/Criterion/SeveralModelCriterion.php
@@ -25,7 +25,7 @@ class SeveralModelCriterion extends AbstractModelCriterion
      *
      * @return void
      */
-    protected function appendPsForUniqueClauseTo(&$sb, array &$params)
+    protected function appendPsForUniqueClauseTo(&$sb, array &$params): void
     {
         if (!is_array($this->value)) {
             throw new InvalidValueException('Only array values are supported by this Criterion');
@@ -58,7 +58,7 @@ class SeveralModelCriterion extends AbstractModelCriterion
      *
      * @return string
      */
-    protected static function strReplaceOnce($search, $replace, $subject)
+    protected static function strReplaceOnce($search, $replace, $subject): string
     {
         $firstChar = strpos($subject, $search);
         if ($firstChar !== false) {

--- a/src/Propel/Runtime/ActiveQuery/InstancePoolTrait.php
+++ b/src/Propel/Runtime/ActiveQuery/InstancePoolTrait.php
@@ -24,7 +24,7 @@ trait InstancePoolTrait
      *
      * @return void
      */
-    public static function addInstanceToPool($object, $key = null)
+    public static function addInstanceToPool($object, $key = null): void
     {
         if (!Propel::isInstancePoolingEnabled()) {
             return;
@@ -43,7 +43,7 @@ trait InstancePoolTrait
      *
      * @return string|null
      */
-    public static function getInstanceKey($value)
+    public static function getInstanceKey($value): ?string
     {
         if (!($value instanceof Criteria) && is_object($value)) {
             $pk = $value->getPrimaryKey();
@@ -70,7 +70,7 @@ trait InstancePoolTrait
      *
      * @return void
      */
-    public static function removeInstanceFromPool($value)
+    public static function removeInstanceFromPool($value): void
     {
         if (Propel::isInstancePoolingEnabled() && $value !== null) {
             $key = static::getInstanceKey($value);
@@ -87,7 +87,7 @@ trait InstancePoolTrait
      *
      * @return object|null
      */
-    public static function getInstanceFromPool($key)
+    public static function getInstanceFromPool($key): ?object
     {
         if (Propel::isInstancePoolingEnabled()) {
             if (isset(self::$instances[$key])) {
@@ -101,7 +101,7 @@ trait InstancePoolTrait
     /**
      * @return void
      */
-    public static function clearInstancePool()
+    public static function clearInstancePool(): void
     {
         self::$instances = [];
     }
@@ -109,7 +109,7 @@ trait InstancePoolTrait
     /**
      * @return void
      */
-    public static function clearRelatedInstancePool()
+    public static function clearRelatedInstancePool(): void
     {
     }
 }

--- a/src/Propel/Runtime/ActiveQuery/Join.php
+++ b/src/Propel/Runtime/ActiveQuery/Join.php
@@ -162,7 +162,7 @@ class Join
      *
      * @return void
      */
-    public function addCondition($left, $right, $operator = self::EQUAL)
+    public function addCondition($left, $right, $operator = self::EQUAL): void
     {
         if (strrpos($left, '.')) {
             [$this->leftTableName, $this->left[]] = explode('.', $left);
@@ -193,7 +193,7 @@ class Join
      *
      * @return void
      */
-    public function addConditions($lefts, $rights, $operators = [])
+    public function addConditions($lefts, $rights, $operators = []): void
     {
         if (count($lefts) != count($rights)) {
             throw new LogicException("Unable to create join because the left column count isn't equal to the right column count");
@@ -234,7 +234,7 @@ class Join
         $rightColumnName = null,
         $rightTableAlias = null,
         $operator = self::EQUAL
-    ) {
+    ): void {
         $this->leftTableName = $leftTableName;
         $this->leftTableAlias = $leftTableAlias;
         $this->rightTableName = $rightTableName;
@@ -256,7 +256,7 @@ class Join
      *
      * @return void
      */
-    public function addLocalValueCondition($leftTableName, $leftColumnName, $leftTableAlias, $leftColumnValue, $operator = self::EQUAL)
+    public function addLocalValueCondition($leftTableName, $leftColumnName, $leftTableAlias, $leftColumnValue, $operator = self::EQUAL): void
     {
         $this->leftTableName = $leftTableName;
         $this->leftTableAlias = $leftTableAlias;
@@ -277,7 +277,7 @@ class Join
      *
      * @return void
      */
-    public function addForeignValueCondition($rightTableName, $rightColumnName, $rightTableAlias, $rightColumnValue, $operator = self::EQUAL)
+    public function addForeignValueCondition($rightTableName, $rightColumnName, $rightTableAlias, $rightColumnValue, $operator = self::EQUAL): void
     {
         $this->rightTableName = $rightTableName;
         $this->rightTableAlias = $rightTableAlias;
@@ -294,7 +294,7 @@ class Join
      *
      * @return int The number of conditions in the join
      */
-    public function countConditions()
+    public function countConditions(): int
     {
         return $this->count;
     }
@@ -304,7 +304,7 @@ class Join
      *
      * @return array An array of arrays representing (left, comparison, right) for each condition
      */
-    public function getConditions()
+    public function getConditions(): array
     {
         $conditions = [];
         for ($i = 0; $i < $this->count; $i++) {
@@ -323,7 +323,7 @@ class Join
      *
      * @return void
      */
-    public function addOperator($operator)
+    public function addOperator($operator): void
     {
         $this->operators[] = $operator;
     }
@@ -333,7 +333,7 @@ class Join
      *
      * @return string the comparison operator for the join condition
      */
-    public function getOperator($index = 0)
+    public function getOperator($index = 0): string
     {
         return $this->operators[$index];
     }
@@ -341,7 +341,7 @@ class Join
     /**
      * @return array<string>
      */
-    public function getOperators()
+    public function getOperators(): array
     {
         return $this->operators;
     }
@@ -355,7 +355,7 @@ class Join
      *
      * @return void
      */
-    public function setJoinType($joinType = null)
+    public function setJoinType($joinType = null): void
     {
         $this->joinType = $joinType;
     }
@@ -366,7 +366,7 @@ class Join
      * @return string The type of the join, i.e. Criteria::LEFT_JOIN(), ...,
      *                or null for adding the join condition to the where Clause
      */
-    public function getJoinType()
+    public function getJoinType(): string
     {
         return $this->joinType ?? self::INNER_JOIN;
     }
@@ -384,7 +384,7 @@ class Join
      *
      * @return void
      */
-    public function addLeftColumnName($left)
+    public function addLeftColumnName($left): void
     {
         $this->left[] = $left;
     }
@@ -396,7 +396,7 @@ class Join
      *
      * @return void
      */
-    public function addLeftValue($value)
+    public function addLeftValue($value): void
     {
         $this->leftValues = $value;
     }
@@ -414,7 +414,7 @@ class Join
      *
      * @return string
      */
-    public function getLeftColumn($index = 0)
+    public function getLeftColumn($index = 0): string
     {
         $tableName = $this->getLeftTableAliasOrName();
 
@@ -434,7 +434,7 @@ class Join
      *
      * @return string
      */
-    public function getLeftColumnName($index = 0)
+    public function getLeftColumnName($index = 0): string
     {
         return $this->left[$index];
     }
@@ -444,7 +444,7 @@ class Join
      *
      * @return array
      */
-    public function getLeftColumns()
+    public function getLeftColumns(): array
     {
         $columns = [];
         foreach ($this->left as $index => $column) {
@@ -469,7 +469,7 @@ class Join
     /**
      * @return string|null
      */
-    public function getLeftTableName()
+    public function getLeftTableName(): ?string
     {
         return $this->leftTableName;
     }
@@ -489,7 +489,7 @@ class Join
     /**
      * @return string|null
      */
-    public function getLeftTableAlias()
+    public function getLeftTableAlias(): ?string
     {
         return $this->leftTableAlias;
     }
@@ -497,7 +497,7 @@ class Join
     /**
      * @return bool
      */
-    public function hasLeftTableAlias()
+    public function hasLeftTableAlias(): bool
     {
         return $this->leftTableAlias !== null;
     }
@@ -505,7 +505,7 @@ class Join
     /**
      * @return string|null
      */
-    public function getLeftTableAliasOrName()
+    public function getLeftTableAliasOrName(): ?string
     {
         return $this->leftTableAlias ?: $this->leftTableName;
     }
@@ -513,7 +513,7 @@ class Join
     /**
      * @return string
      */
-    public function getLeftTableWithAlias()
+    public function getLeftTableWithAlias(): string
     {
         return $this->leftTableAlias ? $this->leftTableName . ' ' . $this->leftTableAlias : $this->leftTableName;
     }
@@ -531,7 +531,7 @@ class Join
      *
      * @return void
      */
-    public function addRightColumnName($right)
+    public function addRightColumnName($right): void
     {
         $this->right[] = $right;
     }
@@ -549,7 +549,7 @@ class Join
      *
      * @return string
      */
-    public function getRightColumn($index = 0)
+    public function getRightColumn($index = 0): string
     {
         $tableName = $this->getRightTableAliasOrName();
 
@@ -569,7 +569,7 @@ class Join
      *
      * @return string
      */
-    public function getRightColumnName($index = 0)
+    public function getRightColumnName($index = 0): string
     {
         return $this->right[$index];
     }
@@ -577,7 +577,7 @@ class Join
     /**
      * @return array All right columns of the join condition
      */
-    public function getRightColumns()
+    public function getRightColumns(): array
     {
         $columns = [];
         foreach ($this->right as $index => $column) {
@@ -602,7 +602,7 @@ class Join
     /**
      * @return string|null
      */
-    public function getRightTableName()
+    public function getRightTableName(): ?string
     {
         return $this->rightTableName;
     }
@@ -622,7 +622,7 @@ class Join
     /**
      * @return string|null
      */
-    public function getRightTableAlias()
+    public function getRightTableAlias(): ?string
     {
         return $this->rightTableAlias;
     }
@@ -630,7 +630,7 @@ class Join
     /**
      * @return bool
      */
-    public function hasRightTableAlias()
+    public function hasRightTableAlias(): bool
     {
         return $this->rightTableAlias !== null;
     }
@@ -638,7 +638,7 @@ class Join
     /**
      * @return string|null
      */
-    public function getRightTableAliasOrName()
+    public function getRightTableAliasOrName(): ?string
     {
         return $this->rightTableAlias ?: $this->rightTableName;
     }
@@ -646,7 +646,7 @@ class Join
     /**
      * @return string
      */
-    public function getRightTableWithAlias()
+    public function getRightTableWithAlias(): string
     {
         return $this->rightTableAlias ? $this->rightTableName . ' ' . $this->rightTableAlias : $this->rightTableName;
     }
@@ -659,7 +659,7 @@ class Join
      *
      * @return \Propel\Runtime\Adapter\AdapterInterface value of db.
      */
-    public function getAdapter()
+    public function getAdapter(): AdapterInterface
     {
         return $this->db;
     }
@@ -673,7 +673,7 @@ class Join
      *
      * @return void
      */
-    public function setAdapter(AdapterInterface $db)
+    public function setAdapter(AdapterInterface $db): void
     {
         $this->db = $db;
     }
@@ -685,7 +685,7 @@ class Join
      *
      * @return void
      */
-    public function setJoinCondition(AbstractCriterion $joinCondition)
+    public function setJoinCondition(AbstractCriterion $joinCondition): void
     {
         $this->joinCondition = $joinCondition;
     }
@@ -695,7 +695,7 @@ class Join
      *
      * @return \Propel\Runtime\ActiveQuery\Criterion\AbstractCriterion
      */
-    public function getJoinCondition()
+    public function getJoinCondition(): AbstractCriterion
     {
         return $this->joinCondition;
     }
@@ -707,7 +707,7 @@ class Join
      *
      * @return void
      */
-    public function buildJoinCondition(Criteria $c)
+    public function buildJoinCondition(Criteria $c): void
     {
         /** @var \Propel\Runtime\ActiveQuery\Criterion\AbstractCriterion|null $joinCondition */
         $joinCondition = null;
@@ -758,7 +758,7 @@ class Join
      *
      * @return string SQL join clause with join condition
      */
-    public function getClause(&$params)
+    public function getClause(&$params): string
     {
         if ($this->joinCondition === null) {
             $conditions = [];
@@ -796,7 +796,7 @@ class Join
      *
      * @return bool
      */
-    public function equals($join)
+    public function equals($join): bool
     {
         $parametersOfThisClauses = [];
         $parametersOfJoinClauses = [];
@@ -813,7 +813,7 @@ class Join
      *
      * @return string A string representation of the object
      */
-    public function toString()
+    public function toString(): string
     {
         $params = [];
 
@@ -823,7 +823,7 @@ class Join
     /**
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->toString();
     }
@@ -831,7 +831,7 @@ class Join
     /**
      * @return bool
      */
-    public function isIdentifierQuotingEnabled()
+    public function isIdentifierQuotingEnabled(): bool
     {
         return $this->identifierQuoting;
     }
@@ -841,7 +841,7 @@ class Join
      *
      * @return void
      */
-    public function setIdentifierQuoting($identifierQuoting)
+    public function setIdentifierQuoting($identifierQuoting): void
     {
         $this->identifierQuoting = $identifierQuoting;
     }

--- a/src/Propel/Runtime/ActiveQuery/Join.php
+++ b/src/Propel/Runtime/ActiveQuery/Join.php
@@ -644,9 +644,9 @@ class Join
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getRightTableWithAlias(): string
+    public function getRightTableWithAlias(): ?string
     {
         return $this->rightTableAlias ? $this->rightTableName . ' ' . $this->rightTableAlias : $this->rightTableName;
     }
@@ -693,9 +693,9 @@ class Join
     /**
      * Get the custom join condition, if previously set
      *
-     * @return \Propel\Runtime\ActiveQuery\Criterion\AbstractCriterion
+     * @return \Propel\Runtime\ActiveQuery\Criterion\AbstractCriterion|null
      */
-    public function getJoinCondition(): AbstractCriterion
+    public function getJoinCondition(): ?AbstractCriterion
     {
         return $this->joinCondition;
     }

--- a/src/Propel/Runtime/ActiveQuery/Join.php
+++ b/src/Propel/Runtime/ActiveQuery/Join.php
@@ -511,9 +511,9 @@ class Join
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getLeftTableWithAlias(): string
+    public function getLeftTableWithAlias(): ?string
     {
         return $this->leftTableAlias ? $this->leftTableName . ' ' . $this->leftTableAlias : $this->leftTableName;
     }
@@ -657,9 +657,9 @@ class Join
      * The AdapterInterface which might be used to get db specific
      * variations of sql.
      *
-     * @return \Propel\Runtime\Adapter\AdapterInterface value of db.
+     * @return \Propel\Runtime\Adapter\AdapterInterface|null value of db.
      */
-    public function getAdapter(): AdapterInterface
+    public function getAdapter(): ?AdapterInterface
     {
         return $this->db;
     }

--- a/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
@@ -1460,8 +1460,8 @@ class ModelCriteria extends BaseModelCriteria
 
         $ret = $this->findOne($con);
         if (!$ret) {
+            /** @var class-string $class */
             $class = $this->getModelName();
-            /** @var object $obj */
             $obj = new $class();
             foreach ($this->keys() as $key) {
                 $obj->setByName($key, $this->getValue($key), TableMap::TYPE_COLNAME);

--- a/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
@@ -534,7 +534,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @see select()
      *
-     * @return array|string A list of column names (e.g. array('Title', 'Category.Name', 'c.Content')) or a single column name (e.g. 'Name')
+     * @return array<string>|string|null A list of column names (e.g. array('Title', 'Category.Name', 'c.Content')) or a single column name (e.g. 'Name')
      */
     public function getSelect()
     {
@@ -894,9 +894,9 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @throws \Propel\Runtime\Exception\RuntimeException
      *
-     * @return self The primary criteria object
+     * @return self|null The primary criteria object
      */
-    public function endUse(): self
+    public function endUse(): ?self
     {
         if ($this->isExistsQuery) {
             return $this->getPrimaryCriteria();
@@ -1461,6 +1461,7 @@ class ModelCriteria extends BaseModelCriteria
         $ret = $this->findOne($con);
         if (!$ret) {
             $class = $this->getModelName();
+            /** @var object $obj */
             $obj = new $class();
             foreach ($this->keys() as $key) {
                 $obj->setByName($key, $this->getValue($key), TableMap::TYPE_COLNAME);

--- a/src/Propel/Runtime/ActiveQuery/ModelJoin.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelJoin.php
@@ -86,9 +86,9 @@ class ModelJoin extends Join
     }
 
     /**
-     * @return \Propel\Runtime\Map\RelationMap
+     * @return \Propel\Runtime\Map\RelationMap|null
      */
-    public function getRelationMap(): RelationMap
+    public function getRelationMap(): ?RelationMap
     {
         return $this->relationMap;
     }
@@ -110,9 +110,9 @@ class ModelJoin extends Join
     /**
      * Gets the right tableMap for this join
      *
-     * @return \Propel\Runtime\Map\TableMap The table map
+     * @return \Propel\Runtime\Map\TableMap|null The table map
      */
-    public function getTableMap(): TableMap
+    public function getTableMap(): ?TableMap
     {
         if ($this->tableMap === null && $this->relationMap !== null) {
             $this->tableMap = $this->relationMap->getRightTable();

--- a/src/Propel/Runtime/ActiveQuery/ModelJoin.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelJoin.php
@@ -134,9 +134,9 @@ class ModelJoin extends Join
     }
 
     /**
-     * @return self
+     * @return self|null
      */
-    public function getPreviousJoin(): self
+    public function getPreviousJoin(): ?self
     {
         return $this->previousJoin;
     }

--- a/src/Propel/Runtime/ActiveQuery/ModelJoin.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelJoin.php
@@ -88,7 +88,7 @@ class ModelJoin extends Join
     /**
      * @return \Propel\Runtime\Map\RelationMap
      */
-    public function getRelationMap()
+    public function getRelationMap(): RelationMap
     {
         return $this->relationMap;
     }
@@ -112,7 +112,7 @@ class ModelJoin extends Join
      *
      * @return \Propel\Runtime\Map\TableMap The table map
      */
-    public function getTableMap()
+    public function getTableMap(): TableMap
     {
         if ($this->tableMap === null && $this->relationMap !== null) {
             $this->tableMap = $this->relationMap->getRightTable();
@@ -136,7 +136,7 @@ class ModelJoin extends Join
     /**
      * @return self
      */
-    public function getPreviousJoin()
+    public function getPreviousJoin(): self
     {
         return $this->previousJoin;
     }
@@ -144,7 +144,7 @@ class ModelJoin extends Join
     /**
      * @return bool
      */
-    public function isPrimary()
+    public function isPrimary(): bool
     {
         return $this->previousJoin === null;
     }
@@ -164,7 +164,7 @@ class ModelJoin extends Join
     /**
      * @return string|null
      */
-    public function getRelationAlias()
+    public function getRelationAlias(): ?string
     {
         return $this->getRightTableAlias();
     }
@@ -172,7 +172,7 @@ class ModelJoin extends Join
     /**
      * @return bool
      */
-    public function hasRelationAlias()
+    public function hasRelationAlias(): bool
     {
         return $this->hasRightTableAlias();
     }
@@ -180,7 +180,7 @@ class ModelJoin extends Join
     /**
      * @return bool
      */
-    public function isIdentifierQuotingEnabled()
+    public function isIdentifierQuotingEnabled(): bool
     {
         return $this->getTableMap()->isIdentifierQuotingEnabled();
     }
@@ -197,7 +197,7 @@ class ModelJoin extends Join
      *
      * @return object The base Object of this join
      */
-    public function getObjectToRelate($startObject)
+    public function getObjectToRelate($startObject): object
     {
         if ($this->isPrimary()) {
             return $startObject;
@@ -215,7 +215,7 @@ class ModelJoin extends Join
      *
      * @return bool
      */
-    public function equals($join)
+    public function equals($join): bool
     {
         /** @phpstan-var \Propel\Runtime\ActiveQuery\ModelJoin $join */
         return parent::equals($join)
@@ -227,7 +227,7 @@ class ModelJoin extends Join
     /**
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return parent::toString()
             . ' tableMap: ' . ($this->tableMap ? get_class($this->tableMap) : 'null')

--- a/src/Propel/Runtime/ActiveQuery/ModelWith.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelWith.php
@@ -285,9 +285,9 @@ class ModelWith
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getLeftPhpName(): string
+    public function getLeftPhpName(): ?string
     {
         return $this->leftPhpName;
     }
@@ -303,9 +303,9 @@ class ModelWith
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getRightPhpName(): string
+    public function getRightPhpName(): ?string
     {
         return $this->rightPhpName;
     }

--- a/src/Propel/Runtime/ActiveQuery/ModelWith.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelWith.php
@@ -9,6 +9,7 @@
 namespace Propel\Runtime\ActiveQuery;
 
 use Propel\Runtime\Map\RelationMap;
+use Propel\Runtime\Map\TableMap;
 
 /**
  * Data object to describe a joined hydration in a Model Query
@@ -91,7 +92,7 @@ class ModelWith
      *
      * @return void
      */
-    public function init(ModelJoin $join)
+    public function init(ModelJoin $join): void
     {
         $tableMap = $join->getTableMap();
         $this->setModelName($tableMap->getClassName());
@@ -122,7 +123,7 @@ class ModelWith
      *
      * @return void
      */
-    public function setModelName($modelName)
+    public function setModelName($modelName): void
     {
         if (strpos($modelName, '\\') === 0) {
             $this->modelName = substr($modelName, 1);
@@ -134,7 +135,7 @@ class ModelWith
     /**
      * @return \Propel\Runtime\Map\TableMap
      */
-    public function getTableMap()
+    public function getTableMap(): TableMap
     {
         return $this->getTableMap;
     }
@@ -142,7 +143,7 @@ class ModelWith
     /**
      * @return string
      */
-    public function getModelName()
+    public function getModelName(): string
     {
         return $this->modelName;
     }
@@ -152,7 +153,7 @@ class ModelWith
      *
      * @return void
      */
-    public function setIsSingleTableInheritance($isSingleTableInheritance)
+    public function setIsSingleTableInheritance($isSingleTableInheritance): void
     {
         $this->isSingleTableInheritance = $isSingleTableInheritance;
     }
@@ -160,7 +161,7 @@ class ModelWith
     /**
      * @return bool
      */
-    public function isSingleTableInheritance()
+    public function isSingleTableInheritance(): bool
     {
         return $this->isSingleTableInheritance;
     }
@@ -170,7 +171,7 @@ class ModelWith
      *
      * @return void
      */
-    public function setIsAdd($isAdd)
+    public function setIsAdd($isAdd): void
     {
         $this->isAdd = $isAdd;
     }
@@ -178,7 +179,7 @@ class ModelWith
     /**
      * @return bool
      */
-    public function isAdd()
+    public function isAdd(): bool
     {
         return $this->isAdd;
     }
@@ -188,7 +189,7 @@ class ModelWith
      *
      * @return void
      */
-    public function setIsWithOneToMany($isWithOneToMany)
+    public function setIsWithOneToMany($isWithOneToMany): void
     {
         $this->isWithOneToMany = $isWithOneToMany;
     }
@@ -196,7 +197,7 @@ class ModelWith
     /**
      * @return bool
      */
-    public function isWithOneToMany()
+    public function isWithOneToMany(): bool
     {
         return $this->isWithOneToMany;
     }
@@ -206,7 +207,7 @@ class ModelWith
      *
      * @return void
      */
-    public function setRelationName($relationName)
+    public function setRelationName($relationName): void
     {
         $this->relationName = $relationName;
     }
@@ -214,7 +215,7 @@ class ModelWith
     /**
      * @return string
      */
-    public function getRelationName()
+    public function getRelationName(): string
     {
         return $this->relationName;
     }
@@ -224,7 +225,7 @@ class ModelWith
      *
      * @return void
      */
-    public function setRelationMethod($relationMethod)
+    public function setRelationMethod($relationMethod): void
     {
         $this->relationMethod = $relationMethod;
     }
@@ -232,7 +233,7 @@ class ModelWith
     /**
      * @return string
      */
-    public function getRelationMethod()
+    public function getRelationMethod(): string
     {
         return $this->relationMethod;
     }
@@ -242,7 +243,7 @@ class ModelWith
      *
      * @return void
      */
-    public function setInitMethod($initMethod)
+    public function setInitMethod($initMethod): void
     {
         $this->initMethod = $initMethod;
     }
@@ -250,7 +251,7 @@ class ModelWith
     /**
      * @return string
      */
-    public function getInitMethod()
+    public function getInitMethod(): string
     {
         return $this->initMethod;
     }
@@ -260,7 +261,7 @@ class ModelWith
      *
      * @return void
      */
-    public function setResetPartialMethod($resetPartialMethod)
+    public function setResetPartialMethod($resetPartialMethod): void
     {
         $this->resetPartialMethod = $resetPartialMethod;
     }
@@ -268,7 +269,7 @@ class ModelWith
     /**
      * @return string
      */
-    public function getResetPartialMethod()
+    public function getResetPartialMethod(): string
     {
         return $this->resetPartialMethod;
     }
@@ -278,7 +279,7 @@ class ModelWith
      *
      * @return void
      */
-    public function setLeftPhpName($leftPhpName)
+    public function setLeftPhpName($leftPhpName): void
     {
         $this->leftPhpName = $leftPhpName;
     }
@@ -286,7 +287,7 @@ class ModelWith
     /**
      * @return string
      */
-    public function getLeftPhpName()
+    public function getLeftPhpName(): string
     {
         return $this->leftPhpName;
     }
@@ -296,7 +297,7 @@ class ModelWith
      *
      * @return void
      */
-    public function setRightPhpName($rightPhpName)
+    public function setRightPhpName($rightPhpName): void
     {
         $this->rightPhpName = $rightPhpName;
     }
@@ -304,7 +305,7 @@ class ModelWith
     /**
      * @return string
      */
-    public function getRightPhpName()
+    public function getRightPhpName(): string
     {
         return $this->rightPhpName;
     }
@@ -314,7 +315,7 @@ class ModelWith
     /**
      * @return bool
      */
-    public function isPrimary()
+    public function isPrimary(): bool
     {
         return $this->leftPhpName === null;
     }
@@ -322,7 +323,7 @@ class ModelWith
     /**
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return sprintf('modelName: %s, relationName: %s, relationMethod: %s, leftPhpName: %s, rightPhpName: %s', $this->modelName, $this->relationName, $this->relationMethod, $this->leftPhpName, $this->rightPhpName);
     }

--- a/src/Propel/Runtime/ActiveQuery/PropelQuery.php
+++ b/src/Propel/Runtime/ActiveQuery/PropelQuery.php
@@ -24,7 +24,7 @@ class PropelQuery
      *
      * @return \Propel\Runtime\ActiveQuery\ModelCriteria
      */
-    public static function from($queryClassAndAlias)
+    public static function from($queryClassAndAlias): ModelCriteria
     {
         [$class, $alias] = ModelCriteria::getClassAndAlias($queryClassAndAlias);
         $queryClass = $class . 'Query';

--- a/src/Propel/Runtime/ActiveQuery/SqlBuilder/AbstractSqlQueryBuilder.php
+++ b/src/Propel/Runtime/ActiveQuery/SqlBuilder/AbstractSqlQueryBuilder.php
@@ -73,7 +73,7 @@ abstract class AbstractSqlQueryBuilder
      *
      * @return string
      */
-    public function quoteIdentifierTable(string $rawTableName)
+    public function quoteIdentifierTable(string $rawTableName): string
     {
         if ($this->criteria->isIdentifierQuotingEnabled()) {
             return $this->adapter->quoteIdentifierTable($rawTableName);
@@ -101,7 +101,7 @@ abstract class AbstractSqlQueryBuilder
      *
      * @return array
      */
-    public function buildParams($columnNames, ?Criteria $values = null)
+    public function buildParams($columnNames, ?Criteria $values = null): array
     {
         if (!$values) {
             $values = $this->criteria;

--- a/src/Propel/Runtime/ActiveQuery/SqlBuilder/DeleteQuerySqlBuilder.php
+++ b/src/Propel/Runtime/ActiveQuery/SqlBuilder/DeleteQuerySqlBuilder.php
@@ -55,7 +55,8 @@ class DeleteQuerySqlBuilder extends AbstractSqlQueryBuilder
     protected function buildDeleteFromClause(string $tableName): string
     {
         $sql = ['DELETE'];
-        if ($queryComment = $this->criteria->getComment()) {
+        $queryComment = $this->criteria->getComment();
+        if ($queryComment) {
             $sql[] = '/* ' . $queryComment . ' */';
         }
 

--- a/src/Propel/Runtime/ActiveQuery/SqlBuilder/SelectQuerySqlBuilder.php
+++ b/src/Propel/Runtime/ActiveQuery/SqlBuilder/SelectQuerySqlBuilder.php
@@ -204,7 +204,9 @@ class SelectQuerySqlBuilder extends AbstractSqlQueryBuilder
     {
         $joinTables = [];
         foreach ($this->criteria->getJoins() as $join) {
-            $joinTables[] = $join->getRightTableWithAlias();
+            /** @var string $table */
+            $table = $join->getRightTableWithAlias();
+            $joinTables[] = $table;
         }
 
         return $joinTables;

--- a/src/Propel/Runtime/ActiveRecord/NestedSetRecursiveIterator.php
+++ b/src/Propel/Runtime/ActiveRecord/NestedSetRecursiveIterator.php
@@ -69,7 +69,7 @@ class NestedSetRecursiveIterator implements RecursiveIterator
      * @return string
      */
     #[\ReturnTypeWillChange]
-    public function key()
+    public function key(): string
     {
         $method = method_exists($this->curNode, 'getPath') ? 'getPath' : 'getAncestors';
         $key = [];

--- a/src/Propel/Runtime/Adapter/AdapterFactory.php
+++ b/src/Propel/Runtime/Adapter/AdapterFactory.php
@@ -26,7 +26,7 @@ class AdapterFactory
      *
      * @return \Propel\Runtime\Adapter\AdapterInterface An instance of a Propel database adapter.
      */
-    public static function create($driver)
+    public static function create($driver): AdapterInterface
     {
         if (!$driver) {
             $adapterClass = '\Propel\Runtime\Adapter\NoneAdapter';

--- a/src/Propel/Runtime/Adapter/AdapterFactory.php
+++ b/src/Propel/Runtime/Adapter/AdapterFactory.php
@@ -39,7 +39,10 @@ class AdapterFactory
             $adapterClass = $driver;
         }
         if (class_exists($adapterClass)) {
-            return new $adapterClass();
+            /** @var \Propel\Runtime\Adapter\AdapterInterface $adapter */
+            $adapter = new $adapterClass();
+
+            return $adapter;
         }
 
         throw new InvalidArgumentException(sprintf('Unsupported Propel driver: "%s". Check your configuration file', $driver));

--- a/src/Propel/Runtime/Adapter/AdapterInterface.php
+++ b/src/Propel/Runtime/Adapter/AdapterInterface.php
@@ -39,7 +39,7 @@ interface AdapterInterface
      *
      * @return \Propel\Runtime\Connection\ConnectionInterface
      */
-    public function getConnection($params);
+    public function getConnection($params): ConnectionInterface;
 
     /**
      * Sets the character encoding using SQL standard SET NAMES statement.
@@ -54,7 +54,7 @@ interface AdapterInterface
      *
      * @return void
      */
-    public function setCharset(ConnectionInterface $con, $charset);
+    public function setCharset(ConnectionInterface $con, $charset): void;
 
     /**
      * This method is used to ignore case in an ORDER BY clause.
@@ -66,7 +66,7 @@ interface AdapterInterface
      *
      * @return string The string in a case that can be ignored.
      */
-    public function ignoreCaseInOrderBy($in);
+    public function ignoreCaseInOrderBy($in): string;
 
     /**
      * Returns the character used to indicate the beginning and end of
@@ -75,7 +75,7 @@ interface AdapterInterface
      *
      * @return string The text delimiter.
      */
-    public function getStringDelimiter();
+    public function getStringDelimiter(): string;
 
     /**
      * Returns SQL which concatenates the second string to the first.
@@ -85,7 +85,7 @@ interface AdapterInterface
      *
      * @return string
      */
-    public function concatString($s1, $s2);
+    public function concatString($s1, $s2): string;
 
     /**
      * Returns SQL which extracts a substring.
@@ -96,7 +96,7 @@ interface AdapterInterface
      *
      * @return string
      */
-    public function subString($s, $pos, $len);
+    public function subString($s, $pos, $len): string;
 
     /**
      * Returns SQL which calculates the length (in chars) of a string.
@@ -105,7 +105,7 @@ interface AdapterInterface
      *
      * @return string
      */
-    public function strLength($s);
+    public function strLength($s): string;
 
     /**
      * Quotes database object identifiers (table names, col names, sequences, etc.).
@@ -114,7 +114,7 @@ interface AdapterInterface
      *
      * @return string The quoted identifier.
      */
-    public function quoteIdentifier($text);
+    public function quoteIdentifier($text): string;
 
     /**
      * Quotes a database table which could have space separating it from an alias,
@@ -126,7 +126,7 @@ interface AdapterInterface
      *
      * @return string The quoted table name
      */
-    public function quoteIdentifierTable($table);
+    public function quoteIdentifierTable($table): string;
 
     /**
      * Quotes full qualified column names and table names.
@@ -138,21 +138,21 @@ interface AdapterInterface
      *
      * @return string
      */
-    public function quote($text);
+    public function quote($text): string;
 
     /**
      * Whether this adapter uses an ID generation system that requires getting ID _before_ performing INSERT.
      *
      * @return bool
      */
-    public function isGetIdBeforeInsert();
+    public function isGetIdBeforeInsert(): bool;
 
     /**
      * Whether this adapter uses an ID generation system that requires getting ID _before_ performing INSERT.
      *
      * @return bool
      */
-    public function isGetIdAfterInsert();
+    public function isGetIdAfterInsert(): bool;
 
     /**
      * Gets the generated ID (either last ID for autoincrement or next sequence ID).
@@ -172,33 +172,33 @@ interface AdapterInterface
      *
      * @return string The formatted temporal value
      */
-    public function formatTemporalValue($value, ColumnMap $cMap);
+    public function formatTemporalValue($value, ColumnMap $cMap): string;
 
     /**
      * Returns timestamp formatter string for use in date() function.
      *
      * @return string
      */
-    public function getTimestampFormatter();
+    public function getTimestampFormatter(): string;
 
     /**
      * Returns date formatter string for use in date() function.
      *
      * @return string
      */
-    public function getDateFormatter();
+    public function getDateFormatter(): string;
 
     /**
      * Returns time formatter string for use in date() function.
      *
      * @return string
      */
-    public function getTimeFormatter();
+    public function getTimeFormatter(): string;
 
     /**
      * @param \Propel\Runtime\ActiveQuery\Criteria $criteria
      *
      * @return string
      */
-    public function getGroupBy(Criteria $criteria);
+    public function getGroupBy(Criteria $criteria): string;
 }

--- a/src/Propel/Runtime/Adapter/MSSQL/MssqlPropelPDO.php
+++ b/src/Propel/Runtime/Adapter/MSSQL/MssqlPropelPDO.php
@@ -25,7 +25,7 @@ class MssqlPropelPDO extends PropelPDO
      *
      * @return bool
      */
-    public function beginTransaction()
+    public function beginTransaction(): bool
     {
         $return = true;
         $opcount = $this->getNestedTransactionCount();
@@ -51,7 +51,7 @@ class MssqlPropelPDO extends PropelPDO
      *
      * @return bool
      */
-    public function commit()
+    public function commit(): bool
     {
         $return = true;
         $opcount = $this->getNestedTransactionCount();
@@ -80,7 +80,7 @@ class MssqlPropelPDO extends PropelPDO
      *
      * @return bool
      */
-    public function rollBack()
+    public function rollBack(): bool
     {
         $return = true;
         $opcount = $this->getNestedTransactionCount();
@@ -108,7 +108,7 @@ class MssqlPropelPDO extends PropelPDO
      *
      * @return bool
      */
-    public function forceRollBack()
+    public function forceRollBack(): bool
     {
         $return = true;
         $opcount = $this->getNestedTransactionCount();
@@ -134,7 +134,7 @@ class MssqlPropelPDO extends PropelPDO
      *
      * @return int
      */
-    public function lastInsertId($name = null)
+    public function lastInsertId($name = null): int
     {
         $result = $this->query('SELECT SCOPE_IDENTITY()');
 
@@ -146,7 +146,7 @@ class MssqlPropelPDO extends PropelPDO
      *
      * @return string
      */
-    public function quoteIdentifier($text)
+    public function quoteIdentifier($text): string
     {
         return '[' . $text . ']';
     }

--- a/src/Propel/Runtime/Adapter/Pdo/MssqlAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/MssqlAdapter.php
@@ -34,7 +34,7 @@ class MssqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return void
      */
-    public function setCharset(ConnectionInterface $con, $charset)
+    public function setCharset(ConnectionInterface $con, $charset): void
     {
     }
 
@@ -46,7 +46,7 @@ class MssqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
-    public function concatString($s1, $s2)
+    public function concatString($s1, $s2): string
     {
         return '(' . $s1 . ' + ' . $s2 . ')';
     }
@@ -60,7 +60,7 @@ class MssqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
-    public function subString($s, $pos, $len)
+    public function subString($s, $pos, $len): string
     {
         return 'SUBSTRING(' . $s . ', ' . $pos . ', ' . $len . ')';
     }
@@ -72,7 +72,7 @@ class MssqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
-    public function strLength($s)
+    public function strLength($s): string
     {
         return 'LEN(' . $s . ')';
     }
@@ -80,7 +80,7 @@ class MssqlAdapter extends PdoAdapter implements SqlAdapterInterface
     /**
      * @inheritDoc
      */
-    public function compareRegex($left, $right)
+    public function compareRegex($left, $right): string
     {
         return sprintf('dbo.RegexMatch(%s, %s', $left, $right);
     }
@@ -92,7 +92,7 @@ class MssqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
-    public function quoteIdentifier($text)
+    public function quoteIdentifier($text): string
     {
         return '[' . $text . ']';
     }
@@ -104,7 +104,7 @@ class MssqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
-    public function quoteIdentifierTable($table)
+    public function quoteIdentifierTable($table): string
     {
         // e.g. 'database.table alias' should be escaped as '[database].[table] [alias]'
         return '[' . strtr($table, ['.' => '].[', ' ' => '] [']) . ']';
@@ -117,7 +117,7 @@ class MssqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
-    public function random($seed = null)
+    public function random($seed = null): string
     {
         return 'RAND(' . ((int)$seed) . ')';
     }
@@ -143,7 +143,7 @@ class MssqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return void
      */
-    public function applyLimit(&$sql, $offset, $limit, $criteria = null)
+    public function applyLimit(&$sql, $offset, $limit, $criteria = null): void
     {
         // make sure offset and limit are numeric
         if (!is_numeric($offset) || !is_numeric($limit)) {
@@ -296,7 +296,7 @@ class MssqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return void
      */
-    public function cleanupSQL(&$sql, array &$params, Criteria $values, DatabaseMap $dbMap)
+    public function cleanupSQL(&$sql, array &$params, Criteria $values, DatabaseMap $dbMap): void
     {
         $i = 1;
         $paramCols = [];

--- a/src/Propel/Runtime/Adapter/Pdo/MysqlAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/MysqlAdapter.php
@@ -32,7 +32,7 @@ class MysqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
-    public function concatString($s1, $s2)
+    public function concatString($s1, $s2): string
     {
         return "CONCAT($s1, $s2)";
     }
@@ -46,7 +46,7 @@ class MysqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
-    public function subString($s, $pos, $len)
+    public function subString($s, $pos, $len): string
     {
         return "SUBSTRING($s, $pos, $len)";
     }
@@ -58,7 +58,7 @@ class MysqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
-    public function strLength($s)
+    public function strLength($s): string
     {
         return "CHAR_LENGTH($s)";
     }
@@ -71,7 +71,7 @@ class MysqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return void
      */
-    public function lockTable($con, $table)
+    public function lockTable($con, $table): void
     {
         $con->exec("LOCK TABLE $table WRITE");
     }
@@ -84,7 +84,7 @@ class MysqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return void
      */
-    public function unlockTable($con, $table)
+    public function unlockTable($con, $table): void
     {
         $con->exec('UNLOCK TABLES');
     }
@@ -96,7 +96,7 @@ class MysqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
-    public function quoteIdentifier($text)
+    public function quoteIdentifier($text): string
     {
         return '`' . $text . '`';
     }
@@ -108,7 +108,7 @@ class MysqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
-    public function quoteIdentifierTable($table)
+    public function quoteIdentifierTable($table): string
     {
         // e.g. 'database.table alias' should be escaped as '`database`.`table` `alias`'
         return '`' . strtr($table, ['.' => '`.`', ' ' => '` `']) . '`';
@@ -124,7 +124,7 @@ class MysqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return void
      */
-    public function applyLimit(&$sql, $offset, $limit, $criteria = null)
+    public function applyLimit(&$sql, $offset, $limit, $criteria = null): void
     {
         $offset = (int)$offset;
         $limit = (int)$limit;
@@ -143,7 +143,7 @@ class MysqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
-    public function random($seed = null)
+    public function random($seed = null): string
     {
         return 'rand(' . ((int)$seed) . ')';
     }
@@ -159,7 +159,7 @@ class MysqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return bool
      */
-    public function bindValue(StatementInterface $stmt, $parameter, $value, ColumnMap $cMap, $position = null)
+    public function bindValue(StatementInterface $stmt, $parameter, $value, ColumnMap $cMap, $position = null): bool
     {
         $pdoType = $cMap->getPdoType();
         // FIXME - This is a temporary hack to get around apparent bugs w/ PDO+MYSQL
@@ -192,7 +192,7 @@ class MysqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return array the modified parameters
      */
-    protected function prepareParams($params)
+    protected function prepareParams($params): array
     {
         if (isset($params['settings']['charset'])) {
             if (strpos($params['dsn'], ';charset=') === false) {

--- a/src/Propel/Runtime/Adapter/Pdo/OracleAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/OracleAdapter.php
@@ -42,7 +42,7 @@ class OracleAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return void
      */
-    public function initConnection(ConnectionInterface $con, array $settings)
+    public function initConnection(ConnectionInterface $con, array $settings): void
     {
         $con->exec("ALTER SESSION SET NLS_DATE_FORMAT='YYYY-MM-DD'");
         $con->exec("ALTER SESSION SET NLS_TIMESTAMP_FORMAT='YYYY-MM-DD HH24:MI:SS'");
@@ -63,7 +63,7 @@ class OracleAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
-    public function concatString($s1, $s2)
+    public function concatString($s1, $s2): string
     {
         return "CONCAT($s1, $s2)";
     }
@@ -71,7 +71,7 @@ class OracleAdapter extends PdoAdapter implements SqlAdapterInterface
     /**
      * @inheritDoc
      */
-    public function compareRegex($left, $right)
+    public function compareRegex($left, $right): string
     {
         return sprintf('REGEXP_LIKE(%s, %s)', $left, $right);
     }
@@ -85,7 +85,7 @@ class OracleAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
-    public function subString($s, $pos, $len)
+    public function subString($s, $pos, $len): string
     {
         return "SUBSTR($s, $pos, $len)";
     }
@@ -97,7 +97,7 @@ class OracleAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
-    public function strLength($s)
+    public function strLength($s): string
     {
         return "LENGTH($s)";
     }
@@ -112,7 +112,7 @@ class OracleAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return void
      */
-    public function applyLimit(&$sql, $offset, $limit, $criteria = null)
+    public function applyLimit(&$sql, $offset, $limit, $criteria = null): void
     {
         $params = [];
         if ($criteria && $criteria->needsSelectAliases()) {
@@ -137,7 +137,7 @@ class OracleAdapter extends PdoAdapter implements SqlAdapterInterface
     /**
      * @return int
      */
-    protected function getIdMethod()
+    protected function getIdMethod(): int
     {
         return AdapterInterface::ID_METHOD_SEQUENCE;
     }
@@ -150,7 +150,7 @@ class OracleAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return int
      */
-    public function getId(ConnectionInterface $con, $name = null)
+    public function getId(ConnectionInterface $con, $name = null): int
     {
         if ($name === null) {
             throw new InvalidArgumentException('Unable to fetch next sequence ID without sequence name.');
@@ -166,7 +166,7 @@ class OracleAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
-    public function random($seed = null)
+    public function random($seed = null): string
     {
         return 'dbms_random.value';
     }
@@ -181,7 +181,7 @@ class OracleAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return \Propel\Runtime\ActiveQuery\Criteria The input, with Select columns replaced by aliases
      */
-    public function turnSelectColumnsToAliases(Criteria $criteria)
+    public function turnSelectColumnsToAliases(Criteria $criteria): Criteria
     {
         $selectColumns = $criteria->getSelectColumns();
         // clearSelectColumns also clears the aliases, so get them too
@@ -222,7 +222,7 @@ class OracleAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return bool
      */
-    public function bindValue(StatementInterface $stmt, $parameter, $value, ColumnMap $cMap, $position = null)
+    public function bindValue(StatementInterface $stmt, $parameter, $value, ColumnMap $cMap, $position = null): bool
     {
         if ($cMap->getType() === PropelTypes::CLOB_EMU) {
             return $stmt->bindParam(':p' . $position, $value, $cMap->getPdoType(), strlen($value));
@@ -246,7 +246,7 @@ class OracleAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return array
      */
-    protected function prepareParams($params)
+    protected function prepareParams($params): array
     {
         if (isset($params['dsn'])) {
             $params['dsn'] = str_replace('oracle:', 'oci:', $params['dsn']);

--- a/src/Propel/Runtime/Adapter/Pdo/PdoAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/PdoAdapter.php
@@ -47,7 +47,7 @@ abstract class PdoAdapter
      *
      * @return \Propel\Runtime\Connection\PdoConnection
      */
-    public function getConnection($params)
+    public function getConnection($params): PdoConnection
     {
         $params = $this->prepareParams($params);
 
@@ -91,7 +91,7 @@ abstract class PdoAdapter
      *
      * @return string
      */
-    public function compareRegex($left, $right)
+    public function compareRegex($left, $right): string
     {
         return sprintf('%s REGEXP %s', $left, $right);
     }
@@ -99,7 +99,7 @@ abstract class PdoAdapter
     /**
      * @return string
      */
-    public function getAdapterId()
+    public function getAdapterId(): string
     {
         $class = str_replace('Adapter', '', static::class);
         $lastSlash = strrpos($class, '\\');
@@ -114,7 +114,7 @@ abstract class PdoAdapter
      *
      * @return array the modified parameters
      */
-    protected function prepareParams($params)
+    protected function prepareParams($params): array
     {
         return $params;
     }
@@ -135,7 +135,7 @@ abstract class PdoAdapter
      *
      * @return void
      */
-    public function initConnection(ConnectionInterface $con, array $settings)
+    public function initConnection(ConnectionInterface $con, array $settings): void
     {
         if (isset($settings['charset'])) {
             $this->setCharset($con, $settings['charset']);
@@ -161,7 +161,7 @@ abstract class PdoAdapter
      *
      * @return void
      */
-    public function setCharset(ConnectionInterface $con, $charset)
+    public function setCharset(ConnectionInterface $con, $charset): void
     {
         $con->exec(sprintf("SET NAMES '%s'", $charset));
     }
@@ -173,7 +173,7 @@ abstract class PdoAdapter
      *
      * @return string The upper case string.
      */
-    public function toUpperCase($in)
+    public function toUpperCase($in): string
     {
         return sprintf('UPPER(%s)', $in);
     }
@@ -185,7 +185,7 @@ abstract class PdoAdapter
      *
      * @return string The string in a case that can be ignored.
      */
-    public function ignoreCase($in)
+    public function ignoreCase($in): string
     {
         return sprintf('UPPER(%s)', $in);
     }
@@ -200,7 +200,7 @@ abstract class PdoAdapter
      *
      * @return string The string in a case that can be ignored.
      */
-    public function ignoreCaseInOrderBy($in)
+    public function ignoreCaseInOrderBy($in): string
     {
         return $this->ignoreCase($in);
     }
@@ -212,7 +212,7 @@ abstract class PdoAdapter
      *
      * @return string The text delimiter.
      */
-    public function getStringDelimiter()
+    public function getStringDelimiter(): string
     {
         return '\'';
     }
@@ -224,7 +224,7 @@ abstract class PdoAdapter
      *
      * @return string The quoted identifier.
      */
-    public function quoteIdentifier($text)
+    public function quoteIdentifier($text): string
     {
         return '"' . $text . '"';
     }
@@ -239,7 +239,7 @@ abstract class PdoAdapter
      *
      * @return string
      */
-    public function quote($text)
+    public function quote($text): string
     {
         $pos = strrpos($text, '.');
         if ($pos !== false) {
@@ -267,7 +267,7 @@ abstract class PdoAdapter
      *
      * @return string The quoted table name
      */
-    public function quoteIdentifierTable($table)
+    public function quoteIdentifierTable($table): string
     {
         return implode(' ', array_map([$this, 'quoteIdentifier'], explode(' ', $table)));
     }
@@ -277,7 +277,7 @@ abstract class PdoAdapter
      *
      * @return int One of AdapterInterface:ID_METHOD_SEQUENCE, AdapterInterface::ID_METHOD_AUTOINCREMENT.
      */
-    protected function getIdMethod()
+    protected function getIdMethod(): int
     {
         return AdapterInterface::ID_METHOD_AUTOINCREMENT;
     }
@@ -287,7 +287,7 @@ abstract class PdoAdapter
      *
      * @return bool
      */
-    public function isGetIdBeforeInsert()
+    public function isGetIdBeforeInsert(): bool
     {
         return $this->getIdMethod() === AdapterInterface::ID_METHOD_SEQUENCE;
     }
@@ -297,7 +297,7 @@ abstract class PdoAdapter
      *
      * @return bool
      */
-    public function isGetIdAfterInsert()
+    public function isGetIdAfterInsert(): bool
     {
         return $this->getIdMethod() === AdapterInterface::ID_METHOD_AUTOINCREMENT;
     }
@@ -323,7 +323,7 @@ abstract class PdoAdapter
      *
      * @return string The formatted temporal value
      */
-    public function formatTemporalValue($value, ColumnMap $cMap)
+    public function formatTemporalValue($value, ColumnMap $cMap): string
     {
         /** @var \Propel\Runtime\Util\PropelDateTime|null $dt */
         $dt = PropelDateTime::newInstance($value);
@@ -354,7 +354,7 @@ abstract class PdoAdapter
      *
      * @return string
      */
-    public function getTimestampFormatter()
+    public function getTimestampFormatter(): string
     {
         return 'Y-m-d H:i:s.u';
     }
@@ -364,7 +364,7 @@ abstract class PdoAdapter
      *
      * @return string
      */
-    public function getGroupBy(Criteria $criteria)
+    public function getGroupBy(Criteria $criteria): string
     {
         $groupBy = $criteria->getGroupByColumns();
         if ($groupBy) {
@@ -379,7 +379,7 @@ abstract class PdoAdapter
      *
      * @return string
      */
-    public function getDateFormatter()
+    public function getDateFormatter(): string
     {
         return 'Y-m-d';
     }
@@ -389,7 +389,7 @@ abstract class PdoAdapter
      *
      * @return string
      */
-    public function getTimeFormatter()
+    public function getTimeFormatter(): string
     {
         return 'H:i:s.u';
     }
@@ -404,7 +404,7 @@ abstract class PdoAdapter
      *
      * @return void
      */
-    public function cleanupSQL(&$sql, array &$params, Criteria $values, DatabaseMap $dbMap)
+    public function cleanupSQL(&$sql, array &$params, Criteria $values, DatabaseMap $dbMap): void
     {
     }
 
@@ -418,7 +418,7 @@ abstract class PdoAdapter
      *
      * @return string
      */
-    public function createSelectSqlPart(Criteria $criteria, &$fromClause, $aliasAll = false)
+    public function createSelectSqlPart(Criteria $criteria, &$fromClause, $aliasAll = false): string
     {
         $selectClause = [];
 
@@ -482,7 +482,7 @@ abstract class PdoAdapter
      *
      * @return array<string>
      */
-    public function getPlainSelectedColumns(Criteria $criteria)
+    public function getPlainSelectedColumns(Criteria $criteria): array
     {
         $selected = [];
         foreach ($criteria->getSelectColumns() as $columnName) {
@@ -510,7 +510,7 @@ abstract class PdoAdapter
      *
      * @return \Propel\Runtime\ActiveQuery\Criteria The input, with Select columns replaced by aliases
      */
-    public function turnSelectColumnsToAliases(Criteria $criteria)
+    public function turnSelectColumnsToAliases(Criteria $criteria): Criteria
     {
         $selectColumns = $criteria->getSelectColumns();
         // clearSelectColumns also clears the aliases, so get them too
@@ -562,7 +562,7 @@ abstract class PdoAdapter
      *
      * @return void
      */
-    public function bindValues(StatementInterface $stmt, array $params, DatabaseMap $dbMap)
+    public function bindValues(StatementInterface $stmt, array $params, DatabaseMap $dbMap): void
     {
         $position = 0;
         foreach ($params as $param) {
@@ -598,7 +598,7 @@ abstract class PdoAdapter
      *
      * @return bool
      */
-    public function bindValue(StatementInterface $stmt, $parameter, $value, ColumnMap $cMap, $position = null)
+    public function bindValue(StatementInterface $stmt, $parameter, $value, ColumnMap $cMap, $position = null): bool
     {
         if ($cMap->isTemporal()) {
             $value = $this->formatTemporalValue($value, $cMap);

--- a/src/Propel/Runtime/Adapter/Pdo/PgsqlAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/PgsqlAdapter.php
@@ -39,7 +39,7 @@ class PgsqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
-    public function concatString($s1, $s2)
+    public function concatString($s1, $s2): string
     {
         return "($s1 || $s2)";
     }
@@ -47,7 +47,7 @@ class PgsqlAdapter extends PdoAdapter implements SqlAdapterInterface
     /**
      * @inheritDoc
      */
-    public function compareRegex($left, $right)
+    public function compareRegex($left, $right): string
     {
         return sprintf('%s ~* %s', $left, $right);
     }
@@ -61,7 +61,7 @@ class PgsqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
-    public function subString($s, $pos, $len)
+    public function subString($s, $pos, $len): string
     {
         return "substring($s from $pos" . ($len > -1 ? "for $len" : '') . ')';
     }
@@ -73,7 +73,7 @@ class PgsqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
-    public function strLength($s)
+    public function strLength($s): string
     {
         return "char_length($s)";
     }
@@ -83,7 +83,7 @@ class PgsqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return int
      */
-    protected function getIdMethod()
+    protected function getIdMethod(): int
     {
         return AdapterInterface::ID_METHOD_SEQUENCE;
     }
@@ -98,7 +98,7 @@ class PgsqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return int
      */
-    public function getId(ConnectionInterface $con, $name = null)
+    public function getId(ConnectionInterface $con, $name = null): int
     {
         if ($name === null) {
             throw new InvalidArgumentException('Unable to fetch next sequence ID without sequence name.');
@@ -113,7 +113,7 @@ class PgsqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
-    public function getTimestampFormatter()
+    public function getTimestampFormatter(): string
     {
         return 'Y-m-d H:i:s.u O';
     }
@@ -123,7 +123,7 @@ class PgsqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
-    public function getTimeFormatter()
+    public function getTimeFormatter(): string
     {
         return 'H:i:s.u O';
     }
@@ -138,7 +138,7 @@ class PgsqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return void
      */
-    public function applyLimit(&$sql, $offset, $limit, $criteria = null)
+    public function applyLimit(&$sql, $offset, $limit, $criteria = null): void
     {
         if ($limit >= 0) {
             $sql .= sprintf(' LIMIT %u', $limit);
@@ -153,7 +153,7 @@ class PgsqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
-    public function getGroupBy(Criteria $criteria)
+    public function getGroupBy(Criteria $criteria): string
     {
         $groupBy = $criteria->getGroupByColumns();
 
@@ -190,7 +190,7 @@ class PgsqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
-    public function random($seed = null)
+    public function random($seed = null): string
     {
         return 'random()';
     }
@@ -202,7 +202,7 @@ class PgsqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
-    public function quoteIdentifierTable($table)
+    public function quoteIdentifierTable($table): string
     {
         // e.g. 'database.table alias' should be escaped as '"database"."table" "alias"'
         return '"' . strtr($table, ['.' => '"."', ' ' => '" "']) . '"';
@@ -244,7 +244,7 @@ class PgsqlAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
-    public function getExplainPlanQuery($query)
+    public function getExplainPlanQuery($query): string
     {
         return 'EXPLAIN ' . $query;
     }

--- a/src/Propel/Runtime/Adapter/Pdo/SqliteAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/SqliteAdapter.php
@@ -28,7 +28,7 @@ class SqliteAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return void
      */
-    public function setCharset(ConnectionInterface $con, $charset)
+    public function setCharset(ConnectionInterface $con, $charset): void
     {
     }
 
@@ -38,7 +38,7 @@ class SqliteAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return void
      */
-    public function initConnection(ConnectionInterface $con, array $settings)
+    public function initConnection(ConnectionInterface $con, array $settings): void
     {
         $con->query('PRAGMA foreign_keys = ON');
         parent::initConnection($con, $settings);
@@ -59,7 +59,7 @@ class SqliteAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
-    public function concatString($s1, $s2)
+    public function concatString($s1, $s2): string
     {
         return "($s1 || $s2)";
     }
@@ -73,7 +73,7 @@ class SqliteAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
-    public function subString($s, $pos, $len)
+    public function subString($s, $pos, $len): string
     {
         return "substr($s, $pos, $len)";
     }
@@ -85,7 +85,7 @@ class SqliteAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
-    public function strLength($s)
+    public function strLength($s): string
     {
         return "length($s)";
     }
@@ -97,7 +97,7 @@ class SqliteAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
-    public function quoteIdentifier($text)
+    public function quoteIdentifier($text): string
     {
         return "[$text]";
     }
@@ -112,7 +112,7 @@ class SqliteAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return void
      */
-    public function applyLimit(&$sql, $offset, $limit, $criteria = null)
+    public function applyLimit(&$sql, $offset, $limit, $criteria = null): void
     {
         if ($limit >= 0) {
             $sql .= ' LIMIT ' . $limit . ($offset > 0 ? ' OFFSET ' . $offset : '');
@@ -126,7 +126,7 @@ class SqliteAdapter extends PdoAdapter implements SqlAdapterInterface
      *
      * @return string
      */
-    public function random($seed = null)
+    public function random($seed = null): string
     {
         return 'random()';
     }

--- a/src/Propel/Runtime/Adapter/Pdo/SqlsrvAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/SqlsrvAdapter.php
@@ -32,7 +32,7 @@ class SqlsrvAdapter extends MssqlAdapter implements SqlAdapterInterface
      *
      * @return void
      */
-    public function initConnection(ConnectionInterface $con, array $settings)
+    public function initConnection(ConnectionInterface $con, array $settings): void
     {
         $con->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $con->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, false);
@@ -50,7 +50,7 @@ class SqlsrvAdapter extends MssqlAdapter implements SqlAdapterInterface
      *
      * @return void
      */
-    public function setCharset(ConnectionInterface $con, $charset)
+    public function setCharset(ConnectionInterface $con, $charset): void
     {
         switch (strtolower($charset)) {
             case 'utf-8':
@@ -76,7 +76,7 @@ class SqlsrvAdapter extends MssqlAdapter implements SqlAdapterInterface
      *
      * @return void
      */
-    public function cleanupSQL(&$sql, array &$params, Criteria $values, DatabaseMap $dbMap)
+    public function cleanupSQL(&$sql, array &$params, Criteria $values, DatabaseMap $dbMap): void
     {
         $i = 1;
         foreach ($params as $param) {
@@ -107,7 +107,7 @@ class SqlsrvAdapter extends MssqlAdapter implements SqlAdapterInterface
      *
      * @return bool
      */
-    public function bindValue(StatementInterface $stmt, $parameter, $value, ColumnMap $cMap, $position = null)
+    public function bindValue(StatementInterface $stmt, $parameter, $value, ColumnMap $cMap, $position = null): bool
     {
         if ($cMap->isTemporal()) {
             $value = $this->formatTemporalValue($value, $cMap);

--- a/src/Propel/Runtime/Adapter/SqlAdapterInterface.php
+++ b/src/Propel/Runtime/Adapter/SqlAdapterInterface.php
@@ -26,7 +26,7 @@ interface SqlAdapterInterface extends AdapterInterface
      *
      * @return string The upper case string.
      */
-    public function toUpperCase($in);
+    public function toUpperCase($in): string;
 
     /**
      * This method is used to ignore case.
@@ -35,7 +35,7 @@ interface SqlAdapterInterface extends AdapterInterface
      *
      * @return string The string in a case that can be ignored.
      */
-    public function ignoreCase($in);
+    public function ignoreCase($in): string;
 
     /**
      * Allows manipulation of the query string before StatementPdo is instantiated.
@@ -47,7 +47,7 @@ interface SqlAdapterInterface extends AdapterInterface
      *
      * @return void
      */
-    public function cleanupSQL(&$sql, array &$params, Criteria $values, DatabaseMap $dbMap);
+    public function cleanupSQL(&$sql, array &$params, Criteria $values, DatabaseMap $dbMap): void;
 
     /**
      * Modifies the passed-in SQL to add LIMIT and/or OFFSET.
@@ -59,7 +59,7 @@ interface SqlAdapterInterface extends AdapterInterface
      *
      * @return void
      */
-    public function applyLimit(&$sql, $offset, $limit, $criteria = null);
+    public function applyLimit(&$sql, $offset, $limit, $criteria = null): void;
 
     /**
      * Modifies the passed-in SQL to add locking capabilities
@@ -78,7 +78,7 @@ interface SqlAdapterInterface extends AdapterInterface
      *
      * @return string
      */
-    public function random($seed = null);
+    public function random($seed = null): string;
 
     /**
      * Builds the SELECT part of a SQL statement based on a Criteria
@@ -90,7 +90,7 @@ interface SqlAdapterInterface extends AdapterInterface
      *
      * @return string
      */
-    public function createSelectSqlPart(Criteria $criteria, &$fromClause, $aliasAll = false);
+    public function createSelectSqlPart(Criteria $criteria, &$fromClause, $aliasAll = false): string;
 
     /**
      * Ensures uniqueness of select column names by turning them all into aliases
@@ -102,7 +102,7 @@ interface SqlAdapterInterface extends AdapterInterface
      *
      * @return \Propel\Runtime\ActiveQuery\Criteria The input, with Select columns replaced by aliases
      */
-    public function turnSelectColumnsToAliases(Criteria $criteria);
+    public function turnSelectColumnsToAliases(Criteria $criteria): Criteria;
 
     /**
      * Binds values in a prepared statement.
@@ -126,7 +126,7 @@ interface SqlAdapterInterface extends AdapterInterface
      *
      * @return void
      */
-    public function bindValues(StatementInterface $stmt, array $params, DatabaseMap $dbMap);
+    public function bindValues(StatementInterface $stmt, array $params, DatabaseMap $dbMap): void;
 
     /**
      * Binds a value to a positioned parameter in a statement,
@@ -140,7 +140,7 @@ interface SqlAdapterInterface extends AdapterInterface
      *
      * @return bool
      */
-    public function bindValue(StatementInterface $stmt, $parameter, $value, ColumnMap $cMap, $position = null);
+    public function bindValue(StatementInterface $stmt, $parameter, $value, ColumnMap $cMap, $position = null): bool;
 
     /**
      * Indicates if the database system can process DELETE statements with

--- a/src/Propel/Runtime/Collection/ArrayCollection.php
+++ b/src/Propel/Runtime/Collection/ArrayCollection.php
@@ -8,6 +8,7 @@
 
 namespace Propel\Runtime\Collection;
 
+use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
 use Propel\Runtime\Collection\Exception\ReadOnlyModelException;
 use Propel\Runtime\Exception\PropelException;
 
@@ -32,7 +33,7 @@ class ArrayCollection extends Collection
      *
      * @return void
      */
-    public function save($con = null)
+    public function save($con = null): void
     {
         if (!method_exists($this->getFullyQualifiedModel(), 'save')) {
             throw new ReadOnlyModelException('Cannot save objects on a read-only model');
@@ -40,7 +41,7 @@ class ArrayCollection extends Collection
         if ($con === null) {
             $con = $this->getWriteConnection();
         }
-        $con->transaction(function () use ($con) {
+        $con->transaction(function () use ($con): void {
             $obj = $this->getWorkerObject();
             foreach ($this as $element) {
                 $obj->clear();
@@ -60,7 +61,7 @@ class ArrayCollection extends Collection
      *
      * @return void
      */
-    public function delete($con = null)
+    public function delete($con = null): void
     {
         if (!method_exists($this->getFullyQualifiedModel(), 'delete')) {
             throw new ReadOnlyModelException('Cannot delete objects on a read-only model');
@@ -68,7 +69,7 @@ class ArrayCollection extends Collection
         if ($con === null) {
             $con = $this->getWriteConnection();
         }
-        $con->transaction(function () use ($con) {
+        $con->transaction(function () use ($con): void {
             foreach ($this as $element) {
                 $obj = $this->getWorkerObject();
                 $obj->setDeleted(false);
@@ -85,7 +86,7 @@ class ArrayCollection extends Collection
      *
      * @return array The list of the primary keys of the collection
      */
-    public function getPrimaryKeys($usePrefix = true)
+    public function getPrimaryKeys($usePrefix = true): array
     {
         $ret = [];
         $tableMapClass = $this->getTableMapClass();
@@ -107,7 +108,7 @@ class ArrayCollection extends Collection
      *
      * @return void
      */
-    public function fromArray($arr)
+    public function fromArray($arr): void
     {
         $obj = $this->getWorkerObject();
         foreach ($arr as $element) {
@@ -145,7 +146,7 @@ class ArrayCollection extends Collection
      *
      * @return array
      */
-    public function toArray($keyColumn = null, $usePrefix = false)
+    public function toArray($keyColumn = null, $usePrefix = false): array
     {
         $ret = [];
         foreach ($this as $key => $element) {
@@ -165,7 +166,7 @@ class ArrayCollection extends Collection
      *
      * @return array
      */
-    public function getArrayCopy($keyColumn = null, $usePrefix = false)
+    public function getArrayCopy($keyColumn = null, $usePrefix = false): array
     {
         if ($keyColumn === null && $usePrefix === false) {
             return parent::getArrayCopy();
@@ -187,7 +188,7 @@ class ArrayCollection extends Collection
      *
      * @return array
      */
-    public function toKeyValue($keyColumn, $valueColumn)
+    public function toKeyValue($keyColumn, $valueColumn): array
     {
         $ret = [];
         foreach ($this as $obj) {
@@ -202,7 +203,7 @@ class ArrayCollection extends Collection
      *
      * @return \Propel\Runtime\ActiveRecord\ActiveRecordInterface
      */
-    protected function getWorkerObject()
+    protected function getWorkerObject(): ActiveRecordInterface
     {
         if ($this->workerObject === null) {
             $model = $this->getModel();

--- a/src/Propel/Runtime/Collection/Collection.php
+++ b/src/Propel/Runtime/Collection/Collection.php
@@ -470,7 +470,8 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
      */
     public function setModel($model): void
     {
-        if (false !== $pos = strrpos($model, '\\')) {
+        $pos = strrpos($model, '\\');
+        if ($pos !== false) {
             $this->model = substr($model, $pos + 1);
         } else {
             $this->model = $model;

--- a/src/Propel/Runtime/Collection/Collection.php
+++ b/src/Propel/Runtime/Collection/Collection.php
@@ -11,8 +11,10 @@ namespace Propel\Runtime\Collection;
 use ArrayAccess;
 use Countable;
 use IteratorAggregate;
+use Propel\Common\Pluralizer\PluralizerInterface;
 use Propel\Common\Pluralizer\StandardEnglishPluralizer;
 use Propel\Runtime\Collection\Exception\ModelNotFoundException;
+use Propel\Runtime\Connection\ConnectionInterface;
 use Propel\Runtime\Exception\BadMethodCallException;
 use Propel\Runtime\Exception\UnexpectedValueException;
 use Propel\Runtime\Formatter\AbstractFormatter;
@@ -98,7 +100,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
      *
      * @return void
      */
-    public function append($value)
+    public function append($value): void
     {
         $this->data[] = $value;
     }
@@ -160,7 +162,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
      *
      * @return void
      */
-    public function exchangeArray($input)
+    public function exchangeArray($input): void
     {
         $this->data = $input;
     }
@@ -170,7 +172,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
      *
      * @return array
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->data;
     }
@@ -178,7 +180,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
     /**
      * @return array
      */
-    public function getArrayCopy()
+    public function getArrayCopy(): array
     {
         return $this->data;
     }
@@ -190,7 +192,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
      *
      * @return void
      */
-    public function setData($data)
+    public function setData($data): void
     {
         $this->data = $data;
     }
@@ -249,7 +251,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
      *
      * @return bool
      */
-    public function isEmpty()
+    public function isEmpty(): bool
     {
         return $this->count() === 0;
     }
@@ -314,7 +316,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
      *
      * @return void
      */
-    public function push($value)
+    public function push($value): void
     {
         $this[] = $value;
     }
@@ -326,7 +328,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
      *
      * @return int The number of new elements in the array
      */
-    public function prepend($value)
+    public function prepend($value): int
     {
         // the reindexing is complicated to deal with through the iterator
         // so let's use the simple solution
@@ -346,7 +348,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
      *
      * @return void
      */
-    public function set($key, $value)
+    public function set($key, $value): void
     {
         $this->offsetSet($key, $value);
     }
@@ -361,7 +363,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
      *
      * @return void
      */
-    public function remove($key)
+    public function remove($key): void
     {
         if (!$this->offsetExists($key)) {
             throw new UnexpectedValueException(sprintf('Unknown key %s.', $key));
@@ -375,7 +377,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
      *
      * @return void
      */
-    public function clear()
+    public function clear(): void
     {
         $this->exchangeArray([]);
     }
@@ -387,7 +389,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
      *
      * @return bool
      */
-    public function contains($element)
+    public function contains($element): bool
     {
         return in_array($element, $this->getArrayCopy(), true);
     }
@@ -410,9 +412,9 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
      *
      * @param \Propel\Runtime\Collection\Collection $collection A Propel collection.
      *
-     * @return \Propel\Runtime\Collection\Collection An array of Propel objects from the collection that are not presents in the given collection.
+     * @return self An array of Propel objects from the collection that are not presents in the given collection.
      */
-    public function diff(Collection $collection)
+    public function diff(Collection $collection): self
     {
         $diff = clone $this;
         $diff->clear();
@@ -432,7 +434,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
      * @return string|null
      */
     #[\ReturnTypeWillChange]
-    public function serialize()
+    public function serialize(): ?string
     {
         $repr = [
             'data' => $this->getArrayCopy(),
@@ -449,7 +451,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
      * @return void
      */
     #[\ReturnTypeWillChange]
-    public function unserialize($data)
+    public function unserialize($data): void
     {
         $repr = unserialize($data);
         $this->exchangeArray($repr['data']);
@@ -466,7 +468,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
      *
      * @return void
      */
-    public function setModel($model)
+    public function setModel($model): void
     {
         if (false !== $pos = strrpos($model, '\\')) {
             $this->model = substr($model, $pos + 1);
@@ -481,7 +483,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
      *
      * @return string Name of the Propel object class stored in the collection
      */
-    public function getModel()
+    public function getModel(): string
     {
         return $this->model;
     }
@@ -491,7 +493,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
      *
      * @return string Fully qualified Name of the Propel object class stored in the collection
      */
-    public function getFullyQualifiedModel()
+    public function getFullyQualifiedModel(): string
     {
         return $this->fullyQualifiedModel;
     }
@@ -503,7 +505,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
      *
      * @return string
      */
-    public function getTableMapClass()
+    public function getTableMapClass(): string
     {
         $model = $this->getModel();
 
@@ -519,7 +521,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
      *
      * @return void
      */
-    public function setFormatter(AbstractFormatter $formatter)
+    public function setFormatter(AbstractFormatter $formatter): void
     {
         $this->formatter = $formatter;
     }
@@ -527,7 +529,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
     /**
      * @return \Propel\Runtime\Formatter\AbstractFormatter
      */
-    public function getFormatter()
+    public function getFormatter(): AbstractFormatter
     {
         return $this->formatter;
     }
@@ -537,7 +539,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
      *
      * @return \Propel\Runtime\Connection\ConnectionInterface A ConnectionInterface connection object
      */
-    public function getWriteConnection()
+    public function getWriteConnection(): ConnectionInterface
     {
         $databaseName = $this->getTableMapClass()::DATABASE_NAME;
 
@@ -588,7 +590,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
      *
      * @return string The exported data
      */
-    public function exportTo($parser, $usePrefix = true, $includeLazyLoadColumns = true, $keyType = TableMap::TYPE_PHPNAME)
+    public function exportTo($parser, $usePrefix = true, $includeLazyLoadColumns = true, $keyType = TableMap::TYPE_PHPNAME): string
     {
         if (!$parser instanceof AbstractParser) {
             $parser = AbstractParser::getParser($parser);
@@ -638,7 +640,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return (string)$this->exportTo($this->getTableMapClass()::DEFAULT_STRING_FORMAT, false);
     }
@@ -660,7 +662,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
     /**
      * @return \Propel\Common\Pluralizer\PluralizerInterface
      */
-    protected function getPluralizer()
+    protected function getPluralizer(): PluralizerInterface
     {
         if ($this->pluralizer === null) {
             $this->pluralizer = $this->createPluralizer();
@@ -674,7 +676,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
      *
      * @return \Propel\Common\Pluralizer\PluralizerInterface
      */
-    protected function createPluralizer()
+    protected function createPluralizer(): PluralizerInterface
     {
         return new StandardEnglishPluralizer();
     }
@@ -682,7 +684,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
     /**
      * @return string
      */
-    protected function getPluralModelName()
+    protected function getPluralModelName(): string
     {
         return $this->getPluralizer()->getPluralForm($this->getModel());
     }
@@ -690,7 +692,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
     /**
      * @return string
      */
-    public function hashCode()
+    public function hashCode(): string
     {
         return spl_object_hash($this);
     }

--- a/src/Propel/Runtime/Collection/CollectionIterator.php
+++ b/src/Propel/Runtime/Collection/CollectionIterator.php
@@ -43,7 +43,7 @@ class CollectionIterator extends ArrayIterator
      *
      * @return \Propel\Runtime\Collection\Collection
      */
-    public function getCollection()
+    public function getCollection(): Collection
     {
         return $this->collection;
     }

--- a/src/Propel/Runtime/Collection/ObjectCollection.php
+++ b/src/Propel/Runtime/Collection/ObjectCollection.php
@@ -47,7 +47,7 @@ class ObjectCollection extends Collection
      *
      * @return void
      */
-    public function exchangeArray($input)
+    public function exchangeArray($input): void
     {
         $this->data = $input;
         $this->rebuildIndex();
@@ -58,7 +58,7 @@ class ObjectCollection extends Collection
      *
      * @return void
      */
-    public function setData($data)
+    public function setData($data): void
     {
         parent::setData($data);
         $this->rebuildIndex();
@@ -73,7 +73,7 @@ class ObjectCollection extends Collection
      *
      * @return void
      */
-    public function save($con = null)
+    public function save($con = null): void
     {
         if (!method_exists($this->getFullyQualifiedModel(), 'save')) {
             throw new ReadOnlyModelException('Cannot save objects on a read-only model');
@@ -81,7 +81,7 @@ class ObjectCollection extends Collection
         if ($con === null) {
             $con = $this->getWriteConnection();
         }
-        $con->transaction(function () use ($con) {
+        $con->transaction(function () use ($con): void {
             /** @var \Propel\Runtime\ActiveRecord\ActiveRecordInterface $element */
             foreach ($this as $element) {
                 $element->save($con);
@@ -98,7 +98,7 @@ class ObjectCollection extends Collection
      *
      * @return void
      */
-    public function delete($con = null)
+    public function delete($con = null): void
     {
         if (!method_exists($this->getFullyQualifiedModel(), 'delete')) {
             throw new ReadOnlyModelException('Cannot delete objects on a read-only model');
@@ -106,7 +106,7 @@ class ObjectCollection extends Collection
         if ($con === null) {
             $con = $this->getWriteConnection();
         }
-        $con->transaction(function () use ($con) {
+        $con->transaction(function () use ($con): void {
             /** @var \Propel\Runtime\ActiveRecord\ActiveRecordInterface $element */
             foreach ($this as $element) {
                 $element->delete($con);
@@ -121,7 +121,7 @@ class ObjectCollection extends Collection
      *
      * @return array The list of the primary keys of the collection
      */
-    public function getPrimaryKeys($usePrefix = true)
+    public function getPrimaryKeys($usePrefix = true): array
     {
         $ret = [];
 
@@ -143,7 +143,7 @@ class ObjectCollection extends Collection
      *
      * @return void
      */
-    public function fromArray($arr)
+    public function fromArray($arr): void
     {
         $class = $this->getFullyQualifiedModel();
         foreach ($arr as $element) {
@@ -194,7 +194,7 @@ class ObjectCollection extends Collection
         $keyType = TableMap::TYPE_PHPNAME,
         $includeLazyLoadColumns = true,
         $alreadyDumpedObjects = []
-    ) {
+    ): array {
         $ret = [];
         $keyGetterMethod = 'get' . $keyColumn;
 
@@ -235,7 +235,7 @@ class ObjectCollection extends Collection
      *
      * @return array
      */
-    public function getArrayCopy($keyColumn = null, $usePrefix = false)
+    public function getArrayCopy($keyColumn = null, $usePrefix = false): array
     {
         if ($keyColumn === null && $usePrefix === false) {
             return parent::getArrayCopy();
@@ -265,7 +265,7 @@ class ObjectCollection extends Collection
      *
      * @return array
      */
-    public function toKeyValue($keyColumn = 'PrimaryKey', $valueColumn = null)
+    public function toKeyValue($keyColumn = 'PrimaryKey', $valueColumn = null): array
     {
         $ret = [];
         $keyGetterMethod = 'get' . $keyColumn;
@@ -295,7 +295,7 @@ class ObjectCollection extends Collection
      *
      * @return array
      */
-    public function toKeyIndex($keyColumn = 'PrimaryKey')
+    public function toKeyIndex($keyColumn = 'PrimaryKey'): array
     {
         $ret = [];
         $keyGetterMethod = 'get' . ucfirst($keyColumn);
@@ -323,7 +323,7 @@ class ObjectCollection extends Collection
      *
      * @return array
      */
-    public function getColumnValues($columnName = 'PrimaryKey')
+    public function getColumnValues($columnName = 'PrimaryKey'): array
     {
         $ret = [];
         $keyGetterMethod = 'get' . ucfirst($columnName);
@@ -345,9 +345,9 @@ class ObjectCollection extends Collection
      * @throws \Propel\Runtime\Exception\RuntimeException
      * @throws \Propel\Runtime\Collection\Exception\UnsupportedRelationException
      *
-     * @return \Propel\Runtime\Collection\ObjectCollection The list of related objects
+     * @return self The list of related objects
      */
-    public function populateRelation($relation, $criteria = null, $con = null)
+    public function populateRelation($relation, $criteria = null, $con = null): self
     {
         if (!Propel::isInstancePoolingEnabled()) {
             throw new RuntimeException(__METHOD__ . ' needs instance pooling to be enabled prior to populating the collection');
@@ -421,7 +421,7 @@ class ObjectCollection extends Collection
     /**
      * @return void
      */
-    protected function rebuildIndex()
+    protected function rebuildIndex(): void
     {
         $this->index = [];
         $this->indexSplHash = [];
@@ -453,7 +453,7 @@ class ObjectCollection extends Collection
      *
      * @return void
      */
-    public function removeObject($element)
+    public function removeObject($element): void
     {
         if (($pos = $this->search($element)) !== false) {
             $this->remove($pos);
@@ -465,7 +465,7 @@ class ObjectCollection extends Collection
      *
      * @return void
      */
-    public function append($value)
+    public function append($value): void
     {
         if (!is_object($value)) {
             parent::append($value);
@@ -520,7 +520,7 @@ class ObjectCollection extends Collection
     /**
      * @inheritDoc
      */
-    public function contains($element)
+    public function contains($element): bool
     {
         if (!is_object($element)) {
             return parent::contains($element);
@@ -536,7 +536,7 @@ class ObjectCollection extends Collection
      *
      * @return string
      */
-    protected function getHashCode($object)
+    protected function getHashCode($object): string
     {
         if (is_object($object) && is_callable([$object, 'hashCode'])) {
             return $object->hashCode();

--- a/src/Propel/Runtime/Collection/ObjectCombinationCollection.php
+++ b/src/Propel/Runtime/Collection/ObjectCombinationCollection.php
@@ -24,7 +24,7 @@ class ObjectCombinationCollection extends ObjectCollection
      *
      * @return array The list of the primary keys of the collection
      */
-    public function getPrimaryKeys($usePrefix = true)
+    public function getPrimaryKeys($usePrefix = true): array
     {
         $ret = [];
 
@@ -43,7 +43,7 @@ class ObjectCombinationCollection extends ObjectCollection
     /**
      * @inheritDoc
      */
-    public function push($value)
+    public function push($value): void
     {
         parent::push(func_get_args());
     }
@@ -55,7 +55,7 @@ class ObjectCombinationCollection extends ObjectCollection
      *
      * @return array
      */
-    public function getObjectsFromPosition($position = 1)
+    public function getObjectsFromPosition($position = 1): array
     {
         $result = [];
         foreach ($this as $array) {
@@ -107,7 +107,7 @@ class ObjectCombinationCollection extends ObjectCollection
     /**
      * @inheritDoc
      */
-    public function removeObject($element)
+    public function removeObject($element): void
     {
         $pos = $this->search(...func_get_args());
         if ($pos !== false) {
@@ -118,7 +118,7 @@ class ObjectCombinationCollection extends ObjectCollection
     /**
      * @inheritDoc
      */
-    public function contains($element)
+    public function contains($element): bool
     {
         return $this->search(...func_get_args()) !== false;
     }

--- a/src/Propel/Runtime/Collection/OnDemandCollection.php
+++ b/src/Propel/Runtime/Collection/OnDemandCollection.php
@@ -33,7 +33,7 @@ class OnDemandCollection extends Collection
      *
      * @return void
      */
-    public function initIterator(AbstractFormatter $formatter, DataFetcherInterface $dataFetcher)
+    public function initIterator(AbstractFormatter $formatter, DataFetcherInterface $dataFetcher): void
     {
         $this->lastIterator = new OnDemandIterator($formatter, $dataFetcher);
     }
@@ -78,7 +78,7 @@ class OnDemandCollection extends Collection
         $keyType = TableMap::TYPE_PHPNAME,
         $includeLazyLoadColumns = true,
         $alreadyDumpedObjects = []
-    ) {
+    ): array {
         $ret = [];
         $keyGetterMethod = 'get' . $keyColumn;
 
@@ -103,7 +103,7 @@ class OnDemandCollection extends Collection
      *
      * @return void
      */
-    public function fromArray($arr)
+    public function fromArray($arr): void
     {
         throw new ReadOnlyModelException('The On Demand Collection is read only');
     }
@@ -180,7 +180,7 @@ class OnDemandCollection extends Collection
      * @return string|null
      */
     #[\ReturnTypeWillChange]
-    public function serialize()
+    public function serialize(): ?string
     {
         throw new PropelException('The On Demand Collection cannot be serialized');
     }
@@ -193,7 +193,7 @@ class OnDemandCollection extends Collection
      * @return void
      */
     #[\ReturnTypeWillChange]
-    public function unserialize($data)
+    public function unserialize($data): void
     {
         throw new PropelException('The On Demand Collection cannot be serialized');
     }
@@ -219,7 +219,7 @@ class OnDemandCollection extends Collection
      *
      * @return void
      */
-    public function append($value)
+    public function append($value): void
     {
         throw new ReadOnlyModelException('The On Demand Collection is read only');
     }
@@ -231,7 +231,7 @@ class OnDemandCollection extends Collection
      *
      * @return int
      */
-    public function prepend($value)
+    public function prepend($value): int
     {
         throw new ReadOnlyModelException('The On Demand Collection is read only');
     }
@@ -243,7 +243,7 @@ class OnDemandCollection extends Collection
      *
      * @return void
      */
-    public function exchangeArray($input)
+    public function exchangeArray($input): void
     {
         throw new ReadOnlyModelException('The On Demand Collection is read only');
     }
@@ -253,7 +253,7 @@ class OnDemandCollection extends Collection
      *
      * @return array
      */
-    public function getArrayCopy()
+    public function getArrayCopy(): array
     {
         throw new PropelException('The On Demand Collection does not allow access by offset');
     }
@@ -263,7 +263,7 @@ class OnDemandCollection extends Collection
      *
      * @throws \Propel\Runtime\Exception\PropelException
      */
-    public function exportTo($parser, $usePrefix = true, $includeLazyLoadColumns = true, $keyType = TableMap::TYPE_PHPNAME)
+    public function exportTo($parser, $usePrefix = true, $includeLazyLoadColumns = true, $keyType = TableMap::TYPE_PHPNAME): string
     {
         throw new PropelException('A OnDemandCollection cannot be exported.');
     }

--- a/src/Propel/Runtime/Collection/OnDemandIterator.php
+++ b/src/Propel/Runtime/Collection/OnDemandIterator.php
@@ -9,6 +9,7 @@
 namespace Propel\Runtime\Collection;
 
 use Iterator;
+use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
 use Propel\Runtime\DataFetcher\DataFetcherInterface;
 use Propel\Runtime\Exception\PropelException;
 use Propel\Runtime\Formatter\AbstractFormatter;
@@ -66,7 +67,7 @@ class OnDemandIterator implements Iterator
     /**
      * @return void
      */
-    public function closeCursor()
+    public function closeCursor(): void
     {
         $this->dataFetcher->close();
         if ($this->enableInstancePoolingOnFinish) {
@@ -98,7 +99,7 @@ class OnDemandIterator implements Iterator
      * @return \Propel\Runtime\ActiveRecord\ActiveRecordInterface
      */
     #[\ReturnTypeWillChange]
-    public function current()
+    public function current(): ActiveRecordInterface
     {
         return $this->formatter->getAllObjectsFromRow($this->currentRow);
     }
@@ -111,7 +112,7 @@ class OnDemandIterator implements Iterator
      * @return int
      */
     #[\ReturnTypeWillChange]
-    public function key()
+    public function key(): int
     {
         return $this->currentKey;
     }

--- a/src/Propel/Runtime/Connection/ConnectionFactory.php
+++ b/src/Propel/Runtime/Connection/ConnectionFactory.php
@@ -32,8 +32,11 @@ class ConnectionFactory
      *
      * @return \Propel\Runtime\Connection\ConnectionInterface
      */
-    public static function create(array $configuration, AdapterInterface $adapter, $defaultConnectionClass = self::DEFAULT_CONNECTION_CLASS)
-    {
+    public static function create(
+        array $configuration,
+        AdapterInterface $adapter,
+        $defaultConnectionClass = self::DEFAULT_CONNECTION_CLASS
+    ): ConnectionInterface {
         if (isset($configuration['classname'])) {
             $connectionClass = $configuration['classname'];
         } else {

--- a/src/Propel/Runtime/Connection/ConnectionInterface.php
+++ b/src/Propel/Runtime/Connection/ConnectionInterface.php
@@ -183,7 +183,7 @@ interface ConnectionInterface
      *
      * @return \Propel\Runtime\DataFetcher\DataFetcherInterface|\PDOStatement|false
      */
-    public function query($statement);
+    public function query(string $statement);
 
     /**
      * Quotes a string for use in a query.

--- a/src/Propel/Runtime/Connection/ConnectionInterface.php
+++ b/src/Propel/Runtime/Connection/ConnectionInterface.php
@@ -9,6 +9,7 @@
 namespace Propel\Runtime\Connection;
 
 use PDO;
+use Propel\Runtime\DataFetcher\DataFetcherInterface;
 
 /**
  * Interface for Propel Connection class.
@@ -25,12 +26,12 @@ interface ConnectionInterface
      *
      * @return void
      */
-    public function setName($name);
+    public function setName($name): void;
 
     /**
      * @return string The datasource name associated to this connection.
      */
-    public function getName();
+    public function getName(): string;
 
     /**
      * Turns off autocommit mode.
@@ -43,7 +44,7 @@ interface ConnectionInterface
      *
      * @return bool TRUE on success or FALSE on failure.
      */
-    public function beginTransaction();
+    public function beginTransaction(): bool;
 
     /**
      * Commits a transaction.
@@ -53,7 +54,7 @@ interface ConnectionInterface
      *
      * @return bool TRUE on success or FALSE on failure.
      */
-    public function commit();
+    public function commit(): bool;
 
     /**
      * Rolls back a transaction.
@@ -65,14 +66,14 @@ interface ConnectionInterface
      *
      * @return bool TRUE on success or FALSE on failure.
      */
-    public function rollBack();
+    public function rollBack(): bool;
 
     /**
      * Checks if inside a transaction.
      *
      * @return bool TRUE if a transaction is currently active, and FALSE if not.
      */
-    public function inTransaction();
+    public function inTransaction(): bool;
 
     /**
      * Retrieve a database connection attribute.
@@ -93,7 +94,7 @@ interface ConnectionInterface
      *
      * @return bool TRUE on success or FALSE on failure.
      */
-    public function setAttribute($attribute, $value);
+    public function setAttribute($attribute, $value): bool;
 
     /**
      * Returns the ID of the last inserted row or sequence value.
@@ -119,14 +120,14 @@ interface ConnectionInterface
      *
      * @return \Propel\Runtime\DataFetcher\DataFetcherInterface
      */
-    public function getSingleDataFetcher($data);
+    public function getSingleDataFetcher($data): DataFetcherInterface;
 
     /**
      * @param mixed $data
      *
      * @return \Propel\Runtime\DataFetcher\DataFetcherInterface
      */
-    public function getDataFetcher($data);
+    public function getDataFetcher($data): DataFetcherInterface;
 
     /**
      * Executes the given callable within a transaction.
@@ -150,7 +151,7 @@ interface ConnectionInterface
      *
      * @return int The number of rows that were modified or deleted.
      */
-    public function exec($statement);
+    public function exec($statement): int;
 
     /**
      * Prepares a statement for execution and returns a statement object.
@@ -199,5 +200,5 @@ interface ConnectionInterface
      *                SQL statement. Returns FALSE if the driver does not support
      *                quoting in this way.
      */
-    public function quote($string, $parameterType = PDO::PARAM_STR);
+    public function quote($string, $parameterType = PDO::PARAM_STR): string;
 }

--- a/src/Propel/Runtime/Connection/ConnectionInterface.php
+++ b/src/Propel/Runtime/Connection/ConnectionInterface.php
@@ -29,9 +29,9 @@ interface ConnectionInterface
     public function setName($name): void;
 
     /**
-     * @return string The datasource name associated to this connection.
+     * @return string|null The datasource name associated to this connection.
      */
-    public function getName(): string;
+    public function getName(): ?string;
 
     /**
      * Turns off autocommit mode.

--- a/src/Propel/Runtime/Connection/ConnectionManagerInterface.php
+++ b/src/Propel/Runtime/Connection/ConnectionManagerInterface.php
@@ -17,29 +17,29 @@ interface ConnectionManagerInterface
      *
      * @return void
      */
-    public function setName($name);
+    public function setName($name): void;
 
     /**
      * @return string The datasource name associated to this connection
      */
-    public function getName();
+    public function getName(): string;
 
     /**
      * @param \Propel\Runtime\Adapter\AdapterInterface|null $adapter
      *
      * @return \Propel\Runtime\Connection\ConnectionInterface
      */
-    public function getWriteConnection(?AdapterInterface $adapter = null);
+    public function getWriteConnection(?AdapterInterface $adapter = null): ConnectionInterface;
 
     /**
      * @param \Propel\Runtime\Adapter\AdapterInterface|null $adapter
      *
      * @return \Propel\Runtime\Connection\ConnectionInterface
      */
-    public function getReadConnection(?AdapterInterface $adapter = null);
+    public function getReadConnection(?AdapterInterface $adapter = null): ConnectionInterface;
 
     /**
      * @return void
      */
-    public function closeConnections();
+    public function closeConnections(): void;
 }

--- a/src/Propel/Runtime/Connection/ConnectionManagerMasterSlave.php
+++ b/src/Propel/Runtime/Connection/ConnectionManagerMasterSlave.php
@@ -22,7 +22,7 @@ class ConnectionManagerMasterSlave extends ConnectionManagerPrimaryReplica
      *
      * @return bool
      */
-    public function isForceMasterConnection()
+    public function isForceMasterConnection(): bool
     {
         return $this->isForcePrimaryConnection();
     }
@@ -36,7 +36,7 @@ class ConnectionManagerMasterSlave extends ConnectionManagerPrimaryReplica
      *
      * @return void
      */
-    public function setForceMasterConnection($isForceMasterConnection)
+    public function setForceMasterConnection($isForceMasterConnection): void
     {
         $this->setForcePrimaryConnection($isForceMasterConnection);
     }

--- a/src/Propel/Runtime/Connection/ConnectionManagerPrimaryReplica.php
+++ b/src/Propel/Runtime/Connection/ConnectionManagerPrimaryReplica.php
@@ -50,7 +50,7 @@ class ConnectionManagerPrimaryReplica implements ConnectionManagerInterface
      *
      * @return void
      */
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
@@ -58,7 +58,7 @@ class ConnectionManagerPrimaryReplica implements ConnectionManagerInterface
     /**
      * @return string The datasource name associated to this connection
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -68,7 +68,7 @@ class ConnectionManagerPrimaryReplica implements ConnectionManagerInterface
      *
      * @return bool
      */
-    public function isForcePrimaryConnection()
+    public function isForcePrimaryConnection(): bool
     {
         return $this->isForcePrimaryConnection;
     }
@@ -80,7 +80,7 @@ class ConnectionManagerPrimaryReplica implements ConnectionManagerInterface
      *
      * @return void
      */
-    public function setForcePrimaryConnection($isForceMasterConnection)
+    public function setForcePrimaryConnection($isForceMasterConnection): void
     {
         $this->isForcePrimaryConnection = (bool)$isForceMasterConnection;
     }
@@ -100,7 +100,7 @@ class ConnectionManagerPrimaryReplica implements ConnectionManagerInterface
      *
      * @return void
      */
-    public function setWriteConfiguration($configuration)
+    public function setWriteConfiguration($configuration): void
     {
         $this->writeConfiguration = $configuration;
         $this->closeConnections();
@@ -128,7 +128,7 @@ class ConnectionManagerPrimaryReplica implements ConnectionManagerInterface
      *
      * @return void
      */
-    public function setReadConfiguration($configuration)
+    public function setReadConfiguration($configuration): void
     {
         $this->readConfiguration = $configuration;
         $this->closeConnections();
@@ -143,7 +143,7 @@ class ConnectionManagerPrimaryReplica implements ConnectionManagerInterface
      *
      * @return \Propel\Runtime\Connection\ConnectionInterface
      */
-    public function getWriteConnection(?AdapterInterface $adapter = null)
+    public function getWriteConnection(?AdapterInterface $adapter = null): ConnectionInterface
     {
         if ($this->writeConnection === null) {
             $this->writeConnection = ConnectionFactory::create($this->writeConfiguration, $adapter);
@@ -163,7 +163,7 @@ class ConnectionManagerPrimaryReplica implements ConnectionManagerInterface
      *
      * @return \Propel\Runtime\Connection\ConnectionInterface
      */
-    public function getReadConnection(?AdapterInterface $adapter = null)
+    public function getReadConnection(?AdapterInterface $adapter = null): ConnectionInterface
     {
         if ($this->writeConnection && $this->writeConnection->inTransaction()) {
             return $this->writeConnection;
@@ -190,7 +190,7 @@ class ConnectionManagerPrimaryReplica implements ConnectionManagerInterface
     /**
      * @return void
      */
-    public function closeConnections()
+    public function closeConnections(): void
     {
         $this->writeConnection = null;
         $this->readConnection = null;

--- a/src/Propel/Runtime/Connection/ConnectionManagerSingle.php
+++ b/src/Propel/Runtime/Connection/ConnectionManagerSingle.php
@@ -36,7 +36,7 @@ class ConnectionManagerSingle implements ConnectionManagerInterface
      *
      * @return void
      */
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
@@ -44,7 +44,7 @@ class ConnectionManagerSingle implements ConnectionManagerInterface
     /**
      * @return string The datasource name associated to this connection
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -52,7 +52,7 @@ class ConnectionManagerSingle implements ConnectionManagerInterface
     /**
      * @return array
      */
-    public function getConfiguration()
+    public function getConfiguration(): array
     {
         return $this->configuration;
     }
@@ -62,7 +62,7 @@ class ConnectionManagerSingle implements ConnectionManagerInterface
      *
      * @return void
      */
-    public function setConnection(ConnectionInterface $connection)
+    public function setConnection(ConnectionInterface $connection): void
     {
         $this->setConfiguration(null);
         $this->connection = $connection;
@@ -73,7 +73,7 @@ class ConnectionManagerSingle implements ConnectionManagerInterface
      *
      * @return void
      */
-    public function setConfiguration($configuration)
+    public function setConfiguration($configuration): void
     {
         $this->configuration = (array)$configuration;
         $this->closeConnections();
@@ -86,7 +86,7 @@ class ConnectionManagerSingle implements ConnectionManagerInterface
      *
      * @return \Propel\Runtime\Connection\ConnectionInterface
      */
-    public function getWriteConnection(?AdapterInterface $adapter = null)
+    public function getWriteConnection(?AdapterInterface $adapter = null): ConnectionInterface
     {
         if ($this->connection === null) {
             if ($adapter === null) {
@@ -105,7 +105,7 @@ class ConnectionManagerSingle implements ConnectionManagerInterface
      *
      * @return \Propel\Runtime\Connection\ConnectionInterface
      */
-    public function getReadConnection(?AdapterInterface $adapter = null)
+    public function getReadConnection(?AdapterInterface $adapter = null): ConnectionInterface
     {
         return $this->getWriteConnection($adapter);
     }
@@ -113,7 +113,7 @@ class ConnectionManagerSingle implements ConnectionManagerInterface
     /**
      * @return void
      */
-    public function closeConnections()
+    public function closeConnections(): void
     {
         $this->connection = null;
     }

--- a/src/Propel/Runtime/Connection/ConnectionWrapper.php
+++ b/src/Propel/Runtime/Connection/ConnectionWrapper.php
@@ -138,9 +138,9 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
     }
 
     /**
-     * @return string The datasource name associated to this connection
+     * @return string|null The datasource name associated to this connection
      */
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }

--- a/src/Propel/Runtime/Connection/ConnectionWrapper.php
+++ b/src/Propel/Runtime/Connection/ConnectionWrapper.php
@@ -146,9 +146,9 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
     }
 
     /**
-     * @return \Propel\Runtime\Connection\ConnectionInterface
+     * @return \Propel\Runtime\Connection\ConnectionInterface|null
      */
-    public function getWrappedConnection(): ConnectionInterface
+    public function getWrappedConnection(): ?ConnectionInterface
     {
         return $this->connection;
     }

--- a/src/Propel/Runtime/Connection/ConnectionWrapper.php
+++ b/src/Propel/Runtime/Connection/ConnectionWrapper.php
@@ -10,6 +10,7 @@ namespace Propel\Runtime\Connection;
 
 use PDOException;
 use Propel\Runtime\Connection\Exception\RollbackException;
+use Propel\Runtime\DataFetcher\DataFetcherInterface;
 use Propel\Runtime\Exception\InvalidArgumentException;
 use Propel\Runtime\Propel;
 use Psr\Log\LoggerAwareInterface;
@@ -131,7 +132,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
      *
      * @return void
      */
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
@@ -139,7 +140,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
     /**
      * @return string The datasource name associated to this connection
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -147,7 +148,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
     /**
      * @return \Propel\Runtime\Connection\ConnectionInterface
      */
-    public function getWrappedConnection()
+    public function getWrappedConnection(): ConnectionInterface
     {
         return $this->connection;
     }
@@ -157,7 +158,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
      *
      * @return int
      */
-    public function getNestedTransactionCount()
+    public function getNestedTransactionCount(): int
     {
         return $this->nestedTransactionCount;
     }
@@ -169,7 +170,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
      *
      * @return void
      */
-    protected function setNestedTransactionCount($v)
+    protected function setNestedTransactionCount($v): void
     {
         $this->nestedTransactionCount = $v;
     }
@@ -180,7 +181,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
      *
      * @return bool
      */
-    public function isInTransaction()
+    public function isInTransaction(): bool
     {
         return ($this->getNestedTransactionCount() > 0);
     }
@@ -191,7 +192,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
      *
      * @return bool True if the connection is in a committable transaction
      */
-    public function isCommitable()
+    public function isCommitable(): bool
     {
         return $this->isInTransaction() && !$this->isUncommitable;
     }
@@ -201,7 +202,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
      *
      * @return bool
      */
-    public function beginTransaction()
+    public function beginTransaction(): bool
     {
         $return = true;
         if (!$this->nestedTransactionCount) {
@@ -224,7 +225,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
      *
      * @return bool
      */
-    public function commit()
+    public function commit(): bool
     {
         $return = true;
         $opcount = $this->nestedTransactionCount;
@@ -253,7 +254,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
      *
      * @return bool Whether operation was successful.
      */
-    public function rollBack()
+    public function rollBack(): bool
     {
         $return = true;
         $opcount = $this->nestedTransactionCount;
@@ -280,7 +281,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
      *
      * @return bool Whether operation was successful.
      */
-    public function forceRollBack()
+    public function forceRollBack(): bool
     {
         $return = true;
 
@@ -306,7 +307,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
      *
      * @return bool TRUE if a transaction is currently active, and FALSE if not.
      */
-    public function inTransaction()
+    public function inTransaction(): bool
     {
         return (bool)$this->connection->inTransaction();
     }
@@ -340,7 +341,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
      *
      * @return bool
      */
-    public function setAttribute($attribute, $value)
+    public function setAttribute($attribute, $value): bool
     {
         if (is_string($attribute)) {
             if (strpos($attribute, '::') === false) {
@@ -407,7 +408,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
     /**
      * @inheritDoc
      */
-    public function exec($statement)
+    public function exec($statement): int
     {
         if ($this->useDebug) {
             $callback = [$this->connection, 'exec'];
@@ -432,7 +433,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
      *
      * @return \Propel\Runtime\DataFetcher\DataFetcherInterface
      */
-    public function query($statement, ...$args)
+    public function query($statement, ...$args): DataFetcherInterface
     {
         $statementWrapper = $this->createStatementWrapper($statement);
 
@@ -494,7 +495,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
      *                SQL statement. Returns FALSE if the driver does not support
      *                quoting in this way.
      */
-    public function quote($string, $parameterType = 2)
+    public function quote($string, $parameterType = 2): string
     {
         return $this->connection->quote($string, $parameterType);
     }
@@ -502,7 +503,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
     /**
      * @inheritDoc
      */
-    public function getSingleDataFetcher($data)
+    public function getSingleDataFetcher($data): DataFetcherInterface
     {
         return $this->connection->getSingleDataFetcher($data);
     }
@@ -510,7 +511,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
     /**
      * @inheritDoc
      */
-    public function getDataFetcher($data)
+    public function getDataFetcher($data): DataFetcherInterface
     {
         return $this->connection->getDataFetcher($data);
     }
@@ -522,7 +523,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
      *
      * @return \Propel\Runtime\Connection\StatementWrapper
      */
-    protected function createStatementWrapper($sql)
+    protected function createStatementWrapper($sql): StatementWrapper
     {
         return new StatementWrapper($sql, $this);
     }
@@ -554,7 +555,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
      *
      * @return void
      */
-    public function clearStatementCache()
+    public function clearStatementCache(): void
     {
         $this->cachedPreparedStatements = [];
     }
@@ -567,7 +568,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
      *
      * @return int
      */
-    public function getQueryCount()
+    public function getQueryCount(): int
     {
         return $this->queryCount;
     }
@@ -579,7 +580,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
      *
      * @return void
      */
-    public function incrementQueryCount()
+    public function incrementQueryCount(): void
     {
         $this->queryCount++;
     }
@@ -589,7 +590,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
      *
      * @return string Executable SQL code
      */
-    public function getLastExecutedQuery()
+    public function getLastExecutedQuery(): string
     {
         return $this->lastExecutedQuery;
     }
@@ -601,7 +602,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
      *
      * @return void
      */
-    public function setLastExecutedQuery($query)
+    public function setLastExecutedQuery($query): void
     {
         $this->lastExecutedQuery = $query;
     }
@@ -613,7 +614,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
      *
      * @return void
      */
-    public function useDebug($value = true)
+    public function useDebug($value = true): void
     {
         if (!$value) {
             // reset query logging
@@ -629,7 +630,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
      *
      * @return void
      */
-    public function setLogMethods($logMethods)
+    public function setLogMethods($logMethods): void
     {
         $this->logMethods = $logMethods;
     }
@@ -637,7 +638,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
     /**
      * @return array
      */
-    public function getLogMethods()
+    public function getLogMethods(): array
     {
         return $this->logMethods;
     }
@@ -647,7 +648,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
      *
      * @return bool
      */
-    protected function isLogEnabledForMethod($methodName)
+    protected function isLogEnabledForMethod($methodName): bool
     {
         return in_array($methodName, $this->getLogMethods());
     }
@@ -668,7 +669,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
      *
      * @return \Psr\Log\LoggerInterface A logger.
      */
-    public function getLogger()
+    public function getLogger(): LoggerInterface
     {
         if ($this->logger === null) {
             return Propel::getServiceContainer()->getLogger($this->getName());
@@ -684,7 +685,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
      *
      * @return void
      */
-    public function log($msg)
+    public function log($msg): void
     {
         $backtrace = debug_backtrace();
         if (!isset($backtrace[1]['function'])) {

--- a/src/Propel/Runtime/Connection/PdoConnection.php
+++ b/src/Propel/Runtime/Connection/PdoConnection.php
@@ -9,6 +9,7 @@
 namespace Propel\Runtime\Connection;
 
 use PDO;
+use Propel\Runtime\DataFetcher\DataFetcherInterface;
 use Propel\Runtime\DataFetcher\PDODataFetcher;
 use Propel\Runtime\Exception\InvalidArgumentException;
 
@@ -47,7 +48,7 @@ class PdoConnection implements ConnectionInterface
      *
      * @return void
      */
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
@@ -55,7 +56,7 @@ class PdoConnection implements ConnectionInterface
     /**
      * @return string The datasource name associated to this connection
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -72,7 +73,7 @@ class PdoConnection implements ConnectionInterface
     {
         // Convert option keys from a string to a PDO:: constant
         $pdoOptions = [];
-        if (is_array($options)) {
+        if ($options) {
             foreach ($options as $key => $option) {
                 $index = (is_numeric($key)) ? $key : constant('PDO::' . $key);
                 $pdoOptions[$index] = $option;
@@ -95,7 +96,7 @@ class PdoConnection implements ConnectionInterface
      *
      * @return bool
      */
-    public function setAttribute($attribute, $value)
+    public function setAttribute($attribute, $value): bool
     {
         if (is_string($attribute) && strpos($attribute, '::') === false) {
             $attribute = '\PDO::' . $attribute;
@@ -111,7 +112,7 @@ class PdoConnection implements ConnectionInterface
     /**
      * @inheritDoc
      */
-    public function getDataFetcher($data)
+    public function getDataFetcher($data): DataFetcherInterface
     {
         return new PDODataFetcher($data);
     }
@@ -119,7 +120,7 @@ class PdoConnection implements ConnectionInterface
     /**
      * @inheritDoc
      */
-    public function getSingleDataFetcher($data)
+    public function getSingleDataFetcher($data): DataFetcherInterface
     {
         return $this->getDataFetcher($data);
     }
@@ -139,7 +140,7 @@ class PdoConnection implements ConnectionInterface
      *
      * @return int
      */
-    public function exec($statement)
+    public function exec($statement): int
     {
         return $this->pdo->exec($statement);
     }
@@ -147,7 +148,7 @@ class PdoConnection implements ConnectionInterface
     /**
      * @inheritDoc
      */
-    public function inTransaction()
+    public function inTransaction(): bool
     {
         return $this->pdo->inTransaction();
     }
@@ -191,7 +192,7 @@ class PdoConnection implements ConnectionInterface
      *
      * @return string
      */
-    public function quote($string, $parameterType = PDO::PARAM_STR)
+    public function quote($string, $parameterType = PDO::PARAM_STR): string
     {
         return $this->pdo->quote($string, $parameterType);
     }
@@ -199,7 +200,7 @@ class PdoConnection implements ConnectionInterface
     /**
      * @return bool
      */
-    public function beginTransaction()
+    public function beginTransaction(): bool
     {
         return $this->pdo->beginTransaction();
     }
@@ -207,7 +208,7 @@ class PdoConnection implements ConnectionInterface
     /**
      * @return bool
      */
-    public function commit()
+    public function commit(): bool
     {
         return $this->pdo->commit();
     }
@@ -215,7 +216,7 @@ class PdoConnection implements ConnectionInterface
     /**
      * @return bool
      */
-    public function rollBack()
+    public function rollBack(): bool
     {
         return $this->pdo->rollBack();
     }

--- a/src/Propel/Runtime/Connection/PdoConnection.php
+++ b/src/Propel/Runtime/Connection/PdoConnection.php
@@ -130,7 +130,7 @@ class PdoConnection implements ConnectionInterface
      *
      * @return \PDOStatement|false
      */
-    public function query($statement)
+    public function query(string $statement)
     {
         return $this->pdo->query($statement);
     }

--- a/src/Propel/Runtime/Connection/PdoConnection.php
+++ b/src/Propel/Runtime/Connection/PdoConnection.php
@@ -54,9 +54,9 @@ class PdoConnection implements ConnectionInterface
     }
 
     /**
-     * @return string The datasource name associated to this connection
+     * @return string|null The datasource name associated to this connection
      */
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }
@@ -101,7 +101,7 @@ class PdoConnection implements ConnectionInterface
         if (is_string($attribute) && strpos($attribute, '::') === false) {
             $attribute = '\PDO::' . $attribute;
             if (!defined($attribute)) {
-                throw new InvalidArgumentException(sprintf('Invalid PDO option/attribute name specified: "%s"', $attribute));
+                throw new InvalidArgumentException(sprintf('Invalid PDO option/attribute name specified: `%s`', $attribute));
             }
             $attribute = constant($attribute);
         }

--- a/src/Propel/Runtime/Connection/ProfilerConnectionWrapper.php
+++ b/src/Propel/Runtime/Connection/ProfilerConnectionWrapper.php
@@ -8,6 +8,7 @@
 
 namespace Propel\Runtime\Connection;
 
+use Propel\Runtime\DataFetcher\DataFetcherInterface;
 use Propel\Runtime\Propel;
 use Propel\Runtime\Util\Profiler;
 
@@ -40,7 +41,7 @@ class ProfilerConnectionWrapper extends ConnectionWrapper
      *
      * @return void
      */
-    public function setProfiler(Profiler $profiler)
+    public function setProfiler(Profiler $profiler): void
     {
         $this->profiler = $profiler;
     }
@@ -48,7 +49,7 @@ class ProfilerConnectionWrapper extends ConnectionWrapper
     /**
      * @return \Propel\Runtime\Util\Profiler
      */
-    public function getProfiler()
+    public function getProfiler(): Profiler
     {
         if ($this->profiler === null) {
             $this->profiler = Propel::getServiceContainer()->getProfiler();
@@ -65,7 +66,7 @@ class ProfilerConnectionWrapper extends ConnectionWrapper
      *
      * @return bool
      */
-    public function setAttribute($attribute, $value)
+    public function setAttribute($attribute, $value): bool
     {
         switch ($attribute) {
             case 'isSlowOnly':
@@ -92,7 +93,7 @@ class ProfilerConnectionWrapper extends ConnectionWrapper
     /**
      * @inheritDoc
      */
-    public function exec($statement)
+    public function exec($statement): int
     {
         $this->getProfiler()->start();
 
@@ -102,7 +103,7 @@ class ProfilerConnectionWrapper extends ConnectionWrapper
     /**
      * @inheritDoc
      */
-    public function query($statement = '', ...$args)
+    public function query($statement = '', ...$args): DataFetcherInterface
     {
         $this->getProfiler()->start();
 
@@ -112,7 +113,7 @@ class ProfilerConnectionWrapper extends ConnectionWrapper
     /**
      * @inheritDoc
      */
-    protected function createStatementWrapper($sql)
+    protected function createStatementWrapper($sql): StatementWrapper
     {
         return new ProfilerStatementWrapper($sql, $this);
     }
@@ -120,7 +121,7 @@ class ProfilerConnectionWrapper extends ConnectionWrapper
     /**
      * @inheritDoc
      */
-    public function log($msg)
+    public function log($msg): void
     {
         if ($this->isSlowOnly && !$this->getProfiler()->isSlow()) {
             return;

--- a/src/Propel/Runtime/Connection/ProfilerStatementWrapper.php
+++ b/src/Propel/Runtime/Connection/ProfilerStatementWrapper.php
@@ -29,7 +29,7 @@ class ProfilerStatementWrapper extends StatementWrapper
      *
      * @return bool
      */
-    public function bindParam($parameter, &$variable, $dataType = PDO::PARAM_STR, $length = 0, $driverOptions = null)
+    public function bindParam($parameter, &$variable, $dataType = PDO::PARAM_STR, $length = 0, $driverOptions = null): bool
     {
         $this->connection->getProfiler()->start();
 
@@ -46,7 +46,7 @@ class ProfilerStatementWrapper extends StatementWrapper
      *
      * @return bool
      */
-    public function bindValue($parameter, $value, $dataType = PDO::PARAM_STR)
+    public function bindValue($parameter, $value, $dataType = PDO::PARAM_STR): bool
     {
         $this->connection->getProfiler()->start();
 
@@ -61,7 +61,7 @@ class ProfilerStatementWrapper extends StatementWrapper
      *
      * @return bool
      */
-    public function execute($inputParameters = null)
+    public function execute($inputParameters = null): bool
     {
         $this->connection->getProfiler()->start();
 

--- a/src/Propel/Runtime/Connection/StatementInterface.php
+++ b/src/Propel/Runtime/Connection/StatementInterface.php
@@ -27,7 +27,7 @@ interface StatementInterface
      *
      * @return bool TRUE on success or FALSE on failure.
      */
-    public function execute($inputParameters = null);
+    public function execute($inputParameters = null): bool;
 
     /**
      * Fetches the next row from a result set.
@@ -51,7 +51,7 @@ interface StatementInterface
      *
      * @return bool TRUE on success or FALSE on failure.
      */
-    public function bindParam($parameter, &$variable, $dataType = PDO::PARAM_STR, $length = null, $driverOptions = null);
+    public function bindParam($parameter, &$variable, $dataType = PDO::PARAM_STR, $length = null, $driverOptions = null): bool;
 
     /**
      * Bind a column to a PHP variable.
@@ -64,7 +64,7 @@ interface StatementInterface
      *
      * @return bool TRUE on success or FALSE on failure.
      */
-    public function bindColumn($column, &$param, $type = null, $maxlen = null, $driverdata = null);
+    public function bindColumn($column, &$param, $type = null, $maxlen = null, $driverdata = null): bool;
 
     /**
      * Binds a value to a parameter
@@ -75,14 +75,14 @@ interface StatementInterface
      *
      * @return bool TRUE on success or FALSE on failure.
      */
-    public function bindValue($parameter, $value, $dataType = PDO::PARAM_STR);
+    public function bindValue($parameter, $value, $dataType = PDO::PARAM_STR): bool;
 
     /**
      * Returns the number of rows affected by the last SQL statement.
      *
      * @return int the number of rows.
      */
-    public function rowCount();
+    public function rowCount(): int;
 
     /**
      * Returns a single column from the next row of a result set.
@@ -91,7 +91,7 @@ interface StatementInterface
      *
      * @return string|null Returns a single column from the next row of a result set or FALSE if there are no more rows.
      */
-    public function fetchColumn($columnIndex = 0);
+    public function fetchColumn($columnIndex = 0): ?string;
 
     /**
      * Returns an array containing all of the result set rows.
@@ -102,7 +102,7 @@ interface StatementInterface
      *
      * @return array returns an array containing all of the remaining rows in the result set.
      */
-    public function fetchAll($fetchStyle = PDO::FETCH_BOTH, $fetchArgument = null, array $ctorArgs = []);
+    public function fetchAll($fetchStyle = PDO::FETCH_BOTH, $fetchArgument = null, array $ctorArgs = []): array;
 
     /**
      * Fetches the next row and returns it as an object.
@@ -119,14 +119,14 @@ interface StatementInterface
      *
      * @return string
      */
-    public function errorCode();
+    public function errorCode(): string;
 
     /**
      * Fetch extended error information associated with the last operation on the statement handle.
      *
      * @return array returns an array of error information about the last operation performed by this statement handle.
      */
-    public function errorInfo();
+    public function errorInfo(): array;
 
     /**
      * Set a statement attribute.
@@ -136,7 +136,7 @@ interface StatementInterface
      *
      * @return bool TRUE on success or FALSE on failure.
      */
-    public function setAttribute($attribute, $value);
+    public function setAttribute($attribute, $value): bool;
 
     /**
      * Retrieve a statement attribute.
@@ -152,7 +152,7 @@ interface StatementInterface
      *
      * @return int the number of columns in the result set represented by the StatementInterface object.
      */
-    public function columnCount();
+    public function columnCount(): int;
 
     /**
      * Returns metadata for a column in a result set.
@@ -172,26 +172,26 @@ interface StatementInterface
      *
      * @return bool TRUE on success or FALSE on failure.
      */
-    public function setFetchMode($mode, $classNameObject = null, array $ctorarfg = []);
+    public function setFetchMode($mode, $classNameObject = null, array $ctorarfg = []): bool;
 
     /**
      * Advances to the next rowset in a multi-rowset statement handle.
      *
      * @return bool TRUE on success or FALSE on failure.
      */
-    public function nextRowset();
+    public function nextRowset(): bool;
 
     /**
      * Closes the cursor, enabling the statement to be executed again.
      *
      * @return bool TRUE on success or FALSE on failure.
      */
-    public function closeCursor();
+    public function closeCursor(): bool;
 
     /**
      * Dump an SQL prepared command.
      *
      * @return void No value is returned.
      */
-    public function debugDumpParams();
+    public function debugDumpParams(): void;
 }

--- a/src/Propel/Runtime/Connection/StatementWrapper.php
+++ b/src/Propel/Runtime/Connection/StatementWrapper.php
@@ -11,6 +11,7 @@ namespace Propel\Runtime\Connection;
 use IteratorAggregate;
 use PDO;
 use PDOStatement;
+use Propel\Runtime\DataFetcher\DataFetcherInterface;
 use Traversable;
 
 /**
@@ -87,7 +88,7 @@ class StatementWrapper implements StatementInterface, IteratorAggregate
     /**
      * @return \Propel\Runtime\DataFetcher\DataFetcherInterface
      */
-    public function query()
+    public function query(): DataFetcherInterface
     {
         if ($this->connection->useDebug) {
             $callback = [$this->connection->getWrappedConnection(), 'query'];
@@ -114,7 +115,7 @@ class StatementWrapper implements StatementInterface, IteratorAggregate
      *
      * @return bool
      */
-    public function bindParam($parameter, &$variable, $dataType = PDO::PARAM_STR, $length = 0, $driverOptions = null)
+    public function bindParam($parameter, &$variable, $dataType = PDO::PARAM_STR, $length = 0, $driverOptions = null): bool
     {
         $return = $this->statement->bindParam($parameter, $variable, $dataType, $length, $driverOptions);
         if ($this->connection->useDebug) {
@@ -138,7 +139,7 @@ class StatementWrapper implements StatementInterface, IteratorAggregate
      *
      * @return bool
      */
-    public function bindValue($parameter, $value, $dataType = PDO::PARAM_STR)
+    public function bindValue($parameter, $value, $dataType = PDO::PARAM_STR): bool
     {
         $return = $this->statement->bindValue($parameter, $value, $dataType);
         if ($this->connection->useDebug) {
@@ -166,7 +167,7 @@ class StatementWrapper implements StatementInterface, IteratorAggregate
      *
      * @return bool Returns TRUE on success or FALSE on failure.
      */
-    public function closeCursor()
+    public function closeCursor(): bool
     {
         return $this->statement->closeCursor();
     }
@@ -188,7 +189,7 @@ class StatementWrapper implements StatementInterface, IteratorAggregate
      * by the PDOStatement object. If there is no result set,
      * this method should return 0.
      */
-    public function columnCount()
+    public function columnCount(): int
     {
         return $this->statement->columnCount();
     }
@@ -203,7 +204,7 @@ class StatementWrapper implements StatementInterface, IteratorAggregate
      *
      * @return bool
      */
-    public function execute($inputParameters = null)
+    public function execute($inputParameters = null): bool
     {
         if ($this->connection->useDebug) {
             $sql = $this->getExecutedQueryString($inputParameters);
@@ -257,7 +258,7 @@ class StatementWrapper implements StatementInterface, IteratorAggregate
      *
      * @return array
      */
-    public function fetchAll($fetchStyle = PDO::FETCH_BOTH, $fetchArgument = null, $ctorArgs = [])
+    public function fetchAll($fetchStyle = PDO::FETCH_BOTH, $fetchArgument = null, $ctorArgs = []): array
     {
         return $this->statement->fetchAll($fetchStyle);
     }
@@ -271,7 +272,7 @@ class StatementWrapper implements StatementInterface, IteratorAggregate
      *
      * @return string|null A single column in the next row of a result set.
      */
-    public function fetchColumn($columnIndex = 0)
+    public function fetchColumn($columnIndex = 0): ?string
     {
         $output = $this->statement->fetchColumn($columnIndex);
 
@@ -291,7 +292,7 @@ class StatementWrapper implements StatementInterface, IteratorAggregate
      *
      * @return int The number of rows.
      */
-    public function rowCount()
+    public function rowCount(): int
     {
         return $this->statement->rowCount();
     }
@@ -309,7 +310,7 @@ class StatementWrapper implements StatementInterface, IteratorAggregate
     /**
      * @return \Propel\Runtime\Connection\ConnectionWrapper
      */
-    public function getConnection()
+    public function getConnection(): ConnectionWrapper
     {
         return $this->connection;
     }
@@ -317,7 +318,7 @@ class StatementWrapper implements StatementInterface, IteratorAggregate
     /**
      * @return \PDOStatement
      */
-    public function getStatement()
+    public function getStatement(): PDOStatement
     {
         return $this->statement;
     }
@@ -327,7 +328,7 @@ class StatementWrapper implements StatementInterface, IteratorAggregate
      *
      * @return void
      */
-    public function setStatement(PDOStatement $statement)
+    public function setStatement(PDOStatement $statement): void
     {
         $this->statement = $statement;
     }
@@ -335,7 +336,7 @@ class StatementWrapper implements StatementInterface, IteratorAggregate
     /**
      * @return array
      */
-    public function getBoundValues()
+    public function getBoundValues(): array
     {
         return $this->boundValues;
     }
@@ -343,7 +344,7 @@ class StatementWrapper implements StatementInterface, IteratorAggregate
     /**
      * @inheritDoc
      */
-    public function bindColumn($column, &$param, $type = null, $maxlen = null, $driverdata = null)
+    public function bindColumn($column, &$param, $type = null, $maxlen = null, $driverdata = null): bool
     {
         return $this->statement->bindColumn($column, $param, $type, $maxlen, $driverdata);
     }
@@ -359,7 +360,7 @@ class StatementWrapper implements StatementInterface, IteratorAggregate
     /**
      * @inheritDoc
      */
-    public function errorCode()
+    public function errorCode(): string
     {
         return $this->statement->errorCode();
     }
@@ -367,7 +368,7 @@ class StatementWrapper implements StatementInterface, IteratorAggregate
     /**
      * @inheritDoc
      */
-    public function errorInfo()
+    public function errorInfo(): array
     {
         return $this->statement->errorInfo();
     }
@@ -375,7 +376,7 @@ class StatementWrapper implements StatementInterface, IteratorAggregate
     /**
      * @inheritDoc
      */
-    public function setAttribute($attribute, $value)
+    public function setAttribute($attribute, $value): bool
     {
         return $this->statement->setAttribute($attribute, $value);
     }
@@ -399,7 +400,7 @@ class StatementWrapper implements StatementInterface, IteratorAggregate
     /**
      * @inheritDoc
      */
-    public function setFetchMode($mode, $classNameObject = null, array $ctorarfg = [])
+    public function setFetchMode($mode, $classNameObject = null, array $ctorarfg = []): bool
     {
         switch (func_num_args()) {
             case 1:
@@ -416,7 +417,7 @@ class StatementWrapper implements StatementInterface, IteratorAggregate
     /**
      * @inheritDoc
      */
-    public function nextRowset()
+    public function nextRowset(): bool
     {
         return $this->statement->nextRowset();
     }

--- a/src/Propel/Runtime/Connection/TransactionTrait.php
+++ b/src/Propel/Runtime/Connection/TransactionTrait.php
@@ -47,15 +47,15 @@ trait TransactionTrait
     /**
      * @return bool
      */
-    abstract public function beginTransaction();
+    abstract public function beginTransaction(): bool;
 
     /**
      * @return bool
      */
-    abstract public function commit();
+    abstract public function commit(): bool;
 
     /**
      * @return bool
      */
-    abstract public function rollBack();
+    abstract public function rollBack(): bool;
 }

--- a/src/Propel/Runtime/DataFetcher/AbstractDataFetcher.php
+++ b/src/Propel/Runtime/DataFetcher/AbstractDataFetcher.php
@@ -31,7 +31,7 @@ abstract class AbstractDataFetcher implements DataFetcherInterface
      *
      * @return void
      */
-    public function setDataObject($dataObject)
+    public function setDataObject($dataObject): void
     {
         $this->dataObject = $dataObject;
     }

--- a/src/Propel/Runtime/DataFetcher/ArrayDataFetcher.php
+++ b/src/Propel/Runtime/DataFetcher/ArrayDataFetcher.php
@@ -88,7 +88,7 @@ class ArrayDataFetcher extends AbstractDataFetcher
     /**
      * @inheritDoc
      */
-    public function getIndexType()
+    public function getIndexType(): string
     {
         return $this->indexType;
     }
@@ -98,7 +98,7 @@ class ArrayDataFetcher extends AbstractDataFetcher
      */
     public function count(): int
     {
-        return $this->dataObject === null ? null : count($this->dataObject);
+        return $this->dataObject === null ? 0 : count($this->dataObject);
     }
 
     /**
@@ -108,7 +108,7 @@ class ArrayDataFetcher extends AbstractDataFetcher
      *
      * @return void
      */
-    public function setIndexType($indexType)
+    public function setIndexType($indexType): void
     {
         $this->indexType = $indexType;
     }
@@ -116,7 +116,7 @@ class ArrayDataFetcher extends AbstractDataFetcher
     /**
      * @return void
      */
-    public function close()
+    public function close(): void
     {
         $this->dataObject = null;
     }

--- a/src/Propel/Runtime/DataFetcher/ArrayDataFetcher.php
+++ b/src/Propel/Runtime/DataFetcher/ArrayDataFetcher.php
@@ -44,7 +44,7 @@ class ArrayDataFetcher extends AbstractDataFetcher
     }
 
     /**
-     * @inheritDoc
+     * @return array|null
      */
     public function fetch(): ?array
     {

--- a/src/Propel/Runtime/DataFetcher/DataFetcherInterface.php
+++ b/src/Propel/Runtime/DataFetcher/DataFetcherInterface.php
@@ -98,9 +98,9 @@ interface DataFetcherInterface extends Iterator, Countable
      * Returns the data of the next row,
      * based on this->next() && this->current();
      *
-     * @return array|null
+     * @return array|bool|null
      */
-    public function fetch(): ?array;
+    public function fetch();
 
     /**
      * Frees the resultSet.

--- a/src/Propel/Runtime/DataFetcher/DataFetcherInterface.php
+++ b/src/Propel/Runtime/DataFetcher/DataFetcherInterface.php
@@ -23,7 +23,7 @@ interface DataFetcherInterface extends Iterator, Countable
      *
      * @return void
      */
-    public function setDataObject($dataObject);
+    public function setDataObject($dataObject): void;
 
     /**
      * Returns the current data object that holds or references to actual data.
@@ -100,14 +100,14 @@ interface DataFetcherInterface extends Iterator, Countable
      *
      * @return array|null
      */
-    public function fetch();
+    public function fetch(): ?array;
 
     /**
      * Frees the resultSet.
      *
      * @return void
      */
-    public function close();
+    public function close(): void;
 
     /**
      * Returns the count of items in the resultSet.
@@ -123,5 +123,5 @@ interface DataFetcherInterface extends Iterator, Countable
      *
      * @return string one of TableMap::TYPE_*
      */
-    public function getIndexType();
+    public function getIndexType(): string;
 }

--- a/src/Propel/Runtime/DataFetcher/PDODataFetcher.php
+++ b/src/Propel/Runtime/DataFetcher/PDODataFetcher.php
@@ -72,9 +72,9 @@ class PDODataFetcher extends AbstractDataFetcher
     /**
      * @param int|null $style
      *
-     * @return array|null
+     * @return array|bool|null
      */
-    public function fetch($style = null): ?array
+    public function fetch(?int $style = null)
     {
         if ($style === null) {
             $style = $this->style;

--- a/src/Propel/Runtime/DataFetcher/PDODataFetcher.php
+++ b/src/Propel/Runtime/DataFetcher/PDODataFetcher.php
@@ -51,7 +51,7 @@ class PDODataFetcher extends AbstractDataFetcher
      *
      * @return int
      */
-    public function setStyle($style)
+    public function setStyle($style): int
     {
         $old_style = $this->style;
         $this->style = $style;
@@ -64,7 +64,7 @@ class PDODataFetcher extends AbstractDataFetcher
      *
      * @return int
      */
-    public function getStyle()
+    public function getStyle(): int
     {
         return $this->style;
     }
@@ -74,7 +74,7 @@ class PDODataFetcher extends AbstractDataFetcher
      *
      * @return array|null
      */
-    public function fetch($style = null)
+    public function fetch($style = null): ?array
     {
         if ($style === null) {
             $style = $this->style;
@@ -161,7 +161,7 @@ class PDODataFetcher extends AbstractDataFetcher
     /**
      * @return void
      */
-    public function close()
+    public function close(): void
     {
         $this->getDataObject()->closeCursor();
         $this->setDataObject(null); //so the connection can be garbage collected
@@ -197,7 +197,7 @@ class PDODataFetcher extends AbstractDataFetcher
     /**
      * @inheritDoc
      */
-    public function getIndexType()
+    public function getIndexType(): string
     {
         return TableMap::TYPE_NUM;
     }
@@ -215,7 +215,7 @@ class PDODataFetcher extends AbstractDataFetcher
      *
      * @return void
      */
-    public function bindColumn($column, &$param, $type = null, $maxlen = null, $driverdata = null)
+    public function bindColumn($column, &$param, $type = null, $maxlen = null, $driverdata = null): void
     {
         if ($this->dataObject) {
             $this->dataObject->bindColumn($column, $param, $type, $maxlen, $driverdata);

--- a/src/Propel/Runtime/Formatter/AbstractFormatter.php
+++ b/src/Propel/Runtime/Formatter/AbstractFormatter.php
@@ -131,9 +131,9 @@ abstract class AbstractFormatter
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getDbName(): string
+    public function getDbName(): ?string
     {
         return $this->dbName;
     }

--- a/src/Propel/Runtime/Formatter/AbstractFormatter.php
+++ b/src/Propel/Runtime/Formatter/AbstractFormatter.php
@@ -12,6 +12,7 @@ use Propel\Runtime\ActiveQuery\BaseModelCriteria;
 use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
 use Propel\Runtime\DataFetcher\DataFetcherInterface;
 use Propel\Runtime\Exception\PropelException;
+use Propel\Runtime\Map\TableMap;
 use Propel\Runtime\Propel;
 
 /**
@@ -79,7 +80,7 @@ abstract class AbstractFormatter
      *
      * @return void
      */
-    public function setDataFetcher(DataFetcherInterface $dataFetcher)
+    public function setDataFetcher(DataFetcherInterface $dataFetcher): void
     {
         $this->dataFetcher = $dataFetcher;
     }
@@ -89,7 +90,7 @@ abstract class AbstractFormatter
      *
      * @return \Propel\Runtime\DataFetcher\DataFetcherInterface
      */
-    public function getDataFetcher()
+    public function getDataFetcher(): DataFetcherInterface
     {
         return $this->dataFetcher;
     }
@@ -124,7 +125,7 @@ abstract class AbstractFormatter
      *
      * @return void
      */
-    public function setDbName($dbName)
+    public function setDbName($dbName): void
     {
         $this->dbName = $dbName;
     }
@@ -132,7 +133,7 @@ abstract class AbstractFormatter
     /**
      * @return string
      */
-    public function getDbName()
+    public function getDbName(): string
     {
         return $this->dbName;
     }
@@ -142,7 +143,7 @@ abstract class AbstractFormatter
      *
      * @return void
      */
-    public function setClass($class)
+    public function setClass($class): void
     {
         $this->class = $class;
         $this->tableMap = $class::TABLE_MAP;
@@ -151,7 +152,7 @@ abstract class AbstractFormatter
     /**
      * @return string|null
      */
-    public function getClass()
+    public function getClass(): ?string
     {
         return $this->class;
     }
@@ -161,7 +162,7 @@ abstract class AbstractFormatter
      *
      * @return void
      */
-    public function setWith($withs = [])
+    public function setWith($withs = []): void
     {
         $this->with = $withs;
     }
@@ -169,7 +170,7 @@ abstract class AbstractFormatter
     /**
      * @return array<\Propel\Runtime\ActiveQuery\ModelWith>
      */
-    public function getWith()
+    public function getWith(): array
     {
         return $this->with;
     }
@@ -179,7 +180,7 @@ abstract class AbstractFormatter
      *
      * @return void
      */
-    public function setAsColumns($asColumns = [])
+    public function setAsColumns($asColumns = []): void
     {
         $this->asColumns = $asColumns;
     }
@@ -187,7 +188,7 @@ abstract class AbstractFormatter
     /**
      * @return array
      */
-    public function getAsColumns()
+    public function getAsColumns(): array
     {
         return $this->asColumns;
     }
@@ -197,7 +198,7 @@ abstract class AbstractFormatter
      *
      * @return void
      */
-    public function setHasLimit($hasLimit = false)
+    public function setHasLimit($hasLimit = false): void
     {
         $this->hasLimit = $hasLimit;
     }
@@ -205,7 +206,7 @@ abstract class AbstractFormatter
     /**
      * @return bool
      */
-    public function hasLimit()
+    public function hasLimit(): bool
     {
         return $this->hasLimit;
     }
@@ -235,7 +236,7 @@ abstract class AbstractFormatter
      *
      * @return string|null
      */
-    public function getCollectionClassName()
+    public function getCollectionClassName(): ?string
     {
         return null;
     }
@@ -245,7 +246,7 @@ abstract class AbstractFormatter
      *
      * @param \Propel\Runtime\ActiveRecord\ActiveRecordInterface|null $record the object to format
      *
-     * @return \Propel\Runtime\ActiveRecord\ActiveRecordInterface The original record
+     * @return \Propel\Runtime\ActiveRecord\ActiveRecordInterface|array The original record
      */
     public function formatRecord(?ActiveRecordInterface $record = null)
     {
@@ -269,14 +270,14 @@ abstract class AbstractFormatter
     /**
      * @return bool
      */
-    abstract public function isObjectFormatter();
+    abstract public function isObjectFormatter(): bool;
 
     /**
      * @throws \Propel\Runtime\Exception\PropelException
      *
      * @return void
      */
-    public function checkInit()
+    public function checkInit(): void
     {
         if ($this->tableMap === null) {
             throw new PropelException('You must initialize a formatter object before calling format() or formatOne()');
@@ -286,7 +287,7 @@ abstract class AbstractFormatter
     /**
      * @return \Propel\Runtime\Map\TableMap
      */
-    public function getTableMap()
+    public function getTableMap(): TableMap
     {
         return Propel::getServiceContainer()->getDatabaseMap($this->dbName)->getTableByPhpName($this->class);
     }
@@ -294,7 +295,7 @@ abstract class AbstractFormatter
     /**
      * @return bool
      */
-    protected function isWithOneToMany()
+    protected function isWithOneToMany(): bool
     {
         foreach ($this->with as $modelWith) {
             if ($modelWith->isWithOneToMany()) {
@@ -315,7 +316,7 @@ abstract class AbstractFormatter
      *
      * @return \Propel\Runtime\ActiveRecord\ActiveRecordInterface
      */
-    public function getSingleObjectFromRow($row, $class, &$col = 0)
+    public function getSingleObjectFromRow($row, $class, &$col = 0): ActiveRecordInterface
     {
         $obj = new $class();
         $col = $obj->hydrate($row, $col, false, $this->getDataFetcher()->getIndexType());

--- a/src/Propel/Runtime/Formatter/ArrayFormatter.php
+++ b/src/Propel/Runtime/Formatter/ArrayFormatter.php
@@ -76,7 +76,7 @@ class ArrayFormatter extends AbstractFormatter
     /**
      * @return string|null
      */
-    public function getCollectionClassName()
+    public function getCollectionClassName(): ?string
     {
         return '\Propel\Runtime\Collection\ArrayCollection';
     }
@@ -88,7 +88,7 @@ class ArrayFormatter extends AbstractFormatter
      *
      * @return array|null
      */
-    public function formatOne(?DataFetcherInterface $dataFetcher = null)
+    public function formatOne(?DataFetcherInterface $dataFetcher = null): ?array
     {
         $this->checkInit();
         $result = null;
@@ -123,7 +123,7 @@ class ArrayFormatter extends AbstractFormatter
      *
      * @return array The original record turned into an array
      */
-    public function formatRecord(?ActiveRecordInterface $record = null)
+    public function formatRecord(?ActiveRecordInterface $record = null): array
     {
         return $record ? $record->toArray() : [];
     }
@@ -131,7 +131,7 @@ class ArrayFormatter extends AbstractFormatter
     /**
      * @return bool
      */
-    public function isObjectFormatter()
+    public function isObjectFormatter(): bool
     {
         return false;
     }
@@ -146,7 +146,7 @@ class ArrayFormatter extends AbstractFormatter
      *
      * @return array
      */
-    public function &getStructuredArrayFromRow($row)
+    public function &getStructuredArrayFromRow($row): array
     {
         $col = 0;
 

--- a/src/Propel/Runtime/Formatter/ArrayFormatter.php
+++ b/src/Propel/Runtime/Formatter/ArrayFormatter.php
@@ -27,9 +27,9 @@ class ArrayFormatter extends AbstractFormatter
     protected $alreadyHydratedObjects = [];
 
     /**
-     * @var mixed
+     * @var array
      */
-    protected $emptyVariable;
+    protected $emptyVariable = [];
 
     /**
      * @param \Propel\Runtime\DataFetcher\DataFetcherInterface|null $dataFetcher

--- a/src/Propel/Runtime/Formatter/ObjectFormatter.php
+++ b/src/Propel/Runtime/Formatter/ObjectFormatter.php
@@ -8,6 +8,7 @@
 
 namespace Propel\Runtime\Formatter;
 
+use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
 use Propel\Runtime\DataFetcher\DataFetcherInterface;
 use Propel\Runtime\Exception\LogicException;
 
@@ -70,7 +71,7 @@ class ObjectFormatter extends AbstractFormatter
     /**
      * @return string|null
      */
-    public function getCollectionClassName()
+    public function getCollectionClassName(): ?string
     {
         return $this->getTableMap()->getCollectionClassName();
     }
@@ -82,7 +83,7 @@ class ObjectFormatter extends AbstractFormatter
      *
      * @return \Propel\Runtime\ActiveRecord\ActiveRecordInterface|null
      */
-    public function formatOne(?DataFetcherInterface $dataFetcher = null)
+    public function formatOne(?DataFetcherInterface $dataFetcher = null): ?ActiveRecordInterface
     {
         $this->checkInit();
         $result = null;
@@ -107,7 +108,7 @@ class ObjectFormatter extends AbstractFormatter
     /**
      * @return bool
      */
-    public function isObjectFormatter()
+    public function isObjectFormatter(): bool
     {
         return true;
     }
@@ -122,7 +123,7 @@ class ObjectFormatter extends AbstractFormatter
      *
      * @return \Propel\Runtime\ActiveRecord\ActiveRecordInterface
      */
-    public function getAllObjectsFromRow($row)
+    public function getAllObjectsFromRow($row): ActiveRecordInterface
     {
         // main object
         [$obj, $col] = $this->getTableMap()->populateObject($row, 0, $this->getDataFetcher()->getIndexType());

--- a/src/Propel/Runtime/Formatter/OnDemandFormatter.php
+++ b/src/Propel/Runtime/Formatter/OnDemandFormatter.php
@@ -9,6 +9,8 @@
 namespace Propel\Runtime\Formatter;
 
 use Propel\Runtime\ActiveQuery\BaseModelCriteria;
+use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
+use Propel\Runtime\Collection\OnDemandCollection;
 use Propel\Runtime\DataFetcher\DataFetcherInterface;
 use Propel\Runtime\Exception\LogicException;
 use ReflectionClass;
@@ -49,7 +51,7 @@ class OnDemandFormatter extends ObjectFormatter
      *
      * @return \Propel\Runtime\Collection\OnDemandCollection
      */
-    public function format(?DataFetcherInterface $dataFetcher = null)
+    public function format(?DataFetcherInterface $dataFetcher = null): OnDemandCollection
     {
         $this->checkInit();
         if ($dataFetcher) {
@@ -73,7 +75,7 @@ class OnDemandFormatter extends ObjectFormatter
      *
      * @return string
      */
-    public function getCollectionClassName()
+    public function getCollectionClassName(): string
     {
         return '\Propel\Runtime\Collection\OnDemandCollection';
     }
@@ -81,7 +83,7 @@ class OnDemandFormatter extends ObjectFormatter
     /**
      * @return \Propel\Runtime\Collection\OnDemandCollection
      */
-    public function getCollection()
+    public function getCollection(): OnDemandCollection
     {
         $class = $this->getCollectionClassName();
 
@@ -101,7 +103,7 @@ class OnDemandFormatter extends ObjectFormatter
      *
      * @return \Propel\Runtime\ActiveRecord\ActiveRecordInterface
      */
-    public function getAllObjectsFromRow($row)
+    public function getAllObjectsFromRow($row): ActiveRecordInterface
     {
         $col = 0;
 

--- a/src/Propel/Runtime/Formatter/SimpleArrayFormatter.php
+++ b/src/Propel/Runtime/Formatter/SimpleArrayFormatter.php
@@ -68,9 +68,9 @@ class SimpleArrayFormatter extends AbstractFormatter
      *
      * @throws \Propel\Runtime\Exception\LogicException
      *
-     * @return array|null
+     * @return array|string|null
      */
-    public function formatOne(?DataFetcherInterface $dataFetcher = null): ?array
+    public function formatOne(?DataFetcherInterface $dataFetcher = null)
     {
         $this->checkInit();
         $result = null;
@@ -86,7 +86,8 @@ class SimpleArrayFormatter extends AbstractFormatter
         }
 
         foreach ($dataFetcher as $row) {
-            if (false !== $rowArray = $this->getStructuredArrayFromRow($row)) {
+            $rowArray = $this->getStructuredArrayFromRow($row);
+            if ($rowArray !== false) {
                 $result = $rowArray;
             }
         }

--- a/src/Propel/Runtime/Formatter/SimpleArrayFormatter.php
+++ b/src/Propel/Runtime/Formatter/SimpleArrayFormatter.php
@@ -57,7 +57,7 @@ class SimpleArrayFormatter extends AbstractFormatter
     /**
      * @return string|null
      */
-    public function getCollectionClassName()
+    public function getCollectionClassName(): ?string
     {
         return '\Propel\Runtime\Collection\ArrayCollection';
     }
@@ -69,7 +69,7 @@ class SimpleArrayFormatter extends AbstractFormatter
      *
      * @return array|null
      */
-    public function formatOne(?DataFetcherInterface $dataFetcher = null)
+    public function formatOne(?DataFetcherInterface $dataFetcher = null): ?array
     {
         $this->checkInit();
         $result = null;
@@ -101,7 +101,7 @@ class SimpleArrayFormatter extends AbstractFormatter
      *
      * @return array The original record turned into an array
      */
-    public function formatRecord(?ActiveRecordInterface $record = null)
+    public function formatRecord(?ActiveRecordInterface $record = null): array
     {
         return $record ? $record->toArray() : [];
     }
@@ -109,7 +109,7 @@ class SimpleArrayFormatter extends AbstractFormatter
     /**
      * @return bool
      */
-    public function isObjectFormatter()
+    public function isObjectFormatter(): bool
     {
         return false;
     }
@@ -119,7 +119,7 @@ class SimpleArrayFormatter extends AbstractFormatter
      *
      * @return array
      */
-    public function getStructuredArrayFromRow($row)
+    public function getStructuredArrayFromRow($row): array
     {
         $columnNames = array_keys($this->getAsColumns());
         if (count($columnNames) > 1 && count($row) > 1) {

--- a/src/Propel/Runtime/Formatter/SimpleArrayFormatter.php
+++ b/src/Propel/Runtime/Formatter/SimpleArrayFormatter.php
@@ -45,7 +45,8 @@ class SimpleArrayFormatter extends AbstractFormatter
         }
 
         foreach ($dataFetcher as $row) {
-            if (false !== $rowArray = $this->getStructuredArrayFromRow($row)) {
+            $rowArray = $this->getStructuredArrayFromRow($row);
+            if ($rowArray !== false) {
                 $collection[] = $rowArray;
             }
         }
@@ -117,9 +118,9 @@ class SimpleArrayFormatter extends AbstractFormatter
     /**
      * @param array $row
      *
-     * @return array
+     * @return array|string|false
      */
-    public function getStructuredArrayFromRow($row): array
+    public function getStructuredArrayFromRow($row)
     {
         $columnNames = array_keys($this->getAsColumns());
         if (count($columnNames) > 1 && count($row) > 1) {

--- a/src/Propel/Runtime/Formatter/StatementFormatter.php
+++ b/src/Propel/Runtime/Formatter/StatementFormatter.php
@@ -25,7 +25,7 @@ class StatementFormatter extends AbstractFormatter
      *
      * @return \Propel\Runtime\DataFetcher\DataFetcherInterface
      */
-    public function format(?DataFetcherInterface $dataFetcher = null)
+    public function format(?DataFetcherInterface $dataFetcher = null): DataFetcherInterface
     {
         if ($dataFetcher) {
             $this->setDataFetcher($dataFetcher);
@@ -41,7 +41,7 @@ class StatementFormatter extends AbstractFormatter
      *
      * @return \Propel\Runtime\DataFetcher\DataFetcherInterface|null
      */
-    public function formatOne(?DataFetcherInterface $dataFetcher = null)
+    public function formatOne(?DataFetcherInterface $dataFetcher = null): ?DataFetcherInterface
     {
         if ($dataFetcher) {
             $this->setDataFetcher($dataFetcher);
@@ -57,7 +57,7 @@ class StatementFormatter extends AbstractFormatter
      *
      * @throws \Propel\Runtime\Exception\PropelException
      *
-     * @return \Propel\Runtime\ActiveRecord\ActiveRecordInterface|null|void
+     * @return \Propel\Runtime\ActiveRecord\ActiveRecordInterface|array
      */
     public function formatRecord(?ActiveRecordInterface $record = null)
     {
@@ -67,7 +67,7 @@ class StatementFormatter extends AbstractFormatter
     /**
      * @return bool
      */
-    public function isObjectFormatter()
+    public function isObjectFormatter(): bool
     {
         return false;
     }

--- a/src/Propel/Runtime/Map/ColumnMap.php
+++ b/src/Propel/Runtime/Map/ColumnMap.php
@@ -58,7 +58,7 @@ class ColumnMap
     /**
      * The default value for this column
      *
-     * @var string|null
+     * @var string|bool|null
      */
     protected $defaultValue;
 
@@ -358,7 +358,7 @@ class ColumnMap
     /**
      * Sets the default value for this column.
      *
-     * @param string|null $defaultValue the default value for the column
+     * @param string|bool|null $defaultValue the default value for the column
      *
      * @return void
      */
@@ -370,9 +370,9 @@ class ColumnMap
     /**
      * Gets the default value for this column.
      *
-     * @return string|null
+     * @return string|bool|null
      */
-    public function getDefaultValue(): ?string
+    public function getDefaultValue()
     {
         return $this->defaultValue;
     }

--- a/src/Propel/Runtime/Map/ColumnMap.php
+++ b/src/Propel/Runtime/Map/ColumnMap.php
@@ -176,9 +176,9 @@ class ColumnMap
     /**
      * Get the name of a column.
      *
-     * @return string A String with the column name.
+     * @return string|null A String with the column name.
      */
-    public function getPhpName(): string
+    public function getPhpName(): ?string
     {
         return $this->phpName;
     }
@@ -198,9 +198,9 @@ class ColumnMap
     /**
      * Get the Propel type of this column.
      *
-     * @return string A string representing the Propel type (e.g. PropelTypes::DATE).
+     * @return string|null A string representing the Propel type (e.g. PropelTypes::DATE).
      */
-    public function getType(): string
+    public function getType(): ?string
     {
         return $this->type;
     }

--- a/src/Propel/Runtime/Map/ColumnMap.php
+++ b/src/Propel/Runtime/Map/ColumnMap.php
@@ -144,9 +144,9 @@ class ColumnMap
     /**
      * Get the name of the table this column is in.
      *
-     * @return string A String with the table name.
+     * @return string|null A String with the table name.
      */
-    public function getTableName(): string
+    public function getTableName(): ?string
     {
         return $this->table->getName();
     }

--- a/src/Propel/Runtime/Map/ColumnMap.php
+++ b/src/Propel/Runtime/Map/ColumnMap.php
@@ -126,7 +126,7 @@ class ColumnMap
      *
      * @return string A String with the column name.
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->columnName;
     }
@@ -136,7 +136,7 @@ class ColumnMap
      *
      * @return \Propel\Runtime\Map\TableMap
      */
-    public function getTable()
+    public function getTable(): TableMap
     {
         return $this->table;
     }
@@ -146,7 +146,7 @@ class ColumnMap
      *
      * @return string A String with the table name.
      */
-    public function getTableName()
+    public function getTableName(): string
     {
         return $this->table->getName();
     }
@@ -156,7 +156,7 @@ class ColumnMap
      *
      * @return string A String with the full column name.
      */
-    public function getFullyQualifiedName()
+    public function getFullyQualifiedName(): string
     {
         return $this->getTableName() . '.' . $this->columnName;
     }
@@ -168,7 +168,7 @@ class ColumnMap
      *
      * @return void
      */
-    public function setPhpName($phpName)
+    public function setPhpName($phpName): void
     {
         $this->phpName = $phpName;
     }
@@ -178,7 +178,7 @@ class ColumnMap
      *
      * @return string A String with the column name.
      */
-    public function getPhpName()
+    public function getPhpName(): string
     {
         return $this->phpName;
     }
@@ -190,7 +190,7 @@ class ColumnMap
      *
      * @return void
      */
-    public function setType($type)
+    public function setType($type): void
     {
         $this->type = $type;
     }
@@ -200,7 +200,7 @@ class ColumnMap
      *
      * @return string A string representing the Propel type (e.g. PropelTypes::DATE).
      */
-    public function getType()
+    public function getType(): string
     {
         return $this->type;
     }
@@ -210,7 +210,7 @@ class ColumnMap
      *
      * @return int The PDO::PARAM_* value
      */
-    public function getPdoType()
+    public function getPdoType(): int
     {
         return PropelTypes::getPdoType($this->type);
     }
@@ -220,7 +220,7 @@ class ColumnMap
      *
      * @return bool
      */
-    public function isLob()
+    public function isLob(): bool
     {
         return in_array($this->type, [
             PropelTypes::BLOB,
@@ -234,7 +234,7 @@ class ColumnMap
      *
      * @return bool
      */
-    public function isTemporal()
+    public function isTemporal(): bool
     {
         return in_array($this->type, [
             PropelTypes::TIMESTAMP,
@@ -250,7 +250,7 @@ class ColumnMap
      *
      * @return bool
      */
-    public function isNumeric()
+    public function isNumeric(): bool
     {
         return in_array($this->type, [
             PropelTypes::NUMERIC,
@@ -270,7 +270,7 @@ class ColumnMap
      *
      * @return bool
      */
-    public function isSetType()
+    public function isSetType(): bool
     {
         return $this->type === PropelTypes::SET;
     }
@@ -280,7 +280,7 @@ class ColumnMap
      *
      * @return bool
      */
-    public function isText()
+    public function isText(): bool
     {
         return in_array($this->type, [
             PropelTypes::VARCHAR,
@@ -296,7 +296,7 @@ class ColumnMap
      *
      * @return void
      */
-    public function setSize($size)
+    public function setSize($size): void
     {
         $this->size = $size;
     }
@@ -306,7 +306,7 @@ class ColumnMap
      *
      * @return int An int specifying the size.
      */
-    public function getSize()
+    public function getSize(): int
     {
         return $this->size;
     }
@@ -318,7 +318,7 @@ class ColumnMap
      *
      * @return void
      */
-    public function setPrimaryKey($pk)
+    public function setPrimaryKey($pk): void
     {
         $this->pk = (bool)$pk;
     }
@@ -328,7 +328,7 @@ class ColumnMap
      *
      * @return bool True if column is a primary key.
      */
-    public function isPrimaryKey()
+    public function isPrimaryKey(): bool
     {
         return $this->pk;
     }
@@ -340,7 +340,7 @@ class ColumnMap
      *
      * @return void
      */
-    public function setNotNull($nn)
+    public function setNotNull($nn): void
     {
         $this->notNull = (bool)$nn;
     }
@@ -350,7 +350,7 @@ class ColumnMap
      *
      * @return bool True if column may not be null.
      */
-    public function isNotNull()
+    public function isNotNull(): bool
     {
         return $this->notNull || $this->isPrimaryKey();
     }
@@ -362,7 +362,7 @@ class ColumnMap
      *
      * @return void
      */
-    public function setDefaultValue($defaultValue)
+    public function setDefaultValue($defaultValue): void
     {
         $this->defaultValue = $defaultValue;
     }
@@ -372,7 +372,7 @@ class ColumnMap
      *
      * @return string|null
      */
-    public function getDefaultValue()
+    public function getDefaultValue(): ?string
     {
         return $this->defaultValue;
     }
@@ -385,7 +385,7 @@ class ColumnMap
      *
      * @return void
      */
-    public function setForeignKey($tableName, $columnName)
+    public function setForeignKey($tableName, $columnName): void
     {
         if ($tableName && $columnName) {
             $this->relatedTableName = $tableName;
@@ -402,7 +402,7 @@ class ColumnMap
      *
      * @return bool True if column is a foreign key.
      */
-    public function isForeignKey()
+    public function isForeignKey(): bool
     {
         return (bool)$this->relatedTableName;
     }
@@ -412,7 +412,7 @@ class ColumnMap
      *
      * @return \Propel\Runtime\Map\RelationMap|null
      */
-    public function getRelation()
+    public function getRelation(): ?RelationMap
     {
         if (!$this->relatedTableName) {
             return null;
@@ -437,7 +437,7 @@ class ColumnMap
      *
      * @return string A String with the full name for the related column.
      */
-    public function getRelatedName()
+    public function getRelatedName(): string
     {
         return $this->relatedTableName . '.' . $this->relatedColumnName;
     }
@@ -447,7 +447,7 @@ class ColumnMap
      *
      * @return string A String with the name for the related table.
      */
-    public function getRelatedTableName()
+    public function getRelatedTableName(): string
     {
         return $this->relatedTableName;
     }
@@ -457,7 +457,7 @@ class ColumnMap
      *
      * @return string A String with the name for the related column.
      */
-    public function getRelatedColumnName()
+    public function getRelatedColumnName(): string
     {
         return $this->relatedColumnName;
     }
@@ -469,7 +469,7 @@ class ColumnMap
      *
      * @return \Propel\Runtime\Map\TableMap The related TableMap object
      */
-    public function getRelatedTable()
+    public function getRelatedTable(): TableMap
     {
         if (!$this->relatedTableName) {
             throw new ForeignKeyNotFoundException(sprintf('Cannot fetch RelatedTable for column with no foreign key: %s.', $this->columnName));
@@ -483,7 +483,7 @@ class ColumnMap
      *
      * @return self The related ColumnMap object
      */
-    public function getRelatedColumn()
+    public function getRelatedColumn(): self
     {
         return $this->getRelatedTable()->getColumn($this->relatedColumnName);
     }
@@ -495,7 +495,7 @@ class ColumnMap
      *
      * @return void
      */
-    public function setValueSet($values)
+    public function setValueSet($values): void
     {
         $this->valueSet = $values;
     }
@@ -505,7 +505,7 @@ class ColumnMap
      *
      * @return array A list of allowed values
      */
-    public function getValueSet()
+    public function getValueSet(): array
     {
         return $this->valueSet;
     }
@@ -515,7 +515,7 @@ class ColumnMap
      *
      * @return bool
      */
-    public function isInValueSet($value)
+    public function isInValueSet($value): bool
     {
         return in_array($value, $this->valueSet);
     }
@@ -538,7 +538,7 @@ class ColumnMap
      *
      * @return string
      */
-    public function ignoreCase($str, AdapterInterface $db)
+    public function ignoreCase($str, AdapterInterface $db): string
     {
         if ($this->isText()) {
             return $db->ignoreCase($str);
@@ -556,7 +556,7 @@ class ColumnMap
      *
      * @return string Normalized column name.
      */
-    public static function normalizeName($name)
+    public static function normalizeName($name): string
     {
         if (($pos = strrpos($name, '.')) !== false) {
             $name = substr($name, $pos + 1);
@@ -573,7 +573,7 @@ class ColumnMap
      *
      * @return void
      */
-    public function setPrimaryString($pkString)
+    public function setPrimaryString($pkString): void
     {
         $this->isPkString = (bool)$pkString;
     }
@@ -583,7 +583,7 @@ class ColumnMap
      *
      * @return bool True, if this column is the primaryString column.
      */
-    public function isPrimaryString()
+    public function isPrimaryString(): bool
     {
         return $this->isPkString;
     }

--- a/src/Propel/Runtime/Map/DatabaseMap.php
+++ b/src/Propel/Runtime/Map/DatabaseMap.php
@@ -147,7 +147,7 @@ class DatabaseMap
     public function getTable($name): TableMap
     {
         if (!isset($this->tables[$name])) {
-            throw new TableNotFoundException(sprintf('Cannot fetch TableMap for undefined table %s in database %s.', $name, $this->getName()));
+            throw new TableNotFoundException(sprintf('Cannot fetch TableMap for undefined table `%s` in database `%s`.', $name, $this->getName()));
         }
 
         return $this->tables[$name];

--- a/src/Propel/Runtime/Map/DatabaseMap.php
+++ b/src/Propel/Runtime/Map/DatabaseMap.php
@@ -8,6 +8,7 @@
 
 namespace Propel\Runtime\Map;
 
+use Propel\Runtime\Adapter\AdapterInterface;
 use Propel\Runtime\Map\Exception\TableNotFoundException;
 use Propel\Runtime\Propel;
 
@@ -73,7 +74,7 @@ class DatabaseMap
      *
      * @return \Propel\Runtime\Map\TableMap The newly created TableMap.
      */
-    public function addTable($tableName)
+    public function addTable($tableName): TableMap
     {
         $this->tables[$tableName] = new TableMap($tableName, $this);
 
@@ -87,7 +88,7 @@ class DatabaseMap
      *
      * @return void
      */
-    public function addTableObject(TableMap $table)
+    public function addTableObject(TableMap $table): void
     {
         $table->setDatabaseMap($this);
 
@@ -110,7 +111,7 @@ class DatabaseMap
      *
      * @return \Propel\Runtime\Map\TableMap The TableMap object
      */
-    public function addTableFromMapClass($tableMapClass)
+    public function addTableFromMapClass($tableMapClass): TableMap
     {
         $table = new $tableMapClass();
         $this->addTableObject($table);
@@ -125,7 +126,7 @@ class DatabaseMap
      *
      * @return bool True if the database contains the table.
      */
-    public function hasTable(string $name)
+    public function hasTable(string $name): bool
     {
         if (strpos($name, '.') > 0) {
             $name = substr($name, 0, strpos($name, '.'));
@@ -143,7 +144,7 @@ class DatabaseMap
      *
      * @return \Propel\Runtime\Map\TableMap A TableMap
      */
-    public function getTable($name)
+    public function getTable($name): TableMap
     {
         if (!isset($this->tables[$name])) {
             throw new TableNotFoundException(sprintf('Cannot fetch TableMap for undefined table %s in database %s.', $name, $this->getName()));
@@ -157,7 +158,7 @@ class DatabaseMap
      *
      * @return array<\Propel\Runtime\Map\TableMap>
      */
-    public function getTables()
+    public function getTables(): array
     {
         return $this->tables;
     }
@@ -170,7 +171,7 @@ class DatabaseMap
      *
      * @return \Propel\Runtime\Map\ColumnMap A TableMap
      */
-    public function getColumn($qualifiedColumnName)
+    public function getColumn($qualifiedColumnName): ColumnMap
     {
         [$tableName, $columnName] = explode('.', $qualifiedColumnName);
 
@@ -184,7 +185,7 @@ class DatabaseMap
      *
      * @return \Propel\Runtime\Map\TableMap
      */
-    public function getTableByPhpName($phpName)
+    public function getTableByPhpName($phpName): TableMap
     {
         if ($phpName[0] !== '\\') {
             $phpName = '\\' . $phpName;
@@ -224,7 +225,7 @@ class DatabaseMap
      *
      * @return \Propel\Runtime\Adapter\AdapterInterface
      */
-    public function getAbstractAdapter()
+    public function getAbstractAdapter(): AdapterInterface
     {
         return Propel::getServiceContainer()->getAdapter($this->name);
     }

--- a/src/Propel/Runtime/Map/RelationMap.php
+++ b/src/Propel/Runtime/Map/RelationMap.php
@@ -174,7 +174,7 @@ class RelationMap
      *
      * @return void
      */
-    public function setType($type): void
+    public function setType(int $type): void
     {
         $this->type = $type;
     }

--- a/src/Propel/Runtime/Map/RelationMap.php
+++ b/src/Propel/Runtime/Map/RelationMap.php
@@ -122,7 +122,7 @@ class RelationMap
     /**
      * @return bool
      */
-    public function isPolymorphic()
+    public function isPolymorphic(): bool
     {
         return $this->polymorphic;
     }
@@ -132,7 +132,7 @@ class RelationMap
      *
      * @return void
      */
-    public function setPolymorphic($polymorphic)
+    public function setPolymorphic($polymorphic): void
     {
         $this->polymorphic = $polymorphic;
     }
@@ -142,7 +142,7 @@ class RelationMap
      *
      * @return string The name of the relation.
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -152,7 +152,7 @@ class RelationMap
      *
      * @return void
      */
-    public function setPluralName($pluralName)
+    public function setPluralName($pluralName): void
     {
         $this->pluralName = $pluralName;
     }
@@ -162,7 +162,7 @@ class RelationMap
      *
      * @return string The plural name of the relation.
      */
-    public function getPluralName()
+    public function getPluralName(): string
     {
         return $this->pluralName ?? ($this->name . 's');
     }
@@ -174,7 +174,7 @@ class RelationMap
      *
      * @return void
      */
-    public function setType($type)
+    public function setType($type): void
     {
         $this->type = $type;
     }
@@ -184,7 +184,7 @@ class RelationMap
      *
      * @return int the relation type
      */
-    public function getType()
+    public function getType(): int
     {
         return $this->type;
     }
@@ -196,7 +196,7 @@ class RelationMap
      *
      * @return void
      */
-    public function setLocalTable(TableMap $table)
+    public function setLocalTable(TableMap $table): void
     {
         $this->localTable = $table;
     }
@@ -206,7 +206,7 @@ class RelationMap
      *
      * @return \Propel\Runtime\Map\TableMap The local table for this relationship
      */
-    public function getLocalTable()
+    public function getLocalTable(): TableMap
     {
         return $this->localTable;
     }
@@ -218,7 +218,7 @@ class RelationMap
      *
      * @return void
      */
-    public function setForeignTable($table)
+    public function setForeignTable($table): void
     {
         $this->foreignTable = $table;
     }
@@ -228,7 +228,7 @@ class RelationMap
      *
      * @return \Propel\Runtime\Map\TableMap The foreign table for this relationship
      */
-    public function getForeignTable()
+    public function getForeignTable(): TableMap
     {
         return $this->foreignTable;
     }
@@ -238,7 +238,7 @@ class RelationMap
      *
      * @return \Propel\Runtime\Map\TableMap The left table for this relationship
      */
-    public function getLeftTable()
+    public function getLeftTable(): TableMap
     {
         return $this->getType() === self::MANY_TO_ONE ? $this->getLocalTable() : $this->getForeignTable();
     }
@@ -248,7 +248,7 @@ class RelationMap
      *
      * @return \Propel\Runtime\Map\TableMap The right table for this relationship
      */
-    public function getRightTable()
+    public function getRightTable(): TableMap
     {
         return $this->getType() === self::MANY_TO_ONE ? $this->getForeignTable() : $this->getLocalTable();
     }
@@ -261,7 +261,7 @@ class RelationMap
      *
      * @return void
      */
-    public function addColumnMapping(ColumnMap $local, $foreign)
+    public function addColumnMapping(ColumnMap $local, $foreign): void
     {
         $this->localColumns[] = $local;
 
@@ -284,7 +284,7 @@ class RelationMap
      *
      * @return array Associative array (local => foreign) of fully qualified column names
      */
-    public function getColumnMappings($direction = self::LOCAL_TO_FOREIGN)
+    public function getColumnMappings($direction = self::LOCAL_TO_FOREIGN): array
     {
         $h = [];
         if (
@@ -310,7 +310,7 @@ class RelationMap
      *
      * @return bool
      */
-    public function isComposite()
+    public function isComposite(): bool
     {
         return $this->countColumnMappings() > 1;
     }
@@ -320,7 +320,7 @@ class RelationMap
      *
      * @return int
      */
-    public function countColumnMappings()
+    public function countColumnMappings(): int
     {
         return count($this->localColumns);
     }
@@ -330,7 +330,7 @@ class RelationMap
      *
      * @return array<\Propel\Runtime\Map\ColumnMap>
      */
-    public function getLocalColumns()
+    public function getLocalColumns(): array
     {
         return $this->localColumns;
     }
@@ -340,7 +340,7 @@ class RelationMap
      *
      * @return array<\Propel\Runtime\Map\ColumnMap>
      */
-    public function getForeignColumns()
+    public function getForeignColumns(): array
     {
         /** @phpstan-var array<\Propel\Runtime\Map\ColumnMap> */
         return $this->foreignColumns;
@@ -351,7 +351,7 @@ class RelationMap
      *
      * @return array<\Propel\Runtime\Map\ColumnMap>
      */
-    public function getLeftColumns()
+    public function getLeftColumns(): array
     {
         return $this->getType() === self::MANY_TO_ONE ? $this->getLocalColumns() : $this->getForeignColumns();
     }
@@ -361,7 +361,7 @@ class RelationMap
      *
      * @return array<\Propel\Runtime\Map\ColumnMap>
      */
-    public function getRightColumns()
+    public function getRightColumns(): array
     {
         return $this->getType() === self::MANY_TO_ONE ? $this->getForeignColumns() : $this->getLocalColumns();
     }
@@ -369,7 +369,7 @@ class RelationMap
     /**
      * @return array
      */
-    public function getLocalValues()
+    public function getLocalValues(): array
     {
         return $this->localValues;
     }
@@ -381,7 +381,7 @@ class RelationMap
      *
      * @return void
      */
-    public function setOnUpdate($onUpdate)
+    public function setOnUpdate($onUpdate): void
     {
         $this->onUpdate = $onUpdate;
     }
@@ -391,7 +391,7 @@ class RelationMap
      *
      * @return string|null
      */
-    public function getOnUpdate()
+    public function getOnUpdate(): ?string
     {
         return $this->onUpdate;
     }
@@ -403,7 +403,7 @@ class RelationMap
      *
      * @return void
      */
-    public function setOnDelete($onDelete)
+    public function setOnDelete($onDelete): void
     {
         $this->onDelete = $onDelete;
     }
@@ -413,7 +413,7 @@ class RelationMap
      *
      * @return string|null
      */
-    public function getOnDelete()
+    public function getOnDelete(): ?string
     {
         return $this->onDelete;
     }
@@ -423,7 +423,7 @@ class RelationMap
      *
      * @return \Propel\Runtime\Map\RelationMap|null
      */
-    public function getSymmetricalRelation()
+    public function getSymmetricalRelation(): ?self
     {
         $localMapping = [$this->getLeftColumns(), $this->getRightColumns()];
         foreach ($this->getRightTable()->getRelations() as $relation) {

--- a/src/Propel/Runtime/Map/RelationMap.php
+++ b/src/Propel/Runtime/Map/RelationMap.php
@@ -182,9 +182,9 @@ class RelationMap
     /**
      * Get the type
      *
-     * @return int the relation type
+     * @return int|null The relation type
      */
-    public function getType(): int
+    public function getType(): ?int
     {
         return $this->type;
     }
@@ -204,9 +204,9 @@ class RelationMap
     /**
      * Get the local table
      *
-     * @return \Propel\Runtime\Map\TableMap The local table for this relationship
+     * @return \Propel\Runtime\Map\TableMap|null The local table for this relationship
      */
-    public function getLocalTable(): TableMap
+    public function getLocalTable(): ?TableMap
     {
         return $this->localTable;
     }
@@ -226,9 +226,9 @@ class RelationMap
     /**
      * Get the foreign table
      *
-     * @return \Propel\Runtime\Map\TableMap The foreign table for this relationship
+     * @return \Propel\Runtime\Map\TableMap|null The foreign table for this relationship
      */
-    public function getForeignTable(): TableMap
+    public function getForeignTable(): ?TableMap
     {
         return $this->foreignTable;
     }
@@ -236,9 +236,9 @@ class RelationMap
     /**
      * Get the left table of the relation
      *
-     * @return \Propel\Runtime\Map\TableMap The left table for this relationship
+     * @return \Propel\Runtime\Map\TableMap|null The left table for this relationship
      */
-    public function getLeftTable(): TableMap
+    public function getLeftTable(): ?TableMap
     {
         return $this->getType() === self::MANY_TO_ONE ? $this->getLocalTable() : $this->getForeignTable();
     }
@@ -246,9 +246,9 @@ class RelationMap
     /**
      * Get the right table of the relation
      *
-     * @return \Propel\Runtime\Map\TableMap The right table for this relationship
+     * @return \Propel\Runtime\Map\TableMap|null The right table for this relationship
      */
-    public function getRightTable(): TableMap
+    public function getRightTable(): ?TableMap
     {
         return $this->getType() === self::MANY_TO_ONE ? $this->getForeignTable() : $this->getLocalTable();
     }

--- a/src/Propel/Runtime/Map/TableMap.php
+++ b/src/Propel/Runtime/Map/TableMap.php
@@ -267,9 +267,9 @@ class TableMap
     /**
      * Get the PHP name of the Table.
      *
-     * @return string A String with the name of the table.
+     * @return string|null A String with the name of the table.
      */
-    public function getPhpName(): string
+    public function getPhpName(): ?string
     {
         return $this->phpName;
     }
@@ -290,9 +290,9 @@ class TableMap
     /**
      * Get the ClassName of the Propel Class belonging to this table.
      *
-     * @return string
+     * @return string|null
      */
-    public function getClassName(): string
+    public function getClassName(): ?string
     {
         return $this->classname;
     }
@@ -327,9 +327,9 @@ class TableMap
     /**
      * Get the Package of the table.
      *
-     * @return string
+     * @return string|null
      */
-    public function getPackage(): string
+    public function getPackage(): ?string
     {
         return $this->package;
     }

--- a/src/Propel/Runtime/Map/TableMap.php
+++ b/src/Propel/Runtime/Map/TableMap.php
@@ -204,7 +204,7 @@ class TableMap
      *
      * @return void
      */
-    public function initialize()
+    public function initialize(): void
     {
     }
 
@@ -215,7 +215,7 @@ class TableMap
      *
      * @return void
      */
-    public function setDatabaseMap(DatabaseMap $dbMap)
+    public function setDatabaseMap(DatabaseMap $dbMap): void
     {
         $this->dbMap = $dbMap;
     }
@@ -225,7 +225,7 @@ class TableMap
      *
      * @return \Propel\Runtime\Map\DatabaseMap A DatabaseMap.
      */
-    public function getDatabaseMap()
+    public function getDatabaseMap(): DatabaseMap
     {
         return $this->dbMap;
     }
@@ -237,7 +237,7 @@ class TableMap
      *
      * @return void
      */
-    public function setName(?string $name)
+    public function setName(?string $name): void
     {
         $this->tableName = $name;
     }
@@ -259,7 +259,7 @@ class TableMap
      *
      * @return void
      */
-    public function setPhpName($phpName)
+    public function setPhpName($phpName): void
     {
         $this->phpName = $phpName;
     }
@@ -269,7 +269,7 @@ class TableMap
      *
      * @return string A String with the name of the table.
      */
-    public function getPhpName()
+    public function getPhpName(): string
     {
         return $this->phpName;
     }
@@ -282,7 +282,7 @@ class TableMap
      *
      * @return void
      */
-    public function setClassName($classname)
+    public function setClassName($classname): void
     {
         $this->classname = $classname;
     }
@@ -292,7 +292,7 @@ class TableMap
      *
      * @return string
      */
-    public function getClassName()
+    public function getClassName(): string
     {
         return $this->classname;
     }
@@ -302,7 +302,7 @@ class TableMap
      *
      * @return string
      */
-    public function getCollectionClassName()
+    public function getCollectionClassName(): string
     {
         $collectionClassName = $this->getClassName() . 'Collection';
         if (class_exists($collectionClassName) && is_subclass_of($collectionClassName, Collection::class)) {
@@ -319,7 +319,7 @@ class TableMap
      *
      * @return void
      */
-    public function setPackage($package)
+    public function setPackage($package): void
     {
         $this->package = $package;
     }
@@ -329,7 +329,7 @@ class TableMap
      *
      * @return string
      */
-    public function getPackage()
+    public function getPackage(): string
     {
         return $this->package;
     }
@@ -341,7 +341,7 @@ class TableMap
      *
      * @return void
      */
-    public function setUseIdGenerator($bit)
+    public function setUseIdGenerator($bit): void
     {
         $this->useIdGenerator = (bool)$bit;
     }
@@ -351,7 +351,7 @@ class TableMap
      *
      * @return bool
      */
-    public function isUseIdGenerator()
+    public function isUseIdGenerator(): bool
     {
         return $this->useIdGenerator;
     }
@@ -363,7 +363,7 @@ class TableMap
      *
      * @return void
      */
-    public function setSingleTableInheritance($bit)
+    public function setSingleTableInheritance($bit): void
     {
         $this->isSingleTableInheritance = $bit;
     }
@@ -373,7 +373,7 @@ class TableMap
      *
      * @return bool
      */
-    public function isSingleTableInheritance()
+    public function isSingleTableInheritance(): bool
     {
         return $this->isSingleTableInheritance;
     }
@@ -385,7 +385,7 @@ class TableMap
      *
      * @return void
      */
-    public function setPrimaryKeyMethodInfo($pkInfo)
+    public function setPrimaryKeyMethodInfo($pkInfo): void
     {
         $this->pkInfo = $pkInfo;
     }
@@ -425,8 +425,17 @@ class TableMap
      *
      * @return \Propel\Runtime\Map\ColumnMap The newly created column.
      */
-    public function addColumn($name, $phpName, $type, $isNotNull = false, $size = null, $defaultValue = null, $pk = false, $fkTable = null, $fkColumn = null)
-    {
+    public function addColumn(
+        $name,
+        $phpName,
+        $type,
+        $isNotNull = false,
+        $size = null,
+        $defaultValue = null,
+        $pk = false,
+        $fkTable = null,
+        $fkColumn = null
+    ): ColumnMap {
         $col = new ColumnMap($name, $this);
         $col->setType($type);
         $col->setSize($size);
@@ -458,7 +467,7 @@ class TableMap
      *
      * @return \Propel\Runtime\Map\ColumnMap The added column map.
      */
-    public function addConfiguredColumn(ColumnMap $cmap)
+    public function addConfiguredColumn(ColumnMap $cmap): ColumnMap
     {
         $this->columns[$cmap->getName()] = $cmap;
 
@@ -473,7 +482,7 @@ class TableMap
      *
      * @return bool True if the table contains the column.
      */
-    public function hasColumn($name, $normalize = true)
+    public function hasColumn($name, $normalize = true): bool
     {
         if ($name instanceof ColumnMap) {
             $name = $name->getName();
@@ -494,7 +503,7 @@ class TableMap
      *
      * @return \Propel\Runtime\Map\ColumnMap A ColumnMap.
      */
-    public function getColumn($name, $normalize = true)
+    public function getColumn($name, $normalize = true): ColumnMap
     {
         if ($normalize) {
             $name = $this->getNormalizedColumnName($name);
@@ -513,7 +522,7 @@ class TableMap
      *
      * @return bool True if the table contains the column.
      */
-    public function hasColumnByPhpName($phpName)
+    public function hasColumnByPhpName($phpName): bool
     {
         return isset($this->columnsByPhpName[$phpName]);
     }
@@ -527,7 +536,7 @@ class TableMap
      *
      * @return \Propel\Runtime\Map\ColumnMap A ColumnMap.
      */
-    public function getColumnByPhpName($phpName)
+    public function getColumnByPhpName($phpName): ColumnMap
     {
         if (!isset($this->columnsByPhpName[$phpName])) {
             throw new ColumnNotFoundException("Cannot fetch ColumnMap for undefined column phpName: $phpName");
@@ -563,7 +572,7 @@ class TableMap
      *
      * @return array<\Propel\Runtime\Map\ColumnMap>
      */
-    public function getColumns()
+    public function getColumns(): array
     {
         return $this->columns;
     }
@@ -580,7 +589,7 @@ class TableMap
      *
      * @return \Propel\Runtime\Map\ColumnMap Newly added PrimaryKey column.
      */
-    public function addPrimaryKey($columnName, $phpName, $type, $isNotNull = false, $size = null, $defaultValue = null)
+    public function addPrimaryKey($columnName, $phpName, $type, $isNotNull = false, $size = null, $defaultValue = null): ColumnMap
     {
         return $this->addColumn($columnName, $phpName, $type, $isNotNull, $size, $defaultValue, true, null, null);
     }
@@ -599,8 +608,16 @@ class TableMap
      *
      * @return \Propel\Runtime\Map\ColumnMap Newly added ForeignKey column.
      */
-    public function addForeignKey($columnName, $phpName, $type, $fkTable, $fkColumn, $isNotNull = false, $size = 0, $defaultValue = null)
-    {
+    public function addForeignKey(
+        $columnName,
+        $phpName,
+        $type,
+        $fkTable,
+        $fkColumn,
+        $isNotNull = false,
+        $size = 0,
+        $defaultValue = null
+    ): ColumnMap {
         return $this->addColumn($columnName, $phpName, $type, $isNotNull, $size, $defaultValue, false, $fkTable, $fkColumn);
     }
 
@@ -618,15 +635,23 @@ class TableMap
      *
      * @return \Propel\Runtime\Map\ColumnMap Newly created foreign pkey column.
      */
-    public function addForeignPrimaryKey($columnName, $phpName, $type, $fkTable, $fkColumn, $isNotNull = false, $size = 0, $defaultValue = null)
-    {
+    public function addForeignPrimaryKey(
+        $columnName,
+        $phpName,
+        $type,
+        $fkTable,
+        $fkColumn,
+        $isNotNull = false,
+        $size = 0,
+        $defaultValue = null
+    ): ColumnMap {
         return $this->addColumn($columnName, $phpName, $type, $isNotNull, $size, $defaultValue, true, $fkTable, $fkColumn);
     }
 
     /**
      * @return bool true if the table is a many to many
      */
-    public function isCrossRef()
+    public function isCrossRef(): bool
     {
         return $this->isCrossRef;
     }
@@ -638,7 +663,7 @@ class TableMap
      *
      * @return void
      */
-    public function setIsCrossRef($isCrossRef)
+    public function setIsCrossRef($isCrossRef): void
     {
         $this->isCrossRef = $isCrossRef;
     }
@@ -648,7 +673,7 @@ class TableMap
      *
      * @return array<\Propel\Runtime\Map\ColumnMap>
      */
-    public function getPrimaryKeys()
+    public function getPrimaryKeys(): array
     {
         return $this->primaryKeys;
     }
@@ -658,7 +683,7 @@ class TableMap
      *
      * @return array<\Propel\Runtime\Map\ColumnMap>
      */
-    public function getForeignKeys()
+    public function getForeignKeys(): array
     {
         return $this->foreignKeys;
     }
@@ -670,7 +695,7 @@ class TableMap
      *
      * @return void
      */
-    public function buildRelations()
+    public function buildRelations(): void
     {
     }
 
@@ -697,7 +722,7 @@ class TableMap
         $onUpdate = null,
         $pluralName = null,
         $polymorphic = false
-    ) {
+    ): RelationMap {
         // note: using phpName for the second table allows the use of DatabaseMap::getTableByPhpName()
         // and this method autoloads the TableMap if the table isn't loaded yet
         $relation = new RelationMap($name);
@@ -753,7 +778,7 @@ class TableMap
      *
      * @return bool true if the relation exists
      */
-    public function hasRelation($name)
+    public function hasRelation($name): bool
     {
         return array_key_exists($name, $this->getRelations());
     }
@@ -768,7 +793,7 @@ class TableMap
      *
      * @return \Propel\Runtime\Map\RelationMap The relation object
      */
-    public function getRelation($name)
+    public function getRelation($name): RelationMap
     {
         if (!array_key_exists($name, $this->getRelations())) {
             throw new RelationNotFoundException(sprintf('Calling getRelation() on an unknown relation: %s.', $name));
@@ -783,7 +808,7 @@ class TableMap
      *
      * @return array<\Propel\Runtime\Map\RelationMap> list of RelationMap objects
      */
-    public function getRelations()
+    public function getRelations(): array
     {
         if (!$this->relationsBuilt) {
             $this->buildRelations();
@@ -798,7 +823,7 @@ class TableMap
      *
      * @return array
      */
-    public function getBehaviors()
+    public function getBehaviors(): array
     {
         return [];
     }
@@ -808,7 +833,7 @@ class TableMap
      *
      * @return bool True if the table has a primaryString column.
      */
-    public function hasPrimaryStringColumn()
+    public function hasPrimaryStringColumn(): bool
     {
         return $this->getPrimaryStringColumn() !== null;
     }
@@ -818,7 +843,7 @@ class TableMap
      *
      * @return \Propel\Runtime\Map\ColumnMap|null
      */
-    public function getPrimaryStringColumn()
+    public function getPrimaryStringColumn(): ?ColumnMap
     {
         foreach ($this->getColumns() as $column) {
             if ($column->isPrimaryString()) {
@@ -856,7 +881,7 @@ class TableMap
     /**
      * @return bool
      */
-    public function isIdentifierQuotingEnabled()
+    public function isIdentifierQuotingEnabled(): bool
     {
         return $this->identifierQuoting;
     }
@@ -866,7 +891,7 @@ class TableMap
      *
      * @return void
      */
-    public function setIdentifierQuoting($identifierQuoting)
+    public function setIdentifierQuoting($identifierQuoting): void
     {
         $this->identifierQuoting = $identifierQuoting;
     }
@@ -876,7 +901,7 @@ class TableMap
      *
      * @return array|null null if not covered by only pk
      */
-    public function extractPrimaryKey(Criteria $criteria)
+    public function extractPrimaryKey(Criteria $criteria): ?array
     {
         $pkCols = $this->getPrimaryKeys();
         if (count($pkCols) !== count($criteria->getMap())) {

--- a/src/Propel/Runtime/Map/TableMapTrait.php
+++ b/src/Propel/Runtime/Map/TableMapTrait.php
@@ -23,7 +23,7 @@ trait TableMapTrait
      *
      * @return array A list of field names
      */
-    public static function getFieldNames($type = TableMap::TYPE_PHPNAME)
+    public static function getFieldNames($type = TableMap::TYPE_PHPNAME): array
     {
         if (!array_key_exists($type, static::$fieldNames)) {
             throw new PropelException('Method getFieldNames() expects the parameter \$type to be one of the class constants TableMap::TYPE_PHPNAME, TableMap::TYPE_CAMELNAME, TableMap::TYPE_COLNAME, TableMap::TYPE_FIELDNAME, TableMap::TYPE_NUM. ' . $type . ' was given.');
@@ -44,7 +44,7 @@ trait TableMapTrait
      *
      * @return string translated name of the field.
      */
-    public static function translateFieldName($name, $fromType, $toType)
+    public static function translateFieldName($name, $fromType, $toType): string
     {
         $toNames = static::getFieldNames($toType);
         $key = static::$fieldKeys[$fromType][$name] ?? null;
@@ -62,7 +62,7 @@ trait TableMapTrait
      *
      * @return array
      */
-    public static function translateFieldNames($row, $fromType, $toType)
+    public static function translateFieldNames($row, $fromType, $toType): array
     {
         $toNames = static::getFieldNames($toType);
         $newRow = [];
@@ -91,7 +91,7 @@ trait TableMapTrait
      *
      * @return string
      */
-    public static function alias($alias, $column)
+    public static function alias($alias, $column): string
     {
         return str_replace(static::TABLE_NAME . '.', $alias . '.', $column);
     }

--- a/src/Propel/Runtime/Parser/AbstractParser.php
+++ b/src/Propel/Runtime/Parser/AbstractParser.php
@@ -92,12 +92,12 @@ abstract class AbstractParser
      * @param string $data The file content
      * @param string|null $path Path of the file to create
      *
-     * @return mixed|null|void
+     * @return int|null|void
      */
-    public function dump($data, $path = null)
+    public function dump(string $data, ?string $path = null)
     {
         if ($path !== null) {
-            return file_put_contents($path, $data);
+            return (int)file_put_contents($path, $data);
         }
 
         echo $data;

--- a/src/Propel/Runtime/Parser/AbstractParser.php
+++ b/src/Propel/Runtime/Parser/AbstractParser.php
@@ -40,7 +40,7 @@ abstract class AbstractParser
      *
      * @return array Converted data
      */
-    abstract public function toArray($data, $rootKey = 'data');
+    abstract public function toArray($data, $rootKey = 'data'): array;
 
     /**
      * @param array $array
@@ -48,7 +48,7 @@ abstract class AbstractParser
      *
      * @return string
      */
-    public function listFromArray($array, $rootKey = 'data')
+    public function listFromArray($array, $rootKey = 'data'): string
     {
         return $this->fromArray($array, $rootKey);
     }
@@ -59,7 +59,7 @@ abstract class AbstractParser
      *
      * @return array
      */
-    public function listToArray($data, $rootKey = 'data')
+    public function listToArray($data, $rootKey = 'data'): array
     {
         return $this->toArray($data, $rootKey);
     }
@@ -73,7 +73,7 @@ abstract class AbstractParser
      *
      * @return string The file content processed by PHP
      */
-    public function load($path)
+    public function load($path): string
     {
         if (!file_exists($path)) {
             throw new FileNotFoundException(sprintf('File "%s" does not exist or is unreadable', $path));
@@ -110,9 +110,9 @@ abstract class AbstractParser
      *
      * @throws \Propel\Runtime\Exception\FileNotFoundException
      *
-     * @return \Propel\Runtime\Parser\AbstractParser A PropelParser subclass instance
+     * @return self A PropelParser subclass instance
      */
-    public static function getParser($type = 'XML')
+    public static function getParser($type = 'XML'): self
     {
         $class = sprintf('\Propel\Runtime\Parser\%sParser', ucfirst(strtolower($type)));
 

--- a/src/Propel/Runtime/Parser/CsvParser.php
+++ b/src/Propel/Runtime/Parser/CsvParser.php
@@ -76,7 +76,7 @@ class CsvParser extends AbstractParser
      *
      * @return string Converted data, as a CSV string
      */
-    public function fromArray($array, $rootKey = null, $isList = false, $includeHeading = true)
+    public function fromArray($array, $rootKey = null, $isList = false, $includeHeading = true): string
     {
         $rows = [];
         if ($isList) {
@@ -102,7 +102,7 @@ class CsvParser extends AbstractParser
      *
      * @return string
      */
-    public function listFromArray($array, $rootKey = null)
+    public function listFromArray($array, $rootKey = null): string
     {
         return $this->fromArray($array, $rootKey, true);
     }
@@ -114,7 +114,7 @@ class CsvParser extends AbstractParser
      *
      * @return array The formatted array
      */
-    protected function formatRow($row)
+    protected function formatRow($row): array
     {
         foreach ($row as &$column) {
             if (!is_scalar($column)) {
@@ -154,7 +154,7 @@ class CsvParser extends AbstractParser
      *
      * @return string Escaped input value
      */
-    protected function escape($input)
+    protected function escape($input): string
     {
         return str_replace(
             $this->quotechar,
@@ -170,7 +170,7 @@ class CsvParser extends AbstractParser
      *
      * @return string Quoted input value
      */
-    protected function quote($input)
+    protected function quote($input): string
     {
         return $this->quotechar . $input . $this->quotechar;
     }
@@ -182,7 +182,7 @@ class CsvParser extends AbstractParser
      *
      * @return bool True if contains any special characters
      */
-    protected function containsSpecialChars($input)
+    protected function containsSpecialChars($input): bool
     {
         $specialChars = str_split($this->lineTerminator);
         $specialChars[] = $this->quotechar;
@@ -203,7 +203,7 @@ class CsvParser extends AbstractParser
      *
      * @return string
      */
-    protected function serialize($input)
+    protected function serialize($input): string
     {
         return serialize($input);
     }
@@ -217,7 +217,7 @@ class CsvParser extends AbstractParser
      *
      * @return string Converted data, as a CSV string
      */
-    public function toCSV($array, $isList = false, $includeHeading = true)
+    public function toCSV($array, $isList = false, $includeHeading = true): string
     {
         return $this->fromArray($array, null, $isList, $includeHeading);
     }
@@ -232,7 +232,7 @@ class CsvParser extends AbstractParser
      *
      * @return array Converted data
      */
-    public function toArray($data, $rootKey = null, $isList = false, $includeHeading = true)
+    public function toArray($data, $rootKey = null, $isList = false, $includeHeading = true): array
     {
         $rows = explode($this->lineTerminator, $data);
         if ($includeHeading) {
@@ -271,7 +271,7 @@ class CsvParser extends AbstractParser
      *
      * @return array
      */
-    public function listToArray($data, $rootKey = null)
+    public function listToArray($data, $rootKey = null): array
     {
         return $this->toArray($data, $rootKey, true);
     }
@@ -281,7 +281,7 @@ class CsvParser extends AbstractParser
      *
      * @return array
      */
-    protected function getColumns($row)
+    protected function getColumns($row): array
     {
         $delim = preg_quote($this->delimiter, '/');
         preg_match_all('/(".+?"|[^' . $delim . ']+)(' . $delim . '|$)/', $row, $matches);
@@ -296,7 +296,7 @@ class CsvParser extends AbstractParser
      *
      * @return array The cleaned up array
      */
-    protected function cleanupRow($row)
+    protected function cleanupRow($row): array
     {
         foreach ($row as $key => $column) {
             if ($this->isQuoted($column)) {
@@ -331,7 +331,7 @@ class CsvParser extends AbstractParser
      *
      * @return string
      */
-    protected function unescape($input)
+    protected function unescape($input): string
     {
         return str_replace(
             $this->escapechar . $this->quotechar,
@@ -345,7 +345,7 @@ class CsvParser extends AbstractParser
      *
      * @return string
      */
-    protected function unquote($input)
+    protected function unquote($input): string
     {
         return trim($input, $this->quotechar);
     }
@@ -383,7 +383,7 @@ class CsvParser extends AbstractParser
      *
      * @return array Converted data
      */
-    public function fromCSV($data, $isList = false, $includeHeading = true)
+    public function fromCSV($data, $isList = false, $includeHeading = true): array
     {
         return $this->toArray($data, null, $isList, $includeHeading);
     }

--- a/src/Propel/Runtime/Parser/JsonParser.php
+++ b/src/Propel/Runtime/Parser/JsonParser.php
@@ -23,7 +23,7 @@ class JsonParser extends AbstractParser
      *
      * @return string Converted data, as a JSON string
      */
-    public function fromArray($array, $rootKey = null)
+    public function fromArray($array, $rootKey = null): string
     {
         return json_encode($rootKey === null ? $array : [$rootKey => $array]);
     }
@@ -36,7 +36,7 @@ class JsonParser extends AbstractParser
      *
      * @return string Converted data, as a JSON string
      */
-    public function toJSON($array, $rootKey = null)
+    public function toJSON($array, $rootKey = null): string
     {
         return $this->fromArray($array, $rootKey);
     }
@@ -49,7 +49,7 @@ class JsonParser extends AbstractParser
      *
      * @return array Converted data
      */
-    public function toArray($data, $rootKey = null)
+    public function toArray($data, $rootKey = null): array
     {
         $data = json_decode($data, true);
 
@@ -72,7 +72,7 @@ class JsonParser extends AbstractParser
      *
      * @return array Converted data
      */
-    public function fromJSON($data, $rootKey = null)
+    public function fromJSON($data, $rootKey = null): array
     {
         return $this->toArray($data, $rootKey);
     }

--- a/src/Propel/Runtime/Parser/XmlParser.php
+++ b/src/Propel/Runtime/Parser/XmlParser.php
@@ -11,6 +11,7 @@ namespace Propel\Runtime\Parser;
 use DateTime;
 use DateTimeInterface;
 use DOMDocument;
+use DOMElement;
 use DOMNode;
 
 /**
@@ -29,7 +30,7 @@ class XmlParser extends AbstractParser
      *
      * @return string Converted data, as an XML string
      */
-    public function fromArray($array, $rootKey = 'data', $charset = null)
+    public function fromArray($array, $rootKey = 'data', $charset = null): string
     {
         $rootNode = $this->getRootNode($rootKey);
         $this->arrayToDOM($array, $rootNode, $charset);
@@ -44,7 +45,7 @@ class XmlParser extends AbstractParser
      *
      * @return string
      */
-    public function listFromArray($array, $rootKey = 'data', $charset = null)
+    public function listFromArray($array, $rootKey = 'data', $charset = null): string
     {
         $rootNode = $this->getRootNode($rootKey);
         $this->arrayToDOM($array, $rootNode, $charset);
@@ -59,7 +60,7 @@ class XmlParser extends AbstractParser
      *
      * @return \DOMElement The root DOMNode
      */
-    protected function getRootNode($rootElementName)
+    protected function getRootNode($rootElementName): DOMElement
     {
         $xml = new DOMDocument('1.0', 'UTF-8');
         $xml->preserveWhiteSpace = false;
@@ -79,7 +80,7 @@ class XmlParser extends AbstractParser
      *
      * @return string Converted data, as an XML string
      */
-    public function toXML($array, $rootElementName = 'data', $charset = null)
+    public function toXML($array, $rootElementName = 'data', $charset = null): string
     {
         return $this->fromArray($array, $rootElementName, $charset);
     }
@@ -93,7 +94,7 @@ class XmlParser extends AbstractParser
      *
      * @return string Converted data, as an XML string
      */
-    public function listToXML($array, $rootElementName = 'data', $charset = null)
+    public function listToXML($array, $rootElementName = 'data', $charset = null): string
     {
         return $this->listFromArray($array, $rootElementName, $charset);
     }
@@ -105,7 +106,7 @@ class XmlParser extends AbstractParser
      *
      * @return \DOMElement
      */
-    protected function arrayToDOM($array, $rootElement, $charset = null)
+    protected function arrayToDOM($array, $rootElement, $charset = null): DOMElement
     {
         foreach ($array as $key => $value) {
             if (is_numeric($key)) {
@@ -152,7 +153,7 @@ class XmlParser extends AbstractParser
      *
      * @return array Converted data
      */
-    public function toArray($data, $rootKey = 'data')
+    public function toArray($data, $rootKey = 'data'): array
     {
         $doc = new DOMDocument('1.0', 'UTF-8');
         $doc->loadXML($data);
@@ -169,7 +170,7 @@ class XmlParser extends AbstractParser
      *
      * @return array Converted data
      */
-    public function fromXML($data, $rootKey = 'data')
+    public function fromXML($data, $rootKey = 'data'): array
     {
         return $this->toArray($data, $rootKey);
     }
@@ -179,7 +180,7 @@ class XmlParser extends AbstractParser
      *
      * @return array
      */
-    protected function convertDOMElementToArray(DOMNode $data)
+    protected function convertDOMElementToArray(DOMNode $data): array
     {
         $array = [];
         $elementNames = [];
@@ -223,7 +224,7 @@ class XmlParser extends AbstractParser
      *
      * @return bool
      */
-    protected function hasOnlyTextNodes(DOMNode $node)
+    protected function hasOnlyTextNodes(DOMNode $node): bool
     {
         foreach ($node->childNodes as $childNode) {
             if ($childNode->nodeType != XML_CDATA_SECTION_NODE && $childNode->nodeType != XML_TEXT_NODE) {

--- a/src/Propel/Runtime/Parser/XmlParser.php
+++ b/src/Propel/Runtime/Parser/XmlParser.php
@@ -35,6 +35,7 @@ class XmlParser extends AbstractParser
         $rootNode = $this->getRootNode($rootKey);
         $this->arrayToDOM($array, $rootNode, $charset);
 
+        /** @phpstan-var string */
         return $rootNode->ownerDocument->saveXML();
     }
 
@@ -126,6 +127,7 @@ class XmlParser extends AbstractParser
             } elseif (is_string($value)) {
                 $charset = $charset ?: 'utf-8';
                 if (function_exists('iconv') && strcasecmp($charset, 'utf-8') !== 0 && strcasecmp($charset, 'utf8') !== 0) {
+                    /** @var string $value */
                     $value = iconv($charset, 'UTF-8', $value);
                 }
                 $value = htmlspecialchars($value, ENT_COMPAT, 'UTF-8');

--- a/src/Propel/Runtime/Parser/YamlParser.php
+++ b/src/Propel/Runtime/Parser/YamlParser.php
@@ -25,7 +25,7 @@ class YamlParser extends AbstractParser
      *
      * @return string Converted data, as a YAML string
      */
-    public function fromArray($array, $rootKey = null)
+    public function fromArray($array, $rootKey = null): string
     {
         return Yaml::dump($rootKey === null ? $array : [$rootKey => $array], 3);
     }
@@ -38,7 +38,7 @@ class YamlParser extends AbstractParser
      *
      * @return string Converted data, as a YAML string
      */
-    public function toYAML($array, $rootKey = null)
+    public function toYAML($array, $rootKey = null): string
     {
         return $this->fromArray($array, $rootKey);
     }
@@ -51,7 +51,7 @@ class YamlParser extends AbstractParser
      *
      * @return array Converted data
      */
-    public function toArray($data, $rootKey = null)
+    public function toArray($data, $rootKey = null): array
     {
         $data = Yaml::parse($data);
 
@@ -74,7 +74,7 @@ class YamlParser extends AbstractParser
      *
      * @return array Converted data
      */
-    public function fromYAML($data, $rootKey = null)
+    public function fromYAML($data, $rootKey = null): array
     {
         return $this->toArray($data, $rootKey);
     }

--- a/src/Propel/Runtime/Propel.php
+++ b/src/Propel/Runtime/Propel.php
@@ -8,8 +8,14 @@
 
 namespace Propel\Runtime;
 
+use Propel\Runtime\Adapter\AdapterInterface;
+use Propel\Runtime\Connection\ConnectionInterface;
+use Propel\Runtime\Connection\ConnectionManagerInterface;
+use Propel\Runtime\Map\DatabaseMap;
 use Propel\Runtime\ServiceContainer\ServiceContainerInterface;
 use Propel\Runtime\ServiceContainer\StandardServiceContainer;
+use Propel\Runtime\Util\Profiler;
+use Psr\Log\LoggerInterface;
 
 /**
  * Propel's main resource pool and initialization & configuration class.
@@ -117,7 +123,7 @@ class Propel
      *
      * @return void
      */
-    public static function init($configFile)
+    public static function init($configFile): void
     {
         $serviceContainer = self::getServiceContainer();
         $serviceContainer->closeConnections();
@@ -130,7 +136,7 @@ class Propel
      *
      * @return \Propel\Runtime\ServiceContainer\ServiceContainerInterface
      */
-    public static function getServiceContainer()
+    public static function getServiceContainer(): ServiceContainerInterface
     {
         if (self::$serviceContainer === null) {
             self::$serviceContainer = new StandardServiceContainer();
@@ -146,7 +152,7 @@ class Propel
      *
      * @return void
      */
-    public static function setServiceContainer(ServiceContainerInterface $serviceContainer)
+    public static function setServiceContainer(ServiceContainerInterface $serviceContainer): void
     {
         self::$serviceContainer = $serviceContainer;
     }
@@ -154,7 +160,7 @@ class Propel
     /**
      * @return string
      */
-    public static function getDefaultDatasource()
+    public static function getDefaultDatasource(): string
     {
         return self::$serviceContainer->getDefaultDatasource();
     }
@@ -168,7 +174,7 @@ class Propel
      *
      * @return \Propel\Runtime\Adapter\AdapterInterface
      */
-    public static function getAdapter($name = null)
+    public static function getAdapter($name = null): AdapterInterface
     {
         return self::$serviceContainer->getAdapter($name);
     }
@@ -182,7 +188,7 @@ class Propel
      *
      * @return \Propel\Runtime\Map\DatabaseMap
      */
-    public static function getDatabaseMap($name = null)
+    public static function getDatabaseMap($name = null): DatabaseMap
     {
         return self::$serviceContainer->getDatabaseMap($name);
     }
@@ -192,7 +198,7 @@ class Propel
      *
      * @return \Propel\Runtime\Connection\ConnectionManagerInterface
      */
-    public static function getConnectionManager($name)
+    public static function getConnectionManager($name): ConnectionManagerInterface
     {
         return self::$serviceContainer->getConnectionManager($name);
     }
@@ -205,7 +211,7 @@ class Propel
      *
      * @return void
      */
-    public static function closeConnections()
+    public static function closeConnections(): void
     {
         self::$serviceContainer->closeConnections();
     }
@@ -221,7 +227,7 @@ class Propel
      *
      * @return \Propel\Runtime\Connection\ConnectionInterface A database connection
      */
-    public static function getConnection($name = null, $mode = ServiceContainerInterface::CONNECTION_WRITE)
+    public static function getConnection($name = null, $mode = ServiceContainerInterface::CONNECTION_WRITE): ConnectionInterface
     {
         return self::$serviceContainer->getConnection($name, $mode);
     }
@@ -237,7 +243,7 @@ class Propel
      *
      * @return \Propel\Runtime\Connection\ConnectionInterface A database connection
      */
-    public static function getWriteConnection($name)
+    public static function getWriteConnection($name): ConnectionInterface
     {
         return self::$serviceContainer->getWriteConnection($name);
     }
@@ -254,7 +260,7 @@ class Propel
      *
      * @return \Propel\Runtime\Connection\ConnectionInterface A database connection
      */
-    public static function getReadConnection($name)
+    public static function getReadConnection($name): ConnectionInterface
     {
         return self::$serviceContainer->getReadConnection($name);
     }
@@ -264,7 +270,7 @@ class Propel
      *
      * @return \Propel\Runtime\Util\Profiler
      */
-    public static function getProfiler()
+    public static function getProfiler(): Profiler
     {
         return self::$serviceContainer->getProfiler();
     }
@@ -274,7 +280,7 @@ class Propel
      *
      * @return \Psr\Log\LoggerInterface Configured log class
      */
-    public static function getLogger()
+    public static function getLogger(): LoggerInterface
     {
         return self::$serviceContainer->getLogger();
     }
@@ -289,7 +295,7 @@ class Propel
      *
      * @return void
      */
-    public static function log($message, $level = self::LOG_DEBUG)
+    public static function log($message, $level = self::LOG_DEBUG): void
     {
         $logger = self::$serviceContainer->getLogger();
 
@@ -333,7 +339,7 @@ class Propel
      * @return bool true if the method changed the instance pooling state,
      * false if it was already disabled
      */
-    public static function disableInstancePooling()
+    public static function disableInstancePooling(): bool
     {
         if (!self::$isInstancePoolingEnabled) {
             return false;
@@ -349,7 +355,7 @@ class Propel
      * @return bool true if the method changed the instance pooling state,
      * false if it was already enabled
      */
-    public static function enableInstancePooling()
+    public static function enableInstancePooling(): bool
     {
         if (self::$isInstancePoolingEnabled) {
             return false;
@@ -364,7 +370,7 @@ class Propel
      *
      * @return bool Whether the pooling is enabled or not.
      */
-    public static function isInstancePoolingEnabled()
+    public static function isInstancePoolingEnabled(): bool
     {
         return self::$isInstancePoolingEnabled;
     }

--- a/src/Propel/Runtime/ServiceContainer/ServiceContainerInterface.php
+++ b/src/Propel/Runtime/ServiceContainer/ServiceContainerInterface.php
@@ -8,6 +8,13 @@
 
 namespace Propel\Runtime\ServiceContainer;
 
+use Propel\Runtime\Adapter\AdapterInterface;
+use Propel\Runtime\Connection\ConnectionInterface;
+use Propel\Runtime\Connection\ConnectionManagerInterface;
+use Propel\Runtime\Map\DatabaseMap;
+use Propel\Runtime\Util\Profiler;
+use Psr\Log\LoggerInterface;
+
 interface ServiceContainerInterface
 {
     /**
@@ -48,7 +55,7 @@ interface ServiceContainerInterface
     /**
      * @return string
      */
-    public function getDefaultDatasource();
+    public function getDefaultDatasource(): string;
 
     /**
      * Get the adapter for a given datasource.
@@ -59,7 +66,7 @@ interface ServiceContainerInterface
      *
      * @return \Propel\Runtime\Adapter\AdapterInterface
      */
-    public function getAdapter($name = null);
+    public function getAdapter($name = null): AdapterInterface;
 
     /**
      * Get the adapter class for a given datasource.
@@ -68,7 +75,7 @@ interface ServiceContainerInterface
      *
      * @return string
      */
-    public function getAdapterClass($name = null);
+    public function getAdapterClass($name = null): string;
 
     /**
      * Get the database map for a given datasource.
@@ -79,21 +86,21 @@ interface ServiceContainerInterface
      *
      * @return \Propel\Runtime\Map\DatabaseMap
      */
-    public function getDatabaseMap($name = null);
+    public function getDatabaseMap($name = null): DatabaseMap;
 
     /**
      * @param string $name The datasource name
      *
      * @return \Propel\Runtime\Connection\ConnectionManagerInterface
      */
-    public function getConnectionManager($name);
+    public function getConnectionManager($name): ConnectionManagerInterface;
 
     /**
      * @param string $name
      *
      * @return bool true if a connectionManager with $name has been registered
      */
-    public function hasConnectionManager($name);
+    public function hasConnectionManager($name): bool;
 
     /**
      * Close any associated resource handles.
@@ -103,7 +110,7 @@ interface ServiceContainerInterface
      *
      * @return void
      */
-    public function closeConnections();
+    public function closeConnections(): void;
 
     /**
      * Get a connection for a given datasource.
@@ -116,7 +123,7 @@ interface ServiceContainerInterface
      *
      * @return \Propel\Runtime\Connection\ConnectionInterface A database connection
      */
-    public function getConnection($name = null, $mode = self::CONNECTION_WRITE);
+    public function getConnection($name = null, $mode = self::CONNECTION_WRITE): ConnectionInterface;
 
     /**
      * Get a write connection for a given datasource.
@@ -131,7 +138,7 @@ interface ServiceContainerInterface
      *
      * @return \Propel\Runtime\Connection\ConnectionInterface A database connection
      */
-    public function getWriteConnection($name);
+    public function getWriteConnection($name): ConnectionInterface;
 
     /**
      * Get a read connection for a given datasource.
@@ -145,14 +152,14 @@ interface ServiceContainerInterface
      *
      * @return \Propel\Runtime\Connection\ConnectionInterface A database connection
      */
-    public function getReadConnection($name);
+    public function getReadConnection($name): ConnectionInterface;
 
     /**
      * Get a profiler instance.
      *
      * @return \Propel\Runtime\Util\Profiler
      */
-    public function getProfiler();
+    public function getProfiler(): Profiler;
 
     /**
      * Get a logger for a given datasource, or the default logger.
@@ -161,7 +168,7 @@ interface ServiceContainerInterface
      *
      * @return \Psr\Log\LoggerInterface
      */
-    public function getLogger($name = 'defaultLogger');
+    public function getLogger($name = 'defaultLogger'): LoggerInterface;
 
     /**
      * Initialize the internal database maps array

--- a/src/Propel/Runtime/ServiceContainer/ServiceContainerInterface.php
+++ b/src/Propel/Runtime/ServiceContainer/ServiceContainerInterface.php
@@ -164,11 +164,11 @@ interface ServiceContainerInterface
     /**
      * Get a logger for a given datasource, or the default logger.
      *
-     * @param string $name
+     * @param string|null $name
      *
      * @return \Psr\Log\LoggerInterface
      */
-    public function getLogger($name = 'defaultLogger'): LoggerInterface;
+    public function getLogger(?string $name = null): LoggerInterface;
 
     /**
      * Initialize the internal database maps array

--- a/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
+++ b/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
@@ -570,7 +570,7 @@ class StandardServiceContainer implements ServiceContainerInterface
             case 'stream':
                 $handler = new StreamHandler(
                     $configuration['path'],
-                    $configuration['level'] ?? null,
+                    $configuration['level'] ?? 500,
                     $configuration['bubble'] ?? true,
                 );
 

--- a/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
+++ b/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
@@ -450,7 +450,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return void
      */
-    public function setConnection($name, ConnectionInterface $connection): void
+    public function setConnection(string $name, ConnectionInterface $connection): void
     {
         $manager = new ConnectionManagerSingle($name);
         $manager->setConnection($connection);

--- a/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
+++ b/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
@@ -527,12 +527,16 @@ class StandardServiceContainer implements ServiceContainerInterface
     /**
      * Get a logger instance
      *
-     * @param string $name
+     * @param string|null $name
      *
      * @return \Psr\Log\LoggerInterface
      */
-    public function getLogger($name = 'defaultLogger'): LoggerInterface
+    public function getLogger(?string $name = null): LoggerInterface
     {
+        if ($name === null) {
+            $name = 'defaultLogger';
+        }
+
         if (!isset($this->loggers[$name])) {
             $this->loggers[$name] = $this->buildLogger($name);
         }
@@ -558,7 +562,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return \Psr\Log\LoggerInterface
      */
-    protected function buildLogger($name = 'defaultLogger'): LoggerInterface
+    protected function buildLogger(string $name = 'defaultLogger'): LoggerInterface
     {
         if (!isset($this->loggerConfigurations[$name])) {
             return $name !== 'defaultLogger' ? $this->getLogger() : new NullLogger();
@@ -595,7 +599,7 @@ class StandardServiceContainer implements ServiceContainerInterface
                 break;
             default:
                 throw new UnexpectedValueException(sprintf(
-                    'Handler type "%s" not supported by StandardServiceContainer. Try setting the Logger manually, or use another ServiceContainer.',
+                    'Handler type `%s` not supported by StandardServiceContainer. Try setting the Logger manually, or use another ServiceContainer.',
                     $configuration['type'],
                 ));
         }

--- a/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
+++ b/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
@@ -22,6 +22,7 @@ use Propel\Runtime\Exception\PropelException;
 use Propel\Runtime\Exception\RuntimeException;
 use Propel\Runtime\Exception\UnexpectedValueException;
 use Propel\Runtime\Map\DatabaseMap;
+use Propel\Runtime\Util\Profiler;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
@@ -109,7 +110,7 @@ class StandardServiceContainer implements ServiceContainerInterface
     /**
      * @return string
      */
-    public function getDefaultDatasource()
+    public function getDefaultDatasource(): string
     {
         return $this->defaultDatasource;
     }
@@ -119,7 +120,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return void
      */
-    public function setDefaultDatasource($defaultDatasource)
+    public function setDefaultDatasource($defaultDatasource): void
     {
         $this->defaultDatasource = $defaultDatasource;
     }
@@ -131,7 +132,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return string
      */
-    public function getAdapterClass($name = null)
+    public function getAdapterClass($name = null): string
     {
         if ($name === null) {
             $name = $this->getDefaultDatasource();
@@ -150,7 +151,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return void
      */
-    public function setAdapterClass($name, $adapterClass)
+    public function setAdapterClass($name, $adapterClass): void
     {
         $this->adapterClasses[$name] = $adapterClass;
         unset($this->adapters[$name]);
@@ -163,7 +164,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return void
      */
-    public function setAdapterClasses($adapterClasses)
+    public function setAdapterClasses($adapterClasses): void
     {
         $this->adapterClasses = $adapterClasses;
         $this->adapters = [];
@@ -180,7 +181,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return \Propel\Runtime\Adapter\AdapterInterface
      */
-    public function getAdapter($name = null)
+    public function getAdapter($name = null): AdapterInterface
     {
         if ($name === null) {
             $name = $this->getDefaultDatasource();
@@ -203,7 +204,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return void
      */
-    public function setAdapter($name, AdapterInterface $adapter)
+    public function setAdapter($name, AdapterInterface $adapter): void
     {
         $this->adapters[$name] = $adapter;
         $this->adapterClasses[$name] = get_class($adapter);
@@ -216,7 +217,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return void
      */
-    public function setAdapters($adapters)
+    public function setAdapters($adapters): void
     {
         $this->adapterClasses = [];
         $this->adapters = [];
@@ -234,7 +235,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return void
      */
-    public function checkVersion($generatorVersion)
+    public function checkVersion($generatorVersion): void
     {
         if ($generatorVersion === static::CONFIGURATION_VERSION) {
             return;
@@ -272,7 +273,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return void
      */
-    public function setDatabaseMapClass($databaseMapClass)
+    public function setDatabaseMapClass($databaseMapClass): void
     {
         $this->databaseMapClass = $databaseMapClass;
     }
@@ -288,7 +289,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return \Propel\Runtime\Map\DatabaseMap
      */
-    public function getDatabaseMap($name = null)
+    public function getDatabaseMap($name = null): DatabaseMap
     {
         if (!$name) {
             $name = $this->getDefaultDatasource();
@@ -316,7 +317,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return void
      */
-    public function setDatabaseMap($name, DatabaseMap $databaseMap)
+    public function setDatabaseMap($name, DatabaseMap $databaseMap): void
     {
         $this->databaseMaps[$name] = $databaseMap;
     }
@@ -327,7 +328,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return void
      */
-    public function setConnectionManager($name, ConnectionManagerInterface $manager)
+    public function setConnectionManager($name, ConnectionManagerInterface $manager): void
     {
         if (isset($this->connectionManagers[$name])) {
             $this->connectionManagers[$name]->closeConnections();
@@ -345,7 +346,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return \Propel\Runtime\Connection\ConnectionManagerInterface
      */
-    public function getConnectionManager($name)
+    public function getConnectionManager($name): ConnectionManagerInterface
     {
         if (!isset($this->connectionManagers[$name])) {
             throw new RuntimeException(sprintf('No connection defined for database "%s". Did you forget to define a connection or is it wrong written?', $name));
@@ -359,7 +360,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return bool true if a connectionManager with $name has been registered
      */
-    public function hasConnectionManager($name)
+    public function hasConnectionManager($name): bool
     {
         return isset($this->connectionManagers[$name]);
     }
@@ -367,7 +368,7 @@ class StandardServiceContainer implements ServiceContainerInterface
     /**
      * @return array<\Propel\Runtime\Connection\ConnectionManagerInterface>
      */
-    public function getConnectionManagers()
+    public function getConnectionManagers(): array
     {
         return $this->connectionManagers;
     }
@@ -380,7 +381,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return void
      */
-    public function closeConnections()
+    public function closeConnections(): void
     {
         foreach ($this->connectionManagers as $manager) {
             $manager->closeConnections();
@@ -398,7 +399,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return \Propel\Runtime\Connection\ConnectionInterface A database connection
      */
-    public function getConnection($name = null, $mode = ServiceContainerInterface::CONNECTION_WRITE)
+    public function getConnection($name = null, $mode = ServiceContainerInterface::CONNECTION_WRITE): ConnectionInterface
     {
         if ($name === null) {
             $name = $this->getDefaultDatasource();
@@ -422,7 +423,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return \Propel\Runtime\Connection\ConnectionInterface A database connection
      */
-    public function getWriteConnection($name)
+    public function getWriteConnection($name): ConnectionInterface
     {
         return $this->getConnectionManager($name)->getWriteConnection($this->getAdapter($name));
     }
@@ -439,7 +440,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return \Propel\Runtime\Connection\ConnectionInterface A database connection
      */
-    public function getReadConnection($name)
+    public function getReadConnection($name): ConnectionInterface
     {
         return $this->getConnectionManager($name)->getReadConnection($this->getAdapter($name));
     }
@@ -452,7 +453,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return void
      */
-    public function setConnection($name, ConnectionInterface $connection)
+    public function setConnection($name, ConnectionInterface $connection): void
     {
         $manager = new ConnectionManagerSingle();
         $manager->setConnection($connection);
@@ -471,7 +472,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return void
      */
-    public function setProfilerClass($profilerClass)
+    public function setProfilerClass($profilerClass): void
     {
         $this->profilerClass = $profilerClass;
         $this->profiler = null;
@@ -486,7 +487,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return void
      */
-    public function setProfilerConfiguration($profilerConfiguration)
+    public function setProfilerConfiguration($profilerConfiguration): void
     {
         $this->profilerConfiguration = $profilerConfiguration;
         $this->profiler = null;
@@ -499,7 +500,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return void
      */
-    public function setProfiler($profiler)
+    public function setProfiler($profiler): void
     {
         $this->profiler = $profiler;
     }
@@ -511,7 +512,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return \Propel\Runtime\Util\Profiler
      */
-    public function getProfiler()
+    public function getProfiler(): Profiler
     {
         if ($this->profiler === null) {
             $class = $this->profilerClass;
@@ -533,7 +534,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return \Psr\Log\LoggerInterface
      */
-    public function getLogger($name = 'defaultLogger')
+    public function getLogger($name = 'defaultLogger'): LoggerInterface
     {
         if (!isset($this->loggers[$name])) {
             $this->loggers[$name] = $this->buildLogger($name);
@@ -548,7 +549,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return void
      */
-    public function setLogger($name, LoggerInterface $logger)
+    public function setLogger($name, LoggerInterface $logger): void
     {
         $this->loggers[$name] = $logger;
     }
@@ -560,7 +561,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return \Psr\Log\LoggerInterface
      */
-    protected function buildLogger($name = 'defaultLogger')
+    protected function buildLogger($name = 'defaultLogger'): LoggerInterface
     {
         if (!isset($this->loggerConfigurations[$name])) {
             return $name !== 'defaultLogger' ? $this->getLogger() : new NullLogger();
@@ -626,7 +627,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return void
      */
-    public function setLoggerConfiguration($name, $loggerConfiguration)
+    public function setLoggerConfiguration($name, $loggerConfiguration): void
     {
         $this->loggerConfigurations[$name] = $loggerConfiguration;
     }

--- a/src/Propel/Runtime/Util/Profiler.php
+++ b/src/Propel/Runtime/Util/Profiler.php
@@ -80,7 +80,7 @@ class Profiler
      *
      * @return void
      */
-    public function setSlowThreshold($slowThreshold)
+    public function setSlowThreshold($slowThreshold): void
     {
         $this->slowThreshold = $slowThreshold;
     }
@@ -92,7 +92,7 @@ class Profiler
      *
      * @return void
      */
-    public function setDetails($details)
+    public function setDetails($details): void
     {
         $this->details = $details;
     }
@@ -104,7 +104,7 @@ class Profiler
      *
      * @return void
      */
-    public function setInnerGlue($innerGlue)
+    public function setInnerGlue($innerGlue): void
     {
         $this->innerGlue = $innerGlue;
     }
@@ -116,7 +116,7 @@ class Profiler
      *
      * @return void
      */
-    public function setOuterGlue($outerGlue)
+    public function setOuterGlue($outerGlue): void
     {
         $this->outerGlue = $outerGlue;
     }
@@ -159,7 +159,7 @@ class Profiler
      *
      * @return void
      */
-    public function setConfiguration($profilerConfiguration)
+    public function setConfiguration($profilerConfiguration): void
     {
         if (isset($profilerConfiguration['slowThreshold'])) {
             $this->setSlowThreshold($profilerConfiguration['slowThreshold']);
@@ -182,7 +182,7 @@ class Profiler
      *
      * @return array
      */
-    public function getConfiguration()
+    public function getConfiguration(): array
     {
         return [
             'slowThreshold' => $this->slowThreshold,
@@ -195,7 +195,7 @@ class Profiler
     /**
      * @return void
      */
-    public function start()
+    public function start(): void
     {
         $this->snapshot = self::getSnapshot();
     }
@@ -203,7 +203,7 @@ class Profiler
     /**
      * @return bool
      */
-    public function isSlow()
+    public function isSlow(): bool
     {
         return microtime(true) - $this->snapshot['microtime'] > $this->slowThreshold;
     }
@@ -211,7 +211,7 @@ class Profiler
     /**
      * @return string
      */
-    public function getProfile()
+    public function getProfile(): string
     {
         $endSnapshot = self::getSnapshot();
         $startSnapshot = ($this->snapshot === null) ? $endSnapshot : $this->snapshot;
@@ -236,7 +236,7 @@ class Profiler
      *
      * @return string
      */
-    public function getProfileBetween($startSnapshot, $endSnapshot)
+    public function getProfileBetween($startSnapshot, $endSnapshot): string
     {
         $profile = '';
 
@@ -282,7 +282,7 @@ class Profiler
      *
      * @return array
      */
-    public static function getSnapshot()
+    public static function getSnapshot(): array
     {
         return [
             'microtime' => microtime(true),
@@ -299,7 +299,7 @@ class Profiler
      *
      * @return string
      */
-    public static function formatMemory($bytes, $precision = 3)
+    public static function formatMemory($bytes, $precision = 3): string
     {
         $absBytes = abs($bytes);
         $sign = ($bytes == $absBytes) ? 1 : -1;
@@ -321,7 +321,7 @@ class Profiler
      *
      * @return string
      */
-    public static function formatDuration($duration, $precision = 3)
+    public static function formatDuration($duration, $precision = 3): string
     {
         if ($duration < 1) {
             $duration *= 1000;
@@ -341,7 +341,7 @@ class Profiler
      *
      * @return string
      */
-    public static function toPrecision($number, $significantFigures = 3)
+    public static function toPrecision($number, $significantFigures = 3): string
     {
         if ((float)$number === 0.0) {
             return '0';

--- a/src/Propel/Runtime/Util/PropelConditionalProxy.php
+++ b/src/Propel/Runtime/Util/PropelConditionalProxy.php
@@ -128,7 +128,7 @@ class PropelConditionalProxy
      *
      * @return bool
      */
-    protected function getConditionalState()
+    protected function getConditionalState(): bool
     {
         return $this->state && $this->parentState;
     }
@@ -149,7 +149,7 @@ class PropelConditionalProxy
     /**
      * @return self|null
      */
-    public function getParentProxy()
+    public function getParentProxy(): ?self
     {
         return $this->parent;
     }

--- a/src/Propel/Runtime/Util/PropelDateTime.php
+++ b/src/Propel/Runtime/Util/PropelDateTime.php
@@ -42,7 +42,7 @@ class PropelDateTime extends DateTime
      *
      * @return bool
      */
-    protected static function isTimestamp($value)
+    protected static function isTimestamp($value): bool
     {
         if (!is_numeric($value)) {
             return false;
@@ -72,7 +72,7 @@ class PropelDateTime extends DateTime
      *
      * @return \DateTime
      */
-    public static function createHighPrecision($time = null)
+    public static function createHighPrecision($time = null): DateTime
     {
         $dateTime = DateTime::createFromFormat('U.u', $time ?: self::getMicrotime());
 
@@ -87,7 +87,7 @@ class PropelDateTime extends DateTime
      *
      * @return string
      */
-    public static function getMicrotime()
+    public static function getMicrotime(): string
     {
         $mtime = microtime(true);
 
@@ -149,7 +149,7 @@ class PropelDateTime extends DateTime
      *
      * @return array<string>
      */
-    public function __sleep()
+    public function __sleep(): array
     {
         // We need to use a string without a time zone, due to
         // PHP bug: http://bugs.php.net/bug.php?id=40743

--- a/src/Propel/Runtime/Util/PropelModelPager.php
+++ b/src/Propel/Runtime/Util/PropelModelPager.php
@@ -11,6 +11,7 @@ namespace Propel\Runtime\Util;
 use Countable;
 use IteratorAggregate;
 use Propel\Runtime\ActiveQuery\ModelCriteria;
+use Propel\Runtime\Collection\Collection;
 use Propel\Runtime\Connection\ConnectionInterface;
 use Propel\Runtime\Exception\BadMethodCallException;
 use Traversable;
@@ -90,7 +91,7 @@ class PropelModelPager implements IteratorAggregate, Countable
      *
      * @return void
      */
-    public function setQuery(ModelCriteria $query)
+    public function setQuery(ModelCriteria $query): void
     {
         $this->query = $query;
     }
@@ -98,7 +99,7 @@ class PropelModelPager implements IteratorAggregate, Countable
     /**
      * @return \Propel\Runtime\ActiveQuery\ModelCriteria
      */
-    public function getQuery()
+    public function getQuery(): ModelCriteria
     {
         return $this->query;
     }
@@ -108,7 +109,7 @@ class PropelModelPager implements IteratorAggregate, Countable
      *
      * @return void
      */
-    public function init(?ConnectionInterface $con = null)
+    public function init(?ConnectionInterface $con = null): void
     {
         $this->con = $con;
         $maxRecordLimit = $this->getMaxRecordLimit();
@@ -152,7 +153,7 @@ class PropelModelPager implements IteratorAggregate, Countable
      *
      * @return \Propel\Runtime\Collection\Collection A collection of results
      */
-    public function getResults()
+    public function getResults(): Collection
     {
         if ($this->results === null) {
             $queryKey = method_exists($this->getQuery(), 'getQueryKey') ? $this->getQuery()->getQueryKey() : null;
@@ -171,7 +172,7 @@ class PropelModelPager implements IteratorAggregate, Countable
     /**
      * @return int
      */
-    public function getCurrentMaxLink()
+    public function getCurrentMaxLink(): int
     {
         return $this->currentMaxLink;
     }
@@ -179,7 +180,7 @@ class PropelModelPager implements IteratorAggregate, Countable
     /**
      * @return int
      */
-    public function getMaxRecordLimit()
+    public function getMaxRecordLimit(): int
     {
         return $this->maxRecordLimit;
     }
@@ -189,7 +190,7 @@ class PropelModelPager implements IteratorAggregate, Countable
      *
      * @return void
      */
-    public function setMaxRecordLimit($limit)
+    public function setMaxRecordLimit($limit): void
     {
         $this->maxRecordLimit = $limit;
     }
@@ -199,7 +200,7 @@ class PropelModelPager implements IteratorAggregate, Countable
      *
      * @return array<int>
      */
-    public function getLinks($nbLinks = 5)
+    public function getLinks($nbLinks = 5): array
     {
         $links = [];
         $tmp = $this->page - floor($nbLinks / 2);
@@ -222,7 +223,7 @@ class PropelModelPager implements IteratorAggregate, Countable
      *
      * @return bool true if the pager displays only a subset of the results
      */
-    public function haveToPaginate()
+    public function haveToPaginate(): bool
     {
         return ($this->getMaxPerPage() !== 0 && $this->getNbResults() > $this->getMaxPerPage());
     }
@@ -233,7 +234,7 @@ class PropelModelPager implements IteratorAggregate, Countable
      *
      * @return int
      */
-    public function getFirstIndex()
+    public function getFirstIndex(): int
     {
         if ($this->page === 0) {
             return 1;
@@ -248,7 +249,7 @@ class PropelModelPager implements IteratorAggregate, Countable
      *
      * @return int
      */
-    public function getLastIndex()
+    public function getLastIndex(): int
     {
         if ($this->page === 0) {
             return $this->nbResults;
@@ -267,7 +268,7 @@ class PropelModelPager implements IteratorAggregate, Countable
      *
      * @return int
      */
-    public function getNbResults()
+    public function getNbResults(): int
     {
         return $this->nbResults;
     }
@@ -279,7 +280,7 @@ class PropelModelPager implements IteratorAggregate, Countable
      *
      * @return void
      */
-    protected function setNbResults($nb)
+    protected function setNbResults($nb): void
     {
         $this->nbResults = $nb;
     }
@@ -289,7 +290,7 @@ class PropelModelPager implements IteratorAggregate, Countable
      *
      * @return bool true if the current page is the first page
      */
-    public function isFirstPage()
+    public function isFirstPage(): bool
     {
         return $this->getPage() === $this->getFirstPage();
     }
@@ -299,7 +300,7 @@ class PropelModelPager implements IteratorAggregate, Countable
      *
      * @return int Always 1
      */
-    public function getFirstPage()
+    public function getFirstPage(): int
     {
         return $this->nbResults === 0 ? 0 : 1;
     }
@@ -309,7 +310,7 @@ class PropelModelPager implements IteratorAggregate, Countable
      *
      * @return bool true if the current page is the last page
      */
-    public function isLastPage()
+    public function isLastPage(): bool
     {
         return $this->getPage() === $this->getLastPage();
     }
@@ -319,7 +320,7 @@ class PropelModelPager implements IteratorAggregate, Countable
      *
      * @return int
      */
-    public function getLastPage()
+    public function getLastPage(): int
     {
         return $this->lastPage;
     }
@@ -331,7 +332,7 @@ class PropelModelPager implements IteratorAggregate, Countable
      *
      * @return void
      */
-    protected function setLastPage($page)
+    protected function setLastPage($page): void
     {
         $this->lastPage = $page;
         if ($this->getPage() > $page) {
@@ -344,7 +345,7 @@ class PropelModelPager implements IteratorAggregate, Countable
      *
      * @return int
      */
-    public function getPage()
+    public function getPage(): int
     {
         return $this->page;
     }
@@ -356,7 +357,7 @@ class PropelModelPager implements IteratorAggregate, Countable
      *
      * @return void
      */
-    public function setPage($page)
+    public function setPage($page): void
     {
         $this->page = (int)$page;
         if ($this->page <= 0 && $this->nbResults > 0) {
@@ -370,7 +371,7 @@ class PropelModelPager implements IteratorAggregate, Countable
      *
      * @return int
      */
-    public function getNextPage()
+    public function getNextPage(): int
     {
         return min($this->getPage() + 1, $this->getLastPage());
     }
@@ -380,7 +381,7 @@ class PropelModelPager implements IteratorAggregate, Countable
      *
      * @return int
      */
-    public function getPreviousPage()
+    public function getPreviousPage(): int
     {
         return max($this->getPage() - 1, $this->getFirstPage());
     }
@@ -390,7 +391,7 @@ class PropelModelPager implements IteratorAggregate, Countable
      *
      * @return int
      */
-    public function getMaxPerPage()
+    public function getMaxPerPage(): int
     {
         return $this->maxPerPage;
     }
@@ -402,7 +403,7 @@ class PropelModelPager implements IteratorAggregate, Countable
      *
      * @return void
      */
-    public function setMaxPerPage($max)
+    public function setMaxPerPage($max): void
     {
         if ($max > 0) {
             $this->maxPerPage = $max;
@@ -427,7 +428,7 @@ class PropelModelPager implements IteratorAggregate, Countable
      *
      * @return bool
      */
-    public function isEmpty()
+    public function isEmpty(): bool
     {
         return $this->getResults()->isEmpty();
     }

--- a/src/Propel/Runtime/Validator/Constraints/DateValidator.php
+++ b/src/Propel/Runtime/Validator/Constraints/DateValidator.php
@@ -25,7 +25,7 @@ class DateValidator extends SymfonyDateValidator
      *
      * @return void
      */
-    public function validate($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint): void
     {
         if ($value instanceof DateTimeInterface) {
             return;

--- a/src/Propel/Runtime/Validator/Constraints/UniqueValidator.php
+++ b/src/Propel/Runtime/Validator/Constraints/UniqueValidator.php
@@ -20,7 +20,7 @@ class UniqueValidator extends ConstraintValidator
      *
      * @return void
      */
-    public function validate($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint): void
     {
         if ($value === null) {
             return;

--- a/tests/Fixtures/behavior-development/src/CollectionBehavior.php
+++ b/tests/Fixtures/behavior-development/src/CollectionBehavior.php
@@ -3,13 +3,13 @@ namespace Propel\Behavior\Collection;
 
 use Propel\Generator\Model\Behavior;
 
-class CollectionBehavior extends Behavior {
-
+class CollectionBehavior extends Behavior
+{
     /* (non-PHPdoc)
      * @see \Propel\Generator\Model\Behavior::modifyTable()
     */
-    public function modifyTable() {
+    public function modifyTable(): void
+    {
         // behavior code
     }
-
 }

--- a/tests/Fixtures/behavior-installer/src/gossi/propel/behavior/l10n/L10nBehavior.php
+++ b/tests/Fixtures/behavior-installer/src/gossi/propel/behavior/l10n/L10nBehavior.php
@@ -4,14 +4,13 @@ namespace gossi\propel\behavior\l10n;
 
 use Propel\Generator\Model\Behavior;
 
-class L10nBehavior extends Behavior {
-
-	
+class L10nBehavior extends Behavior
+{
 	/* (non-PHPdoc)
 	 * @see \Propel\Generator\Model\Behavior::modifyTable()
 	 */
-	public function modifyTable() {
+	public function modifyTable(): void
+    {
 		// behavior code
 	}
-
 }

--- a/tests/Propel/Tests/Common/Util/SetColumnConverterTest.php
+++ b/tests/Propel/Tests/Common/Util/SetColumnConverterTest.php
@@ -31,7 +31,7 @@ class SetColumnConverterTest extends TestCase
     {
         $valueSet = ['a', 'b', 'c', 'd', 'e', 'f'];
         $intValue = SetColumnConverter::convertToInt($values, $valueSet);
-        $this->assertEquals($validInteger, $intValue);
+        $this->assertSame($validInteger, $intValue);
     }
 
     /**
@@ -41,7 +41,7 @@ class SetColumnConverterTest extends TestCase
     {
         $valueSet = ['a', 'b', 'c', 'd', 'e', 'f'];
         $intValue = SetColumnConverter::convertToInt('c', $valueSet);
-        $this->assertEquals('4', $intValue);
+        $this->assertSame('4', $intValue);
     }
 
     /**
@@ -51,7 +51,7 @@ class SetColumnConverterTest extends TestCase
     {
         $valueSet = ['a', 'b', 'c', 'd', 'e', 'f'];
         $intValue = SetColumnConverter::convertToInt(null, $valueSet);
-        $this->assertEquals('0', $intValue);
+        $this->assertSame('0', $intValue);
     }
 
     /**
@@ -87,7 +87,7 @@ class SetColumnConverterTest extends TestCase
     {
         $valueSet = ['a', 'b', 'c', 'd', 'e', 'f'];
         $arrayValue = SetColumnConverter::convertIntToArray(null, $valueSet);
-        $this->assertEquals([], $arrayValue);
+        $this->assertSame([], $arrayValue);
     }
 
     /**

--- a/tests/Propel/Tests/Generator/Behavior/AggregateColumn/AggregateColumnsBehaviorTestClasses.php
+++ b/tests/Propel/Tests/Generator/Behavior/AggregateColumn/AggregateColumnsBehaviorTestClasses.php
@@ -39,7 +39,7 @@ class TestableComment extends AggregateComment
     /**
      * @return void
      */
-    public function delete(?ConnectionInterface $con = null)
+    public function delete(?ConnectionInterface $con = null): void
     {
         $con->beginTransaction();
         try {
@@ -65,13 +65,13 @@ class TestableAggregateCommentQuery extends AggregateCommentQuery
 
     // overrides the parent basePreDelete() to bypass behavior hooks
 
-    protected function basePreDelete(ConnectionInterface $con)
+    protected function basePreDelete(ConnectionInterface $con): ?int
     {
         return $this->preDelete($con);
     }
 
     // overrides the parent basePostDelete() to bypass behavior hooks
-    protected function basePostDelete($affectedRows, ConnectionInterface $con)
+    protected function basePostDelete($affectedRows, ConnectionInterface $con): ?int
     {
         return $this->postDelete($affectedRows, $con);
     }

--- a/tests/Propel/Tests/Generator/Behavior/Sortable/SortableBehaviorObjectBuilderModifierTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Sortable/SortableBehaviorObjectBuilderModifierTest.php
@@ -318,7 +318,7 @@ class SortableBehaviorObjectBuilderModifierTest extends TestCase
         $expected = [1 => 'row1', 2 => 'row3', 3 => 'row4', 4 => 'row2'];
         $this->assertEquals($expected, $this->getFixturesArray(), 'moveToBottom() moves to the bottom');
         $res = $t2->moveToBottom();
-        $this->assertFalse($res, 'moveToBottom() returns false when called on the bottom node');
+        $this->assertNull($res, 'moveToBottom() returns null when called on the bottom node');
         $expected = [1 => 'row1', 2 => 'row3', 3 => 'row4', 4 => 'row2'];
         $this->assertEquals($expected, $this->getFixturesArray(), 'moveToBottom() changes nothing when called on the bottom node');
     }

--- a/tests/Propel/Tests/Generator/Builder/Om/AbstractOMBuilderNamespaceTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/AbstractOMBuilderNamespaceTest.php
@@ -209,41 +209,42 @@ class AbstractOMBuilderNamespaceTest extends TestCase
 
 class TestableOMBuilder2 extends AbstractOMBuilder
 {
-    public static function getRelatedBySuffix(ForeignKey $fk)
+    public static function getRelatedBySuffix(ForeignKey $fk): string
     {
         return parent::getRelatedBySuffix($fk);
     }
 
-    public static function getRefRelatedBySuffix(ForeignKey $fk)
+    public static function getRefRelatedBySuffix(ForeignKey $fk): string
     {
         return parent::getRefRelatedBySuffix($fk);
     }
 
     /**
+     * @return string
+     */
+    public function getUnprefixedClassName(): string
+    {
+        return '';
+    }
+
+    /**
      * @return void
      */
-    public function getUnprefixedClassName()
+    protected function addClassOpen(&$script): void
     {
     }
 
     /**
      * @return void
      */
-    protected function addClassOpen(&$script)
+    protected function addClassBody(&$script): void
     {
     }
 
     /**
      * @return void
      */
-    protected function addClassBody(&$script)
-    {
-    }
-
-    /**
-     * @return void
-     */
-    protected function addClassClose(&$script)
+    protected function addClassClose(&$script): void
     {
     }
 }

--- a/tests/Propel/Tests/Generator/Builder/Om/AbstractOMBuilderRelatedByTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/AbstractOMBuilderRelatedByTest.php
@@ -73,12 +73,12 @@ class AbstractOMBuilderRelatedByTest extends TestCase
 
 class TestableOMBuilder extends AbstractOMBuilder
 {
-    public static function getRelatedBySuffix(ForeignKey $fk)
+    public static function getRelatedBySuffix(ForeignKey $fk): string
     {
         return parent::getRelatedBySuffix($fk);
     }
 
-    public static function getRefRelatedBySuffix(ForeignKey $fk)
+    public static function getRefRelatedBySuffix(ForeignKey $fk): string
     {
         return parent::getRefRelatedBySuffix($fk);
     }
@@ -86,28 +86,29 @@ class TestableOMBuilder extends AbstractOMBuilder
     /**
      * @return void
      */
-    public function getUnprefixedClassName()
+    public function getUnprefixedClassName(): string
+    {
+        return '';
+    }
+
+    /**
+     * @return void
+     */
+    protected function addClassOpen(&$script): void
     {
     }
 
     /**
      * @return void
      */
-    protected function addClassOpen(&$script)
+    protected function addClassBody(&$script): void
     {
     }
 
     /**
      * @return void
      */
-    protected function addClassBody(&$script)
-    {
-    }
-
-    /**
-     * @return void
-     */
-    protected function addClassClose(&$script)
+    protected function addClassClose(&$script): void
     {
     }
 }

--- a/tests/Propel/Tests/Generator/Builder/Om/AbstractOMBuilderTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/AbstractOMBuilderTest.php
@@ -121,7 +121,7 @@ class OMBuilderMock extends AbstractOMBuilder
         $this->pkg = $pkg;
     }
 
-    public function getPackage()
+    public function getPackage(): string
     {
         return $this->pkg;
     }
@@ -129,28 +129,29 @@ class OMBuilderMock extends AbstractOMBuilder
     /**
      * @return void
      */
-    public function getUnprefixedClassName()
+    public function getUnprefixedClassName(): string
+    {
+        return '';
+    }
+
+    /**
+     * @return void
+     */
+    protected function addClassOpen(&$script): void
     {
     }
 
     /**
      * @return void
      */
-    protected function addClassOpen(&$script)
+    protected function addClassBody(&$script): void
     {
     }
 
     /**
      * @return void
      */
-    protected function addClassBody(&$script)
-    {
-    }
-
-    /**
-     * @return void
-     */
-    protected function addClassClose(&$script)
+    protected function addClassClose(&$script): void
     {
     }
 }

--- a/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilderTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/ObjectBuilderTest.php
@@ -79,7 +79,7 @@ class ObjectBuilderTest extends TestCase
 
 class TestableObjectBuilder extends ObjectBuilder
 {
-    public function getDefaultValueString(Column $col)
+    public function getDefaultValueString(Column $col): string
     {
         return parent::getDefaultValueString($col);
     }

--- a/tests/Propel/Tests/Generator/Builder/Om/QueryBuilderTestClasses.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/QueryBuilderTestClasses.php
@@ -44,7 +44,7 @@ class MySecondBookQuery extends BookQuery
     /**
      * @return void
      */
-    public function preSelect(ConnectionInterface $con)
+    public function preSelect(ConnectionInterface $con): void
     {
         self::$preSelectWasCalled = true;
     }

--- a/tests/Propel/Tests/Generator/Builder/Om/TableMapBuilderTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/TableMapBuilderTest.php
@@ -27,6 +27,9 @@ use Propel\Tests\Helpers\Bookstore\BookstoreTestBase;
  */
 class TableMapBuilderTest extends BookstoreTestBase
 {
+    /**
+     * @var \Propel\Runtime\Map\DatabaseMap
+     */
     protected $databaseMap;
 
     /**

--- a/tests/Propel/Tests/Generator/Command/AbstractCommandTest.php
+++ b/tests/Propel/Tests/Generator/Command/AbstractCommandTest.php
@@ -89,7 +89,7 @@ class TestableAbstractCommand extends AbstractCommand
         $this->setName('testable-command');
     }
 
-    public function parseConnection($connection)
+    public function parseConnection($connection): array
     {
         return parent::parseConnection($connection);
     }

--- a/tests/Propel/Tests/Generator/Config/ArrayToPhpConverterTest.php
+++ b/tests/Propel/Tests/Generator/Config/ArrayToPhpConverterTest.php
@@ -33,7 +33,7 @@ class ArrayToPhpConverterTest extends TestCase
         ];
         $expected = <<<EOF
 \$serviceContainer->setAdapterClass('bookstore', 'mysql');
-\$manager = new \Propel\Runtime\Connection\ConnectionManagerSingle();
+\$manager = new \Propel\Runtime\Connection\ConnectionManagerSingle('bookstore');
 \$manager->setConfiguration(array (
   'classname' => 'DebugPDO',
   'dsn' => 'mysql:host=localhost;dbname=bookstore',
@@ -48,8 +48,7 @@ class ArrayToPhpConverterTest extends TestCase
     'ATTR_EMULATE_PREPARES' => true,
   ),
 ));
-\$manager->setName('bookstore');
-\$serviceContainer->setConnectionManager('bookstore', \$manager);
+\$serviceContainer->setConnectionManager(\$manager);
 \$serviceContainer->setDefaultDatasource('bookstore');
 EOF;
         $this->assertEquals($expected, ArrayToPhpConverter::convert($conf));
@@ -74,7 +73,7 @@ EOF;
         ];
         $expected = <<<'EOF'
 $serviceContainer->setAdapterClass('bookstore-cms', 'mysql');
-$manager = new \Propel\Runtime\Connection\ConnectionManagerMasterSlave();
+$manager = new \Propel\Runtime\Connection\ConnectionManagerMasterSlave('bookstore-cms');
 $manager->setReadConfiguration(array (
   0 =>
   array (
@@ -88,8 +87,7 @@ $manager->setReadConfiguration(array (
 $manager->setWriteConfiguration(array (
   'dsn' => 'mysql:host=localhost;dbname=bookstore',
 ));
-$manager->setName('bookstore-cms');
-$serviceContainer->setConnectionManager('bookstore-cms', $manager);
+$serviceContainer->setConnectionManager($manager);
 $serviceContainer->setDefaultDatasource('bookstore-cms');
 EOF;
         $this->assertEquals($expected, ArrayToPhpConverter::convert($conf));
@@ -225,7 +223,7 @@ EOF;
         ];
         $expected = <<<'EOF'
 $serviceContainer->setAdapterClass('bookstore', 'mysql');
-$manager = new \Propel\Runtime\Connection\ConnectionManagerSingle();
+$manager = new \Propel\Runtime\Connection\ConnectionManagerSingle('bookstore');
 $manager->setConfiguration(array (
   'classname' => '\\Propel\\Runtime\\Connection\\DebugPDO',
   'dsn' => 'mysql:host=127.0.0.1;dbname=test',
@@ -244,10 +242,9 @@ $manager->setConfiguration(array (
     'charset' => 'utf8',
   ),
 ));
-$manager->setName('bookstore');
-$serviceContainer->setConnectionManager('bookstore', $manager);
+$serviceContainer->setConnectionManager($manager);
 $serviceContainer->setAdapterClass('bookstore-cms', 'mysql');
-$manager = new \Propel\Runtime\Connection\ConnectionManagerMasterSlave();
+$manager = new \Propel\Runtime\Connection\ConnectionManagerMasterSlave('bookstore-cms');
 $manager->setReadConfiguration(array (
   0 =>
   array (
@@ -261,8 +258,7 @@ $manager->setReadConfiguration(array (
 $manager->setWriteConfiguration(array (
   'dsn' => 'mysql:host=localhost;dbname=bookstore',
 ));
-$manager->setName('bookstore-cms');
-$serviceContainer->setConnectionManager('bookstore-cms', $manager);
+$serviceContainer->setConnectionManager($manager);
 $serviceContainer->setDefaultDatasource('bookstore');
 $serviceContainer->setLoggerConfiguration('defaultLogger', array (
   'type' => 'stream',

--- a/tests/Propel/Tests/Generator/Model/ColumnTest.php
+++ b/tests/Propel/Tests/Generator/Model/ColumnTest.php
@@ -32,7 +32,7 @@ class ColumnTest extends ModelTestCase
         $this->assertSame('COL_TITLE', $column->getConstantName());
         $this->assertSame('public', $column->getMutatorVisibility());
         $this->assertSame('public', $column->getAccessorVisibility());
-        $this->assertFalse($column->getSize());
+        $this->assertNull($column->getSize());
         $this->assertFalse($column->hasPlatform());
         $this->assertFalse($column->hasReferrers());
         $this->assertFalse($column->isAutoIncrement());
@@ -233,7 +233,7 @@ class ColumnTest extends ModelTestCase
         $defaultValue
             ->expects($this->any())
             ->method('getValue')
-            ->will($this->returnValue($value));
+            ->will($this->returnValue((string)$value));
 
         $domain = $this->getDomainMock();
         $domain

--- a/tests/Propel/Tests/Generator/Model/MappingModelTest.php
+++ b/tests/Propel/Tests/Generator/Model/MappingModelTest.php
@@ -43,7 +43,7 @@ class MappingModelTest extends TestCase
 
 class TestableMappingModel extends MappingModel
 {
-    public function getDefaultValueForArray(string $value)
+    public function getDefaultValueForArray(string $value): ?string
     {
         return parent::getDefaultValueForArray($value);
     }
@@ -58,7 +58,7 @@ class TestableMappingModel extends MappingModel
     /**
      * @return void
      */
-    protected function setupObject()
+    protected function setupObject(): void
     {
     }
 }

--- a/tests/Propel/Tests/Generator/Model/PhpNameGeneratorTest.php
+++ b/tests/Propel/Tests/Generator/Model/PhpNameGeneratorTest.php
@@ -71,12 +71,12 @@ class PhpNameGeneratorTest extends TestCase
 
 class TestablePhpNameGenerator extends PhpNameGenerator
 {
-    public function phpnameMethod($schemaName)
+    public function phpnameMethod($schemaName): string
     {
         return parent::phpnameMethod($schemaName);
     }
 
-    public function underscoreMethod($schemaName)
+    public function underscoreMethod($schemaName): string
     {
         return parent::underscoreMethod($schemaName);
     }

--- a/tests/Propel/Tests/Generator/Model/SchemaTest.php
+++ b/tests/Propel/Tests/Generator/Model/SchemaTest.php
@@ -56,7 +56,7 @@ class SchemaTest extends ModelTestCase
             ->expects($this->any())
             ->method('getTable')
             ->with($this->equalTo('books'))
-            ->will($this->returnValue(true));
+            ->will($this->returnValue($booksTable));
 
         $subSchema1 = new Schema($this->getPlatformMock());
         $subSchema1->addDatabase($database1);

--- a/tests/Propel/Tests/Generator/Reverse/MssqlSchemaParserTest.php
+++ b/tests/Propel/Tests/Generator/Reverse/MssqlSchemaParserTest.php
@@ -62,7 +62,7 @@ class MssqlSchemaParserTest extends TestCase
 
 class TestableMssqlSchemaParser extends MssqlSchemaParser
 {
-    public function cleanDelimitedIdentifiers($identifier)
+    public function cleanDelimitedIdentifiers($identifier): string
     {
         return parent::cleanDelimitedIdentifiers($identifier);
     }

--- a/tests/Propel/Tests/Helpers/Bookstore/Behavior/AddClassBehaviorBuilder.php
+++ b/tests/Propel/Tests/Helpers/Bookstore/Behavior/AddClassBehaviorBuilder.php
@@ -14,7 +14,7 @@ class AddClassBehaviorBuilder extends AbstractOMBuilder
 {
     public $overwrite = true;
 
-    public function getPackage()
+    public function getPackage(): string
     {
         return parent::getPackage();
     }
@@ -24,7 +24,7 @@ class AddClassBehaviorBuilder extends AbstractOMBuilder
      *
      * @return string
      */
-    public function getUnprefixedClassName()
+    public function getUnprefixedClassName(): string
     {
         return $this->getStubObjectBuilder()->getUnprefixedClassName() . 'FooClass';
     }
@@ -36,7 +36,7 @@ class AddClassBehaviorBuilder extends AbstractOMBuilder
      *
      * @return void
      */
-    protected function addClassOpen(&$script)
+    protected function addClassOpen(&$script): void
     {
         $table = $this->getTable();
         $tableName = $table->getName();
@@ -58,7 +58,7 @@ class " . $this->getUnqualifiedClassName() . "
      *
      * @return void
      */
-    protected function addClassBody(&$script)
+    protected function addClassBody(&$script): void
     {
         $script .= '  // no code';
     }
@@ -70,10 +70,10 @@ class " . $this->getUnqualifiedClassName() . "
      *
      * @return void
      */
-    protected function addClassClose(&$script)
+    protected function addClassClose(&$script): void
     {
         $script .= "
-} // " . $this->getUnqualifiedClassName() . "
+}
 ";
     }
 }

--- a/tests/Propel/Tests/Helpers/Bookstore/Behavior/TestAuthor.php
+++ b/tests/Propel/Tests/Helpers/Bookstore/Behavior/TestAuthor.php
@@ -53,9 +53,9 @@ class TestAuthor extends Author
     /**
      * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
      *
-     * @return null|void
+     * @return void
      */
-    public function postUpdate(?ConnectionInterface $con = null): ?int
+    public function postUpdate(?ConnectionInterface $con = null): void
     {
         parent::postUpdate($con);
         $this->setLastName('PostUpdatedLastName');

--- a/tests/Propel/Tests/Helpers/Bookstore/Behavior/TestAuthor.php
+++ b/tests/Propel/Tests/Helpers/Bookstore/Behavior/TestAuthor.php
@@ -13,7 +13,12 @@ use Propel\Tests\Bookstore\Author;
 
 class TestAuthor extends Author
 {
-    public function preInsert(?ConnectionInterface $con = null)
+    /**
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
+     *
+     * @return bool
+     */
+    public function preInsert(?ConnectionInterface $con = null): bool
     {
         parent::preInsert($con);
         $this->setFirstName('PreInsertedFirstname');
@@ -22,15 +27,22 @@ class TestAuthor extends Author
     }
 
     /**
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
+     *
      * @return void
      */
-    public function postInsert(?ConnectionInterface $con = null): ?int
+    public function postInsert(?ConnectionInterface $con = null): void
     {
         parent::postInsert($con);
         $this->setLastName('PostInsertedLastName');
     }
 
-    public function preUpdate(?ConnectionInterface $con = null)
+    /**
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
+     *
+     * @return bool
+     */
+    public function preUpdate(?ConnectionInterface $con = null): bool
     {
         parent::preUpdate($con);
         $this->setFirstName('PreUpdatedFirstname');
@@ -39,7 +51,9 @@ class TestAuthor extends Author
     }
 
     /**
-     * @return void
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
+     *
+     * @return null|void
      */
     public function postUpdate(?ConnectionInterface $con = null): ?int
     {
@@ -47,7 +61,12 @@ class TestAuthor extends Author
         $this->setLastName('PostUpdatedLastName');
     }
 
-    public function preSave(?ConnectionInterface $con = null)
+    /**
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
+     *
+     * @return bool
+     */
+    public function preSave(?ConnectionInterface $con = null): bool
     {
         parent::preSave($con);
         $this->setEmail('pre@save.com');
@@ -56,6 +75,8 @@ class TestAuthor extends Author
     }
 
     /**
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
+     *
      * @return void
      */
     public function postSave(?ConnectionInterface $con = null): void
@@ -64,6 +85,11 @@ class TestAuthor extends Author
         $this->setAge(115);
     }
 
+    /**
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
+     *
+     * @return int|null
+     */
     public function preDelete(?ConnectionInterface $con = null): ?int
     {
         parent::preDelete($con);
@@ -73,9 +99,11 @@ class TestAuthor extends Author
     }
 
     /**
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
+     *
      * @return void
      */
-    public function postDelete(?ConnectionInterface $con = null): ?int
+    public function postDelete(?ConnectionInterface $con = null): void
     {
         parent::postDelete($con);
         $this->setLastName('Post-Deleted');

--- a/tests/Propel/Tests/Helpers/Bookstore/Behavior/TestAuthor.php
+++ b/tests/Propel/Tests/Helpers/Bookstore/Behavior/TestAuthor.php
@@ -24,7 +24,7 @@ class TestAuthor extends Author
     /**
      * @return void
      */
-    public function postInsert(?ConnectionInterface $con = null)
+    public function postInsert(?ConnectionInterface $con = null): ?int
     {
         parent::postInsert($con);
         $this->setLastName('PostInsertedLastName');
@@ -41,7 +41,7 @@ class TestAuthor extends Author
     /**
      * @return void
      */
-    public function postUpdate(?ConnectionInterface $con = null)
+    public function postUpdate(?ConnectionInterface $con = null): ?int
     {
         parent::postUpdate($con);
         $this->setLastName('PostUpdatedLastName');
@@ -58,13 +58,13 @@ class TestAuthor extends Author
     /**
      * @return void
      */
-    public function postSave(?ConnectionInterface $con = null)
+    public function postSave(?ConnectionInterface $con = null): ?int
     {
         parent::postSave($con);
         $this->setAge(115);
     }
 
-    public function preDelete(?ConnectionInterface $con = null)
+    public function preDelete(?ConnectionInterface $con = null): ?int
     {
         parent::preDelete($con);
         $this->setFirstName('Pre-Deleted');
@@ -75,7 +75,7 @@ class TestAuthor extends Author
     /**
      * @return void
      */
-    public function postDelete(?ConnectionInterface $con = null)
+    public function postDelete(?ConnectionInterface $con = null): ?int
     {
         parent::postDelete($con);
         $this->setLastName('Post-Deleted');

--- a/tests/Propel/Tests/Helpers/Bookstore/Behavior/TestAuthor.php
+++ b/tests/Propel/Tests/Helpers/Bookstore/Behavior/TestAuthor.php
@@ -58,7 +58,7 @@ class TestAuthor extends Author
     /**
      * @return void
      */
-    public function postSave(?ConnectionInterface $con = null): ?int
+    public function postSave(?ConnectionInterface $con = null): void
     {
         parent::postSave($con);
         $this->setAge(115);

--- a/tests/Propel/Tests/Helpers/Bookstore/Behavior/TestAuthor.php
+++ b/tests/Propel/Tests/Helpers/Bookstore/Behavior/TestAuthor.php
@@ -90,7 +90,7 @@ class TestAuthor extends Author
      *
      * @return int|null
      */
-    public function preDelete(?ConnectionInterface $con = null): ?int
+    public function preDelete(?ConnectionInterface $con = null): bool
     {
         parent::preDelete($con);
         $this->setFirstName('Pre-Deleted');

--- a/tests/Propel/Tests/Helpers/Bookstore/Behavior/TestAuthorDeleteFalse.php
+++ b/tests/Propel/Tests/Helpers/Bookstore/Behavior/TestAuthorDeleteFalse.php
@@ -17,7 +17,7 @@ class TestAuthorDeleteFalse extends TestAuthor
      *
      * @return int|null
      */
-    public function preDelete(?ConnectionInterface $con = null): ?int
+    public function preDelete(?ConnectionInterface $con = null): bool
     {
         parent::preDelete($con);
         $this->setFirstName('Pre-Deleted');

--- a/tests/Propel/Tests/Helpers/Bookstore/Behavior/TestAuthorDeleteFalse.php
+++ b/tests/Propel/Tests/Helpers/Bookstore/Behavior/TestAuthorDeleteFalse.php
@@ -12,7 +12,7 @@ use Propel\Runtime\Connection\ConnectionInterface;
 
 class TestAuthorDeleteFalse extends TestAuthor
 {
-    public function preDelete(?ConnectionInterface $con = null)
+    public function preDelete(?ConnectionInterface $con = null): ?int
     {
         parent::preDelete($con);
         $this->setFirstName('Pre-Deleted');

--- a/tests/Propel/Tests/Helpers/Bookstore/Behavior/TestAuthorDeleteFalse.php
+++ b/tests/Propel/Tests/Helpers/Bookstore/Behavior/TestAuthorDeleteFalse.php
@@ -12,6 +12,11 @@ use Propel\Runtime\Connection\ConnectionInterface;
 
 class TestAuthorDeleteFalse extends TestAuthor
 {
+    /**
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
+     *
+     * @return int|null
+     */
     public function preDelete(?ConnectionInterface $con = null): ?int
     {
         parent::preDelete($con);

--- a/tests/Propel/Tests/Helpers/Bookstore/Behavior/TestAuthorSaveFalse.php
+++ b/tests/Propel/Tests/Helpers/Bookstore/Behavior/TestAuthorSaveFalse.php
@@ -12,7 +12,12 @@ use Propel\Runtime\Connection\ConnectionInterface;
 
 class TestAuthorSaveFalse extends TestAuthor
 {
-    public function preSave(?ConnectionInterface $con = null)
+    /**
+     * @param \Propel\Runtime\Connection\ConnectionInterface|null $con
+     *
+     * @return bool
+     */
+    public function preSave(?ConnectionInterface $con = null): bool
     {
         parent::preSave($con);
         $this->setEmail('pre@save.com');

--- a/tests/Propel/Tests/Helpers/Bookstore/Behavior/Testallhooksbehavior.php
+++ b/tests/Propel/Tests/Helpers/Bookstore/Behavior/Testallhooksbehavior.php
@@ -66,56 +66,111 @@ class TestAllHooksTableModifier
 
 class TestAllHooksObjectBuilderModifier
 {
+    /**
+     * @param \Propel\Generator\Builder\Om\AbstractOMBuilder $builder
+     *
+     * @return string
+     */
     public function objectAttributes($builder)
     {
         return 'public $customAttribute = 1;';
     }
 
+    /**
+     * @param \Propel\Generator\Builder\Om\AbstractOMBuilder $builder
+     *
+     * @return string
+     */
     public function preSave($builder)
     {
         return '$this->preSave = 1;$this->preSaveIsAfterSave = isset($affectedRows);$this->preSaveBuilder="' . get_class($builder) . '";';
     }
 
+    /**
+     * @param \Propel\Generator\Builder\Om\AbstractOMBuilder $builder
+     *
+     * @return string
+     */
     public function postSave($builder)
     {
         return '$this->postSave = 1;$this->postSaveIsAfterSave = isset($affectedRows);$this->postSaveBuilder="' . get_class($builder) . '";';
     }
 
+    /**
+     * @param \Propel\Generator\Builder\Om\AbstractOMBuilder $builder
+     *
+     * @return string
+     */
     public function preInsert($builder)
     {
         return '$this->preInsert = 1;$this->preInsertIsAfterSave = isset($affectedRows);$this->preInsertBuilder="' . get_class($builder) . '";';
     }
 
+    /**
+     * @param \Propel\Generator\Builder\Om\AbstractOMBuilder $builder
+     *
+     * @return string
+     */
     public function postInsert($builder)
     {
         return '$this->postInsert = 1;$this->postInsertIsAfterSave = isset($affectedRows);$this->postInsertBuilder="' . get_class($builder) . '";';
     }
 
+    /**
+     * @param \Propel\Generator\Builder\Om\AbstractOMBuilder $builder
+     *
+     * @return string
+     */
     public function preUpdate($builder)
     {
         return '$this->preUpdate = 1;$this->preUpdateIsAfterSave = isset($affectedRows);$this->preUpdateBuilder="' . get_class($builder) . '";';
     }
 
+    /**
+     * @param \Propel\Generator\Builder\Om\AbstractOMBuilder $builder
+     *
+     * @return string
+     */
     public function postUpdate($builder)
     {
         return '$this->postUpdate = 1;$this->postUpdateIsAfterSave = isset($affectedRows);$this->postUpdateBuilder="' . get_class($builder) . '";';
     }
 
+    /**
+     * @param \Propel\Generator\Builder\Om\AbstractOMBuilder $builder
+     *
+     * @return string
+     */
     public function preDelete($builder)
     {
         return '$this->preDelete = 1;$this->preDeleteIsBeforeDelete = isset(Table3TableMap::$instances[$this->id]);$this->preDeleteBuilder="' . get_class($builder) . '";';
     }
 
+    /**
+     * @param \Propel\Generator\Builder\Om\AbstractOMBuilder $builder
+     *
+     * @return string
+     */
     public function postDelete($builder)
     {
         return '$this->postDelete = 1;$this->postDeleteIsBeforeDelete = isset(Table3TableMap::$instances[$this->id]);$this->postDeleteBuilder="' . get_class($builder) . '";';
     }
 
+    /**
+     * @param \Propel\Generator\Builder\Om\AbstractOMBuilder $builder
+     *
+     * @return string
+     */
     public function objectMethods($builder)
     {
         return 'public function hello() { return "' . get_class($builder) . '"; }';
     }
 
+    /**
+     * @param \Propel\Generator\Builder\Om\AbstractOMBuilder $builder
+     *
+     * @return string
+     */
     public function objectCall($builder)
     {
         return 'if ($name == "foo") return "bar";';
@@ -124,7 +179,7 @@ class TestAllHooksObjectBuilderModifier
     /**
      * @return void
      */
-    public function objectFilter(&$string, $builder)
+    public function objectFilter(&$string, $builder): void
     {
         $string .= 'class testObjectFilter { const FOO = "' . get_class($builder) . '"; }';
     }
@@ -145,7 +200,7 @@ class TestAllHooksQueryBuilderModifier
     /**
      * @return void
      */
-    public function queryFilter(&$string, $builder)
+    public function queryFilter(&$string, $builder): void
     {
         $string .= 'class testQueryFilter { const FOO = "' . get_class($builder) . '"; }';
     }

--- a/tests/Propel/Tests/Helpers/Bookstore/Behavior/Testallhooksbehavior.php
+++ b/tests/Propel/Tests/Helpers/Bookstore/Behavior/Testallhooksbehavior.php
@@ -55,7 +55,7 @@ class TestAllHooksTableModifier
     /**
      * @return void
      */
-    public function modifyTable()
+    public function modifyTable(): void
     {
         $this->table->addColumn([
             'name' => 'test',

--- a/tests/Propel/Tests/Helpers/MultipleBehavior.php
+++ b/tests/Propel/Tests/Helpers/MultipleBehavior.php
@@ -15,7 +15,7 @@ class MultipleBehavior extends Behavior
     /**
      * @return bool
      */
-    public function allowMultiple()
+    public function allowMultiple(): bool
     {
         return true;
     }

--- a/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/CriteriaTest.php
@@ -1163,7 +1163,7 @@ class CriteriaTest extends BookstoreTestBase
         $c = new Criteria();
         $this->assertNull($c->getComment(), 'Comment is null by default');
         $c2 = $c->setComment('foo');
-        $this->assertEquals('foo', $c->getComment(), 'Comment is set by setComment()');
+        $this->assertSame('foo', $c->getComment(), 'Comment is set by setComment()');
         $this->assertEquals($c, $c2, 'setComment() returns the current Criteria');
         $c->setComment();
         $this->assertNull($c->getComment(), 'Comment is reset by setComment(null)');
@@ -1178,7 +1178,7 @@ class CriteriaTest extends BookstoreTestBase
         $c->clear();
 
         $this->assertTrue(is_array($c->getNamedCriterions()), 'namedCriterions is an array');
-        $this->assertEquals(0, count($c->getNamedCriterions()), 'namedCriterions is empty by default');
+        $this->assertSame(0, count($c->getNamedCriterions()), 'namedCriterions is empty by default');
 
         $this->assertFalse($c->getIgnoreCase(), 'ignoreCase is false by default');
 

--- a/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaHooksTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaHooksTest.php
@@ -170,7 +170,7 @@ class ModelCriteriaWithPreSelectHook extends ModelCriteria
     /**
      * @return void
      */
-    public function preSelect(ConnectionInterface $con)
+    public function preSelect(ConnectionInterface $con): void
     {
         $this->where($this->getModelAliasOrName() . '.Title = ?', 'Don Juan');
     }
@@ -178,7 +178,7 @@ class ModelCriteriaWithPreSelectHook extends ModelCriteria
 
 class ModelCriteriaWithPreDeleteHook extends ModelCriteria
 {
-    public function preDelete(ConnectionInterface $con)
+    public function preDelete(ConnectionInterface $con): ?int
     {
         return 12;
     }
@@ -189,7 +189,7 @@ class ModelCriteriaWithPostDeleteHook extends ModelCriteria
     /**
      * @return void
      */
-    public function postDelete($affectedRows, ConnectionInterface $con)
+    public function postDelete($affectedRows, ConnectionInterface $con): ?int
     {
         $con->lastAffectedRows = $affectedRows;
     }
@@ -197,7 +197,7 @@ class ModelCriteriaWithPostDeleteHook extends ModelCriteria
 
 class ModelCriteriaWithPreAndPostDeleteHook extends ModelCriteriaWithPostDeleteHook
 {
-    public function preDelete(ConnectionInterface $con)
+    public function preDelete(ConnectionInterface $con): ?int
     {
         return 12;
     }
@@ -208,7 +208,7 @@ class ModelCriteriaWithPreUpdateHook extends ModelCriteria
     /**
      * @return void
      */
-    public function preUpdate(&$values, ConnectionInterface $con, $forceIndividualSaves = false)
+    public function preUpdate(&$values, ConnectionInterface $con, $forceIndividualSaves = false): ?int
     {
         $values['ISBN'] = '1234';
     }
@@ -219,7 +219,7 @@ class ModelCriteriaWithPostUpdateHook extends ModelCriteria
     /**
      * @return void
      */
-    public function postUpdate($affectedRows, ConnectionInterface $con)
+    public function postUpdate($affectedRows, ConnectionInterface $con): ?int
     {
         $con->lastAffectedRows = $affectedRows;
     }
@@ -227,7 +227,7 @@ class ModelCriteriaWithPostUpdateHook extends ModelCriteria
 
 class ModelCriteriaWithPreAndPostUpdateHook extends ModelCriteriaWithPostUpdateHook
 {
-    public function preUpdate(&$values, ConnectionInterface $con, $forceIndividualSaves = false)
+    public function preUpdate(&$values, ConnectionInterface $con, $forceIndividualSaves = false): ?int
     {
         return 52;
     }

--- a/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaHooksTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/ModelCriteriaHooksTest.php
@@ -192,6 +192,8 @@ class ModelCriteriaWithPostDeleteHook extends ModelCriteria
     public function postDelete($affectedRows, ConnectionInterface $con): ?int
     {
         $con->lastAffectedRows = $affectedRows;
+
+        return $affectedRows;
     }
 }
 
@@ -211,17 +213,21 @@ class ModelCriteriaWithPreUpdateHook extends ModelCriteria
     public function preUpdate(&$values, ConnectionInterface $con, $forceIndividualSaves = false): ?int
     {
         $values['ISBN'] = '1234';
+
+        return null;
     }
 }
 
 class ModelCriteriaWithPostUpdateHook extends ModelCriteria
 {
     /**
-     * @return void
+     * @return int|null
      */
     public function postUpdate($affectedRows, ConnectionInterface $con): ?int
     {
         $con->lastAffectedRows = $affectedRows;
+
+        return $affectedRows;
     }
 }
 

--- a/tests/Propel/Tests/Runtime/ActiveQuery/PropelQueryTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/PropelQueryTest.php
@@ -186,6 +186,9 @@ class PropelQueryTest extends BookstoreTestBase
 
         $bookQuery->select(['Title'])->find();
 
-        $bookQuery->clear()->find();
+        $bookQuery->clear();
+        $result = $bookQuery->find();
+
+        $this->assertNotNull($result);
     }
 }

--- a/tests/Propel/Tests/Runtime/Adapter/Pdo/MysqlAdapterTest.php
+++ b/tests/Propel/Tests/Runtime/Adapter/Pdo/MysqlAdapterTest.php
@@ -181,7 +181,7 @@ class TestableMysqlAdapter extends MysqlAdapter
      *
      * @return array
      */
-    public function prepareParams($conparams)
+    public function prepareParams($conparams): array
     {
         return parent::prepareParams($conparams);
     }

--- a/tests/Propel/Tests/Runtime/Collection/ArrayCollectionTest.php
+++ b/tests/Propel/Tests/Runtime/Collection/ArrayCollectionTest.php
@@ -10,6 +10,7 @@ namespace Propel\Tests\Runtime\Collection;
 
 use Propel\Runtime\ActiveQuery\ModelCriteria;
 use Propel\Runtime\ActiveQuery\PropelQuery;
+use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
 use Propel\Runtime\Collection\ArrayCollection;
 use Propel\Runtime\Exception\BadMethodCallException;
 use Propel\Runtime\Exception\PropelException;
@@ -262,7 +263,7 @@ class ArrayCollectionTest extends BookstoreEmptyTestBase
 
 class TestableArrayCollection extends ArrayCollection
 {
-    public function getWorkerObject()
+    public function getWorkerObject(): ActiveRecordInterface
     {
         return parent::getWorkerObject();
     }

--- a/tests/Propel/Tests/Runtime/Connection/ConnectionManagerMasterSlaveTest.php
+++ b/tests/Propel/Tests/Runtime/Connection/ConnectionManagerMasterSlaveTest.php
@@ -22,19 +22,10 @@ class ConnectionManagerMasterSlaveTest extends BaseTestCase
     /**
      * @return void
      */
-    public function testGetNameReturnsNullByDefault()
-    {
-        $manager = new ConnectionManagerMasterSlave('default');
-        $this->assertNull($manager->getName());
-    }
-
-    /**
-     * @return void
-     */
     public function testGetNameReturnsNameSetUsingSetName()
     {
         $manager = new ConnectionManagerMasterSlave('foo');
-        $this->assertEquals('foo', $manager->getName());
+        $this->assertSame('foo', $manager->getName());
     }
 
     /**

--- a/tests/Propel/Tests/Runtime/Connection/ConnectionManagerPrimaryReplicaTest.php
+++ b/tests/Propel/Tests/Runtime/Connection/ConnectionManagerPrimaryReplicaTest.php
@@ -19,19 +19,10 @@ class ConnectionManagerPrimaryReplicaTest extends BaseTestCase
     /**
      * @return void
      */
-    public function testGetNameReturnsNullByDefault()
-    {
-        $manager = new ConnectionManagerPrimaryReplica('default');
-        $this->assertNull($manager->getName());
-    }
-
-    /**
-     * @return void
-     */
     public function testGetNameReturnsNameSetUsingSetName()
     {
         $manager = new ConnectionManagerPrimaryReplica('foo');
-        $this->assertEquals('foo', $manager->getName());
+        $this->assertSame('foo', $manager->getName());
     }
 
     /**

--- a/tests/Propel/Tests/Runtime/Connection/ConnectionManagerSingleTest.php
+++ b/tests/Propel/Tests/Runtime/Connection/ConnectionManagerSingleTest.php
@@ -19,19 +19,10 @@ class ConnectionManagerSingleTest extends BaseTestCase
     /**
      * @return void
      */
-    public function testGetNameReturnsNullByDefault()
-    {
-        $manager = new ConnectionManagerSingle();
-        $this->assertNull($manager->getName());
-    }
-
-    /**
-     * @return void
-     */
     public function testGetNameReturnsNameSetUsingSetName()
     {
         $manager = new ConnectionManagerSingle('foo');
-        $this->assertEquals('foo', $manager->getName());
+        $this->assertSame('foo', $manager->getName());
     }
 
     /**
@@ -41,7 +32,7 @@ class ConnectionManagerSingleTest extends BaseTestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $manager = new ConnectionManagerSingle();
+        $manager = new ConnectionManagerSingle('single');
         $con = $manager->getWriteConnection(new SqliteAdapter());
     }
 
@@ -50,7 +41,7 @@ class ConnectionManagerSingleTest extends BaseTestCase
      */
     public function testGetWriteConnectionBuildsConnectionBasedOnConfiguration()
     {
-        $manager = new ConnectionManagerSingle();
+        $manager = new ConnectionManagerSingle('single');
         $manager->setConfiguration(['dsn' => 'sqlite::memory:']);
         $con = $manager->getWriteConnection(new SqliteAdapter());
         $this->assertInstanceOf('Propel\Runtime\Connection\ConnectionWrapper', $con);
@@ -73,7 +64,7 @@ class ConnectionManagerSingleTest extends BaseTestCase
      */
     public function testGetReadConnectionReturnsWriteConnection()
     {
-        $manager = new ConnectionManagerSingle();
+        $manager = new ConnectionManagerSingle('single');
         $manager->setConfiguration(['dsn' => 'sqlite::memory:']);
         $writeCon = $manager->getWriteConnection(new SqliteAdapter());
         $readCon = $manager->getReadConnection(new SqliteAdapter());
@@ -86,7 +77,7 @@ class ConnectionManagerSingleTest extends BaseTestCase
     public function testSetConnection()
     {
         $connection = new PdoConnection('sqlite::memory:');
-        $manager = new ConnectionManagerSingle();
+        $manager = new ConnectionManagerSingle('single');
         $manager->setConnection($connection);
         $conn = $manager->getWriteConnection();
         $this->assertSame($connection, $conn);

--- a/tests/Propel/Tests/Runtime/Connection/ConnectionManagerSingleTest.php
+++ b/tests/Propel/Tests/Runtime/Connection/ConnectionManagerSingleTest.php
@@ -55,6 +55,7 @@ class ConnectionManagerSingleTest extends BaseTestCase
     public function testGetWriteConnectionReturnsAConnectionNamedAfterTheManager()
     {
         $manager = new ConnectionManagerSingle('foo');
+        $manager->setConfiguration(['dsn' => 'sqlite::memory:']);
         $con = $manager->getWriteConnection(new SqliteAdapter());
         $this->assertEquals('foo', $con->getName());
     }

--- a/tests/Propel/Tests/Runtime/Connection/ConnectionWrapperTest.php
+++ b/tests/Propel/Tests/Runtime/Connection/ConnectionWrapperTest.php
@@ -25,14 +25,17 @@ class ConnectionWrapperTest extends BookstoreTestBase
     public function testQueriesAreLoggedAfterExecution()
     {
         $wrapper = new class ($this->con) extends ConnectionWrapper{
+            /**
+             * @var array<string>
+             */
             public $orderStack = [];
 
-            public function pushToOrderStack(string $op)
+            public function pushToOrderStack(string $op): void
             {
                 $this->orderStack[] = $op;
             }
 
-            public function log($msg)
+            public function log($msg): void
             {
                 $this->pushToOrderStack('log');
             }

--- a/tests/Propel/Tests/Runtime/Connection/PropelPDOTest.php
+++ b/tests/Propel/Tests/Runtime/Connection/PropelPDOTest.php
@@ -559,13 +559,23 @@ class LastMessageHandler extends AbstractHandler
 {
     public $latestMessage = '';
 
-    public function handle(array $record)
+    /**
+     * @param array $record
+     *
+     * @return bool
+     */
+    public function handle(array $record): bool
     {
         $this->latestMessage = (string)$record['message'];
 
         return false === $this->bubble;
     }
 
+    /**
+     * @param \Propel\Runtime\Connection\ConnectionWrapper $con
+     *
+     * @return array
+     */
     public static function buildHandledConnection(ConnectionWrapper $con): array
     {
         $con = new ConnectionWrapper($con->getWrappedConnection());

--- a/tests/Propel/Tests/Runtime/Map/DatabaseMapTest.php
+++ b/tests/Propel/Tests/Runtime/Map/DatabaseMapTest.php
@@ -190,7 +190,7 @@ class BazTableMap extends TableMap
     /**
      * @return void
      */
-    public function initialize()
+    public function initialize(): void
     {
         $this->setName('baz');
         $this->setPhpName('Baz');

--- a/tests/Propel/Tests/Runtime/Map/RelationMapTest.php
+++ b/tests/Propel/Tests/Runtime/Map/RelationMapTest.php
@@ -87,8 +87,8 @@ class RelationMapTest extends TestCase
             $getter = 'get' . ucfirst($property);
             $setter = 'set' . ucfirst($property);
             $this->assertNull($this->rmap->$getter(), "A new relation has no $property");
-            $this->rmap->$setter('foo_value');
-            $this->assertEquals('foo_value', $this->rmap->$getter(), "The $property is set by setType()");
+            $this->rmap->$setter(RelationMap::MANY_TO_MANY);
+            $this->assertEquals(RelationMap::MANY_TO_MANY, $this->rmap->$getter(), "The $property is set by setType()");
         }
     }
 

--- a/tests/Propel/Tests/Runtime/Map/TableMapTest.php
+++ b/tests/Propel/Tests/Runtime/Map/TableMapTest.php
@@ -301,7 +301,7 @@ class TableMapTest extends TestCase
     {
         $this->assertEquals(ObjectCollection::class, $this->tmap->getCollectionClassName());
     }
-    
+
     /**
      * @return void
      */
@@ -311,7 +311,7 @@ class TableMapTest extends TestCase
         $this->tmap->setClassName($classWithCollection);
         $this->assertEquals(ExtendingTestCollection::class, $this->tmap->getCollectionClassName());
     }
-        
+
     /**
      * @return void
      */
@@ -351,7 +351,7 @@ class FooTableMap extends TableMap
     /**
      * @return void
      */
-    public function buildRelations()
+    public function buildRelations(): void
     {
         $this->rmap = $this->addRelation('Bar', 'Bar', RelationMap::MANY_TO_ONE);
     }
@@ -362,7 +362,7 @@ class BarTableMap extends TableMap
     /**
      * @return void
      */
-    public function initialize()
+    public function initialize(): void
     {
         $this->setName('bar');
         $this->setClassName('Bar');

--- a/tests/Propel/Tests/Runtime/ServiceContainer/StandardServiceContainerTest.php
+++ b/tests/Propel/Tests/Runtime/ServiceContainer/StandardServiceContainerTest.php
@@ -12,7 +12,9 @@ use Monolog\Logger;
 use Propel\Runtime\Adapter\AdapterInterface;
 use Propel\Runtime\Adapter\Pdo\MysqlAdapter;
 use Propel\Runtime\Adapter\Pdo\SqliteAdapter;
+use Propel\Runtime\Connection\ConnectionInterface;
 use Propel\Runtime\Connection\ConnectionManagerSingle;
+use Propel\Runtime\Connection\DebugPDO;
 use Propel\Runtime\Connection\PdoConnection;
 use Propel\Runtime\Exception\PropelException;
 use Propel\Runtime\Exception\RuntimeException;
@@ -677,13 +679,13 @@ class TestableConnectionManagerSingle extends ConnectionManagerSingle
 {
     public $connection;
 
-    public function getWriteConnection(?AdapterInterface $adapter = null)
+    public function getWriteConnection(?AdapterInterface $adapter = null): ConnectionInterface
     {
-        return 'write';
+        return new DebugPDO();
     }
 
-    public function getReadConnection(?AdapterInterface $adapter = null)
+    public function getReadConnection(?AdapterInterface $adapter = null): ConnectionInterface
     {
-        return 'read';
+        return new DebugPDO();
     }
 }

--- a/tests/Propel/Tests/Runtime/Util/PropelConditionalProxyTest.php
+++ b/tests/Propel/Tests/Runtime/Util/PropelConditionalProxyTest.php
@@ -82,7 +82,7 @@ class TestPropelConditionalProxy extends PropelConditionalProxy
         return new TestPropelConditionalProxy($this->criteria, $cond, $this);
     }
 
-    public function getParentProxy()
+    public function getParentProxy(): ?self
     {
         return $this->parent;
     }

--- a/tests/Propel/Tests/Runtime/Util/PropelDateTimeTest.php
+++ b/tests/Propel/Tests/Runtime/Util/PropelDateTimeTest.php
@@ -278,7 +278,7 @@ class TestPropelDateTime extends PropelDateTime
      *
      * @return bool
      */
-    public static function isTimestamp($value)
+    public static function isTimestamp($value): bool
     {
         return parent::isTimestamp($value);
     }

--- a/tests/Propel/Tests/TestCaseFixtures.php
+++ b/tests/Propel/Tests/TestCaseFixtures.php
@@ -64,7 +64,7 @@ class TestCaseFixtures extends TestCase
     /**
      * Combination of $lastBuildDsn and $lastBuildMode, indicating build version of currently active configurations
      *
-     * @var string
+     * @var string|null
      */
     protected static $activeConfigsVersion;
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -20,6 +20,6 @@ echo sprintf("Tests started in temp %s.\n", sys_get_temp_dir());
  * @see https://bugs.php.net/bug.php?id=64760
  * @see https://github.com/sebastianbergmann/phpunit/issues/1052
  */
-ini_set('precision', 14);
-ini_set('serialize_precision', 14);
+ini_set('precision', '14');
+ini_set('serialize_precision', '14');
 setlocale(LC_ALL, 'en_US.utf8'); //fixed issues with hhvm and iconv


### PR DESCRIPTION
First part of https://github.com/propelorm/Propel2/issues/1656

- [x] Return types where possible
- [x] Necessary template changes for tests to run
- [ ] Generated code also adjusted

We still will have to also check param types as well all generated code for both then.

I am quite confused about the hooks and what kind of return types are expected

ActiveRecordInterface
- preInsert() - why bool
- postInsert() - why ?int
- preUpdate() / preSave()
- postUpdate() / postSave()
- base*() vs *()

Could all be bool? or do we need this `?int` part?

> Tests: 1221, Assertions: 1287, Errors: 703, Failures: 23, Skipped: 13, Incomplete: 4.

Is anyone able to help out by making additional PRs against this one?