### PR TITLE
Allow Monolog v2 to enable psr/log v2/v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require-dev": {
         "ext-pdo": "*",
         "ext-json": "*",
-        "monolog/monolog": "^1.3",
+        "monolog/monolog": "^1.3 || ^2.3",
         "phpstan/phpstan": "^1.2",
         "phpunit/phpunit": "^9.5.0",
         "spryker/code-sniffer": "^0.17.2",

--- a/src/Propel/Runtime/Connection/ConnectionWrapper.php
+++ b/src/Propel/Runtime/Connection/ConnectionWrapper.php
@@ -657,7 +657,7 @@ class ConnectionWrapper implements ConnectionInterface, LoggerAwareInterface
      *
      * @return void
      */
-    public function setLogger(LoggerInterface $logger)
+    public function setLogger(LoggerInterface $logger): void
     {
         $this->logger = $logger;
     }


### PR DESCRIPTION
When looking into dependencies, it becomes clear that psr/log v1 is required due to a require-dev (optional) dependendy locking it
We need to prevent this in order to fully test both our min and max promise.

As such, this PR aims to fix it properly - and replaces https://github.com/propelorm/Propel2/pull/1819

Completes https://github.com/propelorm/Propel2/pull/1805

With this PHP7 folks are using psr/log v1, PHP8 folks can use psr/log v2/v3 already.
