### PR TITLE
Prevent errors with Monolog 2.3 and no default log config

### DIFF
--- a/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
+++ b/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
@@ -573,16 +573,16 @@ class StandardServiceContainer implements ServiceContainerInterface
                 $handler = new StreamHandler(
                     $configuration['path'],
                     $configuration['level'] ?? null,
-                    $configuration['bubble'] ?? null,
+                    $configuration['bubble'] ?? true,
                 );
 
                 break;
             case 'rotating_file':
                 $handler = new RotatingFileHandler(
                     $configuration['path'],
-                    $configuration['max_files'] ?? null,
+                    $configuration['max_files'] ?? 0,
                     $configuration['level'] ?? null,
-                    $configuration['bubble'] ?? null,
+                    $configuration['bubble'] ?? true,
                 );
 
                 break;
@@ -591,7 +591,7 @@ class StandardServiceContainer implements ServiceContainerInterface
                     $configuration['ident'],
                     $configuration['facility'] ?? null,
                     $configuration['level'] ?? null,
-                    $configuration['bubble'] ?? null,
+                    $configuration['bubble'] ?? true,
                 );
 
                 break;


### PR DESCRIPTION
Passing in `null` to the handler classes (which now have typed parameters in the constructors) causes an error.  Changed null coalescing to default values instead of `null`.