### PR TITLE
Ensure ConnectionManagerInterface::getName() always return a string

### DIFF
--- a/src/Propel/Generator/Config/ArrayToPhpConverter.php
+++ b/src/Propel/Generator/Config/ArrayToPhpConverter.php
@@ -38,10 +38,10 @@ class ArrayToPhpConverter
 
                 // set connection settings
                 if (isset($params['slaves'])) {
-                    $conf[] = "\$manager = new \Propel\Runtime\Connection\ConnectionManagerMasterSlave();";
+                    $conf[] = "\$manager = new \Propel\Runtime\Connection\ConnectionManagerMasterSlave('{$name}');";
                     $conf[] = '$manager->setReadConfiguration(' . var_export($params['slaves'], true) . ');';
                 } elseif (isset($params['dsn'])) {
-                    $conf[] = "\$manager = new \Propel\Runtime\Connection\ConnectionManagerSingle();";
+                    $conf[] = "\$manager = new \Propel\Runtime\Connection\ConnectionManagerSingle('{$name}');";
                 } else {
                     continue;
                 }
@@ -54,8 +54,7 @@ class ArrayToPhpConverter
                     $conf[] = "\$manager->{$masterConfigurationSetter}(" . var_export($connection, true) . ');';
                 }
 
-                $conf[] = "\$manager->setName('{$name}');";
-                $conf[] = "\$serviceContainer->setConnectionManager('{$name}', \$manager);";
+                $conf[] = "\$serviceContainer->setConnectionManager(\$manager);";
             }
 
             // set default datasource

--- a/src/Propel/Runtime/Connection/ConnectionManagerPrimaryReplica.php
+++ b/src/Propel/Runtime/Connection/ConnectionManagerPrimaryReplica.php
@@ -47,6 +47,14 @@ class ConnectionManagerPrimaryReplica implements ConnectionManagerInterface
 
     /**
      * @param string $name The datasource name associated to this connection
+     */
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @param string $name The datasource name associated to this connection
      *
      * @return void
      */

--- a/src/Propel/Runtime/Connection/ConnectionManagerSingle.php
+++ b/src/Propel/Runtime/Connection/ConnectionManagerSingle.php
@@ -33,6 +33,14 @@ class ConnectionManagerSingle implements ConnectionManagerInterface
 
     /**
      * @param string $name The datasource name associated to this connection
+     */
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @param string $name The datasource name associated to this connection
      *
      * @return void
      */

--- a/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
+++ b/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
@@ -323,20 +323,17 @@ class StandardServiceContainer implements ServiceContainerInterface
     }
 
     /**
-     * @param string $name The datasource name
      * @param \Propel\Runtime\Connection\ConnectionManagerInterface $manager
      *
      * @return void
      */
-    public function setConnectionManager($name, ConnectionManagerInterface $manager): void
+    public function setConnectionManager(ConnectionManagerInterface $manager): void
     {
-        if (isset($this->connectionManagers[$name])) {
-            $this->connectionManagers[$name]->closeConnections();
+        if (isset($this->connectionManagers[$manager->getName()])) {
+            $this->connectionManagers[$manager->getName()]->closeConnections();
         }
-        if (!$manager->getName()) {
-            $manager->setName($name);
-        }
-        $this->connectionManagers[$name] = $manager;
+
+        $this->connectionManagers[$manager->getName()] = $manager;
     }
 
     /**
@@ -455,9 +452,9 @@ class StandardServiceContainer implements ServiceContainerInterface
      */
     public function setConnection($name, ConnectionInterface $connection): void
     {
-        $manager = new ConnectionManagerSingle();
+        $manager = new ConnectionManagerSingle($name);
         $manager->setConnection($connection);
-        $this->setConnectionManager($name, $manager);
+        $this->setConnectionManager($manager);
     }
 
     /**

--- a/tests/Propel/Tests/Runtime/Connection/ConnectionManagerMasterSlaveTest.php
+++ b/tests/Propel/Tests/Runtime/Connection/ConnectionManagerMasterSlaveTest.php
@@ -24,7 +24,7 @@ class ConnectionManagerMasterSlaveTest extends BaseTestCase
      */
     public function testGetNameReturnsNullByDefault()
     {
-        $manager = new ConnectionManagerMasterSlave();
+        $manager = new ConnectionManagerMasterSlave('default');
         $this->assertNull($manager->getName());
     }
 
@@ -33,8 +33,7 @@ class ConnectionManagerMasterSlaveTest extends BaseTestCase
      */
     public function testGetNameReturnsNameSetUsingSetName()
     {
-        $manager = new ConnectionManagerMasterSlave();
-        $manager->setName('foo');
+        $manager = new ConnectionManagerMasterSlave('foo');
         $this->assertEquals('foo', $manager->getName());
     }
 
@@ -45,7 +44,7 @@ class ConnectionManagerMasterSlaveTest extends BaseTestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $manager = new ConnectionManagerMasterSlave();
+        $manager = new ConnectionManagerMasterSlave('default');
         $con = $manager->getWriteConnection(new SqliteAdapter());
     }
 
@@ -54,7 +53,7 @@ class ConnectionManagerMasterSlaveTest extends BaseTestCase
      */
     public function testGetWriteConnectionBuildsConnectionBasedOnWriteConfiguration()
     {
-        $manager = new ConnectionManagerMasterSlave();
+        $manager = new ConnectionManagerMasterSlave('default');
         $manager->setWriteConfiguration(['dsn' => 'sqlite::memory:']);
         $con = $manager->getWriteConnection(new SqliteAdapter());
         $this->assertInstanceOf('Propel\Runtime\Connection\ConnectionWrapper', $con);
@@ -67,7 +66,7 @@ class ConnectionManagerMasterSlaveTest extends BaseTestCase
      */
     public function testGetWriteConnectionBuildsConnectionNotBasedOnReadConfiguration()
     {
-        $manager = new ConnectionManagerMasterSlave();
+        $manager = new ConnectionManagerMasterSlave('default');
         $manager->setWriteConfiguration(['dsn' => 'sqlite::memory:', 'attributes' => ['ATTR_CASE' => PDO::CASE_UPPER]]);
         $manager->setReadConfiguration([['dsn' => 'sqlite::memory:', 'attributes' => ['ATTR_CASE' => PDO::CASE_LOWER]]]);
         $con = $manager->getWriteConnection(new SqliteAdapter());
@@ -80,8 +79,7 @@ class ConnectionManagerMasterSlaveTest extends BaseTestCase
      */
     public function testGetWriteConnectionReturnsAConnectionNamedAfterTheManager()
     {
-        $manager = new ConnectionManagerMasterSlave();
-        $manager->setName('foo');
+        $manager = new ConnectionManagerMasterSlave('foo');
         $manager->setWriteConfiguration(['dsn' => 'sqlite::memory:']);
         $con = $manager->getWriteConnection(new SqliteAdapter());
         $this->assertEquals('foo', $con->getName());
@@ -92,7 +90,7 @@ class ConnectionManagerMasterSlaveTest extends BaseTestCase
      */
     public function testGetReadConnectionBuildsConnectionBasedOnReadConfiguration()
     {
-        $manager = new ConnectionManagerMasterSlave();
+        $manager = new ConnectionManagerMasterSlave('default');
         $manager->setReadConfiguration([['dsn' => 'sqlite::memory:']]);
         $con = $manager->getReadConnection(new SqliteAdapter());
         $this->assertInstanceOf('Propel\Runtime\Connection\ConnectionWrapper', $con);
@@ -105,7 +103,7 @@ class ConnectionManagerMasterSlaveTest extends BaseTestCase
      */
     public function testGetReadConnectionBuildsConnectionNotBasedOnWriteConfiguration()
     {
-        $manager = new ConnectionManagerMasterSlave();
+        $manager = new ConnectionManagerMasterSlave('default');
         $manager->setWriteConfiguration(['dsn' => 'sqlite::memory:', 'attributes' => ['ATTR_CASE' => PDO::CASE_UPPER]]);
         $manager->setReadConfiguration([['dsn' => 'sqlite::memory:', 'attributes' => ['ATTR_CASE' => PDO::CASE_LOWER]]]);
         $con = $manager->getReadConnection(new SqliteAdapter());
@@ -118,7 +116,7 @@ class ConnectionManagerMasterSlaveTest extends BaseTestCase
      */
     public function testGetReadConnectionReturnsWriteConnectionIfNoReadConnectionIsSet()
     {
-        $manager = new ConnectionManagerMasterSlave();
+        $manager = new ConnectionManagerMasterSlave('default');
         $manager->setWriteConfiguration(['dsn' => 'sqlite::memory:']);
         $writeCon = $manager->getWriteConnection(new SqliteAdapter());
         $readCon = $manager->getReadConnection(new SqliteAdapter());
@@ -130,7 +128,7 @@ class ConnectionManagerMasterSlaveTest extends BaseTestCase
      */
     public function testGetReadConnectionBuildsConnectionBasedOnARandomReadConfiguration()
     {
-        $manager = new ConnectionManagerMasterSlave();
+        $manager = new ConnectionManagerMasterSlave('default');
         $manager->setReadConfiguration([
             ['dsn' => 'sqlite::memory:', 'attributes' => ['ATTR_CASE' => PDO::CASE_LOWER]],
             ['dsn' => 'sqlite::memory:', 'attributes' => ['ATTR_CASE' => PDO::CASE_UPPER]],
@@ -146,8 +144,7 @@ class ConnectionManagerMasterSlaveTest extends BaseTestCase
      */
     public function testGetReadConnectionReturnsAConnectionNamedAfterTheManager()
     {
-        $manager = new ConnectionManagerMasterSlave();
-        $manager->setName('foo');
+        $manager = new ConnectionManagerMasterSlave('foo');
         $manager->setReadConfiguration([['dsn' => 'sqlite::memory:']]);
         $con = $manager->getReadConnection(new SqliteAdapter());
         $this->assertEquals('foo', $con->getName());
@@ -158,7 +155,7 @@ class ConnectionManagerMasterSlaveTest extends BaseTestCase
      */
     public function testIsForceMasterConnectionFalseByDefault()
     {
-        $manager = new ConnectionManagerMasterSlave();
+        $manager = new ConnectionManagerMasterSlave('default');
         $this->assertFalse($manager->isForceMasterConnection());
     }
 
@@ -167,7 +164,7 @@ class ConnectionManagerMasterSlaveTest extends BaseTestCase
      */
     public function testSetForceMasterConnection()
     {
-        $manager = new ConnectionManagerMasterSlave();
+        $manager = new ConnectionManagerMasterSlave('default');
         $manager->setForceMasterConnection(true);
         $this->assertTrue($manager->isForceMasterConnection());
         $manager->setForceMasterConnection(false);
@@ -179,7 +176,7 @@ class ConnectionManagerMasterSlaveTest extends BaseTestCase
      */
     public function testForceMasterConnectionForcesMasterConnectionOnRead()
     {
-        $manager = new ConnectionManagerMasterSlave();
+        $manager = new ConnectionManagerMasterSlave('default');
         $manager->setForceMasterConnection(true);
         $manager->setWriteConfiguration(['dsn' => 'sqlite::memory:', 'attributes' => ['ATTR_CASE' => PDO::CASE_UPPER]]);
         $manager->setReadConfiguration([['dsn' => 'sqlite::memory:', 'attributes' => ['ATTR_CASE' => PDO::CASE_LOWER]]]);
@@ -196,7 +193,7 @@ class ConnectionManagerMasterSlaveTest extends BaseTestCase
      */
     public function testReadConnectionWhenMasterIsInTransaction()
     {
-        $manager = new ConnectionManagerMasterSlave();
+        $manager = new ConnectionManagerMasterSlave('default');
         $manager->setWriteConfiguration(['dsn' => 'sqlite::memory:', 'attributes' => ['ATTR_CASE' => PDO::CASE_UPPER]]);
         $manager->setReadConfiguration([['dsn' => 'sqlite::memory:', 'attributes' => ['ATTR_CASE' => PDO::CASE_LOWER]]]);
 

--- a/tests/Propel/Tests/Runtime/Connection/ConnectionManagerPrimaryReplicaTest.php
+++ b/tests/Propel/Tests/Runtime/Connection/ConnectionManagerPrimaryReplicaTest.php
@@ -21,7 +21,7 @@ class ConnectionManagerPrimaryReplicaTest extends BaseTestCase
      */
     public function testGetNameReturnsNullByDefault()
     {
-        $manager = new ConnectionManagerPrimaryReplica();
+        $manager = new ConnectionManagerPrimaryReplica('default');
         $this->assertNull($manager->getName());
     }
 
@@ -30,8 +30,7 @@ class ConnectionManagerPrimaryReplicaTest extends BaseTestCase
      */
     public function testGetNameReturnsNameSetUsingSetName()
     {
-        $manager = new ConnectionManagerPrimaryReplica();
-        $manager->setName('foo');
+        $manager = new ConnectionManagerPrimaryReplica('foo');
         $this->assertEquals('foo', $manager->getName());
     }
 
@@ -42,7 +41,7 @@ class ConnectionManagerPrimaryReplicaTest extends BaseTestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        $manager = new ConnectionManagerPrimaryReplica();
+        $manager = new ConnectionManagerPrimaryReplica('default');
         $manager->getWriteConnection(new SqliteAdapter());
     }
 
@@ -51,7 +50,7 @@ class ConnectionManagerPrimaryReplicaTest extends BaseTestCase
      */
     public function testGetWriteConnectionBuildsConnectionBasedOnWriteConfiguration()
     {
-        $manager = new ConnectionManagerPrimaryReplica();
+        $manager = new ConnectionManagerPrimaryReplica('default');
         $manager->setWriteConfiguration(['dsn' => 'sqlite::memory:']);
         $con = $manager->getWriteConnection(new SqliteAdapter());
         $this->assertInstanceOf('Propel\Runtime\Connection\ConnectionWrapper', $con);
@@ -64,7 +63,7 @@ class ConnectionManagerPrimaryReplicaTest extends BaseTestCase
      */
     public function testGetWriteConnectionBuildsConnectionNotBasedOnReadConfiguration()
     {
-        $manager = new ConnectionManagerPrimaryReplica();
+        $manager = new ConnectionManagerPrimaryReplica('default');
         $manager->setWriteConfiguration(['dsn' => 'sqlite::memory:', 'attributes' => ['ATTR_CASE' => PDO::CASE_UPPER]]);
         $manager->setReadConfiguration([['dsn' => 'sqlite::memory:', 'attributes' => ['ATTR_CASE' => PDO::CASE_LOWER]]]);
         $con = $manager->getWriteConnection(new SqliteAdapter());
@@ -77,8 +76,7 @@ class ConnectionManagerPrimaryReplicaTest extends BaseTestCase
      */
     public function testGetWriteConnectionReturnsAConnectionNamedAfterTheManager()
     {
-        $manager = new ConnectionManagerPrimaryReplica();
-        $manager->setName('foo');
+        $manager = new ConnectionManagerPrimaryReplica('foo');
         $manager->setWriteConfiguration(['dsn' => 'sqlite::memory:']);
         $con = $manager->getWriteConnection(new SqliteAdapter());
         $this->assertEquals('foo', $con->getName());
@@ -89,7 +87,7 @@ class ConnectionManagerPrimaryReplicaTest extends BaseTestCase
      */
     public function testGetReadConnectionBuildsConnectionBasedOnReadConfiguration()
     {
-        $manager = new ConnectionManagerPrimaryReplica();
+        $manager = new ConnectionManagerPrimaryReplica('default');
         $manager->setReadConfiguration([['dsn' => 'sqlite::memory:']]);
         $con = $manager->getReadConnection(new SqliteAdapter());
         $this->assertInstanceOf('Propel\Runtime\Connection\ConnectionWrapper', $con);
@@ -102,7 +100,7 @@ class ConnectionManagerPrimaryReplicaTest extends BaseTestCase
      */
     public function testGetReadConnectionBuildsConnectionNotBasedOnWriteConfiguration()
     {
-        $manager = new ConnectionManagerPrimaryReplica();
+        $manager = new ConnectionManagerPrimaryReplica('default');
         $manager->setWriteConfiguration(['dsn' => 'sqlite::memory:', 'attributes' => ['ATTR_CASE' => PDO::CASE_UPPER]]);
         $manager->setReadConfiguration([['dsn' => 'sqlite::memory:', 'attributes' => ['ATTR_CASE' => PDO::CASE_LOWER]]]);
         $con = $manager->getReadConnection(new SqliteAdapter());
@@ -115,7 +113,7 @@ class ConnectionManagerPrimaryReplicaTest extends BaseTestCase
      */
     public function testGetReadConnectionReturnsWriteConnectionIfNoReadConnectionIsSet()
     {
-        $manager = new ConnectionManagerPrimaryReplica();
+        $manager = new ConnectionManagerPrimaryReplica('default');
         $manager->setWriteConfiguration(['dsn' => 'sqlite::memory:']);
         $writeCon = $manager->getWriteConnection(new SqliteAdapter());
         $readCon = $manager->getReadConnection(new SqliteAdapter());
@@ -127,7 +125,7 @@ class ConnectionManagerPrimaryReplicaTest extends BaseTestCase
      */
     public function testGetReadConnectionBuildsConnectionBasedOnARandomReadConfiguration()
     {
-        $manager = new ConnectionManagerPrimaryReplica();
+        $manager = new ConnectionManagerPrimaryReplica('default');
         $manager->setReadConfiguration([
             ['dsn' => 'sqlite::memory:', 'attributes' => ['ATTR_CASE' => PDO::CASE_LOWER]],
             ['dsn' => 'sqlite::memory:', 'attributes' => ['ATTR_CASE' => PDO::CASE_UPPER]],
@@ -143,8 +141,7 @@ class ConnectionManagerPrimaryReplicaTest extends BaseTestCase
      */
     public function testGetReadConnectionReturnsAConnectionNamedAfterTheManager()
     {
-        $manager = new ConnectionManagerPrimaryReplica();
-        $manager->setName('foo');
+        $manager = new ConnectionManagerPrimaryReplica('foo');
         $manager->setReadConfiguration([['dsn' => 'sqlite::memory:']]);
         $con = $manager->getReadConnection(new SqliteAdapter());
         $this->assertEquals('foo', $con->getName());
@@ -155,7 +152,7 @@ class ConnectionManagerPrimaryReplicaTest extends BaseTestCase
      */
     public function testIsForcePrimaryConnectionFalseByDefault()
     {
-        $manager = new ConnectionManagerPrimaryReplica();
+        $manager = new ConnectionManagerPrimaryReplica('default');
         $this->assertFalse($manager->isForcePrimaryConnection());
     }
 
@@ -164,7 +161,7 @@ class ConnectionManagerPrimaryReplicaTest extends BaseTestCase
      */
     public function testSetForcePrimaryConnection()
     {
-        $manager = new ConnectionManagerPrimaryReplica();
+        $manager = new ConnectionManagerPrimaryReplica('default');
         $manager->setForcePrimaryConnection(true);
         $this->assertTrue($manager->isForcePrimaryConnection());
         $manager->setForcePrimaryConnection(false);
@@ -176,7 +173,7 @@ class ConnectionManagerPrimaryReplicaTest extends BaseTestCase
      */
     public function testForcePrimaryConnectionForcesMasterConnectionOnRead()
     {
-        $manager = new ConnectionManagerPrimaryReplica();
+        $manager = new ConnectionManagerPrimaryReplica('default');
         $manager->setForcePrimaryConnection(true);
         $manager->setWriteConfiguration(['dsn' => 'sqlite::memory:', 'attributes' => ['ATTR_CASE' => PDO::CASE_UPPER]]);
         $manager->setReadConfiguration([['dsn' => 'sqlite::memory:', 'attributes' => ['ATTR_CASE' => PDO::CASE_LOWER]]]);
@@ -193,7 +190,7 @@ class ConnectionManagerPrimaryReplicaTest extends BaseTestCase
      */
     public function testReadConnectionWhenMasterIsInTransaction()
     {
-        $manager = new ConnectionManagerPrimaryReplica();
+        $manager = new ConnectionManagerPrimaryReplica('default');
         $manager->setWriteConfiguration(['dsn' => 'sqlite::memory:', 'attributes' => ['ATTR_CASE' => PDO::CASE_UPPER]]);
         $manager->setReadConfiguration([['dsn' => 'sqlite::memory:', 'attributes' => ['ATTR_CASE' => PDO::CASE_LOWER]]]);
 

--- a/tests/Propel/Tests/Runtime/Connection/ConnectionManagerSingleTest.php
+++ b/tests/Propel/Tests/Runtime/Connection/ConnectionManagerSingleTest.php
@@ -30,8 +30,7 @@ class ConnectionManagerSingleTest extends BaseTestCase
      */
     public function testGetNameReturnsNameSetUsingSetName()
     {
-        $manager = new ConnectionManagerSingle();
-        $manager->setName('foo');
+        $manager = new ConnectionManagerSingle('foo');
         $this->assertEquals('foo', $manager->getName());
     }
 
@@ -64,9 +63,7 @@ class ConnectionManagerSingleTest extends BaseTestCase
      */
     public function testGetWriteConnectionReturnsAConnectionNamedAfterTheManager()
     {
-        $manager = new ConnectionManagerSingle();
-        $manager->setName('foo');
-        $manager->setConfiguration(['dsn' => 'sqlite::memory:']);
+        $manager = new ConnectionManagerSingle('foo');
         $con = $manager->getWriteConnection(new SqliteAdapter());
         $this->assertEquals('foo', $con->getName());
     }

--- a/tests/Propel/Tests/Runtime/ServiceContainer/StandardServiceContainerTest.php
+++ b/tests/Propel/Tests/Runtime/ServiceContainer/StandardServiceContainerTest.php
@@ -366,10 +366,10 @@ class StandardServiceContainerTest extends BaseTestCase
      */
     public function testSetConnectionManagerSetsTheConnectionManagerForAGivenDatasource()
     {
-        $manager1 = new ConnectionManagerSingle();
-        $manager2 = new ConnectionManagerSingle();
-        $this->sc->setConnectionManager('foo1', $manager1);
-        $this->sc->setConnectionManager('foo2', $manager2);
+        $manager1 = new ConnectionManagerSingle('foo1');
+        $manager2 = new ConnectionManagerSingle('foo2');
+        $this->sc->setConnectionManager($manager1);
+        $this->sc->setConnectionManager($manager2);
         $this->assertSame($manager1, $this->sc->getConnectionManager('foo1'));
         $this->assertSame($manager2, $this->sc->getConnectionManager('foo2'));
     }
@@ -379,11 +379,11 @@ class StandardServiceContainerTest extends BaseTestCase
      */
     public function testSetConnectionManagerClosesExistingConnectionManagerForTheSameDatasource()
     {
-        $manager = new TestableConnectionManagerSingle();
+        $manager = new TestableConnectionManagerSingle('foo');
         $manager->setConnection(new PdoConnection('sqlite::memory:'));
         $this->assertNotNull($manager->connection);
-        $this->sc->setConnectionManager('foo', $manager);
-        $this->sc->setConnectionManager('foo', new ConnectionManagerSingle());
+        $this->sc->setConnectionManager($manager);
+        $this->sc->setConnectionManager(new ConnectionManagerSingle('foo'));
         $this->assertNull($manager->connection);
     }
 
@@ -392,10 +392,10 @@ class StandardServiceContainerTest extends BaseTestCase
      */
     public function testGetConnectionManagersReturnsConnectionManagersForAllDatasources()
     {
-        $manager1 = new ConnectionManagerSingle();
-        $manager2 = new ConnectionManagerSingle();
-        $this->sc->setConnectionManager('foo1', $manager1);
-        $this->sc->setConnectionManager('foo2', $manager2);
+        $manager1 = new ConnectionManagerSingle('foo1');
+        $manager2 = new ConnectionManagerSingle('foo2');
+        $this->sc->setConnectionManager($manager1);
+        $this->sc->setConnectionManager($manager2);
         $expected = [
             'foo1' => $manager1,
             'foo2' => $manager2,
@@ -418,7 +418,7 @@ class StandardServiceContainerTest extends BaseTestCase
      */
     public function testHasConnectionManager()
     {
-        $this->sc->setConnectionManager('single', new TestableConnectionManagerSingle());
+        $this->sc->setConnectionManager(new TestableConnectionManagerSingle('single'));
         $this->assertTrue($this->sc->hasConnectionManager('single'));
         $this->assertFalse($this->sc->hasConnectionManager('single_not_existing'));
     }
@@ -428,12 +428,12 @@ class StandardServiceContainerTest extends BaseTestCase
      */
     public function testCloseConnectionsClosesConnectionsOnAllConnectionManagers()
     {
-        $manager1 = new TestableConnectionManagerSingle();
+        $manager1 = new TestableConnectionManagerSingle('foo1');
         $manager1->setConnection(new PdoConnection('sqlite::memory:'));
-        $manager2 = new TestableConnectionManagerSingle();
+        $manager2 = new TestableConnectionManagerSingle('foo2');
         $manager2->setConnection(new PdoConnection('sqlite::memory:'));
-        $this->sc->setConnectionManager('foo1', $manager1);
-        $this->sc->setConnectionManager('foo2', $manager2);
+        $this->sc->setConnectionManager($manager1);
+        $this->sc->setConnectionManager($manager2);
         $this->sc->closeConnections();
         $this->assertNull($manager1->connection);
         $this->assertNull($manager2->connection);
@@ -444,7 +444,7 @@ class StandardServiceContainerTest extends BaseTestCase
      */
     public function testGetConnectionReturnsWriteConnectionByDefault()
     {
-        $this->sc->setConnectionManager('foo', new TestableConnectionManagerSingle());
+        $this->sc->setConnectionManager(new TestableConnectionManagerSingle('foo'));
         $this->sc->setAdapter('foo', new SqliteAdapter());
         $this->assertEquals('write', $this->sc->getConnection('foo'));
     }
@@ -454,7 +454,7 @@ class StandardServiceContainerTest extends BaseTestCase
      */
     public function testGetConnectionReturnsWriteConnectionWhenAskedExplicitly()
     {
-        $this->sc->setConnectionManager('foo', new TestableConnectionManagerSingle());
+        $this->sc->setConnectionManager(new TestableConnectionManagerSingle('foo'));
         $this->sc->setAdapter('foo', new SqliteAdapter());
         $this->assertEquals('write', $this->sc->getConnection('foo', ServiceContainerInterface::CONNECTION_WRITE));
     }
@@ -464,7 +464,7 @@ class StandardServiceContainerTest extends BaseTestCase
      */
     public function testGetConnectionReturnsReadConnectionWhenAskedExplicitly()
     {
-        $this->sc->setConnectionManager('foo', new TestableConnectionManagerSingle());
+        $this->sc->setConnectionManager(new TestableConnectionManagerSingle('foo'));
         $this->sc->setAdapter('foo', new SqliteAdapter());
         $this->assertEquals('read', $this->sc->getConnection('foo', ServiceContainerInterface::CONNECTION_READ));
     }
@@ -474,7 +474,7 @@ class StandardServiceContainerTest extends BaseTestCase
      */
     public function testGetConnectionReturnsConnectionForDefaultDatasourceByDefault()
     {
-        $this->sc->setConnectionManager('default', new TestableConnectionManagerSingle());
+        $this->sc->setConnectionManager(new TestableConnectionManagerSingle('default'));
         $this->sc->setAdapter('default', new SqliteAdapter());
         $this->assertEquals('write', $this->sc->getConnection());
     }
@@ -484,7 +484,7 @@ class StandardServiceContainerTest extends BaseTestCase
      */
     public function testGetWriteConnectionReturnsWriteConnectionForAGivenDatasource()
     {
-        $this->sc->setConnectionManager('foo', new TestableConnectionManagerSingle());
+        $this->sc->setConnectionManager(new TestableConnectionManagerSingle('foo'));
         $this->sc->setAdapter('foo', new SqliteAdapter());
         $this->assertEquals('write', $this->sc->getWriteConnection('foo'));
     }
@@ -494,7 +494,7 @@ class StandardServiceContainerTest extends BaseTestCase
      */
     public function testGetReadConnectionReturnsReadConnectionForAGivenDatasource()
     {
-        $this->sc->setConnectionManager('foo', new TestableConnectionManagerSingle());
+        $this->sc->setConnectionManager(new TestableConnectionManagerSingle('foo'));
         $this->sc->setAdapter('foo', new SqliteAdapter());
         $this->assertEquals('read', $this->sc->getReadConnection('foo'));
     }


### PR DESCRIPTION
This is forced using a constructor.

Also, StandardServiceContainer::setManager() no longer have the manager name
as first argument but retrieve it from the manager itself.