### PR TITLE
Monolog return type compatibility

### DIFF
--- a/tests/Propel/Tests/Runtime/Connection/PropelPDOTest.php
+++ b/tests/Propel/Tests/Runtime/Connection/PropelPDOTest.php
@@ -559,7 +559,7 @@ class LastMessageHandler extends AbstractHandler
 {
     public $latestMessage = '';
 
-    public function handle(array $record)
+    public function handle(array $record): bool
     {
         $this->latestMessage = (string)$record['message'];
 

--- a/tests/composer/composer-symfony6-max.json
+++ b/tests/composer/composer-symfony6-max.json
@@ -29,7 +29,7 @@
     "require-dev": {
         "ext-pdo": "*",
         "ext-json": "*",
-        "monolog/monolog": "^1.3",
+        "monolog/monolog": "^2.3",
         "phpstan/phpstan": "^0.12.4",
         "phpunit/phpunit": "^9.5.0",
         "spryker/code-sniffer": "^0.15.6",


### PR DESCRIPTION
This happen when running tests on PHP 8.1 with monolog 2.