### PR TITLE
Fix issue with identifier quoting being ignored

### DIFF
--- a/src/Propel/Generator/Behavior/Archivable/ArchivableBehavior.php
+++ b/src/Propel/Generator/Behavior/Archivable/ArchivableBehavior.php
@@ -100,7 +100,7 @@ class ArchivableBehavior extends Behavior
                 'package' => $table->getPackage(),
                 'schema' => $table->getSchema(),
                 'namespace' => $table->getNamespace() ? '\\' . $table->getNamespace() : null,
-                'identifierQuoting' => $table->getIdentifierQuoting(),
+                'identifierQuoting' => $table->isIdentifierQuotingEnabled(),
             ]);
             $archiveTable->isArchiveTable = true;
             // copy all the columns

--- a/src/Propel/Generator/Behavior/I18n/I18nBehavior.php
+++ b/src/Propel/Generator/Behavior/I18n/I18nBehavior.php
@@ -230,7 +230,7 @@ class I18nBehavior extends Behavior
                 'schema' => $table->getSchema(),
                 'namespace' => $table->getNamespace() ? '\\' . $table->getNamespace() : null,
                 'skipSql' => $table->isSkipSql(),
-                'identifierQuoting' => $table->getIdentifierQuoting(),
+                'identifierQuoting' => $table->isIdentifierQuotingEnabled(),
             ]);
 
             // every behavior adding a table should re-execute database behaviors

--- a/src/Propel/Generator/Model/Table.php
+++ b/src/Propel/Generator/Model/Table.php
@@ -70,7 +70,7 @@ class Table extends ScopedMappingModel implements IdMethod
 
     private string $commonName;
     private string $originCommonName;
-    private string $description;
+    private ?string $description = null;
     private string $phpName;
     private string $idMethod;
     private bool $allowPkInsert = false;
@@ -1171,9 +1171,9 @@ class Table extends ScopedMappingModel implements IdMethod
     /**
      * Returns the table description.
      *
-     * @return string
+     * @return string|null
      */
-    public function getDescription()
+    public function getDescription(): ?string
     {
         return $this->description;
     }
@@ -1195,7 +1195,7 @@ class Table extends ScopedMappingModel implements IdMethod
      *
      * @return void
      */
-    public function setDescription($description)
+    public function setDescription(?string $description)
     {
         $this->description = $description;
     }

--- a/src/Propel/Generator/Model/Table.php
+++ b/src/Propel/Generator/Model/Table.php
@@ -83,7 +83,7 @@ class Table extends ScopedMappingModel implements IdMethod
     private array $referrers = [];
 
     private bool $containsForeignPK = false;
-    private ?Column $inheritanceColumn;
+    private ?Column $inheritanceColumn = null;
     private bool $skipSql = false;
     private bool $readOnly = false;
     private bool $isAbstract = false;


### PR DESCRIPTION
This PR addresses a bug that prevents identifier quoting from being enabled when defined on the `database` node of the schema config.  Some additional strict typing was added in the process.