### PR TITLE
Bug by query with table relationships one to n

### DIFF
--- a/src/Propel/Runtime/Formatter/ObjectFormatter.php
+++ b/src/Propel/Runtime/Formatter/ObjectFormatter.php
@@ -41,6 +41,7 @@ class ObjectFormatter extends AbstractFormatter
             $dataFetcher = $this->getDataFetcher();
         }
 
+        $collectionInstanceIds = array();
         $collection = $this->getCollection();
 
         if ($this->isWithOneToMany()) {
@@ -54,13 +55,22 @@ class ObjectFormatter extends AbstractFormatter
 
                 if (!isset($this->objects[$serializedPk])) {
                     $this->objects[$serializedPk] = $object;
+                    $collectionInstanceIds[] = spl_object_id($object);
                     $collection[] = $object;
                 }
             }
         } else {
             // only many-to-one relationships
             foreach ($dataFetcher as $row) {
-                $collection[] = clone $this->getAllObjectsFromRow($row);
+                $object = $this->getAllObjectsFromRow($row);
+                $objectId = spl_object_id($object);
+                if(in_array($objectId, $collectionInstanceIds))
+                {
+                    throw new Exception('Duplicate ObjectIds were found in the data collection.');                    
+                }
+                
+                $collectionInstanceIds[] = spl_object_id($object);
+                $collection[] = $object;
             }
         }
         $dataFetcher->close();

--- a/src/Propel/Runtime/Formatter/ObjectFormatter.php
+++ b/src/Propel/Runtime/Formatter/ObjectFormatter.php
@@ -60,7 +60,7 @@ class ObjectFormatter extends AbstractFormatter
         } else {
             // only many-to-one relationships
             foreach ($dataFetcher as $row) {
-                $collection[] = $this->getAllObjectsFromRow($row);
+                $collection[] = clone $this->getAllObjectsFromRow($row);
             }
         }
         $dataFetcher->close();


### PR DESCRIPTION
At this point, problems arise if there is a one to n relationship to its table (tableOne -> tableN). If you build a query from tableOne and now add a withColumn(virtualColumn), all the different ones at tableN will get the same content because the same ObjectId is always fetched by the InstancePoolTrait. Since in my view the ObjectFormatter->format is only used for the find methods, a clone would be a good bug fix for one to n relationships.

user1 (baseball & football) user2 (baseball)

UserOneQuery::create()->useHobbyManyQuery()->endUse()->withColumn(HobbyManyTableMap::COL_HOBBY)->find();
result: 
-user1 | football
-user1 | football
-user2 | baseball

** Update
I have found an alternative to the clone, Propel::disableInstancePooling(). I am now a little unsure which is the better approach for the problem described.