### PR TITLE
Adjust generated code for type strictness.

### DIFF
--- a/src/Propel/Generator/Behavior/Archivable/templates/objectArchive.php
+++ b/src/Propel/Generator/Behavior/Archivable/templates/objectArchive.php
@@ -6,7 +6,7 @@
  *
  * @param ConnectionInterface $con Optional connection object
  *
- * @throws PropelException If the object is new
+ * @throws \Propel\Runtime\Exception\PropelException If the object is new
  *
  * @return     <?php echo $archiveTablePhpName ?> The archive object based on this object
  */

--- a/src/Propel/Generator/Behavior/Archivable/templates/objectRestoreFromArchive.php
+++ b/src/Propel/Generator/Behavior/Archivable/templates/objectRestoreFromArchive.php
@@ -5,7 +5,7 @@
  *
  * @param ConnectionInterface $con Optional connection object
  *
- * @throws PropelException If the object has no corresponding archive.
+ * @throws \Propel\Runtime\Exception\PropelException If the object has no corresponding archive.
  *
  * @return $this The current object (for fluent API support)
  */

--- a/src/Propel/Generator/Behavior/Archivable/templates/queryDeleteWithoutArchive.php
+++ b/src/Propel/Generator/Behavior/Archivable/templates/queryDeleteWithoutArchive.php
@@ -4,7 +4,7 @@
  *
  * @param      ConnectionInterface $con    Connection to use.
  *
- * @return integer the number of deleted rows
+ * @return int The number of deleted rows
  */
 public function deleteWithoutArchive($con = null): int
 {
@@ -18,7 +18,7 @@ public function deleteWithoutArchive($con = null): int
  *
  * @param      ConnectionInterface $con    Connection to use.
  *
- * @return integer the number of deleted rows
+ * @return int The number of deleted rows
  */
 public function deleteAllWithoutArchive($con = null): int
 {

--- a/src/Propel/Generator/Behavior/Archivable/templates/queryUpdateWithoutArchive.php
+++ b/src/Propel/Generator/Behavior/Archivable/templates/queryUpdateWithoutArchive.php
@@ -6,7 +6,7 @@
  * @param      ConnectionInterface $con an optional connection object
  * @param      bool $forceIndividualSaves If false (default), the resulting call is a Criteria::doUpdate(), ortherwise it is a series of save() calls on all the found objects
  *
- * @return integer the number of deleted rows
+ * @return int The number of deleted rows
  */
 public function updateWithoutArchive($values, $con = null, $forceIndividualSaves = false): int
 {

--- a/src/Propel/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceBehavior.php
+++ b/src/Propel/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceBehavior.php
@@ -332,7 +332,7 @@ public function syncParentToChild($parentClass \$parent): void
  *
  * @return    " . $parentClass . " The parent object
  */
-public function getParentOrCreate(\$con = null)
+public function getParentOrCreate(?ConnectionInterface \$con = null)
 {
     if (\$this->isNew()) {
         if (\$this->isPrimaryKeyNull()) {
@@ -374,7 +374,7 @@ public function getParentOrCreate(\$con = null)
  *
  * @return    " . $cptype . " The primary key of the parent object
  */
-public function getSyncParent(\$con = null)
+public function getSyncParent(?ConnectionInterface \$con = null)
 {
     \$parent = \$this->getParentOrCreate(\$con);";
         foreach ($parentTable->getColumns() as $column) {

--- a/src/Propel/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceParentBehavior.php
+++ b/src/Propel/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceParentBehavior.php
@@ -104,7 +104,7 @@ public function hasChildObject(): bool
 /**
  * Get the child object of this object
  *
- * @return    mixed
+ * @return mixed
  */
 public function getChildObject()
 {

--- a/src/Propel/Generator/Behavior/Delegate/DelegateBehavior.php
+++ b/src/Propel/Generator/Behavior/Delegate/DelegateBehavior.php
@@ -219,7 +219,7 @@ if (method_exists({$ARFQCN}::class, \$name)) {
             }
         }
 
-        $newResult .= "{$indent}\$result = array({$values}\n{$indent});";
+        $newResult .= "{$indent}\$result = [{$values}\n{$indent}];";
         $text = str_replace($matches[1], ltrim($newResult), $text);
         $p->replaceMethod('toArray', $text);
         $script = $p->getCode();

--- a/src/Propel/Generator/Behavior/NestedSet/NestedSetBehaviorObjectBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/NestedSet/NestedSetBehaviorObjectBuilderModifier.php
@@ -281,9 +281,10 @@ if (\$this->isInTree()) {
 /**
  * Execute queries that were saved to be run inside the save transaction
  *
- * @param  ConnectionInterface \$con Connection to use.
+ * @param ConnectionInterface \$con Connection to use.
+ * @return void
  */
-protected function processNestedSetQueries(ConnectionInterface \$con)
+protected function processNestedSetQueries(ConnectionInterface \$con): void
 {
     foreach (\$this->nestedSetQueries as ['callable' => \$callable, 'arguments' => \$arguments]) {
         \$arguments[] = \$con;
@@ -306,9 +307,9 @@ protected function processNestedSetQueries(ConnectionInterface \$con)
  * Proxy getter method for the left value of the nested set model.
  * It provides a generic way to get the value, whatever the actual column name is.
  *
- * @return     int The nested set left value
+ * @return int The nested set left value
  */
-public function getLeftValue()
+public function getLeftValue(): int
 {
     return \$this->{$this->getColumnAttribute('left_column')};
 }
@@ -327,9 +328,9 @@ public function getLeftValue()
  * Proxy getter method for the right value of the nested set model.
  * It provides a generic way to get the value, whatever the actual column name is.
  *
- * @return     int The nested set right value
+ * @return int The nested set right value
  */
-public function getRightValue()
+public function getRightValue(): int
 {
     return \$this->{$this->getColumnAttribute('right_column')};
 }
@@ -348,9 +349,9 @@ public function getRightValue()
  * Proxy getter method for the level value of the nested set model.
  * It provides a generic way to get the value, whatever the actual column name is.
  *
- * @return     int The nested set level value
+ * @return int The nested set level value
  */
-public function getLevel()
+public function getLevel(): int
 {
     return \$this->{$this->getColumnAttribute('level_column')};
 }
@@ -369,9 +370,9 @@ public function getLevel()
  * Proxy getter method for the scope value of the nested set model.
  * It provides a generic way to get the value, whatever the actual column name is.
  *
- * @return     int The nested set scope value
+ * @return int The nested set scope value
  */
-public function getScopeValue()
+public function getScopeValue(): int
 {
     return \$this->{$this->getColumnAttribute('scope_column')};
 }
@@ -404,11 +405,13 @@ public function getScopeValue()
  * It provides a generic way to set the value, whatever the actual column name is.
  *
  * @param      int \$v The nested set right value
- * @return     \$this|{$objectClassName} The current object (for fluent API support)
+ * @return     \$this The current object (for fluent API support)
  */
-public function setRightValue(\$v)
+public function setRightValue(int \$v)
 {
-    return \$this->set{$this->getColumnPhpName('right_column')}(\$v);
+    \$this->set{$this->getColumnPhpName('right_column')}(\$v);
+
+    return \$this;
 }
 ";
     }
@@ -428,11 +431,13 @@ public function setRightValue(\$v)
  * It provides a generic way to set the value, whatever the actual column name is.
  *
  * @param      int \$v The nested set level value
- * @return     \$this|{$objectClassName} The current object (for fluent API support)
+ * @return     \$this The current object (for fluent API support)
  */
-public function setLevel(\$v)
+public function setLevel(int \$v)
 {
-    return \$this->set{$this->getColumnPhpName('level_column')}(\$v);
+    \$this->set{$this->getColumnPhpName('level_column')}(\$v);
+
+    return \$this;
 }
 ";
     }
@@ -452,11 +457,13 @@ public function setLevel(\$v)
  * It provides a generic way to set the value, whatever the actual column name is.
  *
  * @param      int \$v The nested set scope value
- * @return     \$this|{$objectClassName} The current object (for fluent API support)
+ * @return     \$this The current object (for fluent API support)
  */
-public function setScopeValue(\$v)
+public function setScopeValue(int \$v)
 {
-    return \$this->set{$this->getColumnPhpName('scope_column')}(\$v);
+    \$this->set{$this->getColumnPhpName('scope_column')}(\$v);
+
+    return \$this;
 }
 ";
     }
@@ -474,7 +481,7 @@ public function setScopeValue(\$v)
 /**
  * Creates the supplied node as the root node.
  *
- * @return     \$this|{$objectClassName} The current object (for fluent API support)
+ * @return     \$this The current object (for fluent API support)
  * @throws     PropelException
  */
 public function makeRoot()
@@ -505,7 +512,7 @@ public function makeRoot()
  *
  * @return     bool
  */
-public function isInTree()
+public function isInTree(): bool
 {
     return \$this->getLeftValue() > 0 && \$this->getRightValue() > \$this->getLeftValue();
 }
@@ -523,9 +530,9 @@ public function isInTree()
 /**
  * Tests if node is a root
  *
- * @return     bool
+ * @return bool
  */
-public function isRoot()
+public function isRoot(): bool
 {
     return \$this->isInTree() && \$this->getLeftValue() == 1;
 }
@@ -545,7 +552,7 @@ public function isRoot()
  *
  * @return     bool
  */
-public function isLeaf()
+public function isLeaf(): bool
 {
     return \$this->isInTree() &&  (\$this->getRightValue() - \$this->getLeftValue()) == 1;
 }
@@ -568,7 +575,7 @@ public function isLeaf()
  * @param      $objectClassName \$parent Propel node object
  * @return     bool
  */
-public function isDescendantOf($objectClassName \$parent)
+public function isDescendantOf($objectClassName \$parent): bool
 {";
         if ($this->behavior->useScope()) {
             $script .= "
@@ -599,7 +606,7 @@ public function isDescendantOf($objectClassName \$parent)
  * @param      $objectClassName \$child Propel node object
  * @return     bool
  */
-public function isAncestorOf($objectClassName \$child)
+public function isAncestorOf($objectClassName \$child): bool
 {
     return \$child->isDescendantOf(\$this);
 }
@@ -642,7 +649,7 @@ public function hasParent(): bool
  * Use moveTofirstChildOf() or moveToLastChildOf() for that purpose
  *
  * @param      $objectClassName \$parent
- * @return     \$this|{$objectClassName} The current object, for fluid interface
+ * @return     \$this The current object, for fluid interface
  */
 public function setParent($objectClassName \$parent = null)
 {
@@ -671,7 +678,7 @@ public function setParent($objectClassName \$parent = null)
  * @param  ConnectionInterface \$con Connection to use.
  * @return $objectClassName|null Propel object if exists else null
  */
-public function getParent(ConnectionInterface \$con = null)
+public function getParent(?ConnectionInterface \$con = null)
 {
     if (null === \$this->aNestedSetParent && \$this->hasParent()) {
         \$this->aNestedSetParent = {$queryClassName}::create()
@@ -701,7 +708,7 @@ public function getParent(ConnectionInterface \$con = null)
  * @param      ConnectionInterface \$con Connection to use.
  * @return     bool
  */
-public function hasPrevSibling(ConnectionInterface \$con = null): bool
+public function hasPrevSibling(?ConnectionInterface \$con = null): bool
 {
     if (!{$queryClassName}::isValid(\$this)) {
         return false;
@@ -736,7 +743,7 @@ public function hasPrevSibling(ConnectionInterface \$con = null): bool
  * @param      ConnectionInterface \$con Connection to use.
  * @return     $objectClassName|null         Propel object if exists else null
  */
-public function getPrevSibling(ConnectionInterface \$con = null)
+public function getPrevSibling(?ConnectionInterface \$con = null)
 {
     return $queryClassName::create()
         ->filterBy" . $this->getColumnPhpName('right_column') . '($this->getLeftValue() - 1)';
@@ -766,7 +773,7 @@ public function getPrevSibling(ConnectionInterface \$con = null)
  * @param      ConnectionInterface \$con Connection to use.
  * @return     bool
  */
-public function hasNextSibling(ConnectionInterface \$con = null): bool
+public function hasNextSibling(?ConnectionInterface \$con = null): bool
 {
     if (!{$queryClassName}::isValid(\$this)) {
         return false;
@@ -801,7 +808,7 @@ public function hasNextSibling(ConnectionInterface \$con = null): bool
  * @param      ConnectionInterface \$con Connection to use.
  * @return     $objectClassName|null         Propel object if exists else null
  */
-public function getNextSibling(ConnectionInterface \$con = null)
+public function getNextSibling(?ConnectionInterface \$con = null)
 {
     return $queryClassName::create()
         ->filterBy" . $this->getColumnPhpName('left_column') . '($this->getRightValue() + 1)';
@@ -831,7 +838,7 @@ public function getNextSibling(ConnectionInterface \$con = null)
  *
  * @return     void
  */
-public function clearNestedSetChildren()
+public function clearNestedSetChildren(): void
 {
     \$this->collNestedSetChildren = null;
 }
@@ -851,7 +858,7 @@ public function clearNestedSetChildren()
  *
  * @return     void
  */
-public function initNestedSetChildren()
+public function initNestedSetChildren(): void
 {
     \$collectionClassName = " . $this->builder->getNewTableMapBuilder($this->table)->getFullyQualifiedClassName() . "::getTableMap()->getCollectionClassName();
 
@@ -881,7 +888,7 @@ public function initNestedSetChildren()
  *
  * @return     void
  */
-public function addNestedSetChild($objectClassName $objectName)
+public function addNestedSetChild($objectClassName $objectName): void
 {
     if (null === \$this->collNestedSetChildren) {
         \$this->initNestedSetChildren();
@@ -932,7 +939,7 @@ public function hasChildren(): bool
  * @param      ConnectionInterface \$con Connection to use.
  * @return     ObjectCollection|{$objectClassName}[] List of $objectClassName objects
  */
-public function getChildren(Criteria \$criteria = null, ConnectionInterface \$con = null)
+public function getChildren(?Criteria \$criteria = null, ?ConnectionInterface \$con = null)
 {
     if (null === \$this->collNestedSetChildren || null !== \$criteria) {
         if (\$this->isLeaf() || (\$this->isNew() && null === \$this->collNestedSetChildren)) {
@@ -972,7 +979,7 @@ public function getChildren(Criteria \$criteria = null, ConnectionInterface \$co
  * @param      ConnectionInterface \$con Connection to use.
  * @return     int       Number of children
  */
-public function countChildren(Criteria \$criteria = null, ConnectionInterface \$con = null)
+public function countChildren(?Criteria \$criteria = null, ?ConnectionInterface \$con = null)
 {
     if (null === \$this->collNestedSetChildren || null !== \$criteria) {
         if (\$this->isLeaf() || (\$this->isNew() && null === \$this->collNestedSetChildren)) {
@@ -1006,7 +1013,7 @@ public function countChildren(Criteria \$criteria = null, ConnectionInterface \$
  * @param      ConnectionInterface \$con Connection to use.
  * @return     $objectClassName|null First child or null if this is a leaf
  */
-public function getFirstChild(Criteria \$criteria = null, ConnectionInterface \$con = null)
+public function getFirstChild(?Criteria \$criteria = null, ?ConnectionInterface \$con = null)
 {
     if (\$this->isLeaf()) {
         return null;
@@ -1038,7 +1045,7 @@ public function getFirstChild(Criteria \$criteria = null, ConnectionInterface \$
  * @param      ConnectionInterface \$con Connection to use.
  * @return     $objectClassName|null Last child or null if this is a leaf
  */
-public function getLastChild(Criteria \$criteria = null, ConnectionInterface \$con = null)
+public function getLastChild(?Criteria \$criteria = null, ?ConnectionInterface \$con = null)
 {
     if (\$this->isLeaf()) {
         return null;
@@ -1072,7 +1079,7 @@ public function getLastChild(Criteria \$criteria = null, ConnectionInterface \$c
  *
  * @return ObjectCollection|{$objectClassName}[] List of $objectClassName objects
  */
-public function getSiblings(\$includeNode = false, Criteria \$criteria = null, ConnectionInterface \$con = null)
+public function getSiblings(\$includeNode = false, ?Criteria \$criteria = null, ?ConnectionInterface \$con = null)
 {
     if (\$this->isRoot()) {
         return array();
@@ -1108,7 +1115,7 @@ public function getSiblings(\$includeNode = false, Criteria \$criteria = null, C
  * @param      ConnectionInterface \$con Connection to use.
  * @return     ObjectCollection|{$objectClassName}[] List of $objectClassName objects
  */
-public function getDescendants(Criteria \$criteria = null, ConnectionInterface \$con = null)
+public function getDescendants(?Criteria \$criteria = null, ?ConnectionInterface \$con = null)
 {
     if (\$this->isLeaf()) {
         return array();
@@ -1139,7 +1146,7 @@ public function getDescendants(Criteria \$criteria = null, ConnectionInterface \
  * @param      ConnectionInterface \$con Connection to use.
  * @return     int         Number of descendants
  */
-public function countDescendants(Criteria \$criteria = null, ConnectionInterface \$con = null)
+public function countDescendants(?Criteria \$criteria = null, ?ConnectionInterface \$con = null)
 {
     if (\$this->isLeaf()) {
         // save one query
@@ -1171,7 +1178,7 @@ public function countDescendants(Criteria \$criteria = null, ConnectionInterface
  * @param      ConnectionInterface \$con Connection to use.
  * @return     ObjectCollection|{$objectClassName}[] List of $objectClassName objects
  */
-public function getBranch(Criteria \$criteria = null, ConnectionInterface \$con = null)
+public function getBranch(?Criteria \$criteria = null, ?ConnectionInterface \$con = null)
 {
     return $queryClassName::create(null, \$criteria)
         ->branchOf(\$this)
@@ -1200,7 +1207,7 @@ public function getBranch(Criteria \$criteria = null, ConnectionInterface \$con 
  * @param      ConnectionInterface \$con Connection to use.
  * @return     ObjectCollection|{$objectClassName}[] List of $objectClassName objects
  */
-public function getAncestors(Criteria \$criteria = null, ConnectionInterface \$con = null)
+public function getAncestors(?Criteria \$criteria = null, ?ConnectionInterface \$con = null)
 {
     if (\$this->isRoot()) {
         // save one query
@@ -1232,7 +1239,7 @@ public function getAncestors(Criteria \$criteria = null, ConnectionInterface \$c
  *
  * @param      $objectClassName \$child    Propel object for child node
  *
- * @return     \$this|{$objectClassName} The current Propel object
+ * @return     \$this The current Propel object
  */
 public function addChild($objectClassName \$child)
 {
@@ -1265,7 +1272,7 @@ public function addChild($objectClassName \$child)
  *
  * @param      $objectClassName \$parent    Propel object for parent node
  *
- * @return     \$this|{$objectClassName} The current Propel object
+ * @return     \$this The current Propel object
  */
 public function insertAsFirstChildOf($objectClassName \$parent)
 {
@@ -1289,10 +1296,10 @@ public function insertAsFirstChildOf($objectClassName \$parent)
     \$parent->addNestedSetChild(\$this);
 
     // Keep the tree modification query for the save() transaction
-    \$this->nestedSetQueries[] = array(
+    \$this->nestedSetQueries[] = [
         'callable'  => array('$queryClassName', 'makeRoomForLeaf'),
         'arguments' => array(\$left" . ($useScope ? ', $scope' : '') . ", \$this->isNew() ? null : \$this)
-    );
+    ];
 
     return \$this;
 }
@@ -1330,7 +1337,7 @@ public function insertAsFirstChildOf($objectClassName \$parent)
  *
  * @param      $objectClassName \$sibling    Propel object for parent node
  *
- * @return     \$this|{$objectClassName} The current Propel object
+ * @return     \$this The current Propel object
  */
 public function insertAsPrevSiblingOf($objectClassName \$sibling)
 {
@@ -1349,10 +1356,10 @@ public function insertAsPrevSiblingOf($objectClassName \$sibling)
         }
         $script .= "
     // Keep the tree modification query for the save() transaction
-    \$this->nestedSetQueries []= array(
+    \$this->nestedSetQueries []= [
         'callable'  => array('$queryClassName', 'makeRoomForLeaf'),
         'arguments' => array(\$left" . ($useScope ? ', $scope' : '') . ", \$this->isNew() ? null : \$this)
-    );
+    ];
 
     return \$this;
 }
@@ -1378,7 +1385,7 @@ public function insertAsPrevSiblingOf($objectClassName \$sibling)
  *
  * @param      $objectClassName \$sibling    Propel object for parent node
  *
- * @return     \$this|{$objectClassName} The current Propel object
+ * @return     \$this The current Propel object
  */
 public function insertAsNextSiblingOf($objectClassName \$sibling)
 {
@@ -1397,10 +1404,10 @@ public function insertAsNextSiblingOf($objectClassName \$sibling)
         }
         $script .= "
     // Keep the tree modification query for the save() transaction
-    \$this->nestedSetQueries []= array(
-        'callable'  => array('$queryClassName', 'makeRoomForLeaf'),
-        'arguments' => array(\$left" . ($useScope ? ', $scope' : '') . ", \$this->isNew() ? null : \$this)
-    );
+    \$this->nestedSetQueries []= [
+        'callable'  => ['$queryClassName', 'makeRoomForLeaf'],
+        'arguments' => [\$left" . ($useScope ? ', $scope' : '') . ", \$this->isNew() ? null : \$this],
+    ];
 
     return \$this;
 }
@@ -1423,9 +1430,9 @@ public function insertAsNextSiblingOf($objectClassName \$sibling)
  * @param      $objectClassName \$parent    Propel object for parent node
  * @param      ConnectionInterface \$con    Connection to use.
  *
- * @return     \$this|{$objectClassName} The current Propel object
+ * @return     \$this The current Propel object
  */
-public function moveToFirstChildOf($objectClassName \$parent, ConnectionInterface \$con = null)
+public function moveToFirstChildOf($objectClassName \$parent, ?ConnectionInterface \$con = null)
 {
     if (!\$this->isInTree()) {
         throw new PropelException('A $objectClassName object must be already in the tree to be moved. Use the insertAsFirstChildOf() instead.');
@@ -1460,9 +1467,9 @@ public function moveToFirstChildOf($objectClassName \$parent, ConnectionInterfac
  * @param      $objectClassName \$parent    Propel object for parent node
  * @param      ConnectionInterface \$con    Connection to use.
  *
- * @return     \$this|{$objectClassName} The current Propel object
+ * @return     \$this The current Propel object
  */
-public function moveToLastChildOf($objectClassName \$parent, ConnectionInterface \$con = null)
+public function moveToLastChildOf($objectClassName \$parent, ?ConnectionInterface \$con = null)
 {
     if (!\$this->isInTree()) {
         throw new PropelException('A $objectClassName object must be already in the tree to be moved. Use the insertAsLastChildOf() instead.');
@@ -1497,9 +1504,9 @@ public function moveToLastChildOf($objectClassName \$parent, ConnectionInterface
  * @param      $objectClassName \$sibling    Propel object for sibling node
  * @param      ConnectionInterface \$con    Connection to use.
  *
- * @return     \$this|{$objectClassName} The current Propel object
+ * @return     \$this The current Propel object
  */
-public function moveToPrevSiblingOf($objectClassName \$sibling, ConnectionInterface \$con = null)
+public function moveToPrevSiblingOf($objectClassName \$sibling, ?ConnectionInterface \$con = null)
 {
     if (!\$this->isInTree()) {
         throw new PropelException('A $objectClassName object must be already in the tree to be moved. Use the insertAsPrevSiblingOf() instead.');
@@ -1537,9 +1544,9 @@ public function moveToPrevSiblingOf($objectClassName \$sibling, ConnectionInterf
  * @param      $objectClassName \$sibling    Propel object for sibling node
  * @param      ConnectionInterface \$con    Connection to use.
  *
- * @return     \$this|{$objectClassName} The current Propel object
+ * @return     \$this The current Propel object
  */
-public function moveToNextSiblingOf($objectClassName \$sibling, ConnectionInterface \$con = null)
+public function moveToNextSiblingOf($objectClassName \$sibling, ?ConnectionInterface \$con = null)
 {
     if (!\$this->isInTree()) {
         throw new PropelException('A $objectClassName object must be already in the tree to be moved. Use the insertAsNextSiblingOf() instead.');
@@ -1579,7 +1586,7 @@ public function moveToNextSiblingOf($objectClassName \$sibling, ConnectionInterf
  * @param      int    \$levelDelta Delta to add to the levels
  * @param      ConnectionInterface \$con        Connection to use.
  */
-protected function moveSubtreeTo(\$destLeft, \$levelDelta" . ($this->behavior->useScope() ? ', $targetScope = null' : '') . ", ConnectionInterface \$con = null)
+protected function moveSubtreeTo(\$destLeft, \$levelDelta" . ($this->behavior->useScope() ? ', $targetScope = null' : '') . ", ?ConnectionInterface \$con = null)
 {
     \$left  = \$this->getLeftValue();
     \$right = \$this->getRightValue();";
@@ -1680,7 +1687,7 @@ protected function moveSubtreeTo(\$destLeft, \$levelDelta" . ($this->behavior->u
  *
  * @return     int         number of deleted nodes
  */
-public function deleteDescendants(ConnectionInterface \$con = null)
+public function deleteDescendants(?ConnectionInterface \$con = null)
 {
     if (\$this->isLeaf()) {
         // save one query

--- a/src/Propel/Generator/Behavior/NestedSet/NestedSetBehaviorQueryBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/NestedSet/NestedSetBehaviorQueryBuilderModifier.php
@@ -154,11 +154,13 @@ class NestedSetBehaviorQueryBuilderModifier
 /**
  * Filter the query to restrict the result to root objects
  *
- * @return    \$this|{$this->queryClassName} The current query, for fluid interface
+ * @return    \$this The current query, for fluid interface
  */
 public function treeRoots()
 {
-    return \$this->addUsingAlias({$this->objectClassName}::LEFT_COL, 1, Criteria::EQUAL);
+    \$this->addUsingAlias({$this->objectClassName}::LEFT_COL, 1, Criteria::EQUAL);
+
+    return \$this;
 }
 ";
     }
@@ -174,13 +176,15 @@ public function treeRoots()
 /**
  * Returns the objects in a certain tree, from the tree scope
  *
- * @param     int \$scope        Scope to determine which objects node to return
+ * @param     int|null \$scope        Scope to determine which objects node to return
  *
- * @return    \$this|{$this->queryClassName} The current query, for fluid interface
+ * @return    \$this The current query, for fluid interface
  */
-public function inTree(\$scope = null)
+public function inTree(?int \$scope = null)
 {
-    return \$this->addUsingAlias({$this->objectClassName}::SCOPE_COL, \$scope, Criteria::EQUAL);
+    \$this->addUsingAlias({$this->objectClassName}::SCOPE_COL, \$scope, Criteria::EQUAL);
+
+    return \$this;
 }
 ";
     }
@@ -199,11 +203,11 @@ public function inTree(\$scope = null)
  *
  * @param     {$this->objectClassName} $objectName The object to use for descendant search
  *
- * @return    \$this|{$this->queryClassName} The current query, for fluid interface
+ * @return    \$this The current query, for fluid interface
  */
 public function descendantsOf($this->objectClassName $objectName)
 {
-    return \$this";
+    \$this";
         if ($this->behavior->useScope()) {
             $script .= "
         ->inTree({$objectName}->getScopeValue())";
@@ -211,6 +215,8 @@ public function descendantsOf($this->objectClassName $objectName)
         $script .= "
         ->addUsingAlias({$this->objectClassName}::LEFT_COL, {$objectName}->getLeftValue(), Criteria::GREATER_THAN)
         ->addUsingAlias({$this->objectClassName}::LEFT_COL, {$objectName}->getRightValue(), Criteria::LESS_THAN);
+
+    return \$this;
 }
 ";
     }
@@ -230,11 +236,11 @@ public function descendantsOf($this->objectClassName $objectName)
  *
  * @param     {$this->objectClassName} $objectName The object to use for branch search
  *
- * @return    \$this|{$this->queryClassName} The current query, for fluid interface
+ * @return    \$this The current query, for fluid interface
  */
 public function branchOf($this->objectClassName $objectName)
 {
-    return \$this";
+    \$this";
         if ($this->behavior->useScope()) {
             $script .= "
         ->inTree({$objectName}->getScopeValue())";
@@ -242,6 +248,8 @@ public function branchOf($this->objectClassName $objectName)
         $script .= "
         ->addUsingAlias({$this->objectClassName}::LEFT_COL, {$objectName}->getLeftValue(), Criteria::GREATER_EQUAL)
         ->addUsingAlias({$this->objectClassName}::LEFT_COL, {$objectName}->getRightValue(), Criteria::LESS_EQUAL);
+
+    return \$this;
 }
 ";
     }
@@ -260,13 +268,15 @@ public function branchOf($this->objectClassName $objectName)
  *
  * @param     {$this->objectClassName} $objectName The object to use for child search
  *
- * @return    \$this|{$this->queryClassName} The current query, for fluid interface
+ * @return    \$this The current query, for fluid interface
  */
 public function childrenOf($this->objectClassName $objectName)
 {
-    return \$this
+    \$this
         ->descendantsOf($objectName)
         ->addUsingAlias({$this->objectClassName}::LEVEL_COL, {$objectName}->getLevel() + 1, Criteria::EQUAL);
+
+    return \$this;
 }
 ";
     }
@@ -287,18 +297,20 @@ public function childrenOf($this->objectClassName $objectName)
  * @param     {$this->objectClassName} $objectName The object to use for sibling search
  * @param      ConnectionInterface \$con Connection to use.
  *
- * @return    \$this|{$this->queryClassName} The current query, for fluid interface
+ * @return    \$this The current query, for fluid interface
  */
-public function siblingsOf($this->objectClassName $objectName, ConnectionInterface \$con = null)
+public function siblingsOf($this->objectClassName $objectName, ?ConnectionInterface \$con = null)
 {
     if ({$objectName}->isRoot()) {
-        return \$this->
+        \$this->
             add({$this->objectClassName}::LEVEL_COL, '1<>1', Criteria::CUSTOM);
     } else {
-        return \$this
+        \$this
             ->childrenOf({$objectName}->getParent(\$con))
             ->prune($objectName);
     }
+
+    return \$this;
 }
 ";
     }
@@ -317,11 +329,11 @@ public function siblingsOf($this->objectClassName $objectName, ConnectionInterfa
  *
  * @param     {$this->objectClassName} $objectName The object to use for ancestors search
  *
- * @return    \$this|{$this->queryClassName} The current query, for fluid interface
+ * @return    \$this The current query, for fluid interface
  */
 public function ancestorsOf($this->objectClassName $objectName)
 {
-    return \$this";
+    \$this";
         if ($this->behavior->useScope()) {
             $script .= "
         ->inTree({$objectName}->getScopeValue())";
@@ -329,6 +341,8 @@ public function ancestorsOf($this->objectClassName $objectName)
         $script .= "
         ->addUsingAlias({$this->objectClassName}::LEFT_COL, {$objectName}->getLeftValue(), Criteria::LESS_THAN)
         ->addUsingAlias({$this->objectClassName}::RIGHT_COL, {$objectName}->getRightValue(), Criteria::GREATER_THAN);
+
+    return \$this;
 }
 ";
     }
@@ -348,11 +362,11 @@ public function ancestorsOf($this->objectClassName $objectName)
  *
  * @param     {$this->objectClassName} $objectName The object to use for roots search
  *
- * @return    \$this|{$this->queryClassName} The current query, for fluid interface
+ * @return    \$this The current query, for fluid interface
  */
 public function rootsOf($this->objectClassName $objectName)
 {
-    return \$this";
+    \$this";
         if ($this->behavior->useScope()) {
             $script .= "
         ->inTree({$objectName}->getScopeValue())";
@@ -360,6 +374,8 @@ public function rootsOf($this->objectClassName $objectName)
         $script .= "
         ->addUsingAlias({$this->objectClassName}::LEFT_COL, {$objectName}->getLeftValue(), Criteria::LESS_EQUAL)
         ->addUsingAlias({$this->objectClassName}::RIGHT_COL, {$objectName}->getRightValue(), Criteria::GREATER_EQUAL);
+
+    return \$this;
 }
 ";
     }
@@ -377,17 +393,19 @@ public function rootsOf($this->objectClassName $objectName)
  *
  * @param     bool \$reverse if true, reverses the order
  *
- * @return    \$this|{$this->queryClassName} The current query, for fluid interface
+ * @return    \$this The current query, for fluid interface
  */
 public function orderByBranch(\$reverse = false)
 {
     if (\$reverse) {
-        return \$this
+        \$this
             ->addDescendingOrderByColumn({$this->objectClassName}::LEFT_COL);
     } else {
-        return \$this
+        \$this
             ->addAscendingOrderByColumn({$this->objectClassName}::LEFT_COL);
     }
+
+    return \$this;
 }
 ";
     }
@@ -405,19 +423,21 @@ public function orderByBranch(\$reverse = false)
  *
  * @param     bool \$reverse if true, reverses the order
  *
- * @return    \$this|{$this->queryClassName} The current query, for fluid interface
+ * @return    \$this The current query, for fluid interface
  */
 public function orderByLevel(\$reverse = false)
 {
     if (\$reverse) {
-        return \$this
+        \$this
             ->addDescendingOrderByColumn({$this->objectClassName}::LEVEL_COL)
             ->addDescendingOrderByColumn({$this->objectClassName}::LEFT_COL);
     } else {
-        return \$this
+        \$this
             ->addAscendingOrderByColumn({$this->objectClassName}::LEVEL_COL)
             ->addAscendingOrderByColumn({$this->objectClassName}::LEFT_COL);
     }
+
+    return \$this;
 }
 ";
     }
@@ -473,7 +493,7 @@ public function findRoot(" . ($useScope ? '$scope = null, ' : '') . "ConnectionI
  *
  * @return    {$this->objectClassName}[]|ObjectCollection|mixed the list of results, formatted by the current formatter
  */
-public function findRoots(ConnectionInterface \$con = null)
+public function findRoots(?ConnectionInterface \$con = null)
 {
     return \$this
         ->treeRoots()
@@ -537,7 +557,7 @@ public function findTree(" . ($useScope ? '$scope = null, ' : '') . "ConnectionI
  * @param      ConnectionInterface \$con    Connection to use.
  * @return     {$this->objectClassName}[]|ObjectCollection|mixed the list of results, formatted by the current formatter
  */
-static public function retrieveRoots(Criteria \$criteria = null, ConnectionInterface \$con = null)
+static public function retrieveRoots(?Criteria \$criteria = null, ?ConnectionInterface \$con = null)
 {
     if (null === \$criteria) {
         \$criteria = new Criteria($tableMapClassName::DATABASE_NAME);
@@ -613,7 +633,7 @@ static public function retrieveRoot(" . ($useScope ? '$scope = null, ' : '') . "
  * @param      ConnectionInterface \$con    Connection to use.
  * @return     {$this->objectClassName}[]|ObjectCollection|mixed the list of results, formatted by the current formatter
  */
-static public function retrieveTree(" . ($useScope ? '$scope = null, ' : '') . "Criteria \$criteria = null, ConnectionInterface \$con = null)
+static public function retrieveTree(" . ($useScope ? '$scope = null, ' : '') . "Criteria \$criteria = null, ?ConnectionInterface \$con = null)
 {
     if (null === \$criteria) {
         \$criteria = new Criteria($tableMapClassName::DATABASE_NAME);
@@ -727,7 +747,7 @@ static public function deleteTree(" . ($useScope ? '$scope = null, ' : '') . "Co
         $script .= "
  * @param ConnectionInterface \$con Connection to use.
  */
-static public function shiftRLValues(\$delta, \$first, \$last = null" . ($useScope ? ', $scope = null' : '') . ", ConnectionInterface \$con = null)
+static public function shiftRLValues(\$delta, \$first, \$last = null" . ($useScope ? ', $scope = null' : '') . ", ?ConnectionInterface \$con = null)
 {
     if (\$con === null) {
         \$con = Propel::getServiceContainer()->getWriteConnection($tableMapClassName::DATABASE_NAME);
@@ -800,7 +820,7 @@ static public function shiftRLValues(\$delta, \$first, \$last = null" . ($useSco
         $script .= "
  * @param      ConnectionInterface \$con        Connection to use.
  */
-static public function shiftLevel(\$delta, \$first, \$last" . ($useScope ? ', $scope = null' : '') . ", ConnectionInterface \$con = null)
+static public function shiftLevel(\$delta, \$first, \$last" . ($useScope ? ', $scope = null' : '') . ", ?ConnectionInterface \$con = null)
 {
     if (\$con === null) {
         \$con = Propel::getServiceContainer()->getWriteConnection($tableMapClassName::DATABASE_NAME);
@@ -841,7 +861,7 @@ static public function shiftLevel(\$delta, \$first, \$last" . ($useScope ? ', $s
  * @param      $objectClassName \$prune        Object to prune from the update
  * @param      ConnectionInterface \$con        Connection to use.
  */
-static public function updateLoadedNodes(\$prune = null, ConnectionInterface \$con = null)
+static public function updateLoadedNodes(\$prune = null, ?ConnectionInterface \$con = null)
 {
     if (Propel::isInstancePoolingEnabled()) {
         \$keys = [];
@@ -948,7 +968,7 @@ static public function updateLoadedNodes(\$prune = null, ConnectionInterface \$c
  * @param      mixed \$prune    Object to prune from the shift
  * @param      ConnectionInterface \$con    Connection to use.
  */
-static public function makeRoomForLeaf(\$left" . ($useScope ? ', $scope' : '') . ", \$prune = null, ConnectionInterface \$con = null)
+static public function makeRoomForLeaf(\$left" . ($useScope ? ', $scope' : '') . ", \$prune = null, ?ConnectionInterface \$con = null)
 {
     // Update database nodes
     $queryClassName::shiftRLValues(2, \$left, null" . ($useScope ? ', $scope' : '') . ", \$con);
@@ -1031,7 +1051,7 @@ static public function fixLevels(" . ($useScope ? '$scope, ' : '') . "Connection
         if (\$level === null) {
             \$level = 0;
             \$i = 0;
-            \$prev = array(\$obj->getRightValue());
+            \$prev = [\$obj->getRightValue()];
         } else {
             while (\$obj->getRightValue() > \$prev[\$i]) {
                 \$i--;
@@ -1067,7 +1087,7 @@ static public function fixLevels(" . ($useScope ? '$scope, ' : '') . "Connection
  * @param      mixed     \$scope
  * @param      ConnectionInterface \$con  Connection to use.
  */
-public static function setNegativeScope(\$scope, ConnectionInterface \$con = null)
+public static function setNegativeScope(\$scope, ?ConnectionInterface \$con = null)
 {
     //adjust scope value to \$scope
     \$whereCriteria = new Criteria($tableMapClassName::DATABASE_NAME);

--- a/src/Propel/Generator/Behavior/NestedSet/templates/objectInsertAsLastChildOf.php
+++ b/src/Propel/Generator/Behavior/NestedSet/templates/objectInsertAsLastChildOf.php
@@ -30,10 +30,10 @@ public function insertAsLastChildOf(<?= $objectClassName ?> $parent)
     $parent->addNestedSetChild($this);
 
     // Keep the tree modification query for the save() transaction
-    $this->nestedSetQueries []= array(
-        'callable'  => array('<?= $queryClassName ?>', 'makeRoomForLeaf'),
-        'arguments' => array($left<?= $useScope ? ', $scope' : '' ?>, $this->isNew() ? null : $this)
-    );
+    $this->nestedSetQueries []= [
+        'callable'  => ['<?= $queryClassName ?>', 'makeRoomForLeaf'],
+        'arguments' => [$left<?= $useScope ? ', $scope' : '' ?>, $this->isNew() ? null : $this],
+    ];
 
     return $this;
 }

--- a/src/Propel/Generator/Behavior/QueryCache/QueryCacheBehavior.php
+++ b/src/Propel/Generator/Behavior/QueryCache/QueryCacheBehavior.php
@@ -225,7 +225,7 @@ public function cacheFetch(\$key)
     protected function addDoSelect(string &$script): void
     {
         $script .= "
-public function doSelect(ConnectionInterface \$con = null): \Propel\Runtime\DataFetcher\DataFetcherInterface
+public function doSelect(?ConnectionInterface \$con = null): \Propel\Runtime\DataFetcher\DataFetcherInterface
 {
     // check that the columns of the main class are already added (if this is the primary ModelCriteria)
     if (!\$this->hasSelectClause() && !\$this->getPrimaryCriteria()) {
@@ -271,7 +271,7 @@ public function doSelect(ConnectionInterface \$con = null): \Propel\Runtime\Data
     protected function addDoCount(string &$script): void
     {
         $script .= "
-public function doCount(ConnectionInterface \$con = null): \Propel\Runtime\DataFetcher\DataFetcherInterface
+public function doCount(?ConnectionInterface \$con = null): \Propel\Runtime\DataFetcher\DataFetcherInterface
 {
     \$dbMap = Propel::getServiceContainer()->getDatabaseMap(\$this->getDbName());
     \$db = Propel::getServiceContainer()->getAdapter(\$this->getDbName());

--- a/src/Propel/Generator/Behavior/Sortable/SortableBehaviorObjectBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/Sortable/SortableBehaviorObjectBuilderModifier.php
@@ -326,11 +326,13 @@ public function getRank()
  * Wrap the setter for rank value
  *
  * @param     int
- * @return    \$this|{$this->objectClassName}
+ * @return    \$this
  */
 public function setRank(\$v)
 {
-    return \$this->{$this->getColumnSetter()}(\$v);
+    \$this->{$this->getColumnSetter()}(\$v);
+
+    return \$this;
 }
 ";
     }
@@ -398,7 +400,7 @@ public function getScopeValue(\$returnNulls = true)
  * Wrap the setter for scope value
  *
  * @param     mixed A array or a native type
- * @return    \$this|{$this->objectClassName}
+ * @return    \$this
  */
 public function setScopeValue(\$v)
 {
@@ -413,7 +415,9 @@ public function setScopeValue(\$v)
         } else {
             $script .= "
 
-    return \$this->{$this->getColumnSetter('scope_column')}(\$v);
+    \$this->{$this->getColumnSetter('scope_column')}(\$v);
+
+    return \$this;
 ";
         }
         $script .= "
@@ -457,7 +461,7 @@ public function isFirst()
  *
  * @return    bool
  */
-public function isLast(ConnectionInterface \$con = null)
+public function isLast(?ConnectionInterface \$con = null)
 {
     return \$this->{$this->getColumnGetter()}() == {$this->queryClassName}::create()->getMaxRankArray(" . ($useScope ? '$this->getScopeValue(), ' : '') . "\$con);
 }
@@ -484,7 +488,7 @@ public function isLast(ConnectionInterface \$con = null)
  *
  * @return    {$this->objectClassName}
  */
-public function getNext(ConnectionInterface \$con = null)
+public function getNext(?ConnectionInterface \$con = null)
 {";
         $script .= "
 
@@ -533,7 +537,7 @@ public function getNext(ConnectionInterface \$con = null)
  *
  * @return    {$this->objectClassName}
  */
-public function getPrevious(ConnectionInterface \$con = null)
+public function getPrevious(?ConnectionInterface \$con = null)
 {";
         $script .= "
 
@@ -578,11 +582,11 @@ public function getPrevious(ConnectionInterface \$con = null)
  * @param     integer    \$rank rank value
  * @param     ConnectionInterface  \$con      optional connection
  *
- * @return    \$this|{$this->objectClassName} the current object
+ * @return    \$this The current object
  *
  * @throws    PropelException
  */
-public function insertAtRank(\$rank, ConnectionInterface \$con = null)
+public function insertAtRank(\$rank, ?ConnectionInterface \$con = null)
 {";
         $script .= "
     \$maxRank = {$this->queryClassName}::create()->getMaxRankArray(" . ($useScope ? '$this->getScopeValue(), ' : '') . "\$con);
@@ -593,10 +597,10 @@ public function insertAtRank(\$rank, ConnectionInterface \$con = null)
     \$this->{$this->getColumnSetter()}(\$rank);
     if (\$rank != \$maxRank + 1) {
         // Keep the list modification query for the save() transaction
-        \$this->sortableQueries []= array(
+        \$this->sortableQueries []= [
             'callable'  => array('{$queryClassName}', 'sortableShiftRank'),
-            'arguments' => array(1, \$rank, null, " . ($useScope ? '$this->getScopeValue()' : '') . ")
-        );
+            'arguments' => array(1, \$rank, null, " . ($useScope ? '$this->getScopeValue()' : '') . "),
+        ];
     }
 
     return \$this;
@@ -619,11 +623,11 @@ public function insertAtRank(\$rank, ConnectionInterface \$con = null)
  *
  * @param ConnectionInterface \$con optional connection
  *
- * @return    \$this|{$this->objectClassName} the current object
+ * @return    \$this the current object
  *
  * @throws    PropelException
  */
-public function insertAtBottom(ConnectionInterface \$con = null)
+public function insertAtBottom(?ConnectionInterface \$con = null)
 {";
         $script .= "
     \$this->{$this->getColumnSetter()}({$this->queryClassName}::create()->getMaxRankArray(" . ($useScope ? '$this->getScopeValue(), ' : '') . "\$con) + 1);
@@ -645,11 +649,13 @@ public function insertAtBottom(ConnectionInterface \$con = null)
  * Insert in the first rank
  * The modifications are not persisted until the object is saved.
  *
- * @return    \$this|{$this->objectClassName} the current object
+ * @return    \$this the current object
  */
 public function insertAtTop()
 {
-    return \$this->insertAtRank(1);
+    \$this->insertAtRank(1);
+
+    return \$this;
 }
 ";
     }
@@ -670,11 +676,11 @@ public function insertAtTop()
  * @param     integer   \$newRank rank value
  * @param     ConnectionInterface \$con optional connection
  *
- * @return    \$this|{$this->objectClassName} the current object
+ * @return    \$this the current object
  *
  * @throws    PropelException
  */
-public function moveToRank(\$newRank, ConnectionInterface \$con = null)
+public function moveToRank(\$newRank, ?ConnectionInterface \$con = null)
 {
     if (\$this->isNew()) {
         throw new PropelException('New objects cannot be moved. Please use insertAtRank() instead');
@@ -720,11 +726,11 @@ public function moveToRank(\$newRank, ConnectionInterface \$con = null)
  * @param     {$this->objectClassName} \$object
  * @param     ConnectionInterface \$con optional connection
  *
- * @return    \$this|{$this->objectClassName} the current object
+ * @return    \$this the current object
  *
  * @throws Exception if the database cannot execute the two updates
  */
-public function swapWith(\$object, ConnectionInterface \$con = null)
+public function swapWith(\$object, ?ConnectionInterface \$con = null)
 {
     if (null === \$con) {
         \$con = Propel::getServiceContainer()->getWriteConnection({$this->tableMapClassName}::DATABASE_NAME);
@@ -769,9 +775,9 @@ public function swapWith(\$object, ConnectionInterface \$con = null)
  *
  * @param     ConnectionInterface \$con optional connection
  *
- * @return    \$this|{$this->objectClassName} the current object
+ * @return    \$this the current object
  */
-public function moveUp(ConnectionInterface \$con = null)
+public function moveUp(?ConnectionInterface \$con = null)
 {
     if (\$this->isFirst()) {
         return \$this;
@@ -802,9 +808,9 @@ public function moveUp(ConnectionInterface \$con = null)
  *
  * @param     ConnectionInterface \$con optional connection
  *
- * @return    \$this|{$this->objectClassName} the current object
+ * @return    \$this the current object
  */
-public function moveDown(ConnectionInterface \$con = null)
+public function moveDown(?ConnectionInterface \$con = null)
 {
     if (\$this->isLast(\$con)) {
         return \$this;
@@ -835,15 +841,17 @@ public function moveDown(ConnectionInterface \$con = null)
  *
  * @param     ConnectionInterface \$con optional connection
  *
- * @return    \$this|{$this->objectClassName} the current object
+ * @return    \$this the current object
  */
-public function moveToTop(ConnectionInterface \$con = null)
+public function moveToTop(?ConnectionInterface \$con = null)
 {
     if (\$this->isFirst()) {
         return \$this;
     }
 
-    return \$this->moveToRank(1, \$con);
+    \$this->moveToRank(1, \$con);
+
+    return \$this;
 }
 ";
     }
@@ -864,7 +872,7 @@ public function moveToTop(ConnectionInterface \$con = null)
  *
  * @return \$this|{$this->objectClassName}|null The old object's rank or null if already last
  */
-public function moveToBottom(ConnectionInterface \$con = null)
+public function moveToBottom(?ConnectionInterface \$con = null)
 {
     if (\$this->isLast(\$con)) {
         return null;
@@ -895,7 +903,7 @@ public function moveToBottom(ConnectionInterface \$con = null)
  * Removes the current object from the list" . ($useScope ? ' (moves it to the null scope)' : '') . ".
  * The modifications are not persisted until the object is saved.
  *
- * @return    \$this|{$this->objectClassName} the current object
+ * @return    \$this the current object
  */
 public function removeFromList()
 {";
@@ -912,10 +920,10 @@ public function removeFromList()
         } else {
             $script .= "
     // Keep the list modification query for the save() transaction
-    \$this->sortableQueries[] = array(
-        'callable'  => array('{$this->queryFullClassName}', 'sortableShiftRank'),
-        'arguments' => array(-1, \$this->{$this->getColumnGetter()}() + 1, null" . ($useScope ? ', $this->getScopeValue()' : '') . ")
-    );
+    \$this->sortableQueries[] = [
+        'callable'  => ['{$this->queryFullClassName}', 'sortableShiftRank'],
+        'arguments' => [-1, \$this->{$this->getColumnGetter()}() + 1, null]
+    ];
     // remove the object from the list
     \$this->{$this->getColumnSetter('rank_column')}(null);
     ";

--- a/src/Propel/Generator/Behavior/Sortable/SortableBehaviorQueryBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/Sortable/SortableBehaviorQueryBuilderModifier.php
@@ -189,7 +189,7 @@ static public function sortableApplyScopeCriteria(Criteria \$criteria, \$scope, 
  *
 $paramsDoc
  *
- * @return    \$this|{$this->queryClassName} The current query, for fluid interface
+ * @return    \$this The current query, for fluid interface
  */
 public function inList($methodSignature)
 {
@@ -477,7 +477,7 @@ public function getMaxRankArray(" . ($useScope ? '$scope, ' : '') . "ConnectionI
  *
  * @return    bool true if the reordering took place, false if a database problem prevented it
  */
-public function reorder(\$order, ConnectionInterface \$con = null)
+public function reorder(\$order, ?ConnectionInterface \$con = null)
 {
     if (null === \$con) {
         \$con = Propel::getServiceContainer()->getReadConnection({$this->tableMapClassName}::DATABASE_NAME);
@@ -559,7 +559,7 @@ static public function retrieveByRank(\$rank, " . ($useScope ? '$scope = null, '
  *
  * @return    array list of sortable objects
  */
-static public function doSelectOrderByRank(Criteria \$criteria = null, \$order = Criteria::ASC, ConnectionInterface \$con = null)
+static public function doSelectOrderByRank(?Criteria \$criteria = null, \$order = Criteria::ASC, ?ConnectionInterface \$con = null)
 {
     if (null === \$con) {
         \$con = Propel::getServiceContainer()->getReadConnection({$this->tableMapClassName}::DATABASE_NAME);
@@ -601,7 +601,7 @@ static public function doSelectOrderByRank(Criteria \$criteria = null, \$order =
  *
  * @return    \Propel\Runtime\Collection\ObjectCollection List of sortable objects
  */
-static public function retrieveList(\$scope, \$order = Criteria::ASC, ConnectionInterface \$con = null)
+static public function retrieveList(\$scope, \$order = Criteria::ASC, ?ConnectionInterface \$con = null)
 {
     \$c = new Criteria();
     static::sortableApplyScopeCriteria(\$c, \$scope);
@@ -627,7 +627,7 @@ static public function retrieveList(\$scope, \$order = Criteria::ASC, Connection
  *
  * @return    int Count.
  */
-static public function countList(\$scope, ConnectionInterface \$con = null): int
+static public function countList(\$scope, ?ConnectionInterface \$con = null): int
 {
     \$c = new Criteria();
     \$c->add({$this->tableMapClassName}::SCOPE_COL, \$scope);
@@ -653,7 +653,7 @@ static public function countList(\$scope, ConnectionInterface \$con = null): int
  *
  * @return    int number of deleted objects
  */
-static public function deleteList(\$scope, ConnectionInterface \$con = null): int
+static public function deleteList(\$scope, ?ConnectionInterface \$con = null): int
 {
     \$c = new Criteria();
     static::sortableApplyScopeCriteria(\$c, \$scope);

--- a/src/Propel/Generator/Behavior/Versionable/VersionableBehaviorObjectBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/Versionable/VersionableBehaviorObjectBuilderModifier.php
@@ -302,7 +302,7 @@ public function getVersion()
 /**
  * Enforce a new Version of this object upon next save.
  *
- * @return \$this|{$objectClass}
+ * @return \$this
  */
 public function enforceVersioning()
 {
@@ -329,7 +329,7 @@ public function enforceVersioning()
  * @param   ConnectionInterface \$con The ConnectionInterface connection to use.
  * @return  bool
  */
-public function isVersioningNecessary(ConnectionInterface \$con = null): bool
+public function isVersioningNecessary(?ConnectionInterface \$con = null): bool
 {
     if (\$this->alreadyInSave) {
         return false;
@@ -416,7 +416,7 @@ public function isVersioningNecessary(ConnectionInterface \$con = null): bool
  *
  * @return  {$versionARClassName} A version object
  */
-public function addVersion(ConnectionInterface \$con = null)
+public function addVersion(?ConnectionInterface \$con = null)
 {
     \$this->enforceVersion = false;
 
@@ -486,9 +486,9 @@ public function addVersion(ConnectionInterface \$con = null)
  * @param   integer \$versionNumber The version number to read
  * @param   ConnectionInterface \$con The ConnectionInterface connection to use.
  *
- * @return  \$this|{$ARclassName} The current object (for fluent API support)
+ * @return  \$this The current object (for fluent API support)
  */
-public function toVersion(\$versionNumber, ConnectionInterface \$con = null)
+public function toVersion(\$versionNumber, ?ConnectionInterface \$con = null)
 {
     \$version = \$this->getOneVersion(\$versionNumber, \$con);
     if (!\$version) {
@@ -522,7 +522,7 @@ public function toVersion(\$versionNumber, ConnectionInterface \$con = null)
  * @param ConnectionInterface   \$con the connection to use
  * @param array                 \$loadedObjects objects that been loaded in a chain of populateFromVersion calls on referrer or fk objects.
  *
- * @return \$this|{$ARclassName} The current object (for fluent API support)
+ * @return \$this The current object (for fluent API support)
  */
 public function populateFromVersion(\$version, \$con = null, &\$loadedObjects = [])
 {";
@@ -625,9 +625,9 @@ public function populateFromVersion(\$version, \$con = null, &\$loadedObjects = 
  *
  * @param   ConnectionInterface \$con The ConnectionInterface connection to use.
  *
- * @return  integer
+ * @return int
  */
-public function getLastVersionNumber(ConnectionInterface \$con = null)
+public function getLastVersionNumber(?ConnectionInterface \$con = null): int
 {
     \$v = {$this->getVersionQueryClassName()}::create()
         ->filterBy{$this->table->getPhpName()}(\$this)
@@ -657,7 +657,7 @@ public function getLastVersionNumber(ConnectionInterface \$con = null)
  *
  * @return  bool
  */
-public function isLastVersion(ConnectionInterface \$con = null)
+public function isLastVersion(?ConnectionInterface \$con = null)
 {
     return \$this->getLastVersionNumber(\$con) == \$this->getVersion();
 }
@@ -681,7 +681,7 @@ public function isLastVersion(ConnectionInterface \$con = null)
  *
  * @return  {$versionARClassName} A version object
  */
-public function getOneVersion(\$versionNumber, ConnectionInterface \$con = null)
+public function getOneVersion(int \$versionNumber, ?ConnectionInterface \$con = null)
 {
     return {$this->getVersionQueryClassName()}::create()
         ->filterBy{$this->table->getPhpName()}(\$this)
@@ -713,7 +713,7 @@ public function getOneVersion(\$versionNumber, ConnectionInterface \$con = null)
  *
  * @return  ObjectCollection|{$versionARClassName}[] A list of {$versionARClassName} objects
  */
-public function getAllVersions(ConnectionInterface \$con = null)
+public function getAllVersions(?ConnectionInterface \$con = null)
 {
     \$criteria = new Criteria();
     \$criteria->addAscendingOrderByColumn({$this->builder->getColumnConstant($versionForeignColumn)});
@@ -780,10 +780,10 @@ protected function computeDiff(\$fromVersion, \$toVersion, \$keys = 'columns', \
                     \$diff[\$toVersionNumber][\$key] = \$toVersion[\$key];
                     break;
                 default:
-                    \$diff[\$key] = array(
+                    \$diff[\$key] = [
                         \$fromVersionNumber => \$value,
                         \$toVersionNumber => \$toVersion[\$key],
-                    );
+                    ];
                     break;
             }
         }
@@ -819,7 +819,7 @@ protected function computeDiff(\$fromVersion, \$toVersion, \$keys = 'columns', \
  *
  * @return  array A list of differences
  */
-public function compareVersion(\$versionNumber, \$keys = 'columns', ConnectionInterface \$con = null, \$ignoredColumns = [])
+public function compareVersion(\$versionNumber, \$keys = 'columns', ?ConnectionInterface \$con = null, \$ignoredColumns = [])
 {
     \$fromVersion = \$this->toArray();
     \$toVersion = \$this->getOneVersion(\$versionNumber, \$con)->toArray();
@@ -855,7 +855,7 @@ public function compareVersion(\$versionNumber, \$keys = 'columns', ConnectionIn
  *
  * @return  array A list of differences
  */
-public function compareVersions(\$fromVersionNumber, \$toVersionNumber, \$keys = 'columns', ConnectionInterface \$con = null, \$ignoredColumns = [])
+public function compareVersions(int \$fromVersionNumber, int \$toVersionNumber, string \$keys = 'columns', ?ConnectionInterface \$con = null, array \$ignoredColumns = []): array
 {
     \$fromVersion = \$this->getOneVersion(\$fromVersionNumber, \$con)->toArray();
     \$toVersion = \$this->getOneVersion(\$toVersionNumber, \$con)->toArray();
@@ -891,7 +891,7 @@ public function compareVersions(\$fromVersionNumber, \$toVersionNumber, \$keys =
  *
  * @return PropelCollection|{$versionARClassName}[] List of {$versionARClassName} objects
  */
-public function getLastVersions(\$number = 10, \$criteria = null, ConnectionInterface \$con = null)
+public function getLastVersions(\$number = 10, \$criteria = null, ?ConnectionInterface \$con = null)
 {
     \$criteria = {$this->getVersionQueryClassName()}::create(null, \$criteria);
     \$criteria->addDescendingOrderByColumn({$versionTableMapClassName}::{$colPrefix}VERSION);

--- a/src/Propel/Generator/Behavior/Versionable/VersionableBehaviorQueryBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/Versionable/VersionableBehaviorQueryBuilderModifier.php
@@ -170,13 +170,15 @@ static \$isVersioningEnabled = true;
 /**
  * Wrap the filter on the version column
  *
- * @param     integer \$version
- * @param     string  \$comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
- * @return    \$this|" . $this->builder->getQueryClassName() . " The current query, for fluid interface
+ * @param     int|null \$version
+ * @param     string|null  \$comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
+ * @return    \$this The current query, for fluid interface
  */
-public function filterByVersion(\$version = null, \$comparison = null)
+public function filterByVersion(\$version = null, ?string \$comparison = null)
 {
-    return \$this->filterBy{$this->getColumnPhpName()}(\$version, \$comparison);
+    \$this->filterBy{$this->getColumnPhpName()}(\$version, \$comparison);
+
+    return \$this;
 }
 ";
     }
@@ -193,11 +195,13 @@ public function filterByVersion(\$version = null, \$comparison = null)
  * Wrap the order on the version column
  *
  * @param   string \$order The sorting order. Criteria::ASC by default, also accepts Criteria::DESC
- * @return  \$this|" . $this->builder->getQueryClassName() . " The current query, for fluid interface
+ * @return  \$this The current query, for fluid interface
  */
-public function orderByVersion(\$order = Criteria::ASC)
+public function orderByVersion(string \$order = Criteria::ASC)
 {
-    return \$this->orderBy('{$this->getColumnPhpName()}', \$order);
+    \$this->orderBy('{$this->getColumnPhpName()}', \$order);
+
+    return \$this;
 }
 ";
     }

--- a/src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
@@ -36,7 +36,7 @@ abstract class AbstractObjectBuilder extends AbstractOMBuilder
 
         foreach ($table->getColumns() as $col) {
             $type = $col->getType();
-            // if they're not using the DateTime class than we will generate "compatibility" accessor method
+            // if they're not using the DateTime class then we will generate "compatibility" accessor method
             if (
                 $type === PropelTypes::DATE
                 || $type === PropelTypes::TIME

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -425,8 +425,10 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
         $script .= "
     /**
      * TableMap class name
+     *
+     * @var string
      */
-    const TABLE_MAP = '" . addslashes($this->getTableMapBuilder()->getFullyQualifiedClassName()) . "';
+    public const TABLE_MAP = '" . addslashes($this->getTableMapBuilder()->getFullyQualifiedClassName()) . "';
 ";
     }
 
@@ -798,7 +800,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
     protected function addApplyDefaultValuesOpen(string &$script): void
     {
         $script .= "
-    public function applyDefaultValues()
+    public function applyDefaultValues(): void
     {";
     }
 
@@ -907,7 +909,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return string|{$dateTimeClass}{$orNull} Formatted date/time value as string or $dateTimeClass object (if format is NULL), NULL if column is NULL" . ($handleMysqlDate ? ', and 0 if column value is ' . $mysqlInvalidDateString : '') . "
      *
-     * @throws PropelException - if unable to parse/validate the date/time value.
+     * @throws \Propel\Runtime\Exception\PropelException - if unable to parse/validate the date/time value.
      *
      * @psalm-return (\$format is null ? {$dateTimeClass}{$orNull} : string{$orNull})
      */";
@@ -1616,7 +1618,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @param      \$con ConnectionInterface (optional) The ConnectionInterface connection to use.
      * @return void
-     * @throws PropelException - any underlying error will be wrapped and re-thrown.
+     * @throws \Propel\Runtime\Exception\PropelException - any underlying error will be wrapped and re-thrown.
      */";
     }
 
@@ -1632,7 +1634,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
     {
         $cfc = $column->getPhpName();
         $script .= "
-    protected function load$cfc(ConnectionInterface \$con = null)
+    protected function load$cfc(?ConnectionInterface \$con = null)
     {";
     }
 
@@ -1655,7 +1657,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
         \$c = \$this->buildPkeyCriteria();
         \$c->addSelectColumn(" . $this->getColumnConstant($column) . ");
         try {
-            \$row = array(0 => null);
+            \$row = [0 => null];
             \$dataFetcher = " . $this->getQueryClassName() . "::create(null, \$c)->setFormatter(ModelCriteria::FORMAT_STATEMENT)->find(\$con);
             if (\$dataFetcher instanceof PDODataFetcher) {
                 \$dataFetcher->bindColumn(1, \$row[0], PDO::PARAM_LOB, 0, PDO::SQLSRV_ENCODING_BINARY);
@@ -1772,7 +1774,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * Set the value of [$clo] column.
      * " . $column->getDescription() . "
      * @param string|array|object{$orNull} \$v new value
-     * @return \$this|" . $this->getObjectClassName(true) . " The current object (for fluent API support)
+     * @return \$this The current object (for fluent API support)
      */";
     }
 
@@ -1797,7 +1799,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * Set the value of [$clo] column.
      * " . $column->getDescription() . "
      * @param " . $type . " \$v New value
-     * @return \$this|" . $this->getObjectClassName(true) . " The current object (for fluent API support)
+     * @return \$this The current object (for fluent API support)
      */";
     }
 
@@ -2063,7 +2065,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * " . $col->getDescription() . "
      * @param  string|integer|\DateTimeInterface{$orNull} \$v string, integer (timestamp), or \DateTimeInterface value.
      *               Empty strings are treated as NULL.
-     * @return \$this|" . $this->getObjectClassName(true) . " The current object (for fluent API support)
+     * @return \$this The current object (for fluent API support)
      */";
     }
 
@@ -2169,14 +2171,14 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
         $script .= "
     /**
      * Adds a value to the [$clo] $columnType column value.
-     * @param  mixed \$value
+     * @param mixed \$value
      * " . $col->getDescription();
         if ($col->isLazyLoad()) {
             $script .= "
-     * @param  ConnectionInterface \$con An optional ConnectionInterface connection to use for fetching this lazy-loaded column.";
+     * @param ConnectionInterface \$con An optional ConnectionInterface connection to use for fetching this lazy-loaded column.";
         }
         $script .= "
-     * @return \$this|" . $this->getObjectClassName(true) . " The current object (for fluent API support)
+     * @return \$this The current object (for fluent API support)
      */
     $visibility function add$singularPhpName(\$value";
         if ($col->isLazyLoad()) {
@@ -2224,7 +2226,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * @param  ConnectionInterface \$con An optional ConnectionInterface connection to use for fetching this lazy-loaded column.";
         }
         $script .= "
-     * @return \$this|" . $this->getObjectClassName(true) . " The current object (for fluent API support)
+     * @return \$this The current object (for fluent API support)
      */
     $visibility function remove$singularPhpName(\$value";
         if ($col->isLazyLoad()) {
@@ -2303,7 +2305,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * Set the value of [$clo] column.
      * " . $column->getDescription() . "
      * @param  string{$orNull} \$v new value
-     * @return \$this|" . $this->getObjectClassName(true) . " The current object (for fluent API support)
+     * @return \$this The current object (for fluent API support)
      * @throws \\Propel\\Runtime\\Exception\\PropelException
      */";
     }
@@ -2368,7 +2370,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * Set the value of [$clo] column.
      * " . $column->getDescription() . "
      * @param  array{$orNull} \$v new value
-     * @return \$this|" . $this->getObjectClassName(true) . " The current object (for fluent API support)
+     * @return \$this The current object (for fluent API support)
      * @throws \\Propel\\Runtime\\Exception\\PropelException
      */";
     }
@@ -2429,7 +2431,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * Check on string values is case insensitive (so 'FaLsE' is seen as 'false').
      * " . $col->getDescription() . "
      * @param  bool|integer|string{$orNull} \$v The new value
-     * @return \$this|" . $this->getObjectClassName(true) . " The current object (for fluent API support)
+     * @return \$this The current object (for fluent API support)
      */";
     }
 
@@ -2624,7 +2626,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *                            TableMap::TYPE_COLNAME, TableMap::TYPE_FIELDNAME, TableMap::TYPE_NUM.
      *
      * @return int             next starting column
-     * @throws PropelException - Any caught Exception will be rewrapped as a PropelException.
+     * @throws \Propel\Runtime\Exception\PropelException - Any caught Exception will be rewrapped as a PropelException.
      */";
     }
 
@@ -2640,7 +2642,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
     protected function addHydrateOpen(string &$script): void
     {
         $script .= "
-    public function hydrate(\$row, \$startcol = 0, \$rehydrate = false, \$indexType = TableMap::TYPE_NUM)
+    public function hydrate(array \$row, int \$startcol = 0, bool \$rehydrate = false, string \$indexType = TableMap::TYPE_NUM): int
     {";
     }
 
@@ -2809,7 +2811,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @throws LogicException if no primary key is defined
      *
-     * @return Criteria The Criteria object containing value(s) for primary key(s).
+     * @return \Propel\Runtime\ActiveQuery\Criteria The Criteria object containing value(s) for primary key(s).
      */";
     }
 
@@ -2825,7 +2827,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
     protected function addBuildPkeyCriteriaOpen(string &$script): void
     {
         $script .= "
-    public function buildPkeyCriteria()
+    public function buildPkeyCriteria(): Criteria
     {";
     }
 
@@ -2904,7 +2906,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
     /**
      * Build a Criteria object containing the values of all modified columns in this object.
      *
-     * @return Criteria The Criteria object containing all modified values.
+     * @return \Propel\Runtime\ActiveQuery\Criteria The Criteria object containing all modified values.
      */";
     }
 
@@ -2920,7 +2922,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
     protected function addBuildCriteriaOpen(string &$script): void
     {
         $script .= "
-    public function buildCriteria()
+    public function buildCriteria(): Criteria
     {";
     }
 
@@ -2998,7 +3000,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
         }
         $script .= "
      *
-     * @return array an associative array containing the field names (as keys) and field values
+     * @return array|string An associative array containing the field names (as keys) and field values
      */
     public function toArray(string \$keyType = TableMap::$defaultKeyType, bool \$includeLazyLoadColumns = true, array \$alreadyDumpedObjects = []" . ($hasFks ? ', bool $includeForeignObjects = false' : '') . ")
     {
@@ -3165,7 +3167,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
     {
         $defaultKeyType = $this->getDefaultKeyType();
         $script .= "
-    public function getByName(\$name, \$type = TableMap::$defaultKeyType)
+    public function getByName(string \$name, string \$type = TableMap::$defaultKeyType)
     {";
     }
 
@@ -3234,7 +3236,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * Retrieves a field from the object by Position as specified in the xml schema.
      * Zero-based.
      *
-     * @param      int \$pos position in xml schema
+     * @param int \$pos Position in XML schema
      * @return mixed Value of field at \$pos
      */";
     }
@@ -3251,7 +3253,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
     protected function addGetByPositionOpen(string &$script): void
     {
         $script .= "
-    public function getByPosition(\$pos)
+    public function getByPosition(int \$pos)
     {";
     }
 
@@ -3319,13 +3321,15 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *                one of the class type constants TableMap::TYPE_PHPNAME, TableMap::TYPE_CAMELNAME
      *                TableMap::TYPE_COLNAME, TableMap::TYPE_FIELDNAME, TableMap::TYPE_NUM.
      *                Defaults to TableMap::$defaultKeyType.
-     * @return \$this|" . $this->getObjectClassName(true) . "
+     * @return \$this
      */
-    public function setByName(\$name, \$value, \$type = TableMap::$defaultKeyType)
+    public function setByName(string \$name, \$value, string \$type = TableMap::$defaultKeyType)
     {
         \$pos = " . $this->getTableMapClassName() . "::translateFieldName(\$name, \$type, TableMap::TYPE_NUM);
 
-        return \$this->setByPosition(\$pos, \$value);
+        \$this->setByPosition(\$pos, \$value);
+
+        return \$this;
     }
 ";
     }
@@ -3345,9 +3349,9 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @param  int \$pos position in xml schema
      * @param  mixed \$value field value
-     * @return \$this|" . $this->getObjectClassName(true) . "
+     * @return \$this
      */
-    public function setByPosition(\$pos, \$value)
+    public function setByPosition(int \$pos, \$value)
     {
         switch (\$pos) {";
         $i = 0;
@@ -3422,9 +3426,9 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @param      array  \$arr     An array to populate the object from.
      * @param      string \$keyType The type of keys the array uses.
-     * @return     \$this|" . $this->getObjectClassName(true) . "
+     * @return     \$this
      */
-    public function fromArray(\$arr, \$keyType = TableMap::$defaultKeyType)
+    public function fromArray(array \$arr, string \$keyType = TableMap::$defaultKeyType)
     {
         \$keys = " . $this->getTableMapClassName() . "::getFieldNames(\$keyType);
 ";
@@ -3468,9 +3472,9 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * @param string \$data The source data to import from
      * @param string \$keyType The type of keys the array uses.
      *
-     * @return \$this|" . $this->getObjectClassName(true) . " The current object, for fluid interface
+     * @return \$this The current object, for fluid interface
      */
-    public function importFrom(\$parser, \$data, \$keyType = TableMap::$defaultKeyType)
+    public function importFrom(\$parser, string \$data, string \$keyType = TableMap::$defaultKeyType)
     {
         if (!\$parser instanceof AbstractParser) {
             \$parser = AbstractParser::getParser(\$parser);
@@ -3516,7 +3520,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @param      ConnectionInterface \$con
      * @return void
-     * @throws PropelException
+     * @throws \Propel\Runtime\Exception\PropelException
      * @see $className::setDeleted()
      * @see $className::isDeleted()
      */";
@@ -3534,7 +3538,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
     protected function addDeleteOpen(string &$script): void
     {
         $script .= "
-    public function delete(ConnectionInterface \$con = null): void
+    public function delete(?ConnectionInterface \$con = null): void
     {";
     }
 
@@ -3625,9 +3629,9 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * @param      bool \$deep (optional) Whether to also de-associated any related objects.
      * @param      ConnectionInterface \$con (optional) The ConnectionInterface connection to use.
      * @return void
-     * @throws PropelException - if this object is deleted, unsaved or doesn't have pk match in db
+     * @throws \Propel\Runtime\Exception\PropelException - if this object is deleted, unsaved or doesn't have pk match in db
      */
-    public function reload(\$deep = false, ConnectionInterface \$con = null)
+    public function reload(bool \$deep = false, ?ConnectionInterface \$con = null): void
     {
         if (\$this->isDeleted()) {
             throw new PropelException(\"Cannot reload a deleted object.\");
@@ -3929,7 +3933,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * @param       $ctype \$key Primary key.
      * @return void
      */
-    public function setPrimaryKey(\$key)
+    public function setPrimaryKey(\$key): void
     {
         \$this->set" . $col->getPhpName() . "(\$key);
     }
@@ -3952,7 +3956,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * @param      array \$keys The elements of the composite key (order must match the order in XML file).
      * @return void
      */
-    public function setPrimaryKey(\$keys)
+    public function setPrimaryKey(\$keys): void
     {";
         $i = 0;
         foreach ($this->getTable()->getPrimaryKey() as $pk) {
@@ -3989,7 +3993,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @deprecated
      */
-    public function setPrimaryKey(\$pk)
+    public function setPrimaryKey(\$pk): void
     {
         // do nothing, because this object doesn't have any primary keys
     }
@@ -4013,7 +4017,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * Returns true if the primary key for this object is null.
      * @return bool
      */
-    public function isPrimaryKeyNull()
+    public function isPrimaryKeyNull(): bool
     {";
         if (count($pkeys) == 1) {
             $script .= "
@@ -4134,8 +4138,8 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * Declares an association between this object and a $className object.
      *
      * @param  {$className}{$orNull} \$v
-     * @return \$this|" . $this->getObjectClassName(true) . " The current object (for fluent API support)
-     * @throws PropelException
+     * @return \$this The current object (for fluent API support)
+     * @throws \Propel\Runtime\Exception\PropelException
      */
     public function set" . $this->getFKPhpNameAffix($fk, false) . "($className \$v = null)
     {";
@@ -4264,9 +4268,9 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @param  ConnectionInterface \$con Optional Connection object.
      * @return {$className}{$orNull} $returnDesc
-     * @throws PropelException
+     * @throws \Propel\Runtime\Exception\PropelException
      */
-    public function get" . $this->getFKPhpNameAffix($fk, false) . "(ConnectionInterface \$con = null)
+    public function get" . $this->getFKPhpNameAffix($fk, false) . "(?ConnectionInterface \$con = null)
     {";
         $script .= "
         if (\$this->$varName === null && ($conditional)) {";
@@ -4360,7 +4364,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * @return ObjectCollection|{$className}[] List of $className objects
      * @phpstan-return ObjectCollection&\Traversable<$className}> List of $className objects
      */
-    public function get" . $relCol . 'Join' . $relCol2 . "(Criteria \$criteria = null, ConnectionInterface \$con = null, \$joinBehavior = $joinBehavior)
+    public function get" . $relCol . 'Join' . $relCol2 . "(?Criteria \$criteria = null, ?ConnectionInterface \$con = null, \$joinBehavior = $joinBehavior)
     {";
                 $script .= "
         \$query = $fkQueryClassName::create(null, \$criteria);
@@ -4574,7 +4578,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * through the $className foreign key attribute.
      *
      * @param  $className \$l $className
-     * @return \$this|" . $this->getObjectClassName(true) . " The current object (for fluent API support)
+     * @return \$this The current object (for fluent API support)
      */
     public function add" . $this->getRefFKPhpNameAffix($refFK, false) . "($className \$l)
     {
@@ -4621,9 +4625,9 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * @param      bool \$distinct
      * @param      ConnectionInterface \$con
      * @return int             Count of related $className objects.
-     * @throws PropelException
+     * @throws \Propel\Runtime\Exception\PropelException
      */
-    public function count{$relCol}(Criteria \$criteria = null, \$distinct = false, ConnectionInterface \$con = null)
+    public function count{$relCol}(?Criteria \$criteria = null, \$distinct = false, ?ConnectionInterface \$con = null)
     {
         \$partial = \$this->{$collName}Partial && !\$this->isNew();
         if (null === \$this->$collName || null !== \$criteria || \$partial) {
@@ -4680,9 +4684,9 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * @param      ConnectionInterface \$con optional connection object
      * @return ObjectCollection|{$className}[] List of $className objects
      * @phpstan-return ObjectCollection&\Traversable<{$className}> List of $className objects
-     * @throws PropelException
+     * @throws \Propel\Runtime\Exception\PropelException
      */
-    public function get$relCol(Criteria \$criteria = null, ConnectionInterface \$con = null)
+    public function get$relCol(?Criteria \$criteria = null, ?ConnectionInterface \$con = null)
     {
         \$partial = \$this->{$collName}Partial && !\$this->isNew();
         if (null === \$this->$collName || null !== \$criteria || \$partial) {
@@ -4767,7 +4771,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * @param      ConnectionInterface \$con Optional connection object
      * @return \$this|" . $this->getObjectClassname() . " The current object (for fluent API support)
      */
-    public function set{$relatedName}(Collection \${$inputCollection}, ConnectionInterface \$con = null)
+    public function set{$relatedName}(Collection \${$inputCollection}, ?ConnectionInterface \$con = null)
     {
         /** @var {$className}[] \${$inputCollection}ToDelete */
         \${$inputCollection}ToDelete = \$this->get{$relatedName}(new Criteria(), \$con)->diff(\${$inputCollection});
@@ -4917,9 +4921,9 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @param  ConnectionInterface \$con optional connection object
      * @return $className|null
-     * @throws PropelException
+     * @throws \Propel\Runtime\Exception\PropelException
      */
-    public function get" . $this->getRefFKPhpNameAffix($refFK, false) . "(ConnectionInterface \$con = null)
+    public function get" . $this->getRefFKPhpNameAffix($refFK, false) . "(?ConnectionInterface \$con = null)
     {
 ";
         $script .= "
@@ -4952,8 +4956,8 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * Sets a single $className object as related to this object by a one-to-one relationship.
      *
      * @param  $className \$v $className
-     * @return \$this|" . $this->getObjectClassName(true) . " The current object (for fluent API support)
-     * @throws PropelException
+     * @return \$this The current object (for fluent API support)
+     * @throws \Propel\Runtime\Exception\PropelException
      */
     public function set" . $this->getRefFKPhpNameAffix($refFK, false) . "($className \$v = null)
     {
@@ -5546,7 +5550,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return $relatedQueryClassName
      */
-    public function create{$firstFkName}Query($signature, Criteria \$criteria = null)
+    public function create{$firstFkName}Query($signature, ?Criteria \$criteria = null)
     {
         \$criteria = $relatedQueryClassName::create(\$criteria)
             ->filterBy{$selfRelationName}(\$this);
@@ -5626,7 +5630,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return ObjectCombinationCollection Combination list of {$classNames} objects
      */
-    public function get{$relatedName}(\$criteria = null, ConnectionInterface \$con = null)
+    public function get{$relatedName}(\$criteria = null, ?ConnectionInterface \$con = null)
     {
         \$partial = \$this->{$collVarName}Partial && !\$this->isNew();
         if (null === \$this->$collVarName || null !== \$criteria || \$partial) {
@@ -5719,7 +5723,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * @return {$relatedObjectClassName}[]|ObjectCollection
      * @phpstan-return ObjectCollection&\Traversable<{$relatedObjectClassName}>
      */
-    public function get{$firstFkName}($signature, Criteria \$criteria = null, ConnectionInterface \$con = null)
+    public function get{$firstFkName}($signature, ?Criteria \$criteria = null, ?ConnectionInterface \$con = null)
     {
         return \$this->create{$firstFkName}Query($shortSignature, \$criteria)->find(\$con);
     }
@@ -5752,7 +5756,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * @return ObjectCollection|{$relatedObjectClassName}[] List of {$relatedObjectClassName} objects
      * @phpstan-return ObjectCollection&\Traversable<{$relatedObjectClassName}> List of {$relatedObjectClassName} objects
      */
-    public function get{$relatedName}(Criteria \$criteria = null, ConnectionInterface \$con = null)
+    public function get{$relatedName}(?Criteria \$criteria = null, ?ConnectionInterface \$con = null)
     {
         \$partial = \$this->{$collName}Partial && !\$this->isNew();
         if (null === \$this->$collName || null !== \$criteria || \$partial) {
@@ -5828,7 +5832,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * @param  ConnectionInterface \$con Optional connection object
      * @return \$this|" . $this->getObjectClassname() . " The current object (for fluent API support)
      */
-    public function set{$relatedNamePlural}(Collection \${$inputCollection}, ConnectionInterface \$con = null)
+    public function set{$relatedNamePlural}(Collection \${$inputCollection}, ?ConnectionInterface \$con = null)
     {
         \$this->clear{$relatedNamePlural}();
         \$current{$relatedNamePlural} = \$this->get{$relatedNamePlural}();
@@ -5905,9 +5909,9 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * @param      bool \$distinct Set to true to force count distinct
      * @param      ConnectionInterface \$con Optional connection object
      *
-     * @return int the number of related $relatedObjectClassName objects
+     * @return int The number of related $relatedObjectClassName objects
      */
-    public function count{$relatedName}(Criteria \$criteria = null, \$distinct = false, ConnectionInterface \$con = null)
+    public function count{$relatedName}(?Criteria \$criteria = null, \$distinct = false, ?ConnectionInterface \$con = null)
     {
         \$partial = \$this->{$collName}Partial && !\$this->isNew();
         if (null === \$this->$collName || null !== \$criteria || \$partial) {
@@ -5959,9 +5963,9 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * @param Criteria \$criteria
      * @param ConnectionInterface \$con
      *
-     * @return integer
+     * @return int
      */
-    public function count{$firstFkName}($signature, Criteria \$criteria = null, ConnectionInterface \$con = null): int
+    public function count{$firstFkName}($signature, ?Criteria \$criteria = null, ?ConnectionInterface \$con = null): int
     {
         return \$this->create{$firstFkName}Query($shortSignature, \$criteria)->count(\$con);
     }
@@ -6286,7 +6290,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
         }
         $script .= "
      * @return int             The number of rows affected by this insert/update and any referring fk objects' save() operations.
-     * @throws PropelException
+     * @throws \Propel\Runtime\Exception\PropelException
      * @see save()
      */
     protected function doSave(ConnectionInterface \$con" . ($reloadOnUpdate || $reloadOnInsert ? ', $skipReload = false' : '') . ")
@@ -6428,7 +6432,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @param      ConnectionInterface \$con
      *
-     * @throws PropelException
+     * @throws \Propel\Runtime\Exception\PropelException
      * @see doSave()
      */
     protected function doInsert(ConnectionInterface \$con)
@@ -6672,7 +6676,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @param      ConnectionInterface \$con
      *
-     * @return Integer Number of updated rows
+     * @return int Number of updated rows
      * @see doSave()
      */
     protected function doUpdate(ConnectionInterface \$con): int
@@ -6766,7 +6770,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
         }
         $script .= "
      * @return int             The number of rows affected by this insert/update and any referring fk objects' save() operations.
-     * @throws PropelException
+     * @throws \Propel\Runtime\Exception\PropelException
      * @see doSave()
      */";
     }
@@ -6786,7 +6790,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
         $reloadOnUpdate = $table->isReloadOnUpdate();
         $reloadOnInsert = $table->isReloadOnInsert();
         $script .= "
-    public function save(ConnectionInterface \$con = null" . ($reloadOnUpdate || $reloadOnInsert ? ', $skipReload = false' : '') . ")
+    public function save(?ConnectionInterface \$con = null" . ($reloadOnUpdate || $reloadOnInsert ? ', $skipReload = false' : '') . ")
     {";
     }
 
@@ -6941,9 +6945,10 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * the base method from the overridden method (i.e. parent::ensureConsistency()),
      * in case your model changes.
      *
-     * @throws PropelException
+     * @throws \Propel\Runtime\Exception\PropelException
+     * @return void
      */
-    public function ensureConsistency()
+    public function ensureConsistency(): void
     {";
         foreach ($table->getColumns() as $col) {
             $clo = $col->getLowercasedName();
@@ -6993,9 +6998,9 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @param  bool \$deepCopy Whether to also copy all rows that refer (by fkey) to the current row.
      * @return " . $this->getObjectClassName(true) . " Clone of current object.
-     * @throws PropelException
+     * @throws \Propel\Runtime\Exception\PropelException
      */
-    public function copy(\$deepCopy = false)
+    public function copy(bool \$deepCopy = false)
     {
         // we use get_class(), because this might be a subclass
         \$clazz = get_class(\$this);
@@ -7029,9 +7034,10 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * @param      object \$copyObj An object of " . $this->getObjectClassName(true) . " (or compatible) type.
      * @param      bool \$deepCopy Whether to also copy all rows that refer (by fkey) to the current row.
      * @param      bool \$makeNew Whether to reset autoincrement PKs and make the object new.
-     * @throws PropelException
+     * @throws \Propel\Runtime\Exception\PropelException
+     * @return void
      */
-    public function copyInto(\$copyObj, \$deepCopy = false, \$makeNew = true)
+    public function copyInto(object \$copyObj, bool \$deepCopy = false, bool \$makeNew = true): void
     {";
 
         $autoIncCols = [];
@@ -7272,7 +7278,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      */
     public function __toString()
     {
-        return (string) \$this->get{$column->getPhpName()}();
+        return (string)\$this->get{$column->getPhpName()}();
     }
 ";
 

--- a/src/Propel/Generator/Builder/Om/QueryBuilder.php
+++ b/src/Propel/Generator/Builder/Om/QueryBuilder.php
@@ -192,8 +192,8 @@ class QueryBuilder extends AbstractOMBuilder
 
         // override the signature of ModelCriteria::findOne() to specify the class of the returned object, for IDE completion
         $script .= "
- * @method     $modelClass|null findOne(ConnectionInterface \$con = null) Return the first $modelClass matching the query
- * @method     $modelClass findOneOrCreate(ConnectionInterface \$con = null) Return the first $modelClass matching the query, or a new $modelClass object populated from the query conditions when no match is found
+ * @method     $modelClass|null findOne(?ConnectionInterface \$con = null) Return the first $modelClass matching the query
+ * @method     $modelClass findOneOrCreate(?ConnectionInterface \$con = null) Return the first $modelClass matching the query, or a new $modelClass object populated from the query conditions when no match is found
  *";
 
         // magic findBy() methods, for IDE completion
@@ -206,8 +206,8 @@ class QueryBuilder extends AbstractOMBuilder
 
         // override the signature of ModelCriteria::require*() to specify the class of the returned object, for IDE completion
         $script .= "
- * @method     $modelClass requirePk(\$key, ConnectionInterface \$con = null) Return the $modelClass by primary key and throws {$this->getEntityNotFoundExceptionClass()} when not found
- * @method     $modelClass requireOne(ConnectionInterface \$con = null) Return the first $modelClass matching the query and throws {$this->getEntityNotFoundExceptionClass()} when not found
+ * @method     $modelClass requirePk(\$key, ?ConnectionInterface \$con = null) Return the $modelClass by primary key and throws {$this->getEntityNotFoundExceptionClass()} when not found
+ * @method     $modelClass requireOne(?ConnectionInterface \$con = null) Return the first $modelClass matching the query and throws {$this->getEntityNotFoundExceptionClass()} when not found
  *";
 
         // magic requireOneBy() methods, for IDE completion
@@ -218,8 +218,8 @@ class QueryBuilder extends AbstractOMBuilder
 
         $script .= "
  *
- * @method     {$modelClass}[]|ObjectCollection find(ConnectionInterface \$con = null) Return $modelClass objects based on current ModelCriteria
- * @psalm-method ObjectCollection&\Traversable<{$modelClass}> find(ConnectionInterface \$con = null) Return $modelClass objects based on current ModelCriteria";
+ * @method     {$modelClass}[]|ObjectCollection find(?ConnectionInterface \$con = null) Return $modelClass objects based on current ModelCriteria
+ * @psalm-method ObjectCollection&\Traversable<{$modelClass}> find(?ConnectionInterface \$con = null) Return $modelClass objects based on current ModelCriteria";
         foreach ($this->getTable()->getColumns() as $column) {
             $script .= "
  * @method     {$modelClass}[]|ObjectCollection findBy" . $column->getPhpName() . '(' . $column->getPhpType() . ' $' . $column->getName() . ") Return $modelClass objects filtered by the " . $column->getName() . ' column' . "
@@ -227,8 +227,8 @@ class QueryBuilder extends AbstractOMBuilder
         }
 
         $script .= "
- * @method     {$modelClass}[]|\\Propel\\Runtime\\Util\\PropelModelPager paginate(\$page = 1, \$maxPerPage = 10, ConnectionInterface \$con = null) Issue a SELECT query based on the current ModelCriteria and uses a page and a maximum number of results per page to compute an offset and a limit
- * @psalm-method \\Propel\\Runtime\\Util\\PropelModelPager&\Traversable<{$modelClass}> paginate(\$page = 1, \$maxPerPage = 10, ConnectionInterface \$con = null) Issue a SELECT query based on the current ModelCriteria and uses a page and a maximum number of results per page to compute an offset and a limit
+ * @method     {$modelClass}[]|\\Propel\\Runtime\\Util\\PropelModelPager paginate(\$page = 1, \$maxPerPage = 10, ?ConnectionInterface \$con = null) Issue a SELECT query based on the current ModelCriteria and uses a page and a maximum number of results per page to compute an offset and a limit
+ * @psalm-method \\Propel\\Runtime\\Util\\PropelModelPager&\Traversable<{$modelClass}> paginate(\$page = 1, \$maxPerPage = 10, ?ConnectionInterface \$con = null) Issue a SELECT query based on the current ModelCriteria and uses a page and a maximum number of results per page to compute an offset and a limit
  *
  */
 abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass . "
@@ -536,7 +536,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
     protected function addFactoryOpen(string &$script): void
     {
         $script .= "
-    public static function create(\$modelAlias = null, Criteria \$criteria = null)
+    public static function create(?string \$modelAlias = null, ?Criteria \$criteria = null): Criteria
     {";
     }
 
@@ -621,7 +621,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
      *
      * @return $class|array|mixed the result, formatted by the current formatter
      */
-    public function findPk(\$key, ConnectionInterface \$con = null)
+    public function findPk(\$key, ?ConnectionInterface \$con = null)
     {";
         if (!$table->hasPrimaryKey()) {
             $this->declareClass('Propel\\Runtime\\Exception\\LogicException');
@@ -860,7 +860,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
      *
      * @return ObjectCollection|array|mixed the list of results, formatted by the current formatter
      */
-    public function findPks(\$keys, ConnectionInterface \$con = null)
+    public function findPks(\$keys, ?ConnectionInterface \$con = null)
     {";
         if (!$table->hasPrimaryKey()) {
             $this->declareClass('Propel\\Runtime\\Exception\\LogicException');
@@ -2035,10 +2035,10 @@ EOT;
      * @param ConnectionInterface \$con the connection to use
      * @return int             The number of affected rows (if supported by underlying database driver).  This includes CASCADE-related rows
      *                         if supported by native driver or if emulated using Propel.
-     * @throws PropelException Any exceptions caught during processing will be
+     * @throws \Propel\Runtime\Exception\PropelException Any exceptions caught during processing will be
      *                         rethrown wrapped into a PropelException.
      */
-    public function delete(ConnectionInterface \$con = null): int
+    public function delete(?ConnectionInterface \$con = null): int
     {
         if (null === \$con) {
             \$con = Propel::getServiceContainer()->getWriteConnection(" . $this->getTableMapClass() . "::DATABASE_NAME);
@@ -2262,7 +2262,7 @@ EOT;
      * @param ConnectionInterface \$con the connection to use
      * @return int The number of affected rows (if supported by underlying database driver).
      */
-    public function doDeleteAll(ConnectionInterface \$con = null): int
+    public function doDeleteAll(?ConnectionInterface \$con = null): int
     {
         if (null === \$con) {
             \$con = Propel::getServiceContainer()->getWriteConnection(" . $this->getTableMapClass() . "::DATABASE_NAME);

--- a/src/Propel/Generator/Builder/Om/QueryInheritanceBuilder.php
+++ b/src/Propel/Generator/Builder/Om/QueryInheritanceBuilder.php
@@ -205,7 +205,7 @@ class " . $this->getUnqualifiedClassName() . ' extends ' . $baseClassName . "
      *
      * @return " . $classname . "
      */
-    public static function create(\$modelAlias = null, Criteria \$criteria = null)
+    public static function create(?string \$modelAlias = null, ?Criteria \$criteria = null): Criteria
     {
         if (\$criteria instanceof " . $classname . ") {
             return \$criteria;
@@ -319,9 +319,9 @@ class " . $this->getUnqualifiedClassName() . ' extends ' . $baseClassName . "
      *
      * @param ConnectionInterface \$con a connection object
      *
-     * @return integer the number of deleted rows
+     * @return int The number of deleted rows
      */
-    public function doDeleteAll(ConnectionInterface \$con = null): int
+    public function doDeleteAll(?ConnectionInterface \$con = null): int
     {
         // condition on class key is already added in preDelete()
         return parent::delete(\$con);

--- a/src/Propel/Generator/Builder/Om/TableMapBuilder.php
+++ b/src/Propel/Generator/Builder/Om/TableMapBuilder.php
@@ -225,9 +225,9 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
         foreach ($this->getTable()->getColumns() as $col) {
             $script .= "
     /**
-     * the column name for the " . $col->getName() . " field
+     * The column name for the " . $col->getName() . " field
      */
-    const " . $col->getConstantName() . " = '" . $this->getTable()->getName() . '.' . $col->getName() . "';
+    public const " . $col->getConstantName() . " = '" . $this->getTable()->getName() . '.' . $col->getName() . "';
 ";
         }
     }
@@ -247,7 +247,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
     /** The enumerated values for the " . $col->getName() . ' field */';
                 foreach ($col->getValueSet() as $value) {
                     $script .= "
-    const " . $col->getConstantName() . '_' . $this->getValueSetConstant($value) . " = '" . $value . "';";
+    public const " . $col->getConstantName() . '_' . $this->getValueSetConstant($value) . " = '" . $value . "';";
                 }
                 $script .= "
 ";
@@ -266,21 +266,21 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
     {
         $script .= "
     /** The enumerated values for this table */
-    protected static \$enumValueSets = array(";
+    protected static \$enumValueSets = [";
         foreach ($this->getTable()->getColumns() as $col) {
             if ($col->isValueSetType()) {
                 $script .= "
-                {$col->getFQConstantName()} => array(
+                {$col->getFQConstantName()} => [
                 ";
                 foreach ($col->getValueSet() as $value) {
                     $script .= '            self::' . $col->getConstantName() . '_' . $this->getValueSetConstant($value) . ",
 ";
                 }
-                $script .= '        ),';
+                $script .= '        ],';
             }
         }
         $script .= "
-    );
+    ];
 ";
     }
 
@@ -298,7 +298,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      * Gets the list of values for all ENUM and SET columns
      * @return array
      */
-    public static function getValueSets()
+    public static function getValueSets(): array
     {
       return static::\$enumValueSets;
     }
@@ -320,7 +320,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      * @param string \$colname
      * @return array list of possible values for the column
      */
-    public static function getValueSet(\$colname)
+    public static function getValueSet(string \$colname): array
     {
         \$valueSets = self::getValueSets();
 
@@ -479,7 +479,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
     /**
      * Holds a list of column names and their normalized version.
      *
-     * @var string[]
+     * @var array<string>
      */
     protected $normalizedColumnNameMap = [' . $arrayString . PHP_EOL
             . '    ];' . PHP_EOL;
@@ -519,7 +519,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      * Relations are not initialized by this method since they are lazy loaded
      *
      * @return void
-     * @throws PropelException
+     * @throws \Propel\Runtime\Exception\PropelException
      */
     public function initialize(): void
     {
@@ -890,9 +890,9 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      * @param string \$indexType One of the class type constants TableMap::TYPE_PHPNAME, TableMap::TYPE_CAMELNAME
      *                           TableMap::TYPE_COLNAME, TableMap::TYPE_FIELDNAME, TableMap::TYPE_NUM
      *
-     * @return string The primary key hash of the row
+     * @return string|null The primary key hash of the row
      */
-    public static function getPrimaryKeyHashFromRow(\$row, \$offset = 0, \$indexType = TableMap::TYPE_NUM)
+    public static function getPrimaryKeyHashFromRow(array \$row, int \$offset = 0, string \$indexType = TableMap::TYPE_NUM): ?string
     {";
         if (count($pk) > 0) {
             $script .= "
@@ -934,7 +934,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      *
      * @return mixed The primary key of the row
      */
-    public static function getPrimaryKeyFromRow(\$row, \$offset = 0, \$indexType = TableMap::TYPE_NUM)
+    public static function getPrimaryKeyFromRow(array \$row, int \$offset = 0, string \$indexType = TableMap::TYPE_NUM)
     {";
 
         // We have to iterate through all the columns so that we
@@ -1027,12 +1027,12 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      * @param array   \$row ConnectionInterface result row.
      * @param int     \$colnum Column to examine for OM class information (first is 0).
      * @param bool \$withPrefix Whether to return the path with the class name
-     * @throws PropelException Any exceptions caught during processing will be
+     * @throws \Propel\Runtime\Exception\PropelException Any exceptions caught during processing will be
      *                         rethrown wrapped into a PropelException.
      *
      * @return string The OM class
      */
-    public static function getOMClass(\$row, \$colnum, \$withPrefix = true)
+    public static function getOMClass(array \$row, int \$colnum, bool \$withPrefix = true): string
     {
         try {
 ";
@@ -1079,7 +1079,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
     }
 
     /**
-     * Adds a getOMClass() for non-abstract tables that do note use inheritance.
+     * Adds a getOMClass() for non-abstract tables that do not use inheritance.
      *
      * @param string $script The script will be modified in this method.
      *
@@ -1099,7 +1099,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      * @param bool \$withPrefix Whether to return the path with the class name
      * @return string path.to.ClassName
      */
-    public static function getOMClass(\$withPrefix = true)
+    public static function getOMClass(bool \$withPrefix = true): string
     {
         return \$withPrefix ? " . $this->getTableMapClass() . '::CLASS_DEFAULT : ' . $this->getTableMapClass() . "::OM_CLASS;
     }
@@ -1125,8 +1125,9 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      * $objectClassName is declared abstract in the schema.
      *
      * @param bool \$withPrefix
+     * @return string
      */
-    public static function getOMClass(\$withPrefix = true)
+    public static function getOMClass(bool \$withPrefix = true): string
     {
         throw new PropelException('$objectClassName is declared abstract, it cannot be instantiated.');
     }
@@ -1153,11 +1154,11 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
                                  One of the class type constants TableMap::TYPE_PHPNAME, TableMap::TYPE_CAMELNAME
      *                           TableMap::TYPE_COLNAME, TableMap::TYPE_FIELDNAME, TableMap::TYPE_NUM.
      *
-     * @throws PropelException Any exceptions caught during processing will be
+     * @throws \Propel\Runtime\Exception\PropelException Any exceptions caught during processing will be
      *                         rethrown wrapped into a PropelException.
      * @return array           (" . $this->getObjectClassName() . " object, last column rank)
      */
-    public static function populateObject(\$row, \$offset = 0, \$indexType = TableMap::TYPE_NUM)
+    public static function populateObject(array \$row, int \$offset = 0, string \$indexType = TableMap::TYPE_NUM): array
     {
         \$key = {$this->getTableMapClassName()}::getPrimaryKeyHashFromRow(\$row, \$offset, \$indexType);
         if (null !== (\$obj = {$this->getTableMapClassName()}::getInstanceFromPool(\$key))) {
@@ -1210,11 +1211,11 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      * objects that inherit from the default.
      *
      * @param DataFetcherInterface \$dataFetcher
-     * @return array
-     * @throws PropelException Any exceptions caught during processing will be
+     * @return array<object>
+     * @throws \Propel\Runtime\Exception\PropelException Any exceptions caught during processing will be
      *                         rethrown wrapped into a PropelException.
      */
-    public static function populateObjects(DataFetcherInterface \$dataFetcher)
+    public static function populateObjects(DataFetcherInterface \$dataFetcher): array
     {
         \$results = [];
     ";
@@ -1279,11 +1280,12 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      * on demand.
      *
      * @param Criteria \$criteria object containing the columns to add.
-     * @param string   \$alias    optional table alias
-     * @throws PropelException Any exceptions caught during processing will be
+     * @param string|null   \$alias    optional table alias
+     * @throws \Propel\Runtime\Exception\PropelException Any exceptions caught during processing will be
      *                         rethrown wrapped into a PropelException.
+     * @return void
      */
-    public static function addSelectColumns(Criteria \$criteria, \$alias = null)
+    public static function addSelectColumns(Criteria \$criteria, ?string \$alias = null): void
     {
         if (null === \$alias) {";
         foreach ($this->getTable()->getColumns() as $col) {
@@ -1326,11 +1328,12 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      * XML schema will not be removed as they are only loaded on demand.
      *
      * @param Criteria \$criteria object containing the columns to remove.
-     * @param string   \$alias    optional table alias
-     * @throws PropelException Any exceptions caught during processing will be
+     * @param string|null \$alias    optional table alias
+     * @throws \Propel\Runtime\Exception\PropelException Any exceptions caught during processing will be
      *                         rethrown wrapped into a PropelException.
+     * @return void
      */
-    public static function removeSelectColumns(Criteria \$criteria, \$alias = null)
+    public static function removeSelectColumns(Criteria \$criteria, ?string \$alias = null): void
     {
         if (null === \$alias) {";
         foreach ($this->getTable()->getColumns() as $col) {
@@ -1370,7 +1373,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      * Returns the TableMap related to this object.
      * This method is not needed for general use but a specific application could have a need.
      * @return TableMap
-     * @throws PropelException Any exceptions caught during processing will be
+     * @throws \Propel\Runtime\Exception\PropelException Any exceptions caught during processing will be
      *                         rethrown wrapped into a PropelException.
      */
     public static function getTableMap()
@@ -1397,7 +1400,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      * @param ConnectionInterface \$con the connection to use
      * @return int The number of affected rows (if supported by underlying database driver).
      */
-    public static function doDeleteAll(ConnectionInterface \$con = null): int
+    public static function doDeleteAll(?ConnectionInterface \$con = null): int
     {
         return " . $this->getQueryClassName() . "::create()->doDeleteAll(\$con);
     }
@@ -1423,10 +1426,10 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      * @param  ConnectionInterface \$con the connection to use
      * @return int             The number of affected rows (if supported by underlying database driver).  This includes CASCADE-related rows
      *                         if supported by native driver or if emulated using Propel.
-     * @throws PropelException Any exceptions caught during processing will be
+     * @throws \Propel\Runtime\Exception\PropelException Any exceptions caught during processing will be
      *                         rethrown wrapped into a PropelException.
      */
-     public static function doDelete(\$values, ConnectionInterface \$con = null): int
+     public static function doDelete(\$values, ?ConnectionInterface \$con = null): int
      {
         if (null === \$con) {
             \$con = Propel::getServiceContainer()->getWriteConnection(" . $this->getTableMapClass() . "::DATABASE_NAME);
@@ -1470,7 +1473,7 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
             // the primary key passed to be an array of pkey values
             if (count(\$values) == count(\$values, COUNT_RECURSIVE)) {
                 // array is not multi-dimensional
-                \$values = array(\$values);
+                \$values = [\$values];
             }
             foreach (\$values as \$value) {";
                 $i = 0;
@@ -1528,10 +1531,10 @@ class " . $this->getUnqualifiedClassName() . " extends TableMap
      * @param mixed               \$criteria Criteria or " . $this->getObjectClassName() . " object containing data that is used to create the INSERT statement.
      * @param ConnectionInterface \$con the ConnectionInterface connection to use
      * @return mixed           The new primary key.
-     * @throws PropelException Any exceptions caught during processing will be
+     * @throws \Propel\Runtime\Exception\PropelException Any exceptions caught during processing will be
      *                         rethrown wrapped into a PropelException.
      */
-    public static function doInsert(\$criteria, ConnectionInterface \$con = null)
+    public static function doInsert(\$criteria, ?ConnectionInterface \$con = null)
     {
         if (null === \$con) {
             \$con = Propel::getServiceContainer()->getWriteConnection(" . $tableMapClass . "::DATABASE_NAME);

--- a/src/Propel/Generator/Builder/Om/templates/baseObjectMethods.php
+++ b/src/Propel/Generator/Builder/Om/templates/baseObjectMethods.php
@@ -137,7 +137,7 @@
      * @param  string $name The virtual column name
      * @return mixed
      *
-     * @throws PropelException
+     * @throws \Propel\Runtime\Exception\PropelException
      */
     public function getVirtualColumn($name)
     {

--- a/src/Propel/Generator/Util/QuickBuilder.php
+++ b/src/Propel/Generator/Util/QuickBuilder.php
@@ -292,7 +292,7 @@ class QuickBuilder
      *
      * @throws \Exception
      *
-     * @return int the number of statements executed
+     * @return int The number of statements executed
      */
     public function buildSQL(ConnectionInterface $con): int
     {

--- a/src/Propel/Generator/Util/SqlParser.php
+++ b/src/Propel/Generator/Util/SqlParser.php
@@ -75,7 +75,7 @@ class SqlParser
      * @param string $input The SQL statements
      * @param \Propel\Runtime\Connection\ConnectionInterface $connection a connection object
      *
-     * @return int the number of executed statements
+     * @return int The number of executed statements
      */
     public static function executeString(string $input, ConnectionInterface $connection): int
     {
@@ -89,7 +89,7 @@ class SqlParser
      * @param string $file the path to the SQL file
      * @param \Propel\Runtime\Connection\ConnectionInterface $connection a connection object
      *
-     * @return int the number of executed statements
+     * @return int The number of executed statements
      */
     public static function executeFile(string $file, ConnectionInterface $connection): int
     {
@@ -103,7 +103,7 @@ class SqlParser
      * @param array $statements a list of SQL statements
      * @param \Propel\Runtime\Connection\ConnectionInterface $connection a connection object
      *
-     * @return int the number of executed statements
+     * @return int The number of executed statements
      */
     protected static function executeStatements(array $statements, ConnectionInterface $connection): int
     {

--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -2402,7 +2402,7 @@ class Criteria
      *
      * @param \Propel\Runtime\Connection\ConnectionInterface|null $con a connection object
      *
-     * @return int the number of deleted rows
+     * @return int The number of deleted rows
      */
     public function doDelete(?ConnectionInterface $con = null): int
     {
@@ -2415,7 +2415,7 @@ class Criteria
      *
      * @param \Propel\Runtime\Connection\ConnectionInterface|null $con a connection object
      *
-     * @return int the number of deleted rows
+     * @return int The number of deleted rows
      */
     public function doDeleteAll(?ConnectionInterface $con = null): int
     {

--- a/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
@@ -1651,7 +1651,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @param \Propel\Runtime\Connection\ConnectionInterface|null $con an optional connection object
      *
-     * @return int the number of results
+     * @return int The number of results
      */
     public function count(?ConnectionInterface $con = null): int
     {
@@ -1796,7 +1796,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @throws \Propel\Runtime\Exception\PropelException
      *
-     * @return int the number of deleted rows
+     * @return int The number of deleted rows
      */
     public function delete(?ConnectionInterface $con = null): int
     {
@@ -1834,7 +1834,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @throws \Propel\Runtime\Exception\PropelException
      *
-     * @return int the number of deleted rows
+     * @return int The number of deleted rows
      */
     public function deleteAll(?ConnectionInterface $con = null): int
     {

--- a/src/Propel/Runtime/ActiveQuery/QueryExecutor/DeleteAllQueryExecutor.php
+++ b/src/Propel/Runtime/ActiveQuery/QueryExecutor/DeleteAllQueryExecutor.php
@@ -33,7 +33,7 @@ class DeleteAllQueryExecutor extends AbstractQueryExecutor
      *
      * @throws \Propel\Runtime\Exception\PropelException
      *
-     * @return int the number of deleted rows
+     * @return int The number of deleted rows
      */
     protected function runDeleteAll(): int
     {

--- a/src/Propel/Runtime/ActiveQuery/QueryExecutor/DeleteQueryExecutor.php
+++ b/src/Propel/Runtime/ActiveQuery/QueryExecutor/DeleteQueryExecutor.php
@@ -33,7 +33,7 @@ class DeleteQueryExecutor extends AbstractQueryExecutor
      *
      * @throws \Propel\Runtime\Exception\PropelException
      *
-     * @return int the number of deleted rows
+     * @return int The number of deleted rows
      */
     protected function runDelete(): int
     {

--- a/src/Propel/Runtime/Collection/ObjectCollection.php
+++ b/src/Propel/Runtime/Collection/ObjectCollection.php
@@ -286,11 +286,11 @@ class ObjectCollection extends Collection
      * <code>
      *   $res = $userCollection->toKeyIndex('Name');
      *
-     *   $res = array(
+     *   $res = [
      *       'peter' => class User #1 {$name => 'peter', ...},
      *       'hans' => class User #2 {$name => 'hans', ...},
      *       ...
-     *   )
+     *   ]
      * </code>
      *
      * @param string $keyColumn
@@ -314,11 +314,11 @@ class ObjectCollection extends Collection
      * <code>
      *   $res = $userCollection->toKeyIndex('Name');
      *
-     *   $res = array(
+     *   $res = [
      *       'peter',
      *       'hans',
      *       ...
-     *   )
+     *   ]
      * </code>
      *
      * @param string $columnName

--- a/src/Propel/Runtime/Connection/StatementInterface.php
+++ b/src/Propel/Runtime/Connection/StatementInterface.php
@@ -80,7 +80,7 @@ interface StatementInterface
     /**
      * Returns the number of rows affected by the last SQL statement.
      *
-     * @return int the number of rows.
+     * @return int The number of rows.
      */
     public function rowCount(): int;
 
@@ -150,7 +150,7 @@ interface StatementInterface
     /**
      * Returns the number of columns in the result set.
      *
-     * @return int the number of columns in the result set represented by the StatementInterface object.
+     * @return int The number of columns in the result set represented by the StatementInterface object.
      */
     public function columnCount(): int;
 


### PR DESCRIPTION
Follow https://github.com/propelorm/Propel2/pull/1833

How can we more easily debug fatal errors of generated code?

> PHP Fatal error:  A function with return type must return a value in vfs://root/propelQuickBuild/Stuff.php on line 1362

Currently, it goes to memory, so it is not easily introspectable.

Follow PRs to this PR are welcome, I started this but I do need some help to finish it up.