### PR TITLE
Support internal evaluation in conditional evaluation functions

### DIFF
--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -2473,13 +2473,13 @@ class Criteria
      * or a PropelConditionalProxy instance otherwise.
      * Allows for conditional statements in a fluid interface.
      *
-     * @param mixed $cond  Casts to bool for variable evaluation
+     * @param mixed $cond Casts to bool for variable evaluation
      *
      * @return \Propel\Runtime\Util\PropelConditionalProxy|$this
      */
     public function _if($cond)
     {
-        $cond = (bool) $cond; // Intentionally not typing the param to allow for evaluation inside this function
+        $cond = (bool)$cond; // Intentionally not typing the param to allow for evaluation inside this function
 
         $this->conditionalProxy = new PropelConditionalProxy($this, $cond, $this->conditionalProxy);
 
@@ -2490,7 +2490,7 @@ class Criteria
      * Returns a PropelConditionalProxy instance.
      * Allows for conditional statements in a fluid interface.
      *
-     * @param mixed $cond  Casts to bool for variable evaluation
+     * @param mixed $cond Casts to bool for variable evaluation
      *
      * @throws \Propel\Runtime\Exception\LogicException
      *
@@ -2498,7 +2498,7 @@ class Criteria
      */
     public function _elseif($cond)
     {
-        $cond = (bool) $cond; // Intentionally not typing the param to allow for evaluation inside this function
+        $cond = (bool)$cond; // Intentionally not typing the param to allow for evaluation inside this function
 
         if (!$this->conditionalProxy) {
             throw new LogicException(__METHOD__ . ' must be called after _if()');

--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -2473,12 +2473,14 @@ class Criteria
      * or a PropelConditionalProxy instance otherwise.
      * Allows for conditional statements in a fluid interface.
      *
-     * @param bool $cond
+     * @param mixed $cond  Casts to bool for variable evaluation
      *
      * @return \Propel\Runtime\Util\PropelConditionalProxy|$this
      */
-    public function _if(bool $cond)
+    public function _if($cond)
     {
+        $cond = (bool) $cond; // Intentionally not typing the param to allow for evaluation inside this function
+
         $this->conditionalProxy = new PropelConditionalProxy($this, $cond, $this->conditionalProxy);
 
         return $this->conditionalProxy->getCriteriaOrProxy();
@@ -2488,14 +2490,16 @@ class Criteria
      * Returns a PropelConditionalProxy instance.
      * Allows for conditional statements in a fluid interface.
      *
-     * @param bool $cond ignored
+     * @param mixed $cond  Casts to bool for variable evaluation
      *
      * @throws \Propel\Runtime\Exception\LogicException
      *
      * @return \Propel\Runtime\Util\PropelConditionalProxy|$this
      */
-    public function _elseif(bool $cond)
+    public function _elseif($cond)
     {
+        $cond = (bool) $cond; // Intentionally not typing the param to allow for evaluation inside this function
+
         if (!$this->conditionalProxy) {
             throw new LogicException(__METHOD__ . ' must be called after _if()');
         }

--- a/src/Propel/Runtime/Util/PropelConditionalProxy.php
+++ b/src/Propel/Runtime/Util/PropelConditionalProxy.php
@@ -81,24 +81,28 @@ class PropelConditionalProxy
      * Returns a new level PropelConditionalProxy instance.
      * Allows for conditional statements in a fluid interface.
      *
-     * @param bool $cond
+     * @param mixed $cond  Casts to bool for variable evaluation
      *
      * @return $this|\Propel\Runtime\ActiveQuery\Criteria
      */
-    public function _if(bool $cond)
+    public function _if($cond)
     {
+        $cond = (bool) $cond; // Intentionally not typing the param to allow for evaluation inside this function
+
         return $this->criteria->_if($cond);
     }
 
     /**
      * Allows for conditional statements in a fluid interface.
      *
-     * @param bool $cond ignored
+     * @param mixed $cond  Casts to bool for variable evaluation
      *
      * @return $this|\Propel\Runtime\ActiveQuery\Criteria
      */
-    public function _elseif(bool $cond)
+    public function _elseif($cond)
     {
+        $cond = (bool) $cond; // Intentionally not typing the param to allow for evaluation inside this function
+
         return $this->setConditionalState(!$this->wasTrue && $cond);
     }
 

--- a/src/Propel/Runtime/Util/PropelConditionalProxy.php
+++ b/src/Propel/Runtime/Util/PropelConditionalProxy.php
@@ -81,13 +81,13 @@ class PropelConditionalProxy
      * Returns a new level PropelConditionalProxy instance.
      * Allows for conditional statements in a fluid interface.
      *
-     * @param mixed $cond  Casts to bool for variable evaluation
+     * @param mixed $cond Casts to bool for variable evaluation
      *
      * @return $this|\Propel\Runtime\ActiveQuery\Criteria
      */
     public function _if($cond)
     {
-        $cond = (bool) $cond; // Intentionally not typing the param to allow for evaluation inside this function
+        $cond = (bool)$cond; // Intentionally not typing the param to allow for evaluation inside this function
 
         return $this->criteria->_if($cond);
     }
@@ -95,13 +95,13 @@ class PropelConditionalProxy
     /**
      * Allows for conditional statements in a fluid interface.
      *
-     * @param mixed $cond  Casts to bool for variable evaluation
+     * @param mixed $cond Casts to bool for variable evaluation
      *
      * @return $this|\Propel\Runtime\ActiveQuery\Criteria
      */
     public function _elseif($cond)
     {
-        $cond = (bool) $cond; // Intentionally not typing the param to allow for evaluation inside this function
+        $cond = (bool)$cond; // Intentionally not typing the param to allow for evaluation inside this function
 
         return $this->setConditionalState(!$this->wasTrue && $cond);
     }


### PR DESCRIPTION
After some of the recent typing improvements, the condition evaluation functions (`_if`, `_elseif`) got updated as well, and IMO, should not be typed, allowing for evaluation to happen within the conditional functions.

This PR provides BC and a desired behavior, exactly like the native `if` statement evaluation.