### PR TITLE
add type-safe access to StandardServiceContainer

### DIFF
--- a/src/Propel/Runtime/Propel.php
+++ b/src/Propel/Runtime/Propel.php
@@ -11,6 +11,7 @@ namespace Propel\Runtime;
 use Propel\Runtime\Adapter\AdapterInterface;
 use Propel\Runtime\Connection\ConnectionInterface;
 use Propel\Runtime\Connection\ConnectionManagerInterface;
+use Propel\Runtime\Exception\PropelException;
 use Propel\Runtime\Map\DatabaseMap;
 use Propel\Runtime\ServiceContainer\ServiceContainerInterface;
 use Propel\Runtime\ServiceContainer\StandardServiceContainer;
@@ -143,6 +144,29 @@ class Propel
         }
 
         return self::$serviceContainer;
+    }
+
+    /**
+     * Returns the service container if it is an instance of
+     * StandardServiceContainer or throws an error if another service container
+     * is used.
+     *
+     * This method allows type-safe access to methods of
+     * StandardServiceContainer, it provides no other advantage over
+     * {@link Propel::getServiceContainer()}
+     *
+     * @throws \Propel\Runtime\Exception\PropelException
+     *
+     * @return \Propel\Runtime\ServiceContainer\StandardServiceContainer
+     */
+    public static function getStandardServiceContainer(): StandardServiceContainer
+    {
+        $sc = self::getServiceContainer();
+        if ($sc instanceof StandardServiceContainer) {
+            return $sc;
+        }
+
+        throw new PropelException('Instance was configured to not use StandardServiceContainer. Use Propel::getServiceContainer()');
     }
 
     /**

--- a/tests/Propel/Tests/Runtime/PropelTest.php
+++ b/tests/Propel/Tests/Runtime/PropelTest.php
@@ -12,6 +12,7 @@ use Propel\Runtime\Propel;
 use Propel\Runtime\ServiceContainer\ServiceContainerInterface;
 use Propel\Runtime\ServiceContainer\StandardServiceContainer;
 use Propel\Tests\Helpers\BaseTestCase;
+use Propel\Runtime\Exception\PropelException;
 
 class PropelTest extends BaseTestCase
 {
@@ -45,4 +46,20 @@ class PropelTest extends BaseTestCase
         $this->assertSame($newSC, Propel::getServiceContainer());
         Propel::setServiceContainer($oldSC);
     }
+    
+    public function testGetStandardServiceContainerWithDefaultContainer()
+    {
+        $sc = Propel::getStandardServiceContainer();
+        $this->assertInstanceOf(StandardServiceContainer::class, $sc);
+    }
+    
+    
+    public function testGetStandardServiceContainerThrowsErrorWithNonStandardContainer()
+    {
+        $sc = $this->createMock(ServiceContainerInterface::class);
+        Propel::setServiceContainer($sc);
+        $this->expectException(PropelException::class);
+        Propel::getStandardServiceContainer();
+    }
+    
 }


### PR DESCRIPTION
When using `Propel::getServiceContainer()`, an instance of ServiceContainerInterface is returned, and users can implement their own service container against this interface.

However, almost all users do not do that, and instead use the StandardServiceContainer, which offers crucial functionality, particularly enabling and configuring the logger.

But since the additional functionality of  StandardServiceContainer is not part of the interface, they have to find those methods without IDE support, and if they use type checkers, those will complain because unknown methods are accessed. See for example [this discussion](https://github.com/propelorm/Propel2/discussions/1871).

Since there are no generics in PHP, a feasible workaround is to add a new method to the Propel runtime object, which allows type-safe access to the StandardServiceContainer.

If there is a better solution, I'd be happy to find out!