### PR TITLE
Set connection debug mode on StandardServiceContainer

### DIFF
--- a/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
+++ b/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
@@ -111,7 +111,7 @@ class StandardServiceContainer implements ServiceContainerInterface
     /**
      * @var bool|null
      */
-    protected $setWrappedConnetionToDebug;
+    protected $useDebugModeFlag;
 
     /**
      * @return string
@@ -482,10 +482,10 @@ class StandardServiceContainer implements ServiceContainerInterface
     {
         if (
             $connection instanceof ConnectionWrapper
-            && $this->setWrappedConnetionToDebug !== null
-            && $connection->useDebug !== $this->setWrappedConnetionToDebug
+            && $this->useDebugModeFlag !== null
+            && $connection->useDebug !== $this->useDebugModeFlag
         ) {
-            $connection->useDebug($this->setWrappedConnetionToDebug);
+            $connection->useDebug($this->useDebugModeFlag);
         }
     }
 
@@ -673,9 +673,10 @@ class StandardServiceContainer implements ServiceContainerInterface
     }
 
     /**
-     * Create connections in debug mode.
+     * Enable or disable debug output.
      *
-     * This only works with the default ConnectionWrapper.
+     * Sets created connections in debug mode. This only works when the
+     * default ConnectionWrapper is used..
      *
      * @see \Propel\Runtime\Connection\ConnectionWrapper::useDebug()
      *
@@ -683,8 +684,8 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @return void
      */
-    public function setWrappedConnectionDebugMode(?bool $useDebug = true): void
+    public function useDebugMode(?bool $useDebug = true): void
     {
-        $this->setWrappedConnetionToDebug = $useDebug;
+        $this->useDebugModeFlag = $useDebug;
     }
 }

--- a/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
+++ b/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
@@ -109,7 +109,7 @@ class StandardServiceContainer implements ServiceContainerInterface
     protected $loggerConfigurations = [];
 
     /**
-     * @var bool | null
+     * @var bool|null
      */
     protected $setWrappedConnetionToDebug;
 
@@ -679,7 +679,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      *
      * @see \Propel\Runtime\Connection\ConnectionWrapper::useDebug()
      *
-     * @param bool | null $useDebug
+     * @param bool|null $useDebug
      *
      * @return void
      */

--- a/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
+++ b/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
@@ -111,7 +111,7 @@ class StandardServiceContainer implements ServiceContainerInterface
     /**
      * @var bool|null
      */
-    protected $useDebugModeFlag;
+    protected $isInDebugMode;
 
     /**
      * @return string
@@ -482,10 +482,10 @@ class StandardServiceContainer implements ServiceContainerInterface
     {
         if (
             $connection instanceof ConnectionWrapper
-            && $this->useDebugModeFlag !== null
-            && $connection->useDebug !== $this->useDebugModeFlag
+            && $this->isInDebugMode !== null
+            && $connection->useDebug !== $this->isInDebugMode
         ) {
-            $connection->useDebug($this->useDebugModeFlag);
+            $connection->useDebug($this->isInDebugMode);
         }
     }
 
@@ -686,6 +686,6 @@ class StandardServiceContainer implements ServiceContainerInterface
      */
     public function useDebugMode(?bool $useDebug = true): void
     {
-        $this->useDebugModeFlag = $useDebug;
+        $this->isInDebugMode = $useDebug;
     }
 }

--- a/tests/Propel/Tests/Runtime/ServiceContainer/StandardServiceContainerTest.php
+++ b/tests/Propel/Tests/Runtime/ServiceContainer/StandardServiceContainerTest.php
@@ -706,7 +706,7 @@ class StandardServiceContainerTest extends BaseTestCase
     protected function assertWrappedConnectionInDebugMode(bool $isDebugMode, ConnectionInterface $connection): void
     {
         $this->assertInstanceOf(ConnectionWrapper::class, $connection, 'Connection should be a ConnectionWrapper');
-        $this->assertEquals($isDebugMode, $connection->useDebug);
+        $this->assertSame($isDebugMode, $connection->useDebug, 'Debug state should match');
     }
 }
 

--- a/tests/Propel/Tests/Runtime/ServiceContainer/StandardServiceContainerTest.php
+++ b/tests/Propel/Tests/Runtime/ServiceContainer/StandardServiceContainerTest.php
@@ -689,7 +689,7 @@ class StandardServiceContainerTest extends BaseTestCase
         
         $testModes = [true, false];
         foreach($testModes as $mode){
-            $this->sc->setWrappedConnectionDebugMode($mode);
+            $this->sc->useDebugMode($mode);
             $this->assertConnectionDebugMode($mode, $connectionName);
         }
     }


### PR DESCRIPTION
In order to get log messages about executed queries, the connection has to be set to debug mode. Currently, this is done by accessing the connection through the service container:
```php
serviceContainer = Propel::getServiceContainer();
$connection = $serviceContainer->getWriteConnection('default');
$connection->useDebug(true);
```
This is a bit cumbersome for two reasons (see [this discussion](https://github.com/propelorm/Propel2/discussions/1871)):

1. Users have to interact with Propel internals
2. The method `useDebug()` is only available on ConnectionWrapper, but not on ConnectionInterface, which is what `ServiceContainerInterface::getWriteConnection()` returns, causing type errors when using a checker (or more boilerplate code).

A simple solution is to allow managing of the connection debug mode through the service container.

Currently, the new method to set connection debug mode allows for three values: true, false and null, where null means to leave the connection unchanged. If you prefer it, I can add consts for those values.