### PR TITLE
Adjust return type of Query::find methods

### DIFF
--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -896,6 +896,8 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
         }
 
         $orNull = $column->isNotNull() ? '' : '|null';
+        $descriptionReturnValueNull = $column->isNotNull() ? '' : ', NULL if column is NULL';
+        $descriptionReturnMysqlInvalidDate = $handleMysqlDate ? ", and 0 if column value is $mysqlInvalidDateString" : '';
 
         $script .= "
     /**
@@ -905,7 +907,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * @param string|null \$format The date/time format string (either date()-style or strftime()-style).
      *   If format is NULL, then the raw $dateTimeClass object will be returned.
      *
-     * @return string|{$dateTimeClass}{$orNull} Formatted date/time value as string or $dateTimeClass object (if format is NULL), NULL if column is NULL" . ($handleMysqlDate ? ', and 0 if column value is ' . $mysqlInvalidDateString : '') . "
+     * @return string|{$dateTimeClass}{$orNull} Formatted date/time value as string or $dateTimeClass object (if format is NULL){$descriptionReturnValueNull}{$descriptionReturnMysqlInvalidDate}.
      *
      * @throws \Propel\Runtime\Exception\PropelException - if unable to parse/validate the date/time value.
      *
@@ -4025,6 +4027,9 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
             }
             $script .= "
         return " . implode(' && ', $tests) . ';';
+        } else {
+            $script .= "
+        return false;";
         }
         $script .= "
     }

--- a/src/Propel/Generator/Builder/Om/QueryBuilder.php
+++ b/src/Propel/Generator/Builder/Om/QueryBuilder.php
@@ -218,12 +218,12 @@ class QueryBuilder extends AbstractOMBuilder
 
         $script .= "
  *
- * @method     {$modelClass}[]|ObjectCollection find(?ConnectionInterface \$con = null) Return $modelClass objects based on current ModelCriteria
- * @psalm-method ObjectCollection&\Traversable<{$modelClass}> find(?ConnectionInterface \$con = null) Return $modelClass objects based on current ModelCriteria";
+ * @method     {$modelClass}[]|Collection find(?ConnectionInterface \$con = null) Return $modelClass objects based on current ModelCriteria
+ * @psalm-method Collection&\Traversable<{$modelClass}> find(?ConnectionInterface \$con = null) Return $modelClass objects based on current ModelCriteria";
         foreach ($this->getTable()->getColumns() as $column) {
             $script .= "
- * @method     {$modelClass}[]|ObjectCollection findBy" . $column->getPhpName() . '(' . $column->getPhpType() . ' $' . $column->getName() . ") Return $modelClass objects filtered by the " . $column->getName() . ' column' . "
- * @psalm-method ObjectCollection&\Traversable<{$modelClass}> findBy" . $column->getPhpName() . '(' . $column->getPhpType() . ' $' . $column->getName() . ") Return $modelClass objects filtered by the " . $column->getName() . ' column';
+ * @method     {$modelClass}[]|Collection findBy" . $column->getPhpName() . '(' . $column->getPhpType() . ' $' . $column->getName() . ") Return $modelClass objects filtered by the " . $column->getName() . ' column' . "
+ * @psalm-method Collection&\Traversable<{$modelClass}> findBy" . $column->getPhpName() . '(' . $column->getPhpType() . ' $' . $column->getName() . ") Return $modelClass objects filtered by the " . $column->getName() . ' column';
         }
 
         $script .= "
@@ -835,7 +835,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
     protected function addFindPks(string &$script): void
     {
         $this->declareClasses(
-            '\Propel\Runtime\Collection\ObjectCollection',
+            '\Propel\Runtime\Collection\Collection',
             '\Propel\Runtime\Connection\ConnectionInterface',
             '\Propel\Runtime\Propel',
         );
@@ -858,7 +858,7 @@ abstract class " . $this->getUnqualifiedClassName() . ' extends ' . $parentClass
      * @param array \$keys Primary keys to use for the query
      * @param ConnectionInterface \$con an optional connection object
      *
-     * @return ObjectCollection|array|mixed the list of results, formatted by the current formatter
+     * @return Collection|array|mixed the list of results, formatted by the current formatter
      */
     public function findPks(\$keys, ?ConnectionInterface \$con = null)
     {";

--- a/src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/BaseModelCriteria.php
@@ -10,6 +10,7 @@ namespace Propel\Runtime\ActiveQuery;
 
 use ArrayIterator;
 use IteratorAggregate;
+use Propel\Runtime\ActiveQuery\Exception\UnknownModelException;
 use Propel\Runtime\Exception\InvalidArgumentException;
 use Propel\Runtime\Exception\LogicException;
 use Propel\Runtime\Formatter\AbstractFormatter;
@@ -184,6 +185,8 @@ class BaseModelCriteria extends Criteria implements IteratorAggregate
      *
      * @param string|null $modelName
      *
+     * @throws \Propel\Runtime\ActiveQuery\Exception\UnknownModelException
+     *
      * @return $this The current object, for fluid interface
      */
     public function setModelName(?string $modelName)
@@ -195,6 +198,10 @@ class BaseModelCriteria extends Criteria implements IteratorAggregate
         }
         if (strpos($modelName, '\\') === 0) {
             $modelName = substr($modelName, 1);
+        }
+
+        if (!class_exists($modelName)) {
+            throw new UnknownModelException('Cannot find model class ' . $modelName);
         }
 
         $this->modelName = $modelName;

--- a/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
@@ -1288,7 +1288,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @param \Propel\Runtime\Connection\ConnectionInterface|null $con an optional connection object
      *
-     * @return \Propel\Runtime\Collection\ObjectCollection|\Propel\Runtime\ActiveRecord\ActiveRecordInterface[]|mixed the list of results, formatted by the current formatter
+     * @return \Propel\Runtime\Collection\Collection|\Propel\Runtime\ActiveRecord\ActiveRecordInterface[]|mixed the list of results, formatted by the current formatter
      */
     public function find(?ConnectionInterface $con = null)
     {
@@ -1553,7 +1553,7 @@ class ModelCriteria extends BaseModelCriteria
      *
      * @throws \Propel\Runtime\Exception\PropelException
      *
-     * @return mixed the list of results, formatted by the current formatter
+     * @return \Propel\Runtime\Collection\Collection|\Propel\Runtime\ActiveRecord\ActiveRecordInterface[]|mixed the list of results, formatted by the current formatter
      */
     public function findPks(array $keys, ?ConnectionInterface $con = null)
     {
@@ -1587,7 +1587,7 @@ class ModelCriteria extends BaseModelCriteria
      * @param mixed $value A value for the condition
      * @param \Propel\Runtime\Connection\ConnectionInterface|null $con An optional connection object
      *
-     * @return mixed the list of results, formatted by the current formatter
+     * @return \Propel\Runtime\Collection\Collection|\Propel\Runtime\ActiveRecord\ActiveRecordInterface[]|mixed the list of results, formatted by the current formatter
      */
     public function findBy(string $column, $value, ?ConnectionInterface $con = null)
     {
@@ -1612,7 +1612,7 @@ class ModelCriteria extends BaseModelCriteria
      * @param mixed $conditions An array of conditions, using column phpNames as key
      * @param \Propel\Runtime\Connection\ConnectionInterface|null $con an optional connection object
      *
-     * @return mixed the list of results, formatted by the current formatter
+     * @return \Propel\Runtime\Collection\Collection|\Propel\Runtime\ActiveRecord\ActiveRecordInterface[]|mixed the list of results, formatted by the current formatter
      */
     public function findByArray($conditions, ?ConnectionInterface $con = null)
     {

--- a/tests/Propel/Tests/Runtime/ActiveQuery/PropelQueryTest.php
+++ b/tests/Propel/Tests/Runtime/ActiveQuery/PropelQueryTest.php
@@ -17,6 +17,8 @@ use Propel\Tests\Bookstore\Book;
 use Propel\Tests\Bookstore\BookQuery;
 use Propel\Tests\Helpers\Bookstore\BookstoreDataPopulator;
 use Propel\Tests\Helpers\Bookstore\BookstoreTestBase;
+use Propel\Runtime\Collection\ObjectCollection;
+use Propel\Runtime\Collection\ArrayCollection;
 
 /**
  * Test class for PropelQuery
@@ -190,5 +192,30 @@ class PropelQueryTest extends BookstoreTestBase
         $result = $bookQuery->find();
 
         $this->assertNotNull($result);
+    }
+
+    /**
+     * @dataProvider findMethodsProvider
+     */
+    public function testReturnTypeOfFind(string $findMethodName, $findMethodArg)
+    {
+        $queryTypes = [
+            ['query' => BookQuery::create(), 'returnType' => ObjectCollection::class],
+            ['query' => BookQuery::create()->select(['id']), 'returnType' => ArrayCollection::class],
+            
+        ];
+        foreach($queryTypes as ['query' => $query, 'returnType' => $returnType]){
+            $result = call_user_func([$query, $findMethodName], $findMethodArg);
+            $this->assertInstanceOf($returnType, $result);
+        }
+    }
+    
+    public function findMethodsProvider()
+    {
+        return [
+            ['find', null],
+            ['findByTitle', 'le title'],
+            ['findPks', 42]
+        ];
     }
 }


### PR DESCRIPTION
I started to work with the new type hints in Propel (very nice!), but ran into some problems with return types:

* The return type of `Query::find()`, `Query::findByXyz()` and `Query::findPks()` is set to ObjectCollection, but it returns ArrayCollection if `->select()` is used
* Docstring of temporal types (`Model::getDate()`) says that method can return null on non-null columns
* Method `Model::isPrimaryKeyNull()` is declared to return a bool, but no return is added if the table has no primary key

Particularly the last two are pretty menial, but it cannot hurt to adjust it.

Also fixed an error from phpstan, where a string was used as a class name without check if the class exists. 