### PR TITLE
restore service container after tests

### DIFF
--- a/tests/Propel/Tests/Runtime/PropelTest.php
+++ b/tests/Propel/Tests/Runtime/PropelTest.php
@@ -16,6 +16,18 @@ use Propel\Runtime\Exception\PropelException;
 
 class PropelTest extends BaseTestCase
 {
+    protected static $initialServiceContainer;
+    
+    public static function setUpBeforeClass(): void
+    {
+        static::$initialServiceContainer = Propel::getServiceContainer();
+    }
+    
+    public function tearDown(): void
+    {
+        Propel::setServiceContainer(static::$initialServiceContainer);
+    }
+    
     /**
      * @return void
      */
@@ -40,11 +52,9 @@ class PropelTest extends BaseTestCase
      */
     public function testSetServiceContainerOverridesTheExistingServiceContainer()
     {
-        $oldSC = Propel::getServiceContainer();
         $newSC = new StandardServiceContainer();
         Propel::setServiceContainer($newSC);
         $this->assertSame($newSC, Propel::getServiceContainer());
-        Propel::setServiceContainer($oldSC);
     }
     
     public function testGetStandardServiceContainerWithDefaultContainer()


### PR DESCRIPTION
Umph, a test I added recently had some unintended consequences, breaking subsequent tests. Not sure why it didn't show sooner.

In the test, the ServiceContainer was changed, but not reset, leading to missing configuration data downstream (mocked adapter, mocked table maps, etc.) and around 40 failing tests with weird error messages.

Pretty stoopid...