### PR TITLE
close connections when changing debug mode

### DIFF
--- a/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
+++ b/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
@@ -664,5 +664,6 @@ class StandardServiceContainer implements ServiceContainerInterface
     {
         ConnectionWrapper::$useDebugMode = $useDebug;
         ConnectionFactory::$useProfilerConnection = $logStatementProfile ?? $useDebug;
+        $this->closeConnections();
     }
 }


### PR DESCRIPTION
Small update to the recent changes around enabling debug mode: when enabling or disabling, connections need to be closed, otherwise old connection will be used and change does not apply.