### PR TITLE
MSSQL/SQLSrv Datetime format fixes

### DIFF
--- a/src/Propel/Runtime/Adapter/Pdo/MssqlAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/MssqlAdapter.php
@@ -337,4 +337,26 @@ class MssqlAdapter extends PdoAdapter implements SqlAdapterInterface
     public function applyLock(string &$sql, Lock $lock): void
     {
     }
+     
+    /**
+     * Returns timestamp formatter string for use in date() function.
+     *
+     * @return string
+     */
+    public function getTimestampFormatter()
+    {
+        return 'Y-m-d H:i:s:000';
+    }
+
+
+    /**
+     * Returns time formatter string for use in date() function.
+     *
+     * @return string
+     */
+    public function getTimeFormatter()
+    {
+        return 'H:i:s:000';
+    }
+    
 }


### PR DESCRIPTION
I know there is an older PR https://github.com/propelorm/Propel2/pull/1328  that covers this change, 
But it's based on 2017 code, and does not look like its going to cleaned up anytime soon.

I have just taken the DateTime fix to it's own PR.