### PR TITLE
Fix #1884 - Incorrect path of template folder

### DIFF
--- a/src/Propel/Common/Util/PathTrait.php
+++ b/src/Propel/Common/Util/PathTrait.php
@@ -34,7 +34,7 @@ trait PathTrait
      */
     protected function getTemplatePath(string $path): string
     {
-        $srcPos = strpos($path, DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR);
+        $srcPos = strrpos($path, DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR);
         if ($srcPos === false) {
             // BC shim for old template paths
             $path .= 'templates' . DIRECTORY_SEPARATOR;


### PR DESCRIPTION
Replace "strpos" with "strrpos" to find the last occurrence of src folder.