### PR TITLE
Added a common return type for Collection::getIterator() method

### DIFF
--- a/src/Propel/Runtime/Collection/Collection.php
+++ b/src/Propel/Runtime/Collection/Collection.php
@@ -201,7 +201,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
     }
 
     /**
-     * @return \Propel\Runtime\Collection\CollectionIterator|\Traversable
+     * @return \Propel\Runtime\Collection\CollectionIterator|\Traversable|\Countable
      */
     public function getIterator(): Traversable
     {

--- a/src/Propel/Runtime/Collection/Collection.php
+++ b/src/Propel/Runtime/Collection/Collection.php
@@ -201,7 +201,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
     }
 
     /**
-     * @return \Propel\Runtime\Collection\CollectionIterator
+     * @return \Propel\Runtime\Collection\CollectionIterator|\Traversable
      */
     public function getIterator(): Traversable
     {

--- a/src/Propel/Runtime/Collection/Collection.php
+++ b/src/Propel/Runtime/Collection/Collection.php
@@ -201,7 +201,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
     }
 
     /**
-     * @return \Propel\Runtime\Collection\CollectionIterator|\Traversable&\Countable
+     * @return \Propel\Runtime\Collection\CollectionIterator|\Propel\Runtime\Collection\IteratorInterface
      */
     public function getIterator(): Traversable
     {

--- a/src/Propel/Runtime/Collection/Collection.php
+++ b/src/Propel/Runtime/Collection/Collection.php
@@ -201,7 +201,7 @@ class Collection implements ArrayAccess, IteratorAggregate, Countable, Serializa
     }
 
     /**
-     * @return \Propel\Runtime\Collection\CollectionIterator|\Traversable|\Countable
+     * @return \Propel\Runtime\Collection\CollectionIterator|\Traversable&\Countable
      */
     public function getIterator(): Traversable
     {

--- a/src/Propel/Runtime/Collection/CollectionIterator.php
+++ b/src/Propel/Runtime/Collection/CollectionIterator.php
@@ -15,7 +15,7 @@ use ArrayIterator;
  *
  * @extends \ArrayIterator<(int|string), mixed>
  */
-class CollectionIterator extends ArrayIterator
+class CollectionIterator extends ArrayIterator implements IteratorInterface
 {
     /**
      * @var \Propel\Runtime\Collection\Collection

--- a/src/Propel/Runtime/Collection/CollectionIterator.php
+++ b/src/Propel/Runtime/Collection/CollectionIterator.php
@@ -12,8 +12,6 @@ use ArrayIterator;
 
 /**
  * Iterator class for iterating over Collection data
- *
- * @implements \Propel\Runtime\Collection\IteratorInterface<(int|string), mixed>
  */
 class CollectionIterator extends ArrayIterator implements IteratorInterface
 {

--- a/src/Propel/Runtime/Collection/CollectionIterator.php
+++ b/src/Propel/Runtime/Collection/CollectionIterator.php
@@ -12,6 +12,8 @@ use ArrayIterator;
 
 /**
  * Iterator class for iterating over Collection data
+ *
+ * @extends \ArrayIterator<(int|string), mixed>
  */
 class CollectionIterator extends ArrayIterator implements IteratorInterface
 {

--- a/src/Propel/Runtime/Collection/CollectionIterator.php
+++ b/src/Propel/Runtime/Collection/CollectionIterator.php
@@ -13,7 +13,7 @@ use ArrayIterator;
 /**
  * Iterator class for iterating over Collection data
  *
- * @extends \ArrayIterator<(int|string), mixed>
+ * @implements \Propel\Runtime\Collection\IteratorInterface<(int|string), mixed>
  */
 class CollectionIterator extends ArrayIterator implements IteratorInterface
 {

--- a/src/Propel/Runtime/Collection/IteratorInterface.php
+++ b/src/Propel/Runtime/Collection/IteratorInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Runtime\Collection;
+
+interface IteratorInterface extends \Iterator, \Countable
+{
+}

--- a/src/Propel/Runtime/Collection/IteratorInterface.php
+++ b/src/Propel/Runtime/Collection/IteratorInterface.php
@@ -8,6 +8,9 @@
 
 namespace Propel\Runtime\Collection;
 
-interface IteratorInterface extends \Iterator, \Countable
+use Countable;
+use Iterator;
+
+interface IteratorInterface extends Iterator, Countable
 {
 }

--- a/src/Propel/Runtime/Collection/IteratorInterface.php
+++ b/src/Propel/Runtime/Collection/IteratorInterface.php
@@ -11,6 +11,9 @@ namespace Propel\Runtime\Collection;
 use Countable;
 use Iterator;
 
+/**
+ * @extends \Iterator<(int|string), mixed>
+ */
 interface IteratorInterface extends Iterator, Countable
 {
 }

--- a/src/Propel/Runtime/Collection/OnDemandCollection.php
+++ b/src/Propel/Runtime/Collection/OnDemandCollection.php
@@ -109,7 +109,7 @@ class OnDemandCollection extends Collection
     }
 
     /**
-     * @return \Propel\Runtime\Collection\OnDemandIterator|\Traversable|\Countable
+     * @return \Propel\Runtime\Collection\OnDemandIterator|\Traversable&\Countable
      */
     public function getIterator(): Traversable
     {

--- a/src/Propel/Runtime/Collection/OnDemandCollection.php
+++ b/src/Propel/Runtime/Collection/OnDemandCollection.php
@@ -108,10 +108,8 @@ class OnDemandCollection extends Collection
         throw new ReadOnlyModelException('The On Demand Collection is read only');
     }
 
-    // IteratorAggregate Interface
-
     /**
-     * @return \Propel\Runtime\Collection\OnDemandIterator
+     * @return \Propel\Runtime\Collection\OnDemandIterator|\Traversable
      */
     public function getIterator(): Traversable
     {

--- a/src/Propel/Runtime/Collection/OnDemandCollection.php
+++ b/src/Propel/Runtime/Collection/OnDemandCollection.php
@@ -109,7 +109,7 @@ class OnDemandCollection extends Collection
     }
 
     /**
-     * @return \Propel\Runtime\Collection\OnDemandIterator|\Traversable
+     * @return \Propel\Runtime\Collection\OnDemandIterator|\Traversable|\Countable
      */
     public function getIterator(): Traversable
     {

--- a/src/Propel/Runtime/Collection/OnDemandCollection.php
+++ b/src/Propel/Runtime/Collection/OnDemandCollection.php
@@ -109,7 +109,7 @@ class OnDemandCollection extends Collection
     }
 
     /**
-     * @return \Propel\Runtime\Collection\OnDemandIterator|\Traversable&\Countable
+     * @return \Propel\Runtime\Collection\OnDemandIterator|\Propel\Runtime\Collection\IteratorInterface
      */
     public function getIterator(): Traversable
     {

--- a/src/Propel/Runtime/Collection/OnDemandIterator.php
+++ b/src/Propel/Runtime/Collection/OnDemandIterator.php
@@ -20,8 +20,6 @@ use Propel\Runtime\Propel;
  * Class for iterating over a statement and returning one Propel object at a time
  *
  * @author Francois Zaninotto
- *
- * @implements \Propel\Runtime\Collection\IteratorInterface<(int|string), mixed>
  */
 class OnDemandIterator implements IteratorInterface
 {

--- a/src/Propel/Runtime/Collection/OnDemandIterator.php
+++ b/src/Propel/Runtime/Collection/OnDemandIterator.php
@@ -21,7 +21,7 @@ use Propel\Runtime\Propel;
  *
  * @author Francois Zaninotto
  *
- * @implements \Iterator<int|string, mixed>
+ * @implements \Propel\Runtime\Collection\IteratorInterface<(int|string), mixed>
  */
 class OnDemandIterator implements IteratorInterface
 {

--- a/src/Propel/Runtime/Collection/OnDemandIterator.php
+++ b/src/Propel/Runtime/Collection/OnDemandIterator.php
@@ -8,6 +8,7 @@
 
 namespace Propel\Runtime\Collection;
 
+use Countable;
 use Iterator;
 use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
 use Propel\Runtime\DataFetcher\DataFetcherInterface;
@@ -22,7 +23,7 @@ use Propel\Runtime\Propel;
  *
  * @implements \Iterator<int|string, mixed>
  */
-class OnDemandIterator implements Iterator
+class OnDemandIterator implements IteratorInterface
 {
     /**
      * @var \Propel\Runtime\Formatter\ObjectFormatter

--- a/src/Propel/Runtime/Collection/OnDemandIterator.php
+++ b/src/Propel/Runtime/Collection/OnDemandIterator.php
@@ -8,8 +8,6 @@
 
 namespace Propel\Runtime\Collection;
 
-use Countable;
-use Iterator;
 use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
 use Propel\Runtime\DataFetcher\DataFetcherInterface;
 use Propel\Runtime\Exception\PropelException;


### PR DESCRIPTION
`OnDemandCollection::getIterator` docblock has not compatible type with the base class. Added a common type for both classes