### PR TITLE
allow datetime type columns

### DIFF
--- a/src/Propel/Generator/Behavior/I18n/I18nBehaviorObjectBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/I18n/I18nBehaviorObjectBuilderModifier.php
@@ -311,6 +311,7 @@ class I18nBehaviorObjectBuilderModifier
     {
         return in_array($columnType, [
             PropelTypes::DATE,
+            PropelTypes::DATETIME,
             PropelTypes::TIME,
             PropelTypes::TIMESTAMP,
         ], true);

--- a/src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/AbstractObjectBuilder.php
@@ -39,6 +39,7 @@ abstract class AbstractObjectBuilder extends AbstractOMBuilder
             // if they're not using the DateTime class then we will generate "compatibility" accessor method
             if (
                 $type === PropelTypes::DATE
+                || $type === PropelTypes::DATETIME
                 || $type === PropelTypes::TIME
                 || $type === PropelTypes::TIMESTAMP
             ) {
@@ -90,6 +91,7 @@ abstract class AbstractObjectBuilder extends AbstractOMBuilder
                 $this->addLobMutator($script, $col);
             } elseif (
                 $col->getType() === PropelTypes::DATE
+                || $col->getType() === PropelTypes::DATETIME
                 || $col->getType() === PropelTypes::TIME
                 || $col->getType() === PropelTypes::TIMESTAMP
             ) {

--- a/src/Propel/Generator/Model/PropelTypes.php
+++ b/src/Propel/Generator/Model/PropelTypes.php
@@ -119,6 +119,11 @@ class PropelTypes
     /**
      * @var string
      */
+    public const DATETIME = 'DATETIME';
+
+    /**
+     * @var string
+     */
     public const TIME = 'TIME';
 
     /**
@@ -279,6 +284,11 @@ class PropelTypes
     /**
      * @var string
      */
+    public const DATETIME_NATIVE_TYPE = 'string';
+
+    /**
+     * @var string
+     */
     public const TIME_NATIVE_TYPE = 'string';
 
     /**
@@ -355,6 +365,7 @@ class PropelTypes
         self::LONGVARBINARY,
         self::BLOB,
         self::DATE,
+        self::DATETIME,
         self::TIME,
         self::TIMESTAMP,
         self::BOOLEAN,
@@ -397,6 +408,7 @@ class PropelTypes
         self::LONGVARBINARY => self::LONGVARBINARY_NATIVE_TYPE,
         self::BLOB => self::BLOB_NATIVE_TYPE,
         self::DATE => self::DATE_NATIVE_TYPE,
+        self::DATETIME => self::DATETIME_NATIVE_TYPE,
         self::BU_DATE => self::BU_DATE_NATIVE_TYPE,
         self::TIME => self::TIME_NATIVE_TYPE,
         self::TIMESTAMP => self::TIMESTAMP_NATIVE_TYPE,
@@ -437,6 +449,7 @@ class PropelTypes
         self::LONGVARBINARY => PDO::PARAM_LOB,
         self::BLOB => PDO::PARAM_LOB,
         self::DATE => PDO::PARAM_STR,
+        self::DATETIME => PDO::PARAM_STR,
         self::TIME => PDO::PARAM_STR,
         self::TIMESTAMP => PDO::PARAM_STR,
         self::BOOLEAN => PDO::PARAM_BOOL,
@@ -524,6 +537,7 @@ class PropelTypes
     {
         return in_array($type, [
             self::DATE,
+            self::DATETIME,
             self::TIME,
             self::TIMESTAMP,
             self::BU_DATE,
@@ -546,6 +560,7 @@ class PropelTypes
             self::LONGVARCHAR,
             self::CLOB,
             self::DATE,
+            self::DATETIME,
             self::TIME,
             self::TIMESTAMP,
             self::BU_DATE,

--- a/src/Propel/Generator/Platform/MssqlPlatform.php
+++ b/src/Propel/Generator/Platform/MssqlPlatform.php
@@ -44,6 +44,7 @@ class MssqlPlatform extends DefaultPlatform
         $this->setSchemaDomainMapping(new Domain(PropelTypes::LONGVARCHAR, 'VARCHAR(MAX)'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::CLOB, 'VARCHAR(MAX)'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::DATE, 'DATE'));
+        $this->setSchemaDomainMapping(new Domain(PropelTypes::DATETIME, 'DATETIME2'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::BU_DATE, 'DATE'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::TIME, 'TIME'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::TIMESTAMP, 'DATETIME2'));

--- a/src/Propel/Generator/Platform/MysqlPlatform.php
+++ b/src/Propel/Generator/Platform/MysqlPlatform.php
@@ -60,7 +60,6 @@ class MysqlPlatform extends DefaultPlatform
         $this->setSchemaDomainMapping(new Domain(PropelTypes::VARBINARY, 'MEDIUMBLOB'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::LONGVARBINARY, 'LONGBLOB'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::CLOB, 'LONGTEXT'));
-        $this->setSchemaDomainMapping(new Domain(PropelTypes::TIMESTAMP, 'DATETIME'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::OBJECT, 'MEDIUMBLOB'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::PHP_ARRAY, 'TEXT'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::ENUM, 'TINYINT'));

--- a/src/Propel/Generator/Platform/OraclePlatform.php
+++ b/src/Propel/Generator/Platform/OraclePlatform.php
@@ -51,6 +51,7 @@ class OraclePlatform extends DefaultPlatform
         $this->setSchemaDomainMapping(new Domain(PropelTypes::LONGVARCHAR, 'NVARCHAR2', 2000));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::TIME, 'DATE'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::DATE, 'DATE'));
+        $this->setSchemaDomainMapping(new Domain(PropelTypes::DATETIME, 'TIMESTAMP'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::TIMESTAMP, 'TIMESTAMP'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::BINARY, 'LONG RAW'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::VARBINARY, 'BLOB'));

--- a/src/Propel/Generator/Platform/PgsqlPlatform.php
+++ b/src/Propel/Generator/Platform/PgsqlPlatform.php
@@ -61,6 +61,7 @@ class PgsqlPlatform extends DefaultPlatform
         $this->setSchemaDomainMapping(new Domain(PropelTypes::ENUM, 'INT2'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::SET, 'INT4'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::DECIMAL, 'NUMERIC'));
+        $this->setSchemaDomainMapping(new Domain(PropelTypes::DATETIME, 'TIMESTAMP'));
     }
 
     /**

--- a/src/Propel/Generator/Platform/SqlitePlatform.php
+++ b/src/Propel/Generator/Platform/SqlitePlatform.php
@@ -62,6 +62,7 @@ class SqlitePlatform extends DefaultPlatform
         $this->setSchemaDomainMapping(new Domain(PropelTypes::NUMERIC, 'DECIMAL'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::LONGVARCHAR, 'MEDIUMTEXT'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::DATE, 'DATETIME'));
+        $this->setSchemaDomainMapping(new Domain(PropelTypes::DATETIME, 'DATETIME'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::BINARY, 'BLOB'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::VARBINARY, 'MEDIUMBLOB'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::LONGVARBINARY, 'LONGBLOB'));

--- a/src/Propel/Generator/Reverse/MysqlSchemaParser.php
+++ b/src/Propel/Generator/Reverse/MysqlSchemaParser.php
@@ -55,7 +55,7 @@ class MysqlSchemaParser extends AbstractSchemaParser
         'date' => PropelTypes::DATE,
         'time' => PropelTypes::TIME,
         'year' => PropelTypes::INTEGER,
-        'datetime' => PropelTypes::TIMESTAMP,
+        'datetime' => PropelTypes::DATETIME,
         'timestamp' => PropelTypes::TIMESTAMP,
         'tinyblob' => PropelTypes::BINARY,
         'blob' => PropelTypes::BLOB,

--- a/src/Propel/Generator/Reverse/SqliteSchemaParser.php
+++ b/src/Propel/Generator/Reverse/SqliteSchemaParser.php
@@ -56,7 +56,7 @@ class SqliteSchemaParser extends AbstractSchemaParser
         'date' => PropelTypes::DATE,
         'time' => PropelTypes::TIME,
         'year' => PropelTypes::INTEGER,
-        'datetime' => PropelTypes::DATE,
+        'datetime' => PropelTypes::DATETIME,
         'timestamp' => PropelTypes::TIMESTAMP,
         'tinyblob' => PropelTypes::BINARY,
         'blob' => PropelTypes::BLOB,

--- a/src/Propel/Generator/Util/QuickBuilder.php
+++ b/src/Propel/Generator/Util/QuickBuilder.php
@@ -344,7 +344,7 @@ class QuickBuilder
             } catch (Exception $e) {
                 //echo $sql; //uncomment for better debugging
                 throw new BuildException(sprintf(
-                    "Can not execute SQL: \n%s\nFrom database: \n%s\n\nTo database: \n%s\n\nDiff:\n%s",
+                    "Cannot execute SQL: \n%s\nFrom database: \n%s\n\nTo database: \n%s\n\nDiff:\n%s",
                     $statement,
                     $this->database,
                     $database,

--- a/src/Propel/Runtime/Adapter/Pdo/PdoAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/PdoAdapter.php
@@ -331,6 +331,7 @@ abstract class PdoAdapter
             switch ($cMap->getType()) {
                 case PropelTypes::TIMESTAMP:
                 case PropelTypes::BU_TIMESTAMP:
+                case PropelTypes::DATETIME:
                     $value = $dt->format($this->getTimestampFormatter());
 
                     break;

--- a/src/Propel/Runtime/Map/ColumnMap.php
+++ b/src/Propel/Runtime/Map/ColumnMap.php
@@ -243,6 +243,7 @@ class ColumnMap
         return in_array($this->type, [
             PropelTypes::TIMESTAMP,
             PropelTypes::DATE,
+            PropelTypes::DATETIME,
             PropelTypes::TIME,
             PropelTypes::BU_DATE,
             PropelTypes::BU_TIMESTAMP,

--- a/tests/Propel/Tests/Generator/Migration/BaseTest.php
+++ b/tests/Propel/Tests/Generator/Migration/BaseTest.php
@@ -247,6 +247,9 @@ class BaseTest extends MigrationTestCase
         <column name="field13" type="TIMESTAMP"/>
 
         <column name="field14" type="ENUM"/>
+
+        <column name="field15" type="TIMESTAMP"/>
+        <column name="field16" type="DATETIME"/>
     </table>
 </database>
 ';
@@ -272,6 +275,10 @@ class BaseTest extends MigrationTestCase
         <column name="field13" type="DATE"/>
 
         <column name="field14" type="VARCHAR" size="200"/>
+
+
+        <column name="field15" type="DATETIME"/>
+        <column name="field16" type="TIMESTAMP"/>
     </table>
 </database>
 ';

--- a/tests/Propel/Tests/Generator/Platform/DefaultPlatformTest.php
+++ b/tests/Propel/Tests/Generator/Platform/DefaultPlatformTest.php
@@ -179,6 +179,7 @@ class DefaultPlatformTest extends TestCase
             [$this->createColumn(PropelTypes::DATE, '2020-02-03'), '$stmt->bindValue(ID, ACCESSOR ? ACCESSOR->format("Y-m-d") : null, PDO::PARAM_STR);'],
             [$this->createColumn(PropelTypes::TIME, '11:01:03'), '$stmt->bindValue(ID, ACCESSOR ? ACCESSOR->format("H:i:s.u") : null, PDO::PARAM_STR);'],
             [$this->createColumn(PropelTypes::TIMESTAMP, '2020-02-03 11:01:03'), '$stmt->bindValue(ID, ACCESSOR ? ACCESSOR->format("Y-m-d H:i:s.u") : null, PDO::PARAM_STR);'],
+            [$this->createColumn(PropelTypes::DATETIME, '2022-06-28 11:01:03'), '$stmt->bindValue(ID, ACCESSOR ? ACCESSOR->format("Y-m-d H:i:s.u") : null, PDO::PARAM_STR);'],
             [$this->createColumn(PropelTypes::BLOB, 'BLOB'), '$stmt->bindValue(ID, ACCESSOR, PDO::PARAM_LOB);'],
         ];
     }

--- a/tests/Propel/Tests/Generator/Platform/MysqlPlatformTest.php
+++ b/tests/Propel/Tests/Generator/Platform/MysqlPlatformTest.php
@@ -18,6 +18,7 @@ use Propel\Generator\Model\Index;
 use Propel\Generator\Model\Table;
 use Propel\Generator\Model\VendorInfo;
 use Propel\Generator\Platform\MysqlPlatform;
+use Propel\Generator\Model\PropelTypes;
 
 class MysqlPlatformTest extends PlatformTestProvider
 {
@@ -956,5 +957,21 @@ CREATE TABLE `foo`
         $table->addColumns([$column]);
         $this->getPlatform()->normalizeTable($table);
         $this->assertEquals('`price` DECIMAL(10,3)', $this->getPlatform()->getColumnDDL($column));
+    }
+    
+    public function typeMappingDataProvider()
+    {
+        return [
+            [PropelTypes::DATETIME, 'DATETIME'],
+            [PropelTypes::TIMESTAMP, 'TIMESTAMP'],
+        ];
+    }
+    
+    /**
+     * @dataProvider typeMappingDataProvider
+     */
+    public function testTypeMapping(string $propelDataType, string $expectedMysqlDataType){
+        $actualMysqlDataType = $this->getPlatform()->getDomainForType($propelDataType)->getSqlType();
+        $this->assertEquals($expectedMysqlDataType, $actualMysqlDataType);
     }
 }


### PR DESCRIPTION
This allows to use column type DATETIME.

At the moment, while Propel handles DATETIME correctly in schema.xml and generates the expected migrations, building the model will lead to an error:

>   Error setting up column receipt_date: Cannot map unknown Propel type 'DATETIME' to native database type. 

Instead, the type "TIMESTAMP" has to be used, which is fine for almost all DBMS, since usually only one datetime/timestamp type is available anyway.

However, in MariaDB, both types are available and they are notably different in that they support different date ranges, and that MariaDB sets default values for the first timestamp in a table (see [here](https://mariadb.com/kb/en/timestamp/#automatic-values)), making TIMESTAMP the type to use if you want to timestamp the row, while DATETIME is DATE + TIME. 

So I think it make sense that the generator can handle both DATETIME and TIMESTAMP. Because while they are synonymous inside Propel, they might mean different things in schema.xml.