### PR TITLE
added simple typed properties

### DIFF
--- a/src/Propel/Generator/Behavior/NestedSet/NestedSetBehaviorObjectBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/NestedSet/NestedSetBehaviorObjectBuilderModifier.php
@@ -311,7 +311,7 @@ protected function processNestedSetQueries(ConnectionInterface \$con): void
  */
 public function getLeftValue(): int
 {
-    return \$this->{$this->getColumnAttribute('left_column')} ?: 0;
+    return \$this->{$this->getColumnAttribute('left_column')} ?? 0;
 }
 ";
     }
@@ -332,7 +332,7 @@ public function getLeftValue(): int
  */
 public function getRightValue(): int
 {
-    return \$this->{$this->getColumnAttribute('right_column')} ?: 0;
+    return \$this->{$this->getColumnAttribute('right_column')} ?? 0;
 }
 ";
     }
@@ -353,7 +353,7 @@ public function getRightValue(): int
  */
 public function getLevel(): int
 {
-    return \$this->{$this->getColumnAttribute('level_column')} ?: 0;
+    return \$this->{$this->getColumnAttribute('level_column')} ?? 0;
 }
 ";
     }

--- a/src/Propel/Generator/Model/Column.php
+++ b/src/Propel/Generator/Model/Column.php
@@ -1703,4 +1703,14 @@ class Column extends MappingModel
     {
         return rtrim($phpName, 's');
     }
+
+    /**
+     * Returns whether the column PHP native type is type-safe as Property.
+     *
+     * @return bool
+     */
+    public function isPhpTypeSafeType(): bool
+    {
+        return $this->isPhpPrimitiveType() && !$this->isTemporalType();
+    }
 }

--- a/src/Propel/Generator/Platform/DefaultPlatform.php
+++ b/src/Propel/Generator/Platform/DefaultPlatform.php
@@ -1493,6 +1493,8 @@ ALTER TABLE %s ADD
 if (is_resource($columnValueAccessor)) {
     rewind($columnValueAccessor);
 }";
+        } elseif ($column->isPhpTypeSafeType()) {
+            $columnValueAccessor = $columnValueAccessor . ' ?? null';
         }
 
         $script .= sprintf(

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectEnumColumnTypeTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectEnumColumnTypeTest.php
@@ -43,7 +43,7 @@ EOF;
             $publicAccessorCode = <<<EOF
 class PublicComplexColumnTypeEntity3 extends ComplexColumnTypeEntity3
 {
-    public \$bar;
+    public ?int \$bar;
 }
 EOF;
             eval($publicAccessorCode);

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectJsonColumnTypeTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectJsonColumnTypeTest.php
@@ -41,7 +41,7 @@ EOF;
             $publicAccessorCode = <<<EOF
 class PublicComplexColumnTypeJsonEntity extends ComplexColumnTypeJsonEntity
 {
-    public \$bar;
+    public ?string \$bar;
 }
 EOF;
             eval($publicAccessorCode);

--- a/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectSetColumnTypeTest.php
+++ b/tests/Propel/Tests/Generator/Builder/Om/GeneratedObjectSetColumnTypeTest.php
@@ -47,8 +47,8 @@ EOF;
             $publicAccessorCode = <<<EOF
 class PublicComplexColumnTypeEntitySet extends MyNameSpace\ComplexColumnTypeEntitySet
 {
-    public \$bar;
-    public \$tags;
+    public ?int \$bar;
+    public ?int \$tags;
 }
 EOF;
             eval($publicAccessorCode);


### PR DESCRIPTION
The Idea of this PR is to prepare and add typed properties in the classes generated by propel.
Goal was to still maintain BC Compatibility

In the future strict return types would be great, but it would cause compatibility issues with many projects