### PR TITLE
fix pipelines (missing allow-plugins in composer.json)

### DIFF
--- a/tests/composer/composer-symfony4-max.json
+++ b/tests/composer/composer-symfony4-max.json
@@ -56,5 +56,10 @@
         "branch-alias": {
             "dev-master": "2.0-dev"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }

--- a/tests/composer/composer-symfony4-min.json
+++ b/tests/composer/composer-symfony4-min.json
@@ -56,5 +56,10 @@
         "branch-alias": {
             "dev-master": "2.0-dev"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }

--- a/tests/composer/composer-symfony5-max.json
+++ b/tests/composer/composer-symfony5-max.json
@@ -56,5 +56,10 @@
         "branch-alias": {
             "dev-master": "2.0-dev"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }

--- a/tests/composer/composer-symfony5-min.json
+++ b/tests/composer/composer-symfony5-min.json
@@ -56,5 +56,10 @@
         "branch-alias": {
             "dev-master": "2.0-dev"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }

--- a/tests/composer/composer-symfony6-max.json
+++ b/tests/composer/composer-symfony6-max.json
@@ -56,5 +56,10 @@
         "branch-alias": {
             "dev-master": "2.0-dev"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }

--- a/tests/composer/composer-symfony6-min.json
+++ b/tests/composer/composer-symfony6-min.json
@@ -56,5 +56,10 @@
         "branch-alias": {
             "dev-master": "2.0-dev"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }


### PR DESCRIPTION
I think this fixes the error currently occurring when running tests on gitlab:

```
 Error: dealerdirect/phpcodesniffer-composer-installer contains a Composer plugin which is blocked by your allow-plugins config. You may add it to the list if you consider it safe.
You can run "composer config --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer [true|false]" to enable it (true) or disable it explicitly and suppress this exception (false)
See https://getcomposer.org/allow-plugins

In PluginManager.php line 769:
                                                                               
  dealerdirect/phpcodesniffer-composer-installer contains a Composer plugin w  
  hich is blocked by your allow-plugins config. You may add it to the list if  
   you consider it safe.                                                       
  You can run "composer config --no-plugins allow-plugins.dealerdirect/phpcod  
  esniffer-composer-installer [true|false]" to enable it (true) or disable it  
   explicitly and suppress this exception (false)                              
  See https://getcomposer.org/allow-plugins                                                                                        
```

This was confusing, since the expected statement was already present in composer.json. But the pipelines use custom composer.json files located in `tests/composer/`, where the statements where missing.

Let's see if this works...