### PR TITLE
Fix invalid duplicate indices using ArchivableBehavior for some platforms

### DIFF
--- a/src/Propel/Generator/Behavior/Archivable/ArchivableBehavior.php
+++ b/src/Propel/Generator/Behavior/Archivable/ArchivableBehavior.php
@@ -15,6 +15,7 @@ use Propel\Generator\Model\Column;
 use Propel\Generator\Model\Index;
 use Propel\Generator\Model\Table;
 use Propel\Generator\Platform\PgsqlPlatform;
+use Propel\Generator\Platform\PlatformInterface;
 use Propel\Generator\Platform\SqlitePlatform;
 
 /**
@@ -131,9 +132,8 @@ class ArchivableBehavior extends Behavior
             // copy the indices
             foreach ($table->getIndices() as $index) {
                 $copiedIndex = clone $index;
-                // Some platforms require unique index names across whole database
-                // by unsetting the name, Propel will generate a unique name based on table and columns
-                if ($platform instanceof PgsqlPlatform || $platform instanceof SqlitePlatform) {
+                if ($this->isDistinctiveIndexNameRequired($platform)) {
+                    // by unsetting the name, Propel will generate a unique name based on table and columns
                     $copiedIndex->setName(null);
                 }
                 $archiveTable->addIndex($copiedIndex);
@@ -160,6 +160,16 @@ class ArchivableBehavior extends Behavior
         } else {
             $this->archiveTable = $database->getTable($archiveTableName);
         }
+    }
+
+    /**
+     * @param \Propel\Generator\Platform\PlatformInterface|null $platform
+     *
+     * @return bool
+     */
+    protected function isDistinctiveIndexNameRequired(?PlatformInterface $platform): bool
+    {
+        return $platform instanceof PgsqlPlatform || $platform instanceof SqlitePlatform;
     }
 
     /**

--- a/tests/Propel/Tests/Generator/Behavior/Archivable/ArchivableBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Archivable/ArchivableBehaviorTest.php
@@ -57,7 +57,7 @@ class ArchivableBehaviorTest extends TestCase
         <foreign-key foreignTable="archivable_test_2">
             <reference local="foo_id" foreign="id"/>
         </foreign-key>
-        <index>
+        <index name="archivable_test_1_idx_title_age">
             <index-column name="title"/>
             <index-column name="age"/>
         </index>


### PR DESCRIPTION
Resolves #1894 

Please let me know, if we can write tests for this behavior depending on different platforms.
Without the fix, test setup will fail because of the error described in the linked issue.

To keep it more simple, we could also discuss to never copy the original's index name which might be a breaking change if someone relies on the archive index name. 