### PR TITLE
Skip init of Propel tables in order to boost performance

### DIFF
--- a/src/Propel/Generator/Builder/Om/TableMapLoaderScriptBuilder.php
+++ b/src/Propel/Generator/Builder/Om/TableMapLoaderScriptBuilder.php
@@ -63,12 +63,14 @@ class TableMapLoaderScriptBuilder
         foreach ($schemas as $schema) {
             foreach ($schema->getDatabases(false) as $database) {
                 $databaseName = $database->getName();
-                $tableMapNames = array_map([$this, 'getFullyQualifiedTableMapClassName'], $database->getTables());
+                $tableMapPhpNames = array_map([$this, 'getFullyQualifiedTableMapClassName'], $database->getTables());
+                $tableNames = array_map([$this, 'getTableName'], $database->getTables());
+                $tableMapNames = array_combine($tableNames, $tableMapPhpNames);
                 if (array_key_exists($databaseName, $databaseNameToTableMapNames)) {
                     $existing = $databaseNameToTableMapNames[$databaseName];
                     $tableMapNames = array_merge($existing, $tableMapNames);
                 }
-                sort($tableMapNames);
+                ksort($tableMapNames);
                 $databaseNameToTableMapNames[$databaseName] = $tableMapNames;
             }
         }

--- a/src/Propel/Generator/Builder/Om/TableMapLoaderScriptBuilder.php
+++ b/src/Propel/Generator/Builder/Om/TableMapLoaderScriptBuilder.php
@@ -92,7 +92,17 @@ class TableMapLoaderScriptBuilder
 
         return $builder->getFullyQualifiedClassName();
     }
-
+    
+    /**
+     * @param \Propel\Generator\Model\Table $table
+     *
+     * @return string
+     */
+    protected function getTableName(Table $table): string
+    {
+        return $table->getCommonName();
+    }
+    
     /**
      * @param array $vars
      *

--- a/src/Propel/Runtime/Map/DatabaseMap.php
+++ b/src/Propel/Runtime/Map/DatabaseMap.php
@@ -144,7 +144,7 @@ class DatabaseMap
      * {@link DatabaseMap::getTables()}
      *
      * @param class-string<\Propel\Runtime\Map\TableMap> $tableMapClass The name of the table map to add
-     * @param string $tableName The name of the table map to add
+     * @param string $tableName The qualified table name
      *
      * @return void
      */

--- a/src/Propel/Runtime/Map/DatabaseMap.php
+++ b/src/Propel/Runtime/Map/DatabaseMap.php
@@ -144,16 +144,13 @@ class DatabaseMap
      * {@link DatabaseMap::getTables()}
      *
      * @param class-string<\Propel\Runtime\Map\TableMap> $tableMapClass The name of the table map to add
+     * @param string $tableName The name of the table map to add
      *
      * @return void
      */
-    public function registerTableMapClass(string $tableMapClass): void
+    public function registerTableMapClass(string $tableMapClass, string $tableName): void
     {
-        $tableName = $tableMapClass::TABLE_NAME;
         $this->tables[$tableName] = $tableMapClass;
-
-        $tablePhpName = $tableMapClass::TABLE_PHP_NAME;
-        $this->addTableByPhpName($tablePhpName, $tableMapClass);
     }
 
     /**
@@ -166,7 +163,7 @@ class DatabaseMap
      */
     public function registerTableMapClasses(array $tableMapClasses): void
     {
-        array_map([$this, 'registerTableMapClass'], $tableMapClasses);
+        array_map([$this, 'registerTableMapClass'], array_values($tableMapClasses), array_keys($tableMapClasses));
     }
 
     /**

--- a/src/Propel/Runtime/Map/DatabaseMap.php
+++ b/src/Propel/Runtime/Map/DatabaseMap.php
@@ -144,12 +144,16 @@ class DatabaseMap
      * {@link DatabaseMap::getTables()}
      *
      * @param class-string<\Propel\Runtime\Map\TableMap> $tableMapClass The name of the table map to add
-     * @param string $tableName The qualified table name
+     * @param string|null $tableName The name of the table map to add
      *
      * @return void
      */
-    public function registerTableMapClass(string $tableMapClass, string $tableName): void
+    public function registerTableMapClass(string $tableMapClass, string $tableName=null): void
     {
+        if (!$tableName) {
+            $tableName = $tableMapClass::TABLE_NAME;
+        }
+
         $this->tables[$tableName] = $tableMapClass;
     }
 


### PR DESCRIPTION
When database table map is initialized, originally we create all table classes.
Regular request uses 5-10 tables, so creation of classes is not required.

With this change, only mapping from the qualified table name to a php class name is stored in the database, and the table map class creation happens only on-demand.