### PR TITLE
load databases without accessing classes

### DIFF
--- a/src/Propel/Generator/Builder/Om/TableMapLoaderScriptBuilder.php
+++ b/src/Propel/Generator/Builder/Om/TableMapLoaderScriptBuilder.php
@@ -11,7 +11,10 @@ namespace Propel\Generator\Builder\Om;
 use Propel\Common\Util\PathTrait;
 use Propel\Generator\Builder\Util\PropelTemplate;
 use Propel\Generator\Config\GeneratorConfigInterface;
+use Propel\Generator\Exception\BuildException;
+use Propel\Generator\Model\Database;
 use Propel\Generator\Model\Table;
+use Propel\Runtime\Map\DatabaseMap;
 use SplFileInfo;
 
 /**
@@ -46,36 +49,73 @@ class TableMapLoaderScriptBuilder
      */
     public function build(array $schemas): string
     {
-        $vars = $this->buildVars($schemas);
+        $templatePath = $this->getTemplatePath(__DIR__);
 
-        return $this->renderTemplate($vars);
+        $filePath = $templatePath . 'tableMapLoaderScript.php';
+        $template = new PropelTemplate();
+        $template->setTemplateFile($filePath);
+
+        $vars = [
+            'databaseNameToTableMapDumps' => $this->buildDatabaseNameToTableMapDumps($schemas),
+        ];
+
+        return $template->render($vars);
     }
 
     /**
      * @param array<\Propel\Generator\Model\Schema> $schemas
      *
+     * @throws \Propel\Generator\Exception\BuildException
+     *
      * @return array
      */
-    protected function buildVars(array $schemas): array
+    protected function buildDatabaseNameToTableMapDumps(array $schemas): array
     {
-        $databaseNameToTableMapNames = [];
-
+        $entries = [];
         foreach ($schemas as $schema) {
             foreach ($schema->getDatabases(false) as $database) {
                 $databaseName = $database->getName();
-                $tableMapNames = array_map([$this, 'getFullyQualifiedTableMapClassName'], $database->getTables());
-                if (array_key_exists($databaseName, $databaseNameToTableMapNames)) {
-                    $existing = $databaseNameToTableMapNames[$databaseName];
-                    $tableMapNames = array_merge($existing, $tableMapNames);
+                if (!$databaseName) {
+                    throw new BuildException('Cannot build table map of unnamed database');
                 }
-                sort($tableMapNames);
-                $databaseNameToTableMapNames[$databaseName] = $tableMapNames;
+                $tableMapDumps = $this->buildDatabaseMap($database)->dumpMaps();
+                $entries[] = [$databaseName => $tableMapDumps];
             }
         }
+        $databaseNameToTableMapDumps = array_merge_recursive(...$entries);
+        $this->sortRecursive($databaseNameToTableMapDumps);
 
-        return [
-            'databaseNameToTableMapNames' => $databaseNameToTableMapNames,
-        ];
+        return $databaseNameToTableMapDumps;
+    }
+
+    /**
+     * @param \Propel\Generator\Model\Database $database
+     *
+     * @return \Propel\Runtime\Map\DatabaseMap
+     */
+    protected function buildDatabaseMap(Database $database): DatabaseMap
+    {
+        $databaseName = $database->getName();
+        $databaseMap = new DatabaseMap($databaseName);
+        foreach ($database->getTables() as $table) {
+            $tableName = $table->getName();
+            $phpName = $table->getPhpName();
+            $tableMapClass = $this->getFullyQualifiedTableMapClassName($table);
+            $databaseMap->registerTableMapClassByName($tableName, $phpName, $tableMapClass);
+        }
+
+        return $databaseMap;
+    }
+
+    /**
+     * @param array $array
+     *
+     * @return void
+     */
+    protected function sortRecursive(array &$array): void
+    {
+        ksort($array, SORT_STRING);
+        array_walk($array, fn (&$value) => is_array($value) && $this->sortRecursive($value));
     }
 
     /**
@@ -89,22 +129,6 @@ class TableMapLoaderScriptBuilder
         $builder->setGeneratorConfig($this->generatorConfig);
 
         return $builder->getFullyQualifiedClassName();
-    }
-
-    /**
-     * @param array $vars
-     *
-     * @return string
-     */
-    protected function renderTemplate(array $vars): string
-    {
-        $templatePath = $this->getTemplatePath(__DIR__);
-
-        $filePath = $templatePath . 'tableMapLoaderScript.php';
-        $template = new PropelTemplate();
-        $template->setTemplateFile($filePath);
-
-        return $template->render($vars);
     }
 
     /**

--- a/src/Propel/Generator/Manager/AbstractManager.php
+++ b/src/Propel/Generator/Manager/AbstractManager.php
@@ -17,7 +17,7 @@ use Propel\Generator\Exception\BuildException;
 use Propel\Generator\Exception\EngineException;
 use Propel\Generator\Model\Database;
 use Propel\Generator\Model\Schema;
-use XsltProcessor;
+use XSLTProcessor;
 
 /**
  * An abstract base Propel manager to perform work related to the XML schema
@@ -323,7 +323,7 @@ abstract class AbstractManager
                     // normalize the document using normalizer stylesheet
                     $xslDom = new DOMDocument('1.0', 'UTF-8');
                     $xslDom->load($this->xsl->getAbsolutePath());
-                    $xsl = new XsltProcessor();
+                    $xsl = new XSLTProcessor();
                     $xsl->importStyleSheet($xslDom);
                     $dom = $xsl->transformToDoc($dom);
                 }

--- a/src/Propel/Generator/Model/Table.php
+++ b/src/Propel/Generator/Model/Table.php
@@ -1,12 +1,12 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+declare(strict_types=1);
 
 namespace Propel\Generator\Model;
 

--- a/src/Propel/Generator/Reverse/SqliteSchemaParser.php
+++ b/src/Propel/Generator/Reverse/SqliteSchemaParser.php
@@ -204,11 +204,11 @@ class SqliteSchemaParser extends AbstractSchemaParser
 
             if (preg_match('/^([^\(]+)\(\s*(\d+)\s*,\s*(\d+)\s*\)$/', $fulltype, $matches)) {
                 $type = $matches[1];
-                $size = $matches[2];
-                $scale = $matches[3];
+                $size = (int)$matches[2];
+                $scale = (int)$matches[3];
             } elseif (preg_match('/^([^\(]+)\(\s*(\d+)\s*\)$/', $fulltype, $matches)) {
                 $type = $matches[1];
-                $size = $matches[2];
+                $size = (int)$matches[2];
             } else {
                 $type = $fulltype;
             }

--- a/src/Propel/Generator/Util/QuickBuilder.php
+++ b/src/Propel/Generator/Util/QuickBuilder.php
@@ -1,10 +1,12 @@
-<?php declare(strict_types = 1);
+<?php
 
 /**
  * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+declare(strict_types=1);
 
 namespace Propel\Generator\Util;
 

--- a/src/Propel/Generator/Util/VfsTrait.php
+++ b/src/Propel/Generator/Util/VfsTrait.php
@@ -1,10 +1,12 @@
-<?php declare(strict_types = 1);
+<?php
 
 /**
  * MIT License. This file is part of the Propel package.
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+declare(strict_types=1);
 
 namespace Propel\Generator\Util;
 

--- a/src/Propel/Runtime/Connection/ConnectionFactory.php
+++ b/src/Propel/Runtime/Connection/ConnectionFactory.php
@@ -46,7 +46,7 @@ class ConnectionFactory
     ): ConnectionInterface {
         if (static::$useProfilerConnection) {
             $connectionClass = ProfilerConnectionWrapper::class;
-        } else if (isset($configuration['classname'])) {
+        } elseif (isset($configuration['classname'])) {
             $connectionClass = $configuration['classname'];
         } else {
             $connectionClass = $defaultConnectionClass;

--- a/src/Propel/Runtime/Map/DatabaseMap.php
+++ b/src/Propel/Runtime/Map/DatabaseMap.php
@@ -25,6 +25,11 @@ use Propel\Runtime\Propel;
  * @author Hans Lellelid <hans@xmpl.org> (Propel)
  * @author John D. McNally <jmcnally@collab.net> (Torque)
  * @author Daniel Rall <dlr@collab.net> (Torque)
+ *
+ * @psalm-consistent-constructor (instantiated by class name in StandardServiceContainer without arguments)
+ *
+ * @psalm-type \Propel\Runtime\Map\MapType = 'tablesByName' | 'tablesByPhpName'
+ * @psalm-type \Propel\Runtime\Map\TableMapDump array<\Propel\Runtime\Map\MapType, array<string, class-string<\Propel\Runtime\Map\TableMap>>>
  */
 class DatabaseMap
 {
@@ -38,14 +43,14 @@ class DatabaseMap
     /**
      * Tables in the database, using table name as key
      *
-     * @var array<\Propel\Runtime\Map\TableMap|class-string<\Propel\Runtime\Map\TableMap>>
+     * @var array<string, \Propel\Runtime\Map\TableMap|class-string<\Propel\Runtime\Map\TableMap>>
      */
     protected $tables = [];
 
     /**
      * Tables in the database, using table phpName as key
      *
-     * @var array<\Propel\Runtime\Map\TableMap|class-string<\Propel\Runtime\Map\TableMap>>
+     * @var array<string, \Propel\Runtime\Map\TableMap|class-string<\Propel\Runtime\Map\TableMap>>
      */
     protected $tablesByPhpName = [];
 
@@ -121,7 +126,7 @@ class DatabaseMap
     /**
      * Add a new table to the database, using the tablemap class name.
      *
-     * @param string $tableMapClass The name of the table map to add
+     * @param class-string<\Propel\Runtime\Map\TableMap> $tableMapClass The name of the table map to add
      *
      * @return \Propel\Runtime\Map\TableMap The TableMap object
      */
@@ -137,23 +142,26 @@ class DatabaseMap
     /**
      * Dump table maps. Used during configuration generation.
      *
-     * @return array A dump that can be loaded again with {@link DatabaseMap::loadMapsFromDump()}
+     * @return \Propel\Runtime\Map\TableMapDump A dump that can be loaded again with {@link DatabaseMap::loadMapsFromDump()}
      */
     public function dumpMaps(): array
     {
+        /**
+         * @param $tableMap class-string<\Propel\Runtime\Map\TableMap>|\Propel\Runtime\Map\TableMap
+         * @return class-string<\Propel\Runtime\Map\TableMap>
+         */
         $toClassString = fn ($tableMap) => is_string($tableMap) ? $tableMap : get_class($tableMap);
-        $maps = [
+
+        return [
             'tablesByName' => array_map($toClassString, $this->tables),
             'tablesByPhpName' => array_map($toClassString, $this->tablesByPhpName),
         ];
-
-        return $maps;
     }
 
     /**
      * Load internal table maps from dump. Used during Propel initialization.
      *
-     * @param $mapsDump Table map dump as created by {@link DatabaseMap::dumpMaps()}
+     * @param \Propel\Runtime\Map\TableMapDump|array $mapsDump Table map dump as created by {@link DatabaseMap::dumpMaps()}
      *
      * @return void
      */
@@ -208,7 +216,7 @@ class DatabaseMap
      * Registers a list of table map classes (by qualified name) as table maps
      * belonging to this database.
      *
-     * @param array<class-string> $tableMapClasses
+     * @param array<class-string<\Propel\Runtime\Map\TableMap>> $tableMapClasses
      *
      * @return void
      */

--- a/src/Propel/Runtime/Map/DatabaseMap.php
+++ b/src/Propel/Runtime/Map/DatabaseMap.php
@@ -142,13 +142,14 @@ class DatabaseMap
     /**
      * Dump table maps. Used during configuration generation.
      *
-     * @return \Propel\Runtime\Map\TableMapDump A dump that can be loaded again with {@link DatabaseMap::loadMapsFromDump()}
+     * @psalm-return \Propel\Runtime\Map\TableMapDump
+     *
+     * @return array<string, array<string, class-string<\Propel\Runtime\Map\TableMap>>> A dump that can be loaded again with {@link DatabaseMap::loadMapsFromDump()}
      */
     public function dumpMaps(): array
     {
         /**
-         * @param $tableMap class-string<\Propel\Runtime\Map\TableMap>|\Propel\Runtime\Map\TableMap
-         * @return class-string<\Propel\Runtime\Map\TableMap>
+         * @psalm-var \Closure( class-string<\Propel\Runtime\Map\TableMap>|\Propel\Runtime\Map\TableMap ): class-string<\Propel\Runtime\Map\TableMap>
          */
         $toClassString = fn ($tableMap) => is_string($tableMap) ? $tableMap : get_class($tableMap);
 
@@ -161,7 +162,9 @@ class DatabaseMap
     /**
      * Load internal table maps from dump. Used during Propel initialization.
      *
-     * @param \Propel\Runtime\Map\TableMapDump|array $mapsDump Table map dump as created by {@link DatabaseMap::dumpMaps()}
+     * @psalm-param \Propel\Runtime\Map\TableMapDump $mapsDump
+     *
+     * @param array<string, array<string, class-string<\Propel\Runtime\Map\TableMap>>> $mapsDump Table map dump as created by {@link DatabaseMap::dumpMaps()}
      *
      * @return void
      */

--- a/src/Propel/Runtime/ServiceContainer/ServiceContainerInterface.php
+++ b/src/Propel/Runtime/ServiceContainer/ServiceContainerInterface.php
@@ -36,7 +36,7 @@ interface ServiceContainerInterface
      *
      * @var string
      */
-    public const DEFAULT_DATABASE_MAP_CLASS = '\Propel\Runtime\Map\DatabaseMap';
+    public const DEFAULT_DATABASE_MAP_CLASS = DatabaseMap::class;
 
     /**
      * The name of the default datasource.
@@ -50,7 +50,7 @@ interface ServiceContainerInterface
      *
      * @var string
      */
-    public const DEFAULT_PROFILER_CLASS = '\Propel\Runtime\Util\Profiler';
+    public const DEFAULT_PROFILER_CLASS = Profiler::class;
 
     /**
      * @return string

--- a/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
+++ b/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
@@ -271,6 +271,23 @@ class StandardServiceContainer implements ServiceContainerInterface
     }
 
     /**
+     * @param array $databaseNameToTableMapDumps
+     *
+     * @return void
+     */
+    public function initDatabaseMapFromDumps(array $databaseNameToTableMapDumps = []): void
+    {
+        if ($this->databaseMaps === null) {
+            $this->databaseMaps = [];
+        }
+
+        foreach ($databaseNameToTableMapDumps as $databaseName => $tableMapDumps) {
+            $databaseMap = $this->getDatabaseMap($databaseName);
+            $databaseMap->loadMapsFromDump($tableMapDumps);
+        }
+    }
+
+    /**
      * @phpstan-param class-string<\Propel\Runtime\Map\DatabaseMap> $databaseMapClass
      *
      * @param string $databaseMapClass

--- a/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
+++ b/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
@@ -28,6 +28,9 @@ use Propel\Runtime\Util\Profiler;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
+/**
+ * @psalm-import-type \Propel\Runtime\Map\TableMapDump from \Propel\Runtime\Map\DatabaseMap
+ */
 class StandardServiceContainer implements ServiceContainerInterface
 {
     /**
@@ -55,7 +58,7 @@ class StandardServiceContainer implements ServiceContainerInterface
     protected $adapters = [];
 
     /**
-     * @phpstan-var array<string, class-string>
+     * @phpstan-var array<string, class-string<\Propel\Runtime\Adapter\AdapterInterface>>
      *
      * @var array<string, string> List of database adapter classes
      */
@@ -151,7 +154,7 @@ class StandardServiceContainer implements ServiceContainerInterface
      * This allows for lazy-loading adapter objects in getAdapter().
      *
      * @param string $name The datasource name
-     * @param string $adapterClass
+     * @param class-string<\Propel\Runtime\Adapter\AdapterInterface> $adapterClass
      *
      * @return void
      */
@@ -164,7 +167,7 @@ class StandardServiceContainer implements ServiceContainerInterface
     /**
      * Reset existing adapters classes and set new classes for all datasources.
      *
-     * @param array<string, string> $adapterClasses A list of adapters
+     * @param array<string, class-string<\Propel\Runtime\Adapter\AdapterInterface>> $adapterClasses A list of adapters
      *
      * @return void
      */
@@ -271,7 +274,7 @@ class StandardServiceContainer implements ServiceContainerInterface
     }
 
     /**
-     * @param array $databaseNameToTableMapDumps
+     * @param array<string, \Propel\Runtime\Map\TableMapDump> $databaseNameToTableMapDumps
      *
      * @return void
      */
@@ -604,7 +607,7 @@ class StandardServiceContainer implements ServiceContainerInterface
                 $handler = new RotatingFileHandler(
                     $configuration['path'],
                     $configuration['max_files'] ?? 0,
-                    $configuration['level'] ?? null,
+                    $configuration['level'] ?? 100,
                     $configuration['bubble'] ?? true,
                 );
 
@@ -612,8 +615,8 @@ class StandardServiceContainer implements ServiceContainerInterface
             case 'syslog':
                 $handler = new SyslogHandler(
                     $configuration['ident'],
-                    $configuration['facility'] ?? null,
-                    $configuration['level'] ?? null,
+                    $configuration['facility'] ?? LOG_USER,
+                    $configuration['level'] ?? 100,
                     $configuration['bubble'] ?? true,
                 );
 

--- a/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
+++ b/src/Propel/Runtime/ServiceContainer/StandardServiceContainer.php
@@ -274,7 +274,9 @@ class StandardServiceContainer implements ServiceContainerInterface
     }
 
     /**
-     * @param array<string, \Propel\Runtime\Map\TableMapDump> $databaseNameToTableMapDumps
+     * @psalm-param array<string, \Propel\Runtime\Map\TableMapDump> $databaseNameToTableMapDumps
+     *
+     * @param array<string, array<string, class-string<\Propel\Runtime\Map\TableMap>>> $databaseNameToTableMapDumps
      *
      * @return void
      */

--- a/src/Propel/Runtime/Util/Profiler.php
+++ b/src/Propel/Runtime/Util/Profiler.php
@@ -12,6 +12,8 @@ use Propel\Common\Config\Exception\InvalidConfigurationException;
 
 /**
  * Profiler for Propel
+ *
+ * @psalm-consistent-constructor (instantiated by class name in StandardServiceContainer without arguments)
  */
 class Profiler
 {

--- a/templates/Builder/Om/tableMapLoaderScript.php
+++ b/templates/Builder/Om/tableMapLoaderScript.php
@@ -1,4 +1,4 @@
 <?= '<?php'?>
 
 $serviceContainer = \Propel\Runtime\Propel::getServiceContainer();
-$serviceContainer->initDatabaseMaps(<?= var_export($databaseNameToTableMapNames, true) ?>);
+$serviceContainer->initDatabaseMapFromDumps(<?= var_export($databaseNameToTableMapDumps, true) ?>);

--- a/tests/Propel/Tests/Runtime/Map/DatabaseMapTest.php
+++ b/tests/Propel/Tests/Runtime/Map/DatabaseMapTest.php
@@ -128,7 +128,8 @@ class DatabaseMapTest extends TestCaseFixtures
         $this->assertTableMapContains($databaseMap, $tableMapClass::TABLE_NAME, '\\' . $tableMapClass::TABLE_PHP_NAME, $tableMapClass);
     }
 
-    protected function assertTableMapContains(DatabaseMapWithGetters $databaseMap, $tableName, $phpTableName, $tableMapClass){
+    protected function assertTableMapContains(DatabaseMapWithGetters $databaseMap, $tableName, $phpTableName, $tableMapClass)
+    {
 
         $tableNameToArray = [
             $tableName => $databaseMap->getTablesByNameMap(),


### PR DESCRIPTION
This MR changes the way tables are registered during initialization to improve performance. Instead of building the internal table lookup structure by accessing static class properties of the table classes, the table lookup is loaded directly from the init file.

#### Background

During initialization, available database tables are registered in Propel. Currently this is done through the qualified class name (i.e. `\Propel\Tests\BookstoreSchemas\Map\BookTableMap`), which is handed to a `DatabaseMap`, which then adds it to its table lookup maps. There are two kinds of lookup, access by name (schema and table name, i.e. `bookstore_schemas.book`) or by PHP name (either set in schema.xml or generated from name, i.e. `\Book`).
Currently, the lookup maps are created by accessing static properties of the supplied class. It was reported that this leads to a measurable slowdown when working with lots of tables (300+), see [here](https://github.com/propelorm/Propel2/pull/1909#issuecomment-1292112844).

#### Proposed Solution
Instead of handing over only the table class name to the DatabaseMap, we can also hand over the name and PHP name, making the static access obsolete. Even simpler, instead of reading the raw table data from the init file (usually `loadDatabase.php`) and then building up the lookup structure every time, we can just write and then retrieve that lookup structure from the init file, and simply load it into the DatabaseMap as it is.
#1909 does something similar, and it reportedly leads to a speed up.

#### Changes
* The `DatabaseMap` class gets a method to dump its lookup maps and a method to load them again from dump.
* The `TableMapLoaderScriptBuilder` class (which generates the `loadDatabase.php` file) does not just write an array of table class names, but registers the tables in a local DatabaseMap, and then writes a dump to the init file.
* During initialization, the dump is loaded back into the DatabaseMaps (through `StandardServiceContainer`).

The changes do not impact BC, even after the update, an old init file can still be used.

#### Result
On my machine, with PHP 8.1 and a project with 40 tables, initialization through static access takes around 0.8 ms (+- 0.3ms), while initialization through dumps takes around 0.25 ms (+- 0.1ms). I am actually surprised how clearly and distinct the difference between the two approaches is. I guess it comes from the time it takes PHP to load the classes, but there is also the repeated calls to a subroutine and writing to the lookup arrays individually. I have tested it through the php dev server, not on an actual webserver, which might give different results.
Of course we are talking about less than a thousand of a second, so this will not make a difference to most users. But it won't hurt either.

I don't have a project with more tables available, but maybe @profuel can supply some measurements for a larger set of tables? I would assume that the static approach grows linear with the number of tables, as each new table leads to another class being loaded, where the dump approach stays mostly the same, as adding another new table just means to read two more lines from a file.