### PR TITLE
Add support for native UUID column type

### DIFF
--- a/src/Propel/Generator/Model/Column.php
+++ b/src/Propel/Generator/Model/Column.php
@@ -1324,6 +1324,16 @@ class Column extends MappingModel
     }
 
     /**
+     * Returns whether this column is a uuid type.
+     *
+     * @return bool
+     */
+    public function isUuidType(): bool
+    {
+        return PropelTypes::isUuidType($this->getType());
+    }
+
+    /**
      * Returns whether the column is an array column.
      *
      * @return bool

--- a/src/Propel/Generator/Model/PropelTypes.php
+++ b/src/Propel/Generator/Model/PropelTypes.php
@@ -342,6 +342,16 @@ class PropelTypes
     public const JSON_TYPE = 'string';
 
     /**
+     * @var string
+     */
+    public const UUID = 'UUID';
+
+    /**
+     * @var string
+     */
+    public const UUID_NATIVE_TYPE = 'string';
+
+    /**
      * Propel mapping types.
      *
      * @var array
@@ -381,6 +391,7 @@ class PropelTypes
         self::BU_TIMESTAMP,
         self::SET,
         self::JSON,
+        self::UUID,
     ];
 
     /**
@@ -421,6 +432,7 @@ class PropelTypes
         self::SET => self::SET_NATIVE_TYPE,
         self::GEOMETRY => self::GEOMETRY,
         self::JSON => self::JSON_TYPE,
+        self::UUID => self::UUID_NATIVE_TYPE,
     ];
 
     /**
@@ -466,6 +478,7 @@ class PropelTypes
         self::BU_DATE => PDO::PARAM_STR,
         self::BU_TIMESTAMP => PDO::PARAM_STR,
         self::JSON => PDO::PARAM_STR,
+        self::UUID => PDO::PARAM_STR,
     ];
 
     /**
@@ -613,6 +626,20 @@ class PropelTypes
     public static function isLobType(string $mappingType): bool
     {
         return in_array($mappingType, [self::VARBINARY, self::LONGVARBINARY, self::BLOB, self::OBJECT, self::GEOMETRY]);
+    }
+
+    /**
+     * Returns whether the given type is a UUID type.
+     *
+     * @param string $type
+     *
+     * @return bool
+     */
+    public static function isUuidType(string $type): bool
+    {
+        return in_array($type, [
+            self::UUID,
+        ]);
     }
 
     /**

--- a/src/Propel/Generator/Model/PropelTypes.php
+++ b/src/Propel/Generator/Model/PropelTypes.php
@@ -555,7 +555,7 @@ class PropelTypes
             self::TIMESTAMP,
             self::BU_DATE,
             self::BU_TIMESTAMP,
-        ]);
+        ], true);
     }
 
     /**
@@ -579,7 +579,7 @@ class PropelTypes
             self::BU_DATE,
             self::BU_TIMESTAMP,
             self::JSON,
-        ]);
+        ], true);
     }
 
     /**
@@ -601,7 +601,7 @@ class PropelTypes
             self::NUMERIC,
             self::DECIMAL,
             self::REAL,
-        ]);
+        ], true);
     }
 
     /**
@@ -613,7 +613,7 @@ class PropelTypes
      */
     public static function isBooleanType(string $mappingType): bool
     {
-        return in_array($mappingType, [self::BOOLEAN, self::BOOLEAN_EMU]);
+        return in_array($mappingType, [self::BOOLEAN, self::BOOLEAN_EMU], true);
     }
 
     /**
@@ -625,7 +625,7 @@ class PropelTypes
      */
     public static function isLobType(string $mappingType): bool
     {
-        return in_array($mappingType, [self::VARBINARY, self::LONGVARBINARY, self::BLOB, self::OBJECT, self::GEOMETRY]);
+        return in_array($mappingType, [self::VARBINARY, self::LONGVARBINARY, self::BLOB, self::OBJECT, self::GEOMETRY], true);
     }
 
     /**
@@ -639,7 +639,7 @@ class PropelTypes
     {
         return in_array($type, [
             self::UUID,
-        ]);
+        ], true);
     }
 
     /**
@@ -651,7 +651,7 @@ class PropelTypes
      */
     public static function isPhpPrimitiveType(string $phpType): bool
     {
-        return in_array($phpType, ['boolean', 'int', 'double', 'float', 'string']);
+        return in_array($phpType, ['boolean', 'int', 'double', 'float', 'string'], true);
     }
 
     /**
@@ -663,7 +663,7 @@ class PropelTypes
      */
     public static function isPhpPrimitiveNumericType(string $phpType): bool
     {
-        return in_array($phpType, ['boolean', 'int', 'double', 'float']);
+        return in_array($phpType, ['boolean', 'int', 'double', 'float'], true);
     }
 
     /**
@@ -675,7 +675,7 @@ class PropelTypes
      */
     public static function isPhpObjectType(string $phpType): bool
     {
-        return !self::isPhpPrimitiveType($phpType) && !in_array($phpType, ['resource', 'array']);
+        return !self::isPhpPrimitiveType($phpType) && !in_array($phpType, ['resource', 'array'], true);
     }
 
     /**

--- a/src/Propel/Generator/Platform/MssqlPlatform.php
+++ b/src/Propel/Generator/Platform/MssqlPlatform.php
@@ -57,6 +57,7 @@ class MssqlPlatform extends DefaultPlatform
         $this->setSchemaDomainMapping(new Domain(PropelTypes::PHP_ARRAY, 'VARCHAR(MAX)'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::ENUM, 'TINYINT'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::SET, 'INT'));
+        $this->setSchemaDomainMapping(new Domain(PropelTypes::UUID, 'UNIQUEIDENTIFIER'));
     }
 
     /**

--- a/src/Propel/Generator/Platform/MysqlPlatform.php
+++ b/src/Propel/Generator/Platform/MysqlPlatform.php
@@ -53,6 +53,7 @@ class MysqlPlatform extends DefaultPlatform
     protected function initialize(): void
     {
         parent::initialize();
+        unset($this->schemaDomainMap[PropelTypes::UUID]);
         $this->setSchemaDomainMapping(new Domain(PropelTypes::BOOLEAN, 'TINYINT', 1));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::NUMERIC, 'DECIMAL'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::LONGVARCHAR, 'TEXT'));

--- a/src/Propel/Generator/Platform/OraclePlatform.php
+++ b/src/Propel/Generator/Platform/OraclePlatform.php
@@ -60,6 +60,7 @@ class OraclePlatform extends DefaultPlatform
         $this->setSchemaDomainMapping(new Domain(PropelTypes::PHP_ARRAY, 'NVARCHAR2', 2000));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::ENUM, 'NUMBER', 3, 0));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::SET, 'NUMBER'));
+        $this->setSchemaDomainMapping(new Domain(PropelTypes::UUID, 'UUID'));
     }
 
     /**

--- a/src/Propel/Generator/Platform/PgsqlPlatform.php
+++ b/src/Propel/Generator/Platform/PgsqlPlatform.php
@@ -583,7 +583,7 @@ ALTER TABLE %s RENAME TO %s;
      */
     public function hasSize(string $sqlType): bool
     {
-        return !in_array($sqlType, ['BYTEA', 'TEXT', 'DOUBLE PRECISION']);
+        return !in_array(strtoupper($sqlType), ['BYTEA', 'TEXT', 'DOUBLE PRECISION'], true);
     }
 
     /**
@@ -737,7 +737,7 @@ DROP SEQUENCE %s CASCADE;
     {
         $strings = ['UUID'];
 
-        return in_array(strtoupper($type), $strings);
+        return in_array(strtoupper($type), $strings, true);
     }
 
     /**
@@ -749,7 +749,7 @@ DROP SEQUENCE %s CASCADE;
     {
         $strings = ['VARCHAR'];
 
-        return in_array(strtoupper($type), $strings);
+        return in_array(strtoupper($type), $strings, true);
     }
 
     /**
@@ -761,7 +761,7 @@ DROP SEQUENCE %s CASCADE;
     {
         $numbers = ['INTEGER', 'INT4', 'INT2', 'NUMBER', 'NUMERIC', 'SMALLINT', 'BIGINT', 'DECIMAL', 'REAL', 'DOUBLE PRECISION', 'SERIAL', 'BIGSERIAL'];
 
-        return in_array(strtoupper($type), $numbers);
+        return in_array(strtoupper($type), $numbers, true);
     }
 
     /**

--- a/src/Propel/Generator/Platform/SqlitePlatform.php
+++ b/src/Propel/Generator/Platform/SqlitePlatform.php
@@ -59,6 +59,8 @@ class SqlitePlatform extends DefaultPlatform
 
         $this->foreignKeySupport = version_compare($version, '3.6.19') >= 0;
 
+        unset($this->schemaDomainMap[PropelTypes::UUID]);
+
         $this->setSchemaDomainMapping(new Domain(PropelTypes::NUMERIC, 'DECIMAL'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::LONGVARCHAR, 'MEDIUMTEXT'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::DATE, 'DATETIME'));

--- a/src/Propel/Generator/Reverse/AbstractSchemaParser.php
+++ b/src/Propel/Generator/Reverse/AbstractSchemaParser.php
@@ -191,11 +191,7 @@ abstract class AbstractSchemaParser implements SchemaParserInterface
             $this->nativeToPropelTypeMap = $this->getTypeMapping();
         }
 
-        if (isset($this->nativeToPropelTypeMap[$nativeType])) {
-            return $this->nativeToPropelTypeMap[$nativeType];
-        }
-
-        return null;
+        return $this->nativeToPropelTypeMap[$nativeType] ?? null;
     }
 
     /**

--- a/src/Propel/Generator/Reverse/MssqlSchemaParser.php
+++ b/src/Propel/Generator/Reverse/MssqlSchemaParser.php
@@ -60,7 +60,7 @@ class MssqlSchemaParser extends AbstractSchemaParser
         'timestamp' => PropelTypes::BINARY,
         'tinyint identity' => PropelTypes::TINYINT,
         'tinyint' => PropelTypes::TINYINT,
-        'uniqueidentifier' => PropelTypes::CHAR,
+        'uniqueidentifier' => PropelTypes::UUID,
         'varbinary' => PropelTypes::VARBINARY,
         'varbinary(max)' => PropelTypes::CLOB,
         'varchar' => PropelTypes::VARCHAR,

--- a/src/Propel/Generator/Reverse/OracleSchemaParser.php
+++ b/src/Propel/Generator/Reverse/OracleSchemaParser.php
@@ -58,6 +58,7 @@ class OracleSchemaParser extends AbstractSchemaParser
         'NUMBER' => PropelTypes::INTEGER,
         'NVARCHAR2' => PropelTypes::VARCHAR,
         'TIMESTAMP' => PropelTypes::TIMESTAMP,
+        'UUID' => PropelTypes::UUID,
         'VARCHAR2' => PropelTypes::VARCHAR,
     ];
 

--- a/src/Propel/Generator/Reverse/PgsqlSchemaParser.php
+++ b/src/Propel/Generator/Reverse/PgsqlSchemaParser.php
@@ -73,6 +73,7 @@ class PgsqlSchemaParser extends AbstractSchemaParser
         'timestamp with time zone' => PropelTypes::TIMESTAMP,
         'double precision' => PropelTypes::DOUBLE,
         'json' => PropelTypes::JSON,
+        'uuid' => PropelTypes::UUID,
     ];
 
     /**

--- a/src/Propel/Generator/Reverse/SqliteSchemaParser.php
+++ b/src/Propel/Generator/Reverse/SqliteSchemaParser.php
@@ -68,6 +68,7 @@ class SqliteSchemaParser extends AbstractSchemaParser
         'text' => PropelTypes::LONGVARCHAR,
         'enum' => PropelTypes::CHAR,
         'set' => PropelTypes::CHAR,
+        'uuid' => PropelTypes::UUID,
     ];
 
     /**

--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -2357,7 +2357,7 @@ class Criteria
      * WHERE some_column = some value AND could_have_another_column =
      * another value AND so on.
      *
-     * @param \Propel\Runtime\ActiveQuery\Criteria|array $updateValues A Criteria object containing values used in set clause.
+     * @param \Propel\Runtime\ActiveQuery\Criteria $updateValues A Criteria object containing values used in set clause.
      * @param \Propel\Runtime\Connection\ConnectionInterface $con The ConnectionInterface connection object to use.
      *
      * @return int The number of rows affected by last update statement.
@@ -2366,7 +2366,7 @@ class Criteria
      *             Note that the return value does require that this information is returned
      *             (supported) by the Propel db driver.
      */
-    public function doUpdate($updateValues, ConnectionInterface $con): int
+    public function doUpdate(Criteria $updateValues, ConnectionInterface $con): int
     {
         return UpdateQueryExecutor::execute($this, $updateValues, $con);
     }

--- a/src/Propel/Runtime/ActiveQuery/SqlBuilder/InsertQuerySqlBuilder.php
+++ b/src/Propel/Runtime/ActiveQuery/SqlBuilder/InsertQuerySqlBuilder.php
@@ -71,6 +71,8 @@ class InsertQuerySqlBuilder extends AbstractSqlQueryBuilder
     }
 
     /**
+     * Build a comma separated list of placeholders, i.e. ":p1,:p2,:p3" for 3 placeholders.
+     *
      * @param int $numberOfPlaceholders
      *
      * @return string

--- a/src/Propel/Runtime/ActiveQuery/SqlBuilder/UpdateQuerySqlBuilder.php
+++ b/src/Propel/Runtime/ActiveQuery/SqlBuilder/UpdateQuerySqlBuilder.php
@@ -23,7 +23,7 @@ class UpdateQuerySqlBuilder extends AbstractSqlQueryBuilder
 
     /**
      * @psalm-var array<string, array<string>>
-     * @var array<string>
+     * @var array<array<string>>
      */
     protected $updateTablesColumns;
 

--- a/src/Propel/Runtime/Map/ColumnMap.php
+++ b/src/Propel/Runtime/Map/ColumnMap.php
@@ -299,7 +299,7 @@ class ColumnMap
      *
      * @return bool
      */
-    public function isUUID(): bool
+    public function isUuid(): bool
     {
         return $this->type === PropelTypes::UUID;
     }

--- a/src/Propel/Runtime/Map/ColumnMap.php
+++ b/src/Propel/Runtime/Map/ColumnMap.php
@@ -295,6 +295,16 @@ class ColumnMap
     }
 
     /**
+     * Whether this column contains UUIDs.
+     *
+     * @return bool
+     */
+    public function isUUID(): bool
+    {
+        return $this->type === PropelTypes::UUID;
+    }
+
+    /**
      * Set the size of this column.
      *
      * @param int|null $size An int specifying the size.

--- a/tests/Propel/Tests/Generator/Model/ColumnTest.php
+++ b/tests/Propel/Tests/Generator/Model/ColumnTest.php
@@ -476,6 +476,7 @@ class ColumnTest extends ModelTestCase
             ['ENUM', PDO::PARAM_INT],
             ['BU_DATE', PDO::PARAM_STR],
             ['BU_TIMESTAMP', PDO::PARAM_STR],
+            ['UUID', PDO::PARAM_STR],
         ];
     }
 
@@ -707,6 +708,31 @@ class ColumnTest extends ModelTestCase
             ['DECIMAL', 'string', false],
             ['REAL', 'double', true],
         ];
+    }
+
+    /**
+     * @return void
+     */
+    public function testUuidType()
+    {
+        $domain = $this->getDomainMock();
+        $domain
+            ->expects($this->once())
+            ->method('setType')
+            ->with($this->equalTo(PropelTypes::UUID));
+
+        $domain
+            ->expects($this->any())
+            ->method('getType')
+            ->will($this->returnValue(PropelTypes::UUID));
+
+        $column = new Column('');
+        $column->setDomain($domain);
+        $column->setType(PropelTypes::UUID);
+
+        $this->assertSame('string', $column->getPhpType());
+        $this->assertTrue($column->isPhpPrimitiveType());
+        $this->assertTrue($column->isUuidType());
     }
 
     /**

--- a/tests/Propel/Tests/Generator/Platform/MssqlPlatformTest.php
+++ b/tests/Propel/Tests/Generator/Platform/MssqlPlatformTest.php
@@ -697,4 +697,23 @@ ALTER TABLE [foo] DROP CONSTRAINT [foo_bar_fk];
 ";
         $this->assertEquals($expected, $this->getPlatform()->getCommentBlockDDL('foo bar'));
     }
+
+    /**
+     * @dataProvider providerForTestCreateSchemaWithUuidColumns
+     *
+     * @return void
+     */
+    public function testCreateSchemaWithUuidColumns($schema)
+    {
+        $table = $this->getTableFromSchema($schema);
+        $expected = "
+CREATE TABLE [foo]
+(
+    [uuid] UNIQUEIDENTIFIER DEFAULT vendor_specific_default() NOT NULL,
+    [other_uuid] UNIQUEIDENTIFIER NULL,
+    CONSTRAINT [foo_pk] PRIMARY KEY ([uuid])
+);
+";
+        $this->assertEquals($expected, $this->getPlatform()->getAddTableDDL($table));
+    }
 }

--- a/tests/Propel/Tests/Generator/Platform/MysqlPlatformTest.php
+++ b/tests/Propel/Tests/Generator/Platform/MysqlPlatformTest.php
@@ -974,4 +974,33 @@ CREATE TABLE `foo`
         $actualMysqlDataType = $this->getPlatform()->getDomainForType($propelDataType)->getSqlType();
         $this->assertEquals($expectedMysqlDataType, $actualMysqlDataType);
     }
+    
+    public function unavailableTypesDataProvider()
+    {
+        return [
+            [PropelTypes::UUID],
+        ];
+    }
+    
+    /**
+     * @dataProvider unavailableTypesDataProvider
+     */
+    public function testExceptionOnAccessOfUnavailableType(string $propelDataType)
+    {
+        $this->expectException(\Propel\Generator\Exception\EngineException::class);
+
+        $this->getPlatform()->getDomainForType($propelDataType);
+    }
+
+    /**
+     * @dataProvider providerForTestCreateSchemaWithUuidColumns
+     *
+     * @return void
+     */
+    public function testCreateSchemaWithUuidColumns($schema)
+    {
+        $this->expectException(\Propel\Generator\Exception\EngineException::class);
+
+        $table = $this->getTableFromSchema($schema);
+    }
 }

--- a/tests/Propel/Tests/Generator/Platform/OraclePlatformMigrationTest.php
+++ b/tests/Propel/Tests/Generator/Platform/OraclePlatformMigrationTest.php
@@ -518,4 +518,22 @@ ALTER TABLE foo2
 ";
         $this->assertEquals($expected, $this->getPlatform()->getModifyDatabaseDDL($databaseDiff));
     }
+
+    /**
+     * @dataProvider providerForTestMigrateToUUIDColumn
+     *
+     * @return void
+     */
+    public function testMigrateToUUIDColumn($tableDiff)
+    {
+        $expected = <<<END
+
+ALTER TABLE foo MODIFY
+(
+    id UUID DEFAULT vendor_specific_uuid_generator_function() NOT NULL
+);
+
+END;
+        $this->assertEquals($expected, $this->getPlatform()->getModifyTableColumnsDDL($tableDiff));
+    }
 }

--- a/tests/Propel/Tests/Generator/Platform/OraclePlatformTest.php
+++ b/tests/Propel/Tests/Generator/Platform/OraclePlatformTest.php
@@ -651,4 +651,24 @@ EOF;
 
         $this->assertEquals($expected, $this->getPlatform()->getAddTablesDDL($database));
     }
+
+    /**
+     * @dataProvider providerForTestCreateSchemaWithUuidColumns
+     *
+     * @return void
+     */
+    public function testCreateSchemaWithUuidColumns($schema)
+    {
+        $table = $this->getTableFromSchema($schema);
+        $expected = "
+CREATE TABLE foo
+(
+    uuid UUID DEFAULT vendor_specific_default() NOT NULL,
+    other_uuid UUID
+);
+
+ALTER TABLE foo ADD CONSTRAINT foo_pk PRIMARY KEY (uuid);
+";
+        $this->assertEquals($expected, $this->getPlatform()->getAddTableDDL($table));
+    }
 }

--- a/tests/Propel/Tests/Generator/Platform/PgsqlPlatformMigrationTest.php
+++ b/tests/Propel/Tests/Generator/Platform/PgsqlPlatformMigrationTest.php
@@ -12,6 +12,7 @@ use Propel\Generator\Builder\Util\SchemaReader;
 use Propel\Generator\Model\Column;
 use Propel\Generator\Model\ColumnDefaultValue;
 use Propel\Generator\Model\Diff\ColumnComparator;
+use Propel\Generator\Model\Diff\TableDiff;
 use Propel\Generator\Model\Table;
 use Propel\Generator\Platform\PgsqlPlatform;
 
@@ -20,9 +21,9 @@ class PgsqlPlatformMigrationTest extends PlatformMigrationTestProvider
     /**
      * Get the Platform object for this class
      *
-     * @return \Propel\Generator\Platform\PlatformInterface
+     * @return PgsqlPlatform
      */
-    protected function getPlatform()
+    protected function getPlatform(): PgsqlPlatform
     {
         return new PgsqlPlatform();
     }
@@ -447,5 +448,22 @@ EOF;
     public function testGetModifyTableForeignKeysSkipSql4DDL($databaseDiff)
     {
         $this->assertFalse($databaseDiff);
+    }
+
+    /**
+     * @dataProvider providerForTestMigrateToUUIDColumn
+     *
+     * @return void
+     */
+    public function testMigrateToUUIDColumn($tableDiff)
+    {
+        $expected = <<<END
+
+ALTER TABLE "foo" ALTER COLUMN "id" TYPE uuid USING id::uuid;
+
+ALTER TABLE "foo" ALTER COLUMN "id" SET DEFAULT vendor_specific_uuid_generator_function();
+
+END;
+        $this->assertEquals($expected, $this->getPlatform()->getModifyTableColumnsDDL($tableDiff));
     }
 }

--- a/tests/Propel/Tests/Generator/Platform/PgsqlPlatformTest.php
+++ b/tests/Propel/Tests/Generator/Platform/PgsqlPlatformTest.php
@@ -834,4 +834,25 @@ ALTER TABLE "foo" DROP CONSTRAINT "foo_bar_fk";
 ";
         $this->assertEquals($expected, $this->getPlatform()->getCommentBlockDDL('foo bar'));
     }
+
+    /**
+     * @dataProvider providerForTestCreateSchemaWithUuidColumns
+     *
+     * @return void
+     */
+    public function testCreateSchemaWithUuidColumns($schema)
+    {
+        $table = $this->getTableFromSchema($schema);
+        $expected = <<< 'EOT'
+
+CREATE TABLE "foo"
+(
+    "uuid" uuid DEFAULT vendor_specific_default() NOT NULL,
+    "other_uuid" uuid,
+    PRIMARY KEY ("uuid")
+);
+
+EOT;
+        $this->assertEquals($expected, $this->getPlatform()->getAddTableDDL($table));
+    }
 }

--- a/tests/Propel/Tests/Generator/Platform/PlatformMigrationTestProvider.php
+++ b/tests/Propel/Tests/Generator/Platform/PlatformMigrationTestProvider.php
@@ -12,6 +12,8 @@ use Propel\Generator\Model\Column;
 use Propel\Generator\Model\Diff\ColumnComparator;
 use Propel\Generator\Model\Diff\DatabaseComparator;
 use Propel\Generator\Model\Diff\TableComparator;
+use Propel\Generator\Model\Diff\TableDiff;
+use Propel\Generator\Model\PropelTypes;
 use Propel\Generator\Model\Table;
 
 /**
@@ -578,5 +580,44 @@ EOF;
         $diff = DatabaseComparator::computeDiff($d2, $d1);
 
         return [[$diff]];
+    }
+
+    protected function buildTableDiff(string $tableName, string $tableColumnsFrom, string $tableColumnsTo): TableDiff
+    {
+        $schema1 = <<<EOF
+<database name="test" identifierQuoting="true">
+    <table name="$tableName">
+        $tableColumnsFrom
+    </table>
+</database>
+EOF;
+        $schema2 = <<<EOF
+<database name="test" identifierQuoting="true">
+    <table name="$tableName">
+        $tableColumnsTo
+    </table>
+</database>
+EOF;
+
+        $t1 = $this->getDatabaseFromSchema($schema1)->getTable($tableName);
+        $t2 = $this->getDatabaseFromSchema($schema2)->getTable($tableName);
+        $tc = new TableComparator();
+        $tc->setFromTable($t1);
+        $tc->setToTable($t2);
+        $tc->compareColumns();
+
+        return $tc->getTableDiff();
+    }
+
+    public function providerForTestMigrateToUUIDColumn()
+    {
+        $tableColumnsFrom = <<<EOF
+        <column name="id" primaryKey="true" type="VARCHAR" size="36" autoIncrement="true"/>
+EOF;
+        $tableColumnsTo = <<<EOF
+        <column name="id" primaryKey="true" type="UUID" default="vendor_specific_uuid_generator_function()"/>
+EOF;
+
+        return [[$this->buildTableDiff('foo', $tableColumnsFrom, $tableColumnsTo)]];
     }
 }

--- a/tests/Propel/Tests/Generator/Platform/PlatformTestProvider.php
+++ b/tests/Propel/Tests/Generator/Platform/PlatformTestProvider.php
@@ -360,4 +360,18 @@ EOF;
         [$table1],
         ];
     }
+
+    public function providerForTestCreateSchemaWithUuidColumns()
+    {
+        $schema = <<<EOF
+<database name="test" identifierQuoting="true">
+    <table name="foo">
+        <column name="uuid" primaryKey="true" type="UUID" default="vendor_specific_default()"/>
+        <column name="other_uuid" type="UUID"/>
+    </table>
+</database>
+EOF;
+
+        return [[$schema]];
+    }
 }

--- a/tests/Propel/Tests/Generator/Platform/SqlitePlatformTest.php
+++ b/tests/Propel/Tests/Generator/Platform/SqlitePlatformTest.php
@@ -12,6 +12,7 @@ use Propel\Generator\Model\Column;
 use Propel\Generator\Model\ColumnDefaultValue;
 use Propel\Generator\Model\IdMethod;
 use Propel\Generator\Model\IdMethodParameter;
+use Propel\Generator\Model\PropelTypes;
 use Propel\Generator\Model\Table;
 use Propel\Generator\Platform\SqlitePlatform;
 use Propel\Runtime\Adapter\AdapterFactory;
@@ -428,5 +429,34 @@ DROP INDEX [babar];
 -----------------------------------------------------------------------
 ";
         $this->assertEquals($expected, $this->getPlatform()->getCommentBlockDDL('foo bar'));
+    }
+    
+    public function unavailableTypesDataProvider()
+    {
+        return [
+            [PropelTypes::UUID],
+        ];
+    }
+    
+    /**
+     * @dataProvider unavailableTypesDataProvider
+     */
+    public function testExceptionOnAccessOfUnavailableType(string $propelDataType)
+    {
+        $this->expectException(\Propel\Generator\Exception\EngineException::class);
+
+        $this->getPlatform()->getDomainForType($propelDataType);
+    }
+
+    /**
+     * @dataProvider providerForTestCreateSchemaWithUuidColumns
+     *
+     * @return void
+     */
+    public function testCreateSchemaWithUuidColumns($schema)
+    {
+        $this->expectException(\Propel\Generator\Exception\EngineException::class);
+
+        $table = $this->getTableFromSchema($schema);
     }
 }

--- a/tests/Propel/Tests/Generator/Reverse/PgsqlSchemaParserTest.php
+++ b/tests/Propel/Tests/Generator/Reverse/PgsqlSchemaParserTest.php
@@ -12,6 +12,7 @@ use PDO;
 use Propel\Generator\Config\QuickGeneratorConfig;
 use Propel\Generator\Model\ColumnDefaultValue;
 use Propel\Generator\Model\Database;
+use Propel\Generator\Model\PropelTypes;
 use Propel\Generator\Platform\DefaultPlatform;
 use Propel\Generator\Reverse\PgsqlSchemaParser;
 use Propel\Runtime\Propel;
@@ -58,11 +59,12 @@ class PgsqlSchemaParserTest extends TestCaseFixturesDatabase
     public function parseDataProvider()
     {
         return [
-            // columnDDL, expectedColumnPhpName, expectedColumnDefaultType, expectedColumnDefaultValue, expectedSize, expectedScale
-            ['my_column varchar(20) default null', 'MyColumn', ColumnDefaultValue::TYPE_VALUE, 'NULL', 20, null],
-            ["my_column varchar(20) default ''", 'MyColumn', ColumnDefaultValue::TYPE_VALUE, '', 20, null],
-            ['my_column numeric(11,0) default 0', 'MyColumn', ColumnDefaultValue::TYPE_VALUE, 0, 11, 0],
-            ['my_column numeric(55,8) default 0', 'MyColumn', ColumnDefaultValue::TYPE_VALUE, 0, 55, 8],
+            // columnDDL, expectedColumnPhpName, type, expectedColumnDefaultType, expectedColumnDefaultValue, expectedSize, expectedScale
+            ['my_column varchar(20) default null', 'MyColumn', PropelTypes::VARCHAR, ColumnDefaultValue::TYPE_VALUE, 'NULL', 20, null],
+            ["my_column varchar(20) default ''", 'MyColumn', PropelTypes::VARCHAR, ColumnDefaultValue::TYPE_VALUE, '', 20, null],
+            ['my_column numeric(11,0) default 0', 'MyColumn', PropelTypes::DECIMAL, ColumnDefaultValue::TYPE_VALUE, 0, 11, 0],
+            ['my_column numeric(55,8) default 0', 'MyColumn', PropelTypes::DECIMAL, ColumnDefaultValue::TYPE_VALUE, 0, 55, 8],
+            ['my_column uuid default null', 'MyColumn', PropelTypes::UUID, null, null, null, null],
         ];
     }
 
@@ -71,7 +73,7 @@ class PgsqlSchemaParserTest extends TestCaseFixturesDatabase
      *
      * @return void
      */
-    public function testParse($columnDDL, $expectedColumnPhpName, $expectedColumnDefaultType, $expectedColumnDefaultValue, $expectedSize, $expectedScale)
+    public function testParse($columnDDL, $expectedPhpName, $expectedType, $expectedDefaultType, $expectedDefaultValue, $expectedSize, $expectedScale)
     {
         $this->con->query("create table foo ( {$columnDDL} );");
         $parser = new PgsqlSchemaParser($this->con);
@@ -86,13 +88,22 @@ class PgsqlSchemaParserTest extends TestCaseFixturesDatabase
         $table = $database->getTable('foo');
         $columns = $table->getColumns();
         $this->assertEquals(1, count($columns));
+        $column = $columns[0];
+        $this->assertNotEmpty($column);
 
         // check out our rev-eng column info
-        $defaultValue = $columns[0]->getDefaultValue();
-        $this->assertEquals($expectedColumnPhpName, $columns[0]->getPhpName());
-        $this->assertEquals($expectedColumnDefaultType, $defaultValue->getType());
-        $this->assertEquals($expectedColumnDefaultValue, $defaultValue->getValue());
-        $this->assertEquals($expectedSize, $columns[0]->getSize());
-        $this->assertEquals($expectedScale, $columns[0]->getScale());
+        $this->assertEquals($expectedPhpName, $column->getPhpName());
+        $this->assertEquals($expectedType, $column->getType());
+
+        $defaultValue = $column->getDefaultValue();
+        if($expectedDefaultType === null){
+            $this->assertNull($expectedDefaultType);
+        } else {
+            $this->assertEquals($expectedDefaultType, $defaultValue->getType());
+            $this->assertEquals($expectedDefaultValue, $defaultValue->getValue());
+        }
+        
+        $this->assertEquals($expectedSize, $column->getSize());
+        $this->assertEquals($expectedScale, $column->getScale());
     }
 }

--- a/tests/bin/setup.mysql.sh
+++ b/tests/bin/setup.mysql.sh
@@ -6,7 +6,7 @@ if [ "$mysql" = "" ]; then
 fi
 
 if [ "$mysql" = "" ]; then
-    echo "Can not find mysql binary. Is it installed?";
+    echo "Cannot find mysql binary. Is it installed?";
     exit 1;
 fi
 
@@ -21,20 +21,21 @@ if [ "$DB_PW" != "" ]; then
 fi
 
 DB_HOSTNAME=${DB_HOSTNAME-127.0.0.1};
+DB_NAME=${DB_NAME-test};
 
 "$mysql" --version;
 
 retry_count=0
 while true; do
-    "$mysql" --host="$DB_HOSTNAME" -u"$DB_USER" $pw_option -e '
+    "$mysql" --host="$DB_HOSTNAME" -u"$DB_USER" $pw_option -e "
 SET FOREIGN_KEY_CHECKS = 0;
-DROP DATABASE IF EXISTS test;
+DROP DATABASE IF EXISTS $DB_NAME;
 DROP SCHEMA IF EXISTS second_hand_books;
 DROP SCHEMA IF EXISTS contest;
 DROP SCHEMA IF EXISTS bookstore_schemas;
 DROP SCHEMA IF EXISTS migration;
 SET FOREIGN_KEY_CHECKS = 1;
-'
+"
     if [ $? -eq 0 ] || [ $retry_count -ge 6 ]; then break; fi
     retry_count=$((retry_count + 1))
     sleep "$(awk "BEGIN{print 2 ^ $retry_count}")"
@@ -42,7 +43,7 @@ done
 
 "$mysql" --host="$DB_HOSTNAME" -u"$DB_USER" $pw_option -e "
 SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));
-CREATE DATABASE test;
+CREATE DATABASE $DB_NAME;
 CREATE SCHEMA bookstore_schemas;
 CREATE SCHEMA contest;
 CREATE SCHEMA second_hand_books;

--- a/tests/bin/setup.mysql.sh
+++ b/tests/bin/setup.mysql.sh
@@ -53,5 +53,5 @@ CREATE SCHEMA migration;
 
 
 DIR=`dirname $0`;
-dsn="mysql:host=$DB_HOSTNAME;dbname=test";
+dsn="mysql:host=$DB_HOSTNAME;dbname=$DB_NAME";
 php $DIR/../../bin/propel test:prepare --vendor="mysql" --dsn="$dsn" --user="$DB_USER" --password="$DB_PW";

--- a/tests/bin/setup.pgsql.sh
+++ b/tests/bin/setup.pgsql.sh
@@ -25,9 +25,9 @@ fi
 
 "$psql" --version;
 
-dropdb  --host="$DB_HOSTNAME" --username="$DB_USER" "$NO_PWD" "$DB_NAME";
+dropdb  --host="$DB_HOSTNAME" --username="$DB_USER" $NO_PWD "$DB_NAME";
 
-createdb  --host="$DB_HOSTNAME" --username="$DB_USER" "$NO_PWD" "$DB_NAME";
+createdb  --host="$DB_HOSTNAME" --username="$DB_USER" $NO_PWD "$DB_NAME";
 
 "$psql" --host="$DB_HOSTNAME" --username="$DB_USER" -c '
 CREATE SCHEMA bookstore_schemas;


### PR DESCRIPTION
As discussed in #1914, this allows to use `UUID` as column type in schema.xml. Underlying columns are set to the native uuid type of the database system (`uuid` in Postgres and Oracle, `UNIQUEIDENTIFIER` in mssql). In Mysql/MariaDB and SQLite, an error is thrown. Inside the model and query classes, the uuid columns use string values.

This is pretty straight forward, a new type literal is registered and associated with strings, and register the type in the vendor adapters with the corresponding type. For Postgres, I added cast statements used during migration. Tests check generated `create` and `alter` statements and internal mapping of uuid to string.

I have played around with it on Postgres, and it seems to work there.

I also added a commit with two fixes for the test setup scripts:
- `setup.mysql.sh` always used "test" as database name, even though the fixtures are build using an environment variable (`$DB_NAME`) with "test" only as fallback
- in `setup.pgsql.sh` some statements failed when a variable was empty, leading to empty string parameters