### PR TITLE
setup postres tests without password prompt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,6 @@ jobs:
               if: matrix.db-type == 'pgsql'
               run: tests/bin/setup.pgsql.sh
               env:
-                  PGPASSWORD: 'postgres'
                   DB_NAME: 'propel-tests'
                   DB_USER: 'postgres'
                   DB_PW: 'postgres'


### PR DESCRIPTION
While playing around with the postgres tests, I stumbled over having to enter the database password three times every time I ran the setup script, even though I provided the password in the designated `DB_PW` variable.

This can be remedied by registering connection in a `.pgpass` file or setting the `PGPASSWORD` variable, but having to change the system to run tests seamlessly should not be necessary. Fortunately, the issue can easily be addressed in the setup script. All we need to do is setting postgres' `PGPASSWORD` variable to the password in `DB_PW` before running dropdb, createdb and psql. I do that in a subshell, so the value of `PGPASSWORD` in the actual shell is not altered.

That's it, no more triple password prompt.

The gitlab workflows used the `DB_PW`+`PGPASSWORD` approach, let's see how it does without `PGPASSWORD` 
