### PR TITLE
Add type to store UUIDs as binary (UUID_BINARY)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,33 +24,40 @@ jobs:
                     php-version: '7.4'
                   - symfony-version: '6-max'
                     php-version: '7.4'
+        env:
+            DB_NAME: 'propel_tests'
+            DB_USER: 'propel'
+            DB_PW: 'propel'
         steps:
             - name: Install PostgreSQL latest
-              if: matrix.db-type == 'pgsql' && matrix.php-version != '7.3'
+              if: matrix.db-type == 'pgsql' && matrix.php-version != '7.4'
               uses: CasperWA/postgresql-action@v1.2
               with:
-                  postgresql db: 'propel-tests'
-                  postgresql user: 'postgres'
-                  postgresql password: 'postgres'
+                  postgresql db: $DB_NAME
+                  postgresql user: $DB_USER
+                  postgresql password: $DB_PW
 
             - name: Install PostgreSQL min
-              if: matrix.db-type == 'pgsql' && matrix.php-version == '7.3'
+              if: matrix.db-type == 'pgsql' && matrix.php-version == '7.4'
               uses: CasperWA/postgresql-action@v1.2
               with:
                   postgresql version: 9
-                  postgresql db: 'propel-tests'
-                  postgresql user: 'postgres'
-                  postgresql password: 'postgres'
+                  postgresql db: $DB_NAME
+                  postgresql user: $DB_USER
+                  postgresql password: $DB_PW
 
-            - name: Install MariaDb latest
-              if: matrix.db-type == 'mysql' && matrix.php-version != '7.3'
-              uses: getong/mariadb-action@v1.1
+            - name: Install MySQL latest
+              if: matrix.db-type == 'mysql' && matrix.php-version != '7.4'
+              uses: mirromutth/mysql-action@v1.1
+              with:
+                  mysql root password: $DB_PW
 
             - name: Install MariaDb min
-              if: matrix.db-type == 'mysql' && matrix.php-version == '7.3'
+              if: matrix.db-type == 'mysql' && matrix.php-version == '7.4'
               uses: getong/mariadb-action@v1.1
               with:
                   mariadb version: '10.2'
+                  mysql root password: $DB_PW
 
             - name: Setup PHP, with composer and extensions
               uses: shivammathur/setup-php@v2
@@ -79,34 +86,39 @@ jobs:
             - name: Composer install (Symfony version ${{ matrix.symfony-version }})
               run: composer install --no-progress --prefer-dist --optimize-autoloader
 
-            - name: Setup Postgresql database for test suite
-              if: matrix.db-type == 'pgsql'
-              run: tests/bin/setup.pgsql.sh
+            - name: Wait for MySQL server to load
+              if: matrix.db-type == 'mysql'
+              run: |
+                bash -c "
+                for i in {1..10}; do
+                  mysqladmin -h 127.0.0.1 -u root status >/dev/null 2>&1 && exit 0 || sleep 6
+                  echo 'trying again'
+                done;
+                echo 'could not establish connection after 10 tries'
+                exit 1
+                "
               env:
-                  DB_NAME: 'propel-tests'
-                  DB_USER: 'postgres'
-                  DB_PW: 'postgres'
+                MYSQL_PWD: ${{ env.DB_PW }}
 
-            - name: Setup the database for test suite
-              if: matrix.db-type != 'agnostic' && matrix.db-type != 'pgsql'
+            - name: Create MySQL Propel user
+              if: matrix.db-type == 'mysql'
+              run: |
+                mysql -h 127.0.0.1 -u root -e "
+                  CREATE USER '$DB_USER'@'localhost' IDENTIFIED BY '$DB_PW';
+                  CREATE USER '$DB_USER'@'%' IDENTIFIED BY '$DB_PW';
+                  GRANT ALL PRIVILEGES ON *.* TO '$DB_USER'@'localhost';
+                  GRANT ALL PRIVILEGES ON *.* TO '$DB_USER'@'%';
+                  FLUSH PRIVILEGES;
+                "
+              env:
+                MYSQL_PWD: ${{ env.DB_PW }}
+
+            - name: Setup database for test suite
+              if: matrix.db-type != 'agnostic'
               run: tests/bin/setup.${{ matrix.db-type }}.sh
 
-            - name: Run PostgreSQL tests
-              if: matrix.db-type == 'pgsql'
-              shell: 'script -q -e -c "bash {0}"'
-              run: |
-                  if [[ ${{ matrix.php-version }} == '7.4' && ${{ matrix.symfony-version == '5-max' }} ]]; then
-                    export CODECOVERAGE=1 && vendor/bin/phpunit -c tests/pgsql.phpunit.xml --verbose --coverage-clover=tests/coverage.xml
-                  else
-                    vendor/bin/phpunit -c tests/pgsql.phpunit.xml
-                  fi
-              env:
-                  DB_NAME: 'propel-tests'
-                  DB_USER: 'postgres'
-                  DB_PW: 'postgres'
-
-            - name: Run ${{ matrix.db-type }} tests
-              if: matrix.db-type != 'pgsql'
+            - name: Run database tests
+              if: matrix.db-type != 'agnostic'
               shell: 'script -q -e -c "bash {0}"'
               run: |
                   if [[ ${{ matrix.php-version }} == '7.4' && ${{ matrix.symfony-version == '5-max' }} ]]; then

--- a/src/Propel/Generator/Builder/Om/AbstractOMBuilder.php
+++ b/src/Propel/Generator/Builder/Om/AbstractOMBuilder.php
@@ -14,7 +14,6 @@ use Propel\Generator\Builder\Util\PropelTemplate;
 use Propel\Generator\Exception\InvalidArgumentException;
 use Propel\Generator\Exception\LogicException;
 use Propel\Generator\Exception\RuntimeException;
-use Propel\Generator\Exception\SchemaException;
 use Propel\Generator\Model\Column;
 use Propel\Generator\Model\CrossForeignKeys;
 use Propel\Generator\Model\ForeignKey;
@@ -1205,26 +1204,14 @@ abstract class AbstractOMBuilder extends DataModelBuilder
     }
 
     /**
-     * Returns the value for the uuid swap flag as set in the vendor information
-     * block in schema.xml as a literal ('true' or 'false').
-     *
      * @psalm-return 'true'|'false'
      *
-     * @see \Propel\Runtime\Util\UuidConverter::uuidToBin()
-     *
-     * @throws \Propel\Generator\Exception\SchemaException
+     * @see \Propel\Generator\Model\VendorInfo::getUuidSwapFlagLiteral()
      *
      * @return string
      */
     protected function getUuidSwapFlagLiteral(): string
     {
-        $vendorInformation = $this->getVendorInfo();
-
-        $uuidSwapFlag = $vendorInformation->getParameter('UuidSwapFlag') ?? 'true';
-        if (!in_array($uuidSwapFlag, ['true', 'false'], true)) {
-            throw new SchemaException('Value for /database/vendor/parameter[name="UuidSwapFlag"] must be "true" or "false", but it is ' . $uuidSwapFlag);
-        }
-
-        return $uuidSwapFlag;
+        return $this->getVendorInfo()->getUuidSwapFlagLiteral();
     }
 }

--- a/src/Propel/Generator/Builder/Om/AbstractOMBuilder.php
+++ b/src/Propel/Generator/Builder/Om/AbstractOMBuilder.php
@@ -14,10 +14,12 @@ use Propel\Generator\Builder\Util\PropelTemplate;
 use Propel\Generator\Exception\InvalidArgumentException;
 use Propel\Generator\Exception\LogicException;
 use Propel\Generator\Exception\RuntimeException;
+use Propel\Generator\Exception\SchemaException;
 use Propel\Generator\Model\Column;
 use Propel\Generator\Model\CrossForeignKeys;
 use Propel\Generator\Model\ForeignKey;
 use Propel\Generator\Model\Table;
+use Propel\Generator\Model\VendorInfo;
 
 /**
  * Baseclass for OM-building classes.
@@ -1189,4 +1191,40 @@ abstract class AbstractOMBuilder extends DataModelBuilder
      * @return void
      */
     abstract protected function addClassClose(string &$script): void;
+
+    /**
+     * Returns the vendor info from the table for the configured platform.
+     *
+     * @return \Propel\Generator\Model\VendorInfo
+     */
+    protected function getVendorInfo(): VendorInfo
+    {
+        $dbVendorId = $this->getPlatform()->getDatabaseType();
+
+        return $this->getTable()->getVendorInfoForType($dbVendorId);
+    }
+
+    /**
+     * Returns the value for the uuid swap flag as set in the vendor information
+     * block in schema.xml as a literal ('true' or 'false').
+     *
+     * @psalm-return 'true'|'false'
+     *
+     * @see \Propel\Runtime\Util\UuidConverter::uuidToBin()
+     *
+     * @throws \Propel\Generator\Exception\SchemaException
+     *
+     * @return string
+     */
+    protected function getUuidSwapFlagLiteral(): string
+    {
+        $vendorInformation = $this->getVendorInfo();
+
+        $uuidSwapFlag = $vendorInformation->getParameter('UuidSwapFlag') ?? 'true';
+        if (!in_array($uuidSwapFlag, ['true', 'false'], true)) {
+            throw new SchemaException('Value for /database/vendor/parameter[name="UuidSwapFlag"] must be "true" or "false", but it is ' . $uuidSwapFlag);
+        }
+
+        return $uuidSwapFlag;
+    }
 }

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -323,6 +323,12 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
         }
 
         $table = $this->getTable();
+
+        $additionalModelClasses = $table->getAdditionalModelClassImports();
+        if ($additionalModelClasses) {
+            $this->declareClasses(...$additionalModelClasses);
+        }
+
         if (!$table->isAlias()) {
             $this->addConstants($script);
             $this->addAttributes($script);
@@ -1709,6 +1715,13 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
         } elseif ($column->isPhpObjectType()) {
             $script .= "
             \$this->$clo = (\$firstColumn !== null) ? new " . $column->getPhpType() . '($firstColumn) : null;';
+        } elseif ($column->getType() === PropelTypes::UUID_BINARY) {
+            $uuidSwapFlag = $this->getUuidSwapFlagLiteral();
+            $script .= "
+            if (is_resource(\$firstColumn)) {
+                \$firstColumn = stream_get_contents(\$firstColumn);
+            }
+            \$this->$clo = (\$firstColumn) ? UuidConverter::binToUuid(\$firstColumn, $uuidSwapFlag) : null;";
         } else {
             $script .= "
             \$this->$clo = \$firstColumn;";
@@ -2716,6 +2729,13 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
                     }
                     $script .= "
             \$this->$clo = (null !== \$col) ? PropelDateTime::newInstance(\$col, null, '$dateTimeClass') : null;";
+                } elseif ($col->isUuidBinaryType()) {
+                    $uuidSwapFlag = $this->getUuidSwapFlagLiteral();
+                    $script .= "
+            if (is_resource(\$col)) {
+                \$col = stream_get_contents(\$col);
+            }
+            \$this->$clo = (\$col) ? UuidConverter::binToUuid(\$col, $uuidSwapFlag) : null;";
                 } elseif ($col->isPhpPrimitiveType()) {
                     $script .= "
             \$this->$clo = (null !== \$col) ? (" . $col->getPhpType() . ') $col : null;';
@@ -2745,8 +2765,8 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
 
         if ($this->getBuildProperty('generator.objectModel.addSaveMethod')) {
             $script .= "
-            \$this->resetModified();
-";
+
+            \$this->resetModified();";
         }
 
         $script .= "
@@ -2950,10 +2970,11 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
         \$criteria = new Criteria(" . $this->getTableMapClass() . "::DATABASE_NAME);
 ";
         foreach ($this->getTable()->getColumns() as $col) {
-            $clo = $col->getLowercasedName();
+            $accessValueStatement = $this->getAccessValueStatement($col);
+            $columnConstant = $this->getColumnConstant($col);
             $script .= "
-        if (\$this->isColumnModified(" . $this->getColumnConstant($col) . ")) {
-            \$criteria->add(" . $this->getColumnConstant($col) . ", \$this->$clo);
+        if (\$this->isColumnModified($columnConstant)) {
+            \$criteria->add($columnConstant, $accessValueStatement);
         }";
         }
     }
@@ -6599,12 +6620,15 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
             \$stmt = \$con->prepare(\$sql);
             foreach (\$modifiedColumns as \$identifier => \$columnName) {
                 switch (\$columnName) {";
+
+        $tab = '                        ';
         foreach ($table->getColumns() as $column) {
             $columnNameCase = var_export($this->quoteIdentifier($column->getName()), true);
+            $accessValueStatement = $this->getAccessValueStatement($column);
+            $bindValueStatement = $platform->getColumnBindingPHP($column, '$identifier', $accessValueStatement, $tab);
             $script .= "
-                    case $columnNameCase:";
-            $script .= $platform->getColumnBindingPHP($column, '$identifier', '$this->' . $column->getLowercasedName(), '                        ');
-            $script .= "
+                    case $columnNameCase:$bindValueStatement
+
                         break;";
         }
         $script .= "
@@ -6643,6 +6667,30 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
         }
 
         return $script;
+    }
+
+    /**
+     * Get the statement how a column value is accessed in the script.
+     *
+     * Note that this is not necessarily just the getter. If the value is
+     * stored on the model in an encoded format, the statement returned by
+     * this method includes the statement to decode the value.
+     *
+     * @param \Propel\Generator\Model\Column $column
+     *
+     * @return string
+     */
+    protected function getAccessValueStatement(Column $column): string
+    {
+        $columnName = $column->getLowercasedName();
+
+        if ($column->isUuidBinaryType()) {
+            $uuidSwapFlag = $this->getUuidSwapFlagLiteral();
+
+            return "(\$this->$columnName) ? UuidConverter::uuidToBin(\$this->$columnName, $uuidSwapFlag) : null";
+        }
+
+        return "\$this->$columnName";
     }
 
     /**

--- a/src/Propel/Generator/Builder/Om/QueryBuilder.php
+++ b/src/Propel/Generator/Builder/Om/QueryBuilder.php
@@ -174,6 +174,10 @@ class QueryBuilder extends AbstractOMBuilder
         );
         $this->declareClassFromBuilder($this->getStubQueryBuilder(), 'Child');
         $this->declareClassFromBuilder($this->getTableMapBuilder());
+        $additionalModelClasses = $table->getAdditionalModelClassImports();
+        if ($additionalModelClasses) {
+            $this->declareClasses(...$additionalModelClasses);
+        }
 
         // apply behaviors
         $this->applyBehaviorModifier('queryAttributes', $script, '    ');
@@ -1147,6 +1151,10 @@ class QueryBuilder extends AbstractOMBuilder
         if (is_string(\$$variableName)) {
             \$$variableName = in_array(strtolower(\$$variableName), array('false', 'off', '-', 'no', 'n', '0', '')) ? false : true;
         }";
+        } elseif ($col->isUuidBinaryType()) {
+            $uuidSwapFlag = $this->getUuidSwapFlagLiteral();
+            $script .= "
+        \$$variableName = UuidConverter::uuidToBinRecursive(\$$variableName, $uuidSwapFlag);";
         }
         $script .= "
 

--- a/src/Propel/Generator/Model/Column.php
+++ b/src/Propel/Generator/Model/Column.php
@@ -1334,6 +1334,16 @@ class Column extends MappingModel
     }
 
     /**
+     * Returns whether this column is a uuid bin type.
+     *
+     * @return bool
+     */
+    public function isUuidBinaryType(): bool
+    {
+        return $this->getType() === PropelTypes::UUID_BINARY;
+    }
+
+    /**
      * Returns whether the column is an array column.
      *
      * @return bool

--- a/src/Propel/Generator/Model/Column.php
+++ b/src/Propel/Generator/Model/Column.php
@@ -1244,6 +1244,18 @@ class Column extends MappingModel
     }
 
     /**
+     * Returns the SQL type as a string.
+     *
+     * @see Domain::getSqlType()
+     *
+     * @return string
+     */
+    public function getSqlType(): string
+    {
+        return $this->getDomain()->getSqlType();
+    }
+
+    /**
      * Returns the column PDO type integer for this column's mapping type.
      *
      * @return int
@@ -1722,5 +1734,19 @@ class Column extends MappingModel
     public static function generatePhpSingularName(string $phpName): string
     {
         return rtrim($phpName, 's');
+    }
+
+    /**
+     * Checks if xml attributes from schema.xml matches expected content declaration.
+     *
+     * @param string $content
+     *
+     * @return bool
+     */
+    public function isContent(string $content): bool
+    {
+        $contentAttribute = $this->getAttribute('content');
+
+        return $contentAttribute && strtoupper($contentAttribute) === strtoupper($contentAttribute);
     }
 }

--- a/src/Propel/Generator/Model/Diff/TableComparator.php
+++ b/src/Propel/Generator/Model/Diff/TableComparator.php
@@ -304,18 +304,17 @@ class TableComparator
                 $sameName = $caseInsensitive ?
                     strtolower($fromTableFk->getName()) == strtolower($toTableFk->getName()) :
                     $fromTableFk->getName() == $toTableFk->getName();
-                if ($sameName && !$toTableFk->isPolymorphic()) {
-                    if (ForeignKeyComparator::computeDiff($fromTableFk, $toTableFk, $caseInsensitive) === false) {
-                        unset($fromTableFks[$fromTableFkPos]);
-                        unset($toTableFks[$toTableFkPos]);
-                    } else {
-                        // same name, but different columns
-                        $this->tableDiff->addModifiedFk($fromTableFk->getName(), $fromTableFk, $toTableFk);
-                        unset($fromTableFks[$fromTableFkPos]);
-                        unset($toTableFks[$toTableFkPos]);
-                        $fkDifferences++;
-                    }
+                if (!$sameName || $toTableFk->isPolymorphic()) {
+                    continue;
                 }
+                $hasChanged = ForeignKeyComparator::computeDiff($fromTableFk, $toTableFk, $caseInsensitive);
+                if ($hasChanged) {
+                    // same name, but different columns
+                    $this->tableDiff->addModifiedFk($fromTableFk->getName(), $fromTableFk, $toTableFk);
+                    $fkDifferences++;
+                }
+                unset($fromTableFks[$fromTableFkPos]);
+                unset($toTableFks[$toTableFkPos]);
             }
         }
 

--- a/src/Propel/Generator/Model/ForeignKey.php
+++ b/src/Propel/Generator/Model/ForeignKey.php
@@ -648,7 +648,7 @@ class ForeignKey extends MappingModel
     /**
      * Returns an array of local column names.
      *
-     * @return array
+     * @return array<string>
      */
     public function getLocalColumns(): array
     {
@@ -781,7 +781,7 @@ class ForeignKey extends MappingModel
     /**
      * Returns an array of foreign column names.
      *
-     * @return array
+     * @return array<string>
      */
     public function getForeignColumns(): array
     {

--- a/src/Propel/Generator/Model/ForeignKey.php
+++ b/src/Propel/Generator/Model/ForeignKey.php
@@ -781,7 +781,7 @@ class ForeignKey extends MappingModel
     /**
      * Returns an array of foreign column names.
      *
-     * @return array<string>
+     * @return array<string|null>
      */
     public function getForeignColumns(): array
     {

--- a/src/Propel/Generator/Model/PropelTypes.php
+++ b/src/Propel/Generator/Model/PropelTypes.php
@@ -352,6 +352,11 @@ class PropelTypes
     public const UUID_NATIVE_TYPE = 'string';
 
     /**
+     * @var string
+     */
+    public const UUID_BINARY = 'UUID_BINARY';
+
+    /**
      * Propel mapping types.
      *
      * @var array
@@ -392,6 +397,7 @@ class PropelTypes
         self::SET,
         self::JSON,
         self::UUID,
+        self::UUID_BINARY,
     ];
 
     /**
@@ -433,6 +439,7 @@ class PropelTypes
         self::GEOMETRY => self::GEOMETRY,
         self::JSON => self::JSON_TYPE,
         self::UUID => self::UUID_NATIVE_TYPE,
+        self::UUID_BINARY => self::UUID_NATIVE_TYPE,
     ];
 
     /**
@@ -479,6 +486,7 @@ class PropelTypes
         self::BU_TIMESTAMP => PDO::PARAM_STR,
         self::JSON => PDO::PARAM_STR,
         self::UUID => PDO::PARAM_STR,
+        self::UUID_BINARY => PDO::PARAM_LOB,
     ];
 
     /**
@@ -639,6 +647,7 @@ class PropelTypes
     {
         return in_array($type, [
             self::UUID,
+            self::UUID_BINARY,
         ], true);
     }
 

--- a/src/Propel/Generator/Model/Schema.php
+++ b/src/Propel/Generator/Model/Schema.php
@@ -193,16 +193,15 @@ class Schema
             return $this->databases[0];
         }
 
-        $db = null;
         foreach ($this->databases as $database) {
-            if ($database->getName() === $name) {
-                $db = $database;
-
-                break;
+            if ($database->getName() !== $name) {
+                continue;
             }
+
+            return $database;
         }
 
-        return $db;
+        return null;
     }
 
     /**

--- a/src/Propel/Generator/Model/Table.php
+++ b/src/Propel/Generator/Model/Table.php
@@ -1038,6 +1038,20 @@ class Table extends ScopedMappingModel implements IdMethod
     }
 
     /**
+     * Get indexes on a column
+     *
+     * @param \Propel\Generator\Model\Column $column
+     *
+     * @return array<\Propel\Generator\Model\Index>
+     */
+    public function getIndexesOnColumn(Column $column): array
+    {
+        $columnName = $column->getName();
+
+        return array_filter($this->indices, fn ($idx) => $idx->hasColumn($columnName));
+    }
+
+    /**
      * Adds a new index to the indices list and set the
      * parent table of the column to the current table.
      *
@@ -1804,14 +1818,9 @@ class Table extends ScopedMappingModel implements IdMethod
      */
     public function getForeignKeysReferencingTable(string $tableName): array
     {
-        $matches = [];
-        foreach ($this->foreignKeys as $fk) {
-            if ($fk->getForeignTableName() === $tableName) {
-                $matches[] = $fk;
-            }
-        }
+        $filter = fn (ForeignKey $fk) => $fk->getForeignTableName() === $tableName;
 
-        return $matches;
+        return array_values(array_filter($this->foreignKeys, $filter));
     }
 
     /**
@@ -1827,14 +1836,9 @@ class Table extends ScopedMappingModel implements IdMethod
      */
     public function getColumnForeignKeys(string $column): array
     {
-        $matches = [];
-        foreach ($this->foreignKeys as $fk) {
-            if (in_array($column, $fk->getLocalColumns())) {
-                $matches[] = $fk;
-            }
-        }
+        $filter = fn (ForeignKey $fk) => in_array($column, $fk->getLocalColumns(), true);
 
-        return $matches;
+        return array_values(array_filter($this->foreignKeys, $filter));
     }
 
     /**
@@ -1926,7 +1930,7 @@ class Table extends ScopedMappingModel implements IdMethod
     public function quoteIdentifier(string $text): string
     {
         if (!$this->getPlatform()) {
-            throw new RuntimeException('No platform specified. Can not quote without knowing which platform this table\'s database is using.');
+            throw new RuntimeException('No platform specified. Cannot quote without knowing which platform this table\'s database is using.');
         }
 
         if ($this->isIdentifierQuotingEnabled()) {

--- a/src/Propel/Generator/Model/VendorInfo.php
+++ b/src/Propel/Generator/Model/VendorInfo.php
@@ -8,6 +8,8 @@
 
 namespace Propel\Generator\Model;
 
+use Propel\Generator\Exception\SchemaException;
+
 /**
  * Object to hold vendor specific information.
  *
@@ -160,5 +162,27 @@ class VendorInfo extends MappingModel
     protected function setupObject(): void
     {
         $this->type = $this->getAttribute('type');
+    }
+
+    /**
+     * Returns the value for the uuid swap flag as set in the vendor information
+     * block in schema.xml as a literal ('true' or 'false').
+     *
+     * @psalm-return 'true'|'false'
+     *
+     * @see \Propel\Runtime\Util\UuidConverter::uuidToBin()
+     *
+     * @throws \Propel\Generator\Exception\SchemaException
+     *
+     * @return string
+     */
+    public function getUuidSwapFlagLiteral(): string
+    {
+        $uuidSwapFlag = $this->getParameter('UuidSwapFlag') ?? 'true';
+        if (!in_array($uuidSwapFlag, ['true', 'false'], true)) {
+            throw new SchemaException('Value for `/database/vendor/parameter[name="UuidSwapFlag"]` must be `true` or `false`, but it is `' . $uuidSwapFlag . '`');
+        }
+
+        return $uuidSwapFlag;
     }
 }

--- a/src/Propel/Generator/Platform/DefaultPlatform.php
+++ b/src/Propel/Generator/Platform/DefaultPlatform.php
@@ -23,6 +23,7 @@ use Propel\Generator\Model\Index;
 use Propel\Generator\Model\PropelTypes;
 use Propel\Generator\Model\Table;
 use Propel\Generator\Model\Unique;
+use Propel\Generator\Platform\Util\AlterTableStatementMerger;
 use Propel\Runtime\Connection\ConnectionInterface;
 use ReflectionClass;
 
@@ -896,41 +897,7 @@ ALTER TABLE %s RENAME TO %s;
             $columnChangeString .= $this->getAddPrimaryKeyDDL($tableDiff->getToTable());
         }
 
-        if ($columnChangeString) {
-            //merge column changes into one command. This is more compatible especially with PK constraints.
-
-            $changes = explode(';', $columnChangeString);
-            $columnChanges = [];
-
-            foreach ($changes as $change) {
-                if (!trim($change)) {
-                    continue;
-                }
-                $isCompatibleCall = preg_match(
-                    sprintf('/ALTER TABLE %s (?!RENAME)/', $this->quoteIdentifier($toTable->getName())),
-                    $change,
-                );
-                if ($isCompatibleCall) {
-                    $columnChanges[] = preg_replace(
-                        sprintf('/ALTER TABLE %s /', $this->quoteIdentifier($toTable->getName())),
-                        "\n\n  ",
-                        trim($change),
-                    );
-                } else {
-                    $ret .= $change . ";\n";
-                }
-            }
-
-            if (0 < count($columnChanges)) {
-                $ret .= sprintf(
-                    "
-ALTER TABLE %s%s;
-",
-                    $this->quoteIdentifier($toTable->getName()),
-                    implode(',', $columnChanges),
-                );
-            }
-        }
+        $ret .= AlterTableStatementMerger::merge($toTable, $columnChangeString);
 
         // create indices, foreign keys
         foreach ($tableDiff->getModifiedIndices() as $indexModification) {
@@ -1278,7 +1245,7 @@ ALTER TABLE %s ADD
      *
      * @return string Quoted identifier.
      */
-    protected function quoteIdentifier(string $text): string
+    public function quoteIdentifier(string $text): string
     {
         return $this->isIdentifierQuotingEnabled() ? $this->doQuoting($text) : $text;
     }

--- a/src/Propel/Generator/Platform/DefaultPlatform.php
+++ b/src/Propel/Generator/Platform/DefaultPlatform.php
@@ -1495,13 +1495,8 @@ if (is_resource($columnValueAccessor)) {
 }";
         }
 
-        $script .= sprintf(
-            "
-\$stmt->bindValue(%s, %s, %s);",
-            $identifier,
-            $columnValueAccessor,
-            PropelTypes::getPdoTypeString($column->getType()),
-        );
+        $pdoType = PropelTypes::getPdoTypeString($column->getType());
+        $script .= "\n\$stmt->bindValue($identifier, $columnValueAccessor, $pdoType);";
 
         return preg_replace('/^(.+)/m', $tab . '$1', $script);
     }

--- a/src/Propel/Generator/Platform/MssqlPlatform.php
+++ b/src/Propel/Generator/Platform/MssqlPlatform.php
@@ -58,6 +58,7 @@ class MssqlPlatform extends DefaultPlatform
         $this->setSchemaDomainMapping(new Domain(PropelTypes::ENUM, 'TINYINT'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::SET, 'INT'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::UUID, 'UNIQUEIDENTIFIER'));
+        $this->setSchemaDomainMapping(new Domain(PropelTypes::UUID_BINARY, 'BINARY(16)'));
     }
 
     /**

--- a/src/Propel/Generator/Platform/MysqlPlatform.php
+++ b/src/Propel/Generator/Platform/MysqlPlatform.php
@@ -58,7 +58,7 @@ class MysqlPlatform extends DefaultPlatform
         $this->setSchemaDomainMapping(new Domain(PropelTypes::NUMERIC, 'DECIMAL'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::LONGVARCHAR, 'TEXT'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::BINARY, 'BINARY'));
-        $this->setSchemaDomainMapping(new Domain(PropelTypes::VARBINARY, 'VARBINARY'));
+        $this->setSchemaDomainMapping(new Domain(PropelTypes::VARBINARY, 'MEDIUMBLOB'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::LONGVARBINARY, 'LONGBLOB'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::CLOB, 'LONGTEXT'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::OBJECT, 'MEDIUMBLOB'));

--- a/src/Propel/Generator/Platform/MysqlPlatform.php
+++ b/src/Propel/Generator/Platform/MysqlPlatform.php
@@ -66,6 +66,7 @@ class MysqlPlatform extends DefaultPlatform
         $this->setSchemaDomainMapping(new Domain(PropelTypes::ENUM, 'TINYINT'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::SET, 'INT'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::REAL, 'DOUBLE'));
+        $this->setSchemaDomainMapping(new Domain(PropelTypes::UUID_BINARY, 'BINARY(16)'));
     }
 
     /**
@@ -331,9 +332,7 @@ CREATE TABLE %s
      */
     protected function getTableOptions(Table $table): array
     {
-        $dbVI = $table->getDatabase()->getVendorInfoForType('mysql');
-        $tableVI = $table->getVendorInfoForType('mysql');
-        $vi = $dbVI->getMergedVendorInfo($tableVI);
+        $vi = $table->getVendorInfoForType('mysql');
         $tableOptions = [];
         // List of supported table options
         // see http://dev.mysql.com/doc/refman/5.5/en/create-table.html

--- a/src/Propel/Generator/Platform/MysqlPlatform.php
+++ b/src/Propel/Generator/Platform/MysqlPlatform.php
@@ -21,6 +21,7 @@ use Propel\Generator\Model\Index;
 use Propel\Generator\Model\PropelTypes;
 use Propel\Generator\Model\Table;
 use Propel\Generator\Model\Unique;
+use Propel\Generator\Platform\Util\MysqlUuidMigrationBuilder;
 
 /**
  * MySql PlatformInterface implementation.
@@ -56,8 +57,8 @@ class MysqlPlatform extends DefaultPlatform
         $this->setSchemaDomainMapping(new Domain(PropelTypes::BOOLEAN, 'TINYINT', 1));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::NUMERIC, 'DECIMAL'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::LONGVARCHAR, 'TEXT'));
-        $this->setSchemaDomainMapping(new Domain(PropelTypes::BINARY, 'BLOB'));
-        $this->setSchemaDomainMapping(new Domain(PropelTypes::VARBINARY, 'MEDIUMBLOB'));
+        $this->setSchemaDomainMapping(new Domain(PropelTypes::BINARY, 'BINARY'));
+        $this->setSchemaDomainMapping(new Domain(PropelTypes::VARBINARY, 'VARBINARY'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::LONGVARBINARY, 'LONGBLOB'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::CLOB, 'LONGTEXT'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::OBJECT, 'MEDIUMBLOB'));
@@ -65,7 +66,7 @@ class MysqlPlatform extends DefaultPlatform
         $this->setSchemaDomainMapping(new Domain(PropelTypes::ENUM, 'TINYINT'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::SET, 'INT'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::REAL, 'DOUBLE'));
-        $this->setSchemaDomainMapping(new Domain(PropelTypes::UUID_BINARY, 'BINARY(16)'));
+        $this->setSchemaDomainMapping(new Domain(PropelTypes::UUID_BINARY, 'BINARY', 16));
 
         // no native UUID type, use UUID_BINARY
         $this->schemaDomainMap[PropelTypes::UUID] = $this->schemaDomainMap[PropelTypes::UUID_BINARY];
@@ -435,11 +436,8 @@ DROP TABLE IF EXISTS " . $this->quoteIdentifier($table->getName()) . ";
         }
 
         $ddl = [$this->quoteIdentifier($col->getName())];
-        if ($this->hasSize($sqlType) && $col->isDefaultSqlType($this)) {
-            $ddl[] = $sqlType . $col->getSizeDefinition();
-        } else {
-            $ddl[] = $sqlType;
-        }
+        $ddl[] = $this->getSqlTypeExpression($col);
+
         $colinfo = $col->getVendorInfoForType($this->getDatabaseType());
         if ($colinfo->hasParameter('Unsigned')) {
             $unsigned = $colinfo->getParameter('Unsigned');
@@ -492,6 +490,45 @@ DROP TABLE IF EXISTS " . $this->quoteIdentifier($table->getName()) . ";
     }
 
     /**
+     * Returns the SQL type as a string.
+     *
+     * @see Domain::getSqlType()
+     *
+     * @param \Propel\Generator\Model\Column $column
+     *
+     * @return string
+     */
+    public function getSqlTypeExpression(Column $column): string
+    {
+        $sqlType = $column->getSqlType();
+        $hasSize = $this->hasSize($sqlType) && $column->isDefaultSqlType($this);
+
+        return (!$hasSize) ? $sqlType : $sqlType . $column->getSizeDefinition();
+    }
+
+    /**
+     * @param \Propel\Generator\Model\Column $fromColumn
+     * @param \Propel\Generator\Model\Column $toColumn
+     *
+     * @return string
+     */
+    protected function getChangeColumnToUuidBinaryType(Column $fromColumn, Column $toColumn): string
+    {
+        return MysqlUuidMigrationBuilder::create($this)->buildMigration($fromColumn, $toColumn, true);
+    }
+
+    /**
+     * @param \Propel\Generator\Model\Column $fromColumn
+     * @param \Propel\Generator\Model\Column $toColumn
+     *
+     * @return string
+     */
+    protected function getChangeColumnFromUuidBinaryType(Column $fromColumn, Column $toColumn): string
+    {
+        return MysqlUuidMigrationBuilder::create($this)->buildMigration($fromColumn, $toColumn, false);
+    }
+
+    /**
      * Creates a comma-separated list of column names for the index.
      * For MySQL unique indexes there is the option of specifying size, so we cannot simply use
      * the getColumnsList() method.
@@ -504,7 +541,8 @@ DROP TABLE IF EXISTS " . $this->quoteIdentifier($table->getName()) . ";
     {
         $list = [];
         foreach ($index->getColumns() as $col) {
-            $list[] = $this->quoteIdentifier($col) . ($index->hasColumnSize($col) ? '(' . $index->getColumnSize($col) . ')' : '');
+            $size = $index->hasColumnSize($col) ? '(' . $index->getColumnSize($col) . ')' : '';
+            $list[] = $this->quoteIdentifier($col) . $size;
         }
 
         return implode(', ', $list);
@@ -523,14 +561,9 @@ DROP TABLE IF EXISTS " . $this->quoteIdentifier($table->getName()) . ";
             return '';
         }
 
-        $pattern = "
-ALTER TABLE %s DROP PRIMARY KEY;
-";
+        $tableName = $this->quoteIdentifier($table->getName());
 
-        return sprintf(
-            $pattern,
-            $this->quoteIdentifier($table->getName()),
-        );
+        return "\nALTER TABLE $tableName DROP PRIMARY KEY;\n";
     }
 
     /**
@@ -792,7 +825,20 @@ ALTER TABLE %s DROP %s;
      */
     public function getModifyColumnDDL(ColumnDiff $columnDiff): string
     {
-        return $this->getChangeColumnDDL($columnDiff->getFromColumn(), $columnDiff->getToColumn());
+        $fromColumn = $columnDiff->getFromColumn();
+        $toColumn = $columnDiff->getToColumn();
+
+        if ($fromColumn->isTextType() && $toColumn->isUuidBinaryType()) {
+            return $this->getChangeColumnToUuidBinaryType($fromColumn, $toColumn);
+        }
+
+        // binary column from database does not know it is a UUID column
+        $fromBinaryColumn = in_array($fromColumn->getType(), [PropelTypes::BINARY, PropelTypes::UUID_BINARY], true);
+        if ($fromBinaryColumn && $toColumn->isTextType() && $toColumn->isContent('UUID')) {
+            return $this->getChangeColumnFromUuidBinaryType($fromColumn, $toColumn);
+        }
+
+        return $this->getChangeColumnDDL($fromColumn, $toColumn);
     }
 
     /**
@@ -805,16 +851,12 @@ ALTER TABLE %s DROP %s;
      */
     public function getChangeColumnDDL(Column $fromColumn, Column $toColumn): string
     {
-        $pattern = "
-ALTER TABLE %s CHANGE %s %s;
-";
+        $tableName = $this->quoteIdentifier($fromColumn->getTable()->getName());
+        $columnName = $this->quoteIdentifier($fromColumn->getName());
+        $columnDefinition = $this->getColumnDDL($toColumn);
+        $pattern = "\nALTER TABLE %s CHANGE %s %s;\n";
 
-        return sprintf(
-            $pattern,
-            $this->quoteIdentifier($fromColumn->getTable()->getName()),
-            $this->quoteIdentifier($fromColumn->getName()),
-            $this->getColumnDDL($toColumn),
-        );
+        return sprintf($pattern, $tableName, $columnName, $columnDefinition);
     }
 
     /**
@@ -826,12 +868,9 @@ ALTER TABLE %s CHANGE %s %s;
      */
     public function getModifyColumnsDDL(array $columnDiffs): string
     {
-        $ret = '';
-        foreach ($columnDiffs as $columnDiff) {
-            $ret .= $this->getModifyColumnDDL($columnDiff);
-        }
+        $modifyColumnStatements = array_map([$this, 'getModifyColumnDDL'], $columnDiffs);
 
-        return $ret;
+        return implode('', $modifyColumnStatements);
     }
 
     /**

--- a/src/Propel/Generator/Platform/MysqlPlatform.php
+++ b/src/Propel/Generator/Platform/MysqlPlatform.php
@@ -53,7 +53,6 @@ class MysqlPlatform extends DefaultPlatform
     protected function initialize(): void
     {
         parent::initialize();
-        unset($this->schemaDomainMap[PropelTypes::UUID]);
         $this->setSchemaDomainMapping(new Domain(PropelTypes::BOOLEAN, 'TINYINT', 1));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::NUMERIC, 'DECIMAL'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::LONGVARCHAR, 'TEXT'));
@@ -67,6 +66,9 @@ class MysqlPlatform extends DefaultPlatform
         $this->setSchemaDomainMapping(new Domain(PropelTypes::SET, 'INT'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::REAL, 'DOUBLE'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::UUID_BINARY, 'BINARY(16)'));
+
+        // no native UUID type, use UUID_BINARY
+        $this->schemaDomainMap[PropelTypes::UUID] = $this->schemaDomainMap[PropelTypes::UUID_BINARY];
     }
 
     /**

--- a/src/Propel/Generator/Platform/OraclePlatform.php
+++ b/src/Propel/Generator/Platform/OraclePlatform.php
@@ -61,6 +61,7 @@ class OraclePlatform extends DefaultPlatform
         $this->setSchemaDomainMapping(new Domain(PropelTypes::ENUM, 'NUMBER', 3, 0));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::SET, 'NUMBER'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::UUID, 'UUID'));
+        $this->setSchemaDomainMapping(new Domain(PropelTypes::UUID_BINARY, 'RAW(16)'));
     }
 
     /**

--- a/src/Propel/Generator/Platform/PgsqlPlatform.php
+++ b/src/Propel/Generator/Platform/PgsqlPlatform.php
@@ -63,6 +63,7 @@ class PgsqlPlatform extends DefaultPlatform
         $this->setSchemaDomainMapping(new Domain(PropelTypes::DECIMAL, 'NUMERIC'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::DATETIME, 'TIMESTAMP'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::UUID, 'uuid'));
+        $this->setSchemaDomainMapping(new Domain(PropelTypes::UUID_BINARY, 'BYTEA'));
     }
 
     /**

--- a/src/Propel/Generator/Platform/PlatformInterface.php
+++ b/src/Propel/Generator/Platform/PlatformInterface.php
@@ -338,4 +338,11 @@ interface PlatformInterface
      * @return void
      */
     public function setIdentifierQuoting(bool $enabled): void;
+
+    /**
+     * @param \Propel\Generator\Model\Table $table
+     *
+     * @return string
+     */
+    public function getAddTableDDL(Table $table): string;
 }

--- a/src/Propel/Generator/Platform/PlatformInterface.php
+++ b/src/Propel/Generator/Platform/PlatformInterface.php
@@ -345,4 +345,14 @@ interface PlatformInterface
      * @return string
      */
     public function getAddTableDDL(Table $table): string;
+
+    /**
+     * Quotes identifiers used in database SQL if isIdentifierQuotingEnabled is true.
+     * Calls doQuoting() when identifierQuoting is enabled.
+     *
+     * @param string $text
+     *
+     * @return string Quoted identifier.
+     */
+    public function quoteIdentifier(string $text): string;
 }

--- a/src/Propel/Generator/Platform/SqlitePlatform.php
+++ b/src/Propel/Generator/Platform/SqlitePlatform.php
@@ -59,8 +59,6 @@ class SqlitePlatform extends DefaultPlatform
 
         $this->foreignKeySupport = version_compare($version, '3.6.19') >= 0;
 
-        unset($this->schemaDomainMap[PropelTypes::UUID]);
-
         $this->setSchemaDomainMapping(new Domain(PropelTypes::NUMERIC, 'DECIMAL'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::LONGVARCHAR, 'MEDIUMTEXT'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::DATE, 'DATETIME'));
@@ -75,6 +73,9 @@ class SqlitePlatform extends DefaultPlatform
         $this->setSchemaDomainMapping(new Domain(PropelTypes::ENUM, 'TINYINT'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::SET, 'INT'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::UUID_BINARY, 'BLOB'));
+
+        // no native UUID type, use UUID_BINARY
+        $this->schemaDomainMap[PropelTypes::UUID] = $this->schemaDomainMap[PropelTypes::UUID_BINARY];
     }
 
     /**

--- a/src/Propel/Generator/Platform/SqlitePlatform.php
+++ b/src/Propel/Generator/Platform/SqlitePlatform.php
@@ -74,6 +74,7 @@ class SqlitePlatform extends DefaultPlatform
         $this->setSchemaDomainMapping(new Domain(PropelTypes::PHP_ARRAY, 'MEDIUMTEXT'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::ENUM, 'TINYINT'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::SET, 'INT'));
+        $this->setSchemaDomainMapping(new Domain(PropelTypes::UUID_BINARY, 'BLOB'));
     }
 
     /**

--- a/src/Propel/Generator/Platform/Util/AlterTableStatementMerger.php
+++ b/src/Propel/Generator/Platform/Util/AlterTableStatementMerger.php
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Generator\Platform\Util;
+
+use Propel\Generator\Model\Table;
+
+/**
+ * Merges several ALTER TABLE statements when creating migrations.
+ *
+ * @phpstan-consistent-constructor
+ */
+class AlterTableStatementMerger
+{
+    /**
+     * @var string
+     */
+    public const NO_MERGE_ACROSS_THIS_LINE = "\n;--sql statement block;\n";
+
+    /**
+     * @var \Propel\Generator\Model\Table table
+     */
+    protected Table $table;
+
+    protected string $quotedTableName;
+
+    /**
+     * Summary of merge
+     *
+     * @param \Propel\Generator\Model\Table $table
+     * @param string $sql
+     *
+     * @return string
+     */
+    public static function merge(Table $table, string $sql): string
+    {
+        $merger = new static($table);
+
+        return $merger->mergeStatements($sql);
+    }
+
+    /**
+     * @param \Propel\Generator\Model\Table $table
+     */
+    public function __construct(Table $table)
+    {
+        $this->table = $table;
+
+        // quoting needs to come from platform, not from table (bug?)
+        //$this->quotedTableName = $this->table->quoteIdentifier($this->table->getName());
+        $this->quotedTableName = $this->table->getPlatform()->quoteIdentifier($this->table->getName());
+    }
+
+    /**
+     * Merges column changes into one command. This is more compatible
+     * especially with PK constraints.
+     *
+     * @param string $sql
+     *
+     * @return string
+     */
+    public function mergeStatements(string $sql): string
+    {
+        $statements = explode(';', $sql);
+        $blocks = [];
+        $currentBlock = [];
+
+        foreach ($statements as $statement) {
+            $statement = trim($statement);
+
+            if (!$statement) {
+                continue;
+            }
+
+            $canMerge = $this->canMergeStatement($statement);
+            if ($canMerge) {
+                $currentBlock[] = $statement;
+
+                continue;
+            }
+
+            if ($currentBlock) {
+                $blocks[] = $this->mergeAlterTableStatements($currentBlock);
+                $currentBlock = [];
+            }
+
+            if ("\n;$statement;\n" === static::NO_MERGE_ACROSS_THIS_LINE) {
+                continue;
+            }
+            $blocks[] = $statement . ';';
+        }
+        if ($currentBlock) {
+            $blocks[] = $this->mergeAlterTableStatements($currentBlock);
+        }
+
+        return "\n" . implode("\n\n", $blocks);
+    }
+
+    /**
+     * @param array $statements
+     *
+     * @return string
+     */
+    protected function mergeAlterTableStatements(array $statements): string
+    {
+        if (!$statements) {
+            return '';
+        }
+        $alterTableExpression = "ALTER TABLE {$this->quotedTableName} ";
+        $changeStatements = array_map(fn ($statement) => str_replace($alterTableExpression, '', $statement), $statements);
+        $mergedStatements = "\n\n  " . implode(",\n\n  ", $changeStatements);
+
+        return "ALTER TABLE {$this->quotedTableName}$mergedStatements;\n";
+    }
+
+    /**
+     * @param string $statement
+     *
+     * @return bool
+     */
+    protected function canMergeStatement(string $statement): bool
+    {
+        $canMergeStatementRegex = "/ALTER TABLE {$this->quotedTableName} (?!RENAME)/"; // alter table statements but not rename
+
+        return (bool)preg_match($canMergeStatementRegex, $statement);
+    }
+}

--- a/src/Propel/Generator/Platform/Util/MysqlUuidMigrationBuilder.php
+++ b/src/Propel/Generator/Platform/Util/MysqlUuidMigrationBuilder.php
@@ -1,0 +1,178 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Generator\Platform\Util;
+
+use Propel\Generator\Model\Column;
+use Propel\Generator\Model\Index;
+use Propel\Generator\Platform\MysqlPlatform;
+
+/**
+ * Creates migration statements for UUID columns in MySQL.
+ *
+ * @phpstan-consistent-constructor
+ */
+class MysqlUuidMigrationBuilder
+{
+    protected MysqlPlatform $platform;
+
+    /**
+     * @param \Propel\Generator\Platform\MysqlPlatform $platform
+     */
+    public function __construct(MysqlPlatform $platform)
+    {
+        $this->platform = $platform;
+    }
+
+    /**
+     * @param \Propel\Generator\Platform\MysqlPlatform $platform
+     *
+     * @return static
+     */
+    public static function create(MysqlPlatform $platform)
+    {
+        return new static($platform);
+    }
+
+    /**
+     * @param \Propel\Generator\Model\Column $fromColumn
+     * @param \Propel\Generator\Model\Column $toColumn
+     * @param bool $toUuidBinary
+     *
+     * @return string
+     */
+    public function buildMigration(Column $fromColumn, Column $toColumn, bool $toUuidBinary): string
+    {
+        $sqlBlock = [AlterTableStatementMerger::NO_MERGE_ACROSS_THIS_LINE];
+        $sqlBlock[] = $this->getMigrateUuidNotification($toColumn);
+        $sqlBlock[] = AlterTableStatementMerger::NO_MERGE_ACROSS_THIS_LINE;
+
+        // remove constraints and indexes
+        $indexes = $this->getSharedIndexes($fromColumn, $toColumn);
+        foreach ($indexes as $index) {
+            $sqlBlock[] = $this->platform->getDropIndexDDL($index);
+        }
+        $movePrimaryKey = $fromColumn->isPrimaryKey() && $toColumn->isPrimaryKey();
+        if ($movePrimaryKey) {
+            $sqlBlock[] = $this->platform->getDropPrimaryKeyDDL($fromColumn->getTable());
+        }
+
+        $sqlBlock[] = $this->buildUuidMigrationStatements($toColumn, $toUuidBinary);
+
+        // restore column constraints
+        if ($movePrimaryKey) {
+            $sqlBlock[] = $this->platform->getAddPrimaryKeyDDL($toColumn->getTable());
+        }
+        foreach ($indexes as $index) {
+            $sqlBlock[] = $this->platform->getAddIndexDDL($index);
+        }
+
+        $sqlBlock[] = "# END migration of UUIDs in column '{$fromColumn->getName()}'\n";
+        $sqlBlock[] = AlterTableStatementMerger::NO_MERGE_ACROSS_THIS_LINE;
+
+        return implode('', $sqlBlock);
+    }
+
+    /**
+     * Get foreign keys in both given columns.
+     *
+     * @param \Propel\Generator\Model\Column $fromColumn
+     * @param \Propel\Generator\Model\Column $toColumn
+     *
+     * @return array
+     */
+    protected function getSharedFks(Column $fromColumn, Column $toColumn): array
+    {
+        $sharedKeys = [];
+
+        foreach (['getReferrers', 'getForeignKeys'] as $getFk) {
+            $oldFks = $fromColumn->$getFk();
+            $newFks = $toColumn->$getFk();
+
+            foreach ($oldFks as $oldFk) {
+                foreach ($newFks as $newFk) {
+                    if ($oldFk->equals($newFk)) {
+                        continue;
+                    }
+                    $sharedKeys[] = $oldFk;
+                }
+            }
+        }
+
+        return $sharedKeys;
+    }
+
+    /**
+     * Get indexes in both given columns.
+     *
+     * @param \Propel\Generator\Model\Column $fromColumn
+     * @param \Propel\Generator\Model\Column $toColumn
+     *
+     * @return array
+     */
+    protected function getSharedIndexes(Column $fromColumn, Column $toColumn): array
+    {
+        $toIndexes = $toColumn->getTable()->getIndexesOnColumn($toColumn);
+        $fromTable = $fromColumn->getTable();
+
+        return array_filter($toIndexes, fn (Index $index) => $fromTable->hasIndex($index->getName()));
+    }
+
+    /**
+     * @param \Propel\Generator\Model\Column $column
+     *
+     * @return string
+     */
+    protected function getMigrateUuidNotification(Column $column)
+    {
+        $columnName = $column->getName();
+        $tableName = $column->getTable()->getName();
+
+        return <<< EOT
+# START migration of UUIDs in column '$tableName.$columnName'.
+# This can break your DB. Validate and edit these statements as you see fit.
+# Please be aware of Propel's ABSOLUTELY NO WARRANTY policy!
+
+EOT;
+    }
+
+    /**
+     * @param \Propel\Generator\Model\Column $column
+     * @param bool $toUuidBinary
+     *
+     * @return string
+     */
+    protected function buildUuidMigrationStatements(Column $column, bool $toUuidBinary): string
+    {
+        $tableName = $this->quoteIdentifier($column->getTable()->getName());
+        $columnName = $this->quoteIdentifier($column->getName());
+        $tmpColumnName = $this->quoteIdentifier($column->getName() . '_' . bin2hex(random_bytes(4)));
+        $swapFlag = $column->getTable()->getVendorInfoForType('mysql')->getUuidSwapFlagLiteral();
+        $columnDefinition = $this->platform->getColumnDDL($column);
+        $sqlType = $this->platform->getSqlTypeExpression($column);
+
+        $convertFunction = ($toUuidBinary) ? 'UUID_TO_BIN' : 'BIN_TO_UUID';
+
+        return <<< EOT
+ALTER TABLE $tableName ADD COLUMN $tmpColumnName $sqlType AFTER $columnName;
+UPDATE $tableName SET $tmpColumnName = $convertFunction($columnName, $swapFlag);
+ALTER TABLE $tableName DROP COLUMN $columnName;
+ALTER TABLE $tableName CHANGE COLUMN $tmpColumnName $columnDefinition;
+EOT;
+    }
+
+    /**
+     * @param string $identifier
+     *
+     * @return string
+     */
+    protected function quoteIdentifier(string $identifier): string
+    {
+        return $this->platform->quoteIdentifier($identifier);
+    }
+}

--- a/src/Propel/Generator/Reverse/MysqlSchemaParser.php
+++ b/src/Propel/Generator/Reverse/MysqlSchemaParser.php
@@ -59,7 +59,7 @@ class MysqlSchemaParser extends AbstractSchemaParser
         'timestamp' => PropelTypes::TIMESTAMP,
         'tinyblob' => PropelTypes::BINARY,
         'blob' => PropelTypes::BLOB,
-        'mediumblob' => PropelTypes::VARBINARY,
+        'mediumblob' => PropelTypes::OBJECT,
         'longblob' => PropelTypes::LONGVARBINARY,
         'longtext' => PropelTypes::CLOB,
         'tinytext' => PropelTypes::VARCHAR,
@@ -67,6 +67,8 @@ class MysqlSchemaParser extends AbstractSchemaParser
         'text' => PropelTypes::LONGVARCHAR,
         'enum' => PropelTypes::CHAR,
         'set' => PropelTypes::CHAR,
+        'binary' => PropelTypes::BINARY,
+        'varbinary' => PropelTypes::VARBINARY,
     ];
 
     /**

--- a/src/Propel/Generator/Reverse/MysqlSchemaParser.php
+++ b/src/Propel/Generator/Reverse/MysqlSchemaParser.php
@@ -59,7 +59,7 @@ class MysqlSchemaParser extends AbstractSchemaParser
         'timestamp' => PropelTypes::TIMESTAMP,
         'tinyblob' => PropelTypes::BINARY,
         'blob' => PropelTypes::BLOB,
-        'mediumblob' => PropelTypes::OBJECT,
+        'mediumblob' => PropelTypes::VARBINARY,
         'longblob' => PropelTypes::LONGVARBINARY,
         'longtext' => PropelTypes::CLOB,
         'tinytext' => PropelTypes::VARCHAR,
@@ -68,7 +68,6 @@ class MysqlSchemaParser extends AbstractSchemaParser
         'enum' => PropelTypes::CHAR,
         'set' => PropelTypes::CHAR,
         'binary' => PropelTypes::BINARY,
-        'varbinary' => PropelTypes::VARBINARY,
     ];
 
     /**

--- a/src/Propel/Runtime/Map/ColumnMap.php
+++ b/src/Propel/Runtime/Map/ColumnMap.php
@@ -301,7 +301,7 @@ class ColumnMap
      */
     public function isUuid(): bool
     {
-        return $this->type === PropelTypes::UUID;
+        return PropelTypes::isUuidType($this->type);
     }
 
     /**

--- a/src/Propel/Runtime/Util/UuidConverter.php
+++ b/src/Propel/Runtime/Util/UuidConverter.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Runtime\Util;
+
+/**
+ * Helpes to manually convert uuids to byte types
+ */
+class UuidConverter
+{
+    /**
+     * Transforms a uuid string to a binary string.
+     *
+     * @param string $uuid
+     * @param bool $swapFlag Swap first four bytes for better indexing of version-1 UUIDs (@link https://dev.mysql.com/doc/refman/8.0/en/miscellaneous-functions.html#function_uuid-to-bin)
+     *
+     * @return string
+     */
+    public static function uuidToBin(string $uuid, bool $swapFlag = true): string
+    {
+        $rawHex = (!$swapFlag)
+            ? str_replace('-', '', $uuid)
+            : preg_replace(
+                '/([^-]+)-([^-]+)-([^-]+)-([^-]+)-(.*)/',
+                '$3$2$1$4$5',
+                $uuid,
+            );
+
+        return hex2bin($rawHex);
+    }
+
+    /**
+     * Transforms a binary string to a uuid string.
+     *
+     * @param string $bin
+     * @param bool $swapFlag Assume bytes were swapped (@link https://dev.mysql.com/doc/refman/8.0/en/miscellaneous-functions.html#function_bin-to-uuid)
+     *
+     * @return string
+     */
+    public static function binToUuid(string $bin, bool $swapFlag = true): string
+    {
+        $rawHex = bin2hex($bin);
+        $recombineFormat = $swapFlag ? '$3$4-$2-$1-$5-$6' : '$1$2-$3-$4-$5-$6';
+
+        return preg_replace(
+            '/(\w{4})(\w{4})(\w{4})(\w{4})(\w{4})(\w{12})/',
+            $recombineFormat,
+            $rawHex,
+        );
+    }
+
+    /**
+     * @param array|string|null $uuid
+     * @param bool $swapFlag
+     *
+     * @return array|string|null
+     */
+    public static function uuidToBinRecursive($uuid, bool $swapFlag = true)
+    {
+        if (!$uuid) {
+            return $uuid;
+        }
+        if (is_string($uuid)) {
+            return self::uuidToBin($uuid, $swapFlag);
+        }
+
+        return array_map(fn ($uuidItem) => self::uuidToBinRecursive($uuidItem, $swapFlag), $uuid);
+    }
+
+    /**
+     * @param array|string|null $bin
+     * @param bool $swapFlag
+     *
+     * @return array|string|null
+     */
+    public static function binToUuidRecursive($bin, bool $swapFlag = true)
+    {
+        if (!$bin) {
+            return $bin;
+        }
+        if (is_string($bin)) {
+            return self::binToUuid($bin, $swapFlag);
+        }
+
+        return array_map(fn ($binItem) => self::binToUuidRecursive($binItem, $swapFlag), $bin);
+    }
+}

--- a/tests/Fixtures/bookstore/schema.xml
+++ b/tests/Fixtures/bookstore/schema.xml
@@ -347,6 +347,10 @@
         <column name="style" type="ENUM" valueSet="novel, essay, poetry"/>
         <column name="style2" type="SET" valueSet="novel, essay, poetry"/>
         <column name="tags" type="ARRAY"/>
+        <column name="uuid_bin" required="false" type="UUID_BINARY"/>
+        <index>
+            <index-column name="uuid_bin"/>
+        </index>
     </table>
 
     <!-- Test single table inheritance with Abstract true -->

--- a/tests/Fixtures/bookstore/schema.xml
+++ b/tests/Fixtures/bookstore/schema.xml
@@ -347,6 +347,7 @@
         <column name="style" type="ENUM" valueSet="novel, essay, poetry"/>
         <column name="style2" type="SET" valueSet="novel, essay, poetry"/>
         <column name="tags" type="ARRAY"/>
+        <column name="uuid" required="false" type="UUID"/>
         <column name="uuid_bin" required="false" type="UUID_BINARY"/>
         <index>
             <index-column name="uuid_bin"/>

--- a/tests/Propel/Tests/Generator/Migration/BaseTest.php
+++ b/tests/Propel/Tests/Generator/Migration/BaseTest.php
@@ -238,7 +238,7 @@ class BaseTest extends MigrationTestCase
         <column name="field6" type="DOUBLE"/>
 
         <column name="field7" type="BINARY" size="6"/>
-        <column name="field8" type="VARBINARY" size="6"/>
+        <column name="field8" type="VARBINARY"/>
         <column name="field9" type="LONGVARBINARY"/>
         <column name="field10" type="BLOB"/>
 
@@ -265,7 +265,7 @@ class BaseTest extends MigrationTestCase
         <column name="field5" type="DOUBLE"/>
         <column name="field6" type="BIGINT"/>
 
-        <column name="field7" type="VARBINARY" size="12"/>
+        <column name="field7" type="VARBINARY"/>
         <column name="field8" type="LONGVARBINARY"/>
         <column name="field9" type="BLOB"/>
         <column name="field10" type="BINARY" size="8"/>

--- a/tests/Propel/Tests/Generator/Migration/BaseTest.php
+++ b/tests/Propel/Tests/Generator/Migration/BaseTest.php
@@ -237,8 +237,8 @@ class BaseTest extends MigrationTestCase
         <column name="field5" type="FLOAT"/>
         <column name="field6" type="DOUBLE"/>
 
-        <column name="field7" type="BINARY"/>
-        <column name="field8" type="VARBINARY"/>
+        <column name="field7" type="BINARY" size="6"/>
+        <column name="field8" type="VARBINARY" size="6"/>
         <column name="field9" type="LONGVARBINARY"/>
         <column name="field10" type="BLOB"/>
 
@@ -265,10 +265,10 @@ class BaseTest extends MigrationTestCase
         <column name="field5" type="DOUBLE"/>
         <column name="field6" type="BIGINT"/>
 
-        <column name="field7" type="VARBINARY"/>
+        <column name="field7" type="VARBINARY" size="12"/>
         <column name="field8" type="LONGVARBINARY"/>
         <column name="field9" type="BLOB"/>
-        <column name="field10" type="BINARY"/>
+        <column name="field10" type="BINARY" size="8"/>
 
         <column name="field11" type="TIME"/>
         <column name="field12" type="TIMESTAMP"/>

--- a/tests/Propel/Tests/Generator/Migration/MysqlMigrateUuidColumnTest.php
+++ b/tests/Propel/Tests/Generator/Migration/MysqlMigrateUuidColumnTest.php
@@ -1,0 +1,311 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Tests\Generator\Migration;
+
+use Propel\Generator\Exception\BuildException;
+use Propel\Tests\Helpers\CheckMysql8Trait;
+
+/**
+ * @group mysql
+ * @group database
+ */
+class MysqlMigrateUuidColumnTest extends MigrationTestCase
+{
+    use CheckMysql8Trait;
+
+    /**
+     * @return void
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        if (!$this->checkMysqlVersionAtLeast8('migration')) {
+            $this->markTestSkipped('Test can only be run on MySQL version >= 8');
+
+            return;
+        }
+        $this->con->exec('DROP TABLE IF EXISTS migration.table_with_uuid;');
+    }
+
+    /**
+     * @dataProvider migrationDataProvider
+     *
+     * @param string $description
+     * @param string $fromColumns
+     * @param string $toColumns
+     * @param array|null $values
+     *
+     * @return void
+     */
+    public function testMigrations(string $description, string $fromColumns, string $toColumns, ?array $values)
+    {
+        $this->applyWithFail($description . ' - failed to apply initial schema', $fromColumns, false);
+        $values && $this->insertValues($values['in']);
+
+        $this->applyWithFail($description . ' - failed to apply migration', $toColumns, true);
+        $values && $this->assertTableDataMatches($values['out'], $description);
+    }
+
+    /**
+     * @param array $values
+     *
+     * @return void
+     */
+    protected function insertValues(array $values)
+    {
+        $valueS = "'" . implode("','", $values) . "'";
+        $this->con->exec("INSERT INTO migration.table_with_uuid VALUES($valueS);");
+    }
+
+    /**
+     * @param array $values
+     * @param string $description
+     *
+     * @return void
+     */
+    protected function assertTableDataMatches(array $values, string $description)
+    {
+        $row = $this->con->query('SELECT * FROM migration.table_with_uuid;')->fetch();
+        //var_dump($values, $row);
+        $this->assertEquals($values, $row, $description);
+    }
+
+    /**
+     * @param string $description
+     * @param string $columns
+     * @param bool $changeRequired
+     *
+     * @return void
+     */
+    protected function applyWithFail(string $description, string $columns, bool $changeRequired)
+    {
+        $databaseXml = $this->buildDatabaseTableXml($columns);
+
+        try {
+            $this->applyXmlAndTest($databaseXml, $changeRequired);
+        } catch (BuildException $e) {
+            $this->fail($description . "\n\n" . $e->getMessage());
+        }
+    }
+
+    /**
+     * @param string $columnDef
+     *
+     * @return string
+     */
+    protected function buildDatabaseTableXml(string $columnDef): string
+    {
+        return <<< EOF
+<database>
+    <table name="table_with_uuid">
+        $columnDef
+    </table>
+</database>
+EOF;
+    }
+
+    /**
+     * @return array
+     */
+    public function migrationDataProvider(): array
+    {
+        $uuid = '6cb1a126-2b34-4856-9a39-455d8b5efd29';
+        $bin = hex2bin('48562b346cb1a1269a39455d8b5efd29');
+
+        $uuid2 = 'a3b98dbb-2bb3-4319-a010-21e2301e7d3c';
+        $bin2 = hex2bin('43192bb3a3b98dbba01021e2301e7d3c');
+
+        return [
+        [
+            'From varchar to uuid',
+                '<column name="id" type="varchar" size="100" />',
+                '<column name="id" type="UUID" />',
+            ['in' => [$uuid], 'out' => [$bin]],
+        ], [
+            'From char to uuid',
+                '<column name="id" type="char" size="100" />',
+                '<column name="id" type="UUID" />',
+            ['in' => [$uuid], 'out' => [$bin]],
+        ], [
+            'From uuid to varchar',
+                '<column name="id" type="UUID" />',
+                '<column name="id" type="varchar" size="36" content="UUID" />',
+            ['in' => [$bin], 'out' => [$uuid]],
+        ], [
+            'From uuid to char',
+                '<column name="id" type="UUID" />',
+                '<column name="id" type="char" size="36" content="UUID" />',
+            ['in' => [$bin], 'out' => [$uuid]],
+        ], [
+            'Preserve column order',
+            '
+                <column name="col1" type="integer" />
+                <column name="id" type="UUID" />
+                <column name="col2" type="integer" />
+            ', '
+                <column name="col1" type="integer" />
+                <column name="id" type="varchar" size="36" content="UUID" />
+                <column name="col2" type="integer" />
+            ',
+            null,
+        ], [
+            'Change column order',
+            '
+                <column name="col1" type="integer" />
+                <column name="id" type="varchar" size="36" />
+                <column name="col2" type="integer" />
+                <column name="col3" type="integer" />
+            ', '
+                <column name="col1" type="integer" />
+                <column name="col2" type="integer" />
+                <column name="id" type="UUID" />
+                <column name="col3" type="integer" />
+            ',
+            null,
+        ], [
+            'Drop primary key',
+                '<column name="id" type="varchar" size="36" primaryKey="true" />',
+                '<column name="id" type="UUID" />',
+            ['in' => [$uuid], 'out' => [$bin]],
+        ], [
+            'Add primary key',
+                '<column name="id" type="varchar" size="36" />',
+                '<column name="id" type="UUID" primaryKey="true" />',
+            ['in' => [$uuid], 'out' => [$bin]],
+        ], [
+            'Swap uuid and varchar in complex primary key',
+            '
+                <column name="id1" type="varchar" size="36" primaryKey="true" />
+                <column name="id2" type="UUID" primaryKey="true" />
+            ', '
+                <column name="id1" type="UUID" primaryKey="true" />
+                <column name="id2" type="varchar" size="36" primaryKey="true" content="UUID" />
+            ', [
+                'in' => [$uuid, $bin2], 'out' => [$bin, $uuid2],
+            ],
+        ], [
+            'Swap uuid and varchar and drop complex primary key',
+            '
+                <column name="id1" type="varchar" size="36" primaryKey="true" />
+                <column name="id2" type="UUID" primaryKey="true" />
+            ', '
+                <column name="id1" type="UUID" />
+                <column name="id2" type="varchar" size="36" content="UUID" />
+            ', ['in' => [$uuid, $bin2], 'out' => [$bin, $uuid2]],
+        ], [
+            'Swap uuid and varchar and add complex primary key',
+            '
+                <column name="id1" type="varchar" size="36" />
+                <column name="id2" type="UUID" />
+            ', '
+                <column name="id1" type="UUID" primaryKey="true" />
+                <column name="id2" type="varchar" size="36" content="UUID" primaryKey="true" />
+            ', ['in' => [$uuid, $bin2], 'out' => [$bin, $uuid2]],
+        ], [
+            'Preserve complex PK',
+            '
+                <column name="id" type="varchar" size="36" primaryKey="true" />
+                <column name="title" primaryKey="true" />
+            ', '
+                <column name="id" type="UUID" primaryKey="true" />
+                <column name="title" primaryKey="true" />
+            ', ['in' => [$uuid, 'le title'], 'out' => [$bin, 'le title']],
+        ], [
+            'Preserve index',
+            '
+                <column name="id" type="varchar" size="36" />
+                <index name="le_id_index">
+                    <index-column name="id" />
+                </index>
+            ', '
+                <column name="id" type="UUID" />
+                <index name="le_id_index">
+                    <index-column name="id" />
+                </index>
+            ', ['in' => [$uuid], 'out' => [$bin]],
+        ], [
+            'Drop index',
+            '
+                <column name="id" type="varchar" size="36" />
+                <index name="le_id_index">
+                    <index-column name="id" />
+                </index>
+            ', '
+                <column name="id" type="UUID" />
+            ', ['in' => [$uuid], 'out' => [$bin]],
+        ], [
+            'Add index',
+            '
+                <column name="id" type="varchar" size="36" />
+            ', '
+                <column name="id" type="UUID" />
+                <index name="le_id_index">
+                    <index-column name="id" />
+                </index>
+            ', ['in' => [$uuid], 'out' => [$bin]],
+        ], [
+            'Preserve index on multiple columns',
+            '
+                <column name="id" type="varchar" size="36" />
+                <column name="title" type="varchar" size="64" />
+                <index name="le_joined_index">
+                    <index-column name="id" />
+                    <index-column name="title" />
+                </index>
+            ', '
+                <column name="id" type="UUID" />
+                <column name="title" type="varchar" size="64" />
+                <index name="le_joined_index">
+                    <index-column name="id" />
+                    <index-column name="title" />
+                </index>
+            ', ['in' => [$uuid, 'le title'], 'out' => [$bin, 'le title']],
+        ], [
+            'Preserve FK',
+            '
+                <column name="id" type="varchar" size="36" primaryKey="true"  />
+                <column name="fk" type="varchar" size="36" />
+                <foreign-key foreignTable="table_with_uuid">
+                    <reference local="fk" foreign="id" />
+                </foreign-key>
+            ', '
+                <column name="id" type="UUID" primaryKey="true" />
+                <column name="fk" type="UUID" />
+                <foreign-key foreignTable="table_with_uuid">
+                    <reference local="fk" foreign="id" />
+                </foreign-key>
+            ', ['in' => [$uuid, $uuid], 'out' => [$bin, $bin]],
+        ], [
+            'Add FK',
+            '
+                <column name="id" type="varchar" size="36" primaryKey="true"  />
+                <column name="fk" type="varchar" size="36" />
+            ', '
+                <column name="id" type="UUID" primaryKey="true" />
+                <column name="fk" type="UUID" />
+                <foreign-key foreignTable="table_with_uuid">
+                    <reference local="fk" foreign="id" />
+                </foreign-key>
+            ', ['in' => [$uuid, $uuid], 'out' => [$bin, $bin]],
+        ], [
+            'Remove FK',
+            '
+                <column name="id" type="varchar" size="36" primaryKey="true"  />
+                <column name="fk" type="varchar" size="36" />
+                <foreign-key foreignTable="table_with_uuid">
+                    <reference local="fk" foreign="id" />
+                </foreign-key>
+            ', '
+                <column name="id" type="UUID" primaryKey="true" />
+                <column name="fk" type="UUID" />
+            ', ['in' => [$uuid, $uuid], 'out' => [$bin, $bin]],
+        ],
+        ];
+    }
+}

--- a/tests/Propel/Tests/Generator/Model/ColumnTest.php
+++ b/tests/Propel/Tests/Generator/Model/ColumnTest.php
@@ -476,7 +476,8 @@ class ColumnTest extends ModelTestCase
             ['ENUM', PDO::PARAM_INT],
             ['BU_DATE', PDO::PARAM_STR],
             ['BU_TIMESTAMP', PDO::PARAM_STR],
-            ['UUID', PDO::PARAM_STR],
+            [PropelTypes::UUID, PDO::PARAM_STR],
+            [PropelTypes::UUID_BINARY, PDO::PARAM_LOB],
         ];
     }
 
@@ -711,29 +712,41 @@ class ColumnTest extends ModelTestCase
     }
 
     /**
+     * @dataProvider provideMappingUuidTypes
+     *
      * @return void
      */
-    public function testUuidType()
+    public function testUuidType(string $columnType, string $phpType)
     {
         $domain = $this->getDomainMock();
         $domain
             ->expects($this->once())
             ->method('setType')
-            ->with($this->equalTo(PropelTypes::UUID));
+            ->with($this->equalTo($columnType));
 
         $domain
             ->expects($this->any())
             ->method('getType')
-            ->will($this->returnValue(PropelTypes::UUID));
+            ->will($this->returnValue($columnType));
 
         $column = new Column('');
         $column->setDomain($domain);
-        $column->setType(PropelTypes::UUID);
+        $column->setType($columnType);
 
-        $this->assertSame('string', $column->getPhpType());
+        $this->assertSame($phpType, $column->getPhpType());
         $this->assertTrue($column->isPhpPrimitiveType());
         $this->assertTrue($column->isUuidType());
     }
+
+    public function provideMappingUuidTypes()
+    {
+        return [
+            // column type, php type, 
+            [PropelTypes::UUID, 'string'],
+            [PropelTypes::UUID_BINARY, 'string'],
+        ];
+    }
+
 
     /**
      * @dataProvider provideMappingTextTypes

--- a/tests/Propel/Tests/Generator/Platform/DefaultPlatformTest.php
+++ b/tests/Propel/Tests/Generator/Platform/DefaultPlatformTest.php
@@ -11,6 +11,7 @@ namespace Propel\Tests\Generator\Platform;
 use Propel\Generator\Model\Column;
 use Propel\Generator\Model\PropelTypes;
 use Propel\Generator\Platform\DefaultPlatform;
+use Propel\Generator\Platform\PlatformInterface;
 use Propel\Tests\TestCase;
 
 class DefaultPlatformTest extends TestCase
@@ -22,7 +23,7 @@ class DefaultPlatformTest extends TestCase
      *
      * @return \Propel\Generator\Platform\PlatformInterface
      */
-    protected function getPlatform()
+    protected function getPlatform(): PlatformInterface
     {
         if (null === $this->platform) {
             $this->platform = new DefaultPlatform();

--- a/tests/Propel/Tests/Generator/Platform/MssqlPlatformTest.php
+++ b/tests/Propel/Tests/Generator/Platform/MssqlPlatformTest.php
@@ -14,6 +14,7 @@ use Propel\Generator\Model\IdMethod;
 use Propel\Generator\Model\IdMethodParameter;
 use Propel\Generator\Model\Table;
 use Propel\Generator\Platform\MssqlPlatform;
+use Propel\Generator\Platform\PlatformInterface;
 
 class MssqlPlatformTest extends PlatformTestProvider
 {
@@ -22,7 +23,7 @@ class MssqlPlatformTest extends PlatformTestProvider
      *
      * @return \Propel\Generator\Platform\MssqlPlatform
      */
-    protected function getPlatform()
+    protected function getPlatform(): PlatformInterface
     {
         return new MssqlPlatform();
     }
@@ -705,7 +706,6 @@ ALTER TABLE [foo] DROP CONSTRAINT [foo_bar_fk];
      */
     public function testCreateSchemaWithUuidColumns($schema)
     {
-        $table = $this->getTableFromSchema($schema);
         $expected = "
 CREATE TABLE [foo]
 (
@@ -714,6 +714,25 @@ CREATE TABLE [foo]
     CONSTRAINT [foo_pk] PRIMARY KEY ([uuid])
 );
 ";
-        $this->assertEquals($expected, $this->getPlatform()->getAddTableDDL($table));
+
+        $this->assertCreateTableMatches($expected, $schema);
+    }
+
+    /**
+     * @dataProvider providerForTestCreateSchemaWithUuidBinaryColumns
+     *
+     * @return void
+     */
+    public function testCreateSchemaWithUuidBinaryColumns($schema)
+    {
+        $expected = "
+CREATE TABLE [foo]
+(
+    [uuid-bin] BINARY(16) DEFAULT vendor_specific_default() NOT NULL,
+    [other_uuid-bin] BINARY(16) NULL,
+    CONSTRAINT [foo_pk] PRIMARY KEY ([uuid-bin])
+);
+";
+        $this->assertCreateTableMatches($expected, $schema);
     }
 }

--- a/tests/Propel/Tests/Generator/Platform/MysqlPlatformMigrationMyISAMTest.php
+++ b/tests/Propel/Tests/Generator/Platform/MysqlPlatformMigrationMyISAMTest.php
@@ -10,6 +10,7 @@ namespace Propel\Tests\Generator\Platform;
 
 use Propel\Generator\Config\GeneratorConfig;
 use Propel\Generator\Platform\MysqlPlatform;
+use Propel\Generator\Platform\PlatformInterface;
 use Propel\Generator\Util\VfsTrait;
 
 class MysqlPlatformMigrationMyISAMTest extends PlatformMigrationTestProvider
@@ -21,9 +22,9 @@ class MysqlPlatformMigrationMyISAMTest extends PlatformMigrationTestProvider
     /**
      * Get the Platform object for this class
      *
-     * @return \Propel\Generator\Platform\PlatformInterface
+     * @return \Propel\Generator\Platform\MysqlPlatform
      */
-    protected function getPlatform()
+    protected function getPlatform(): PlatformInterface
     {
         if (!$this->platform) {
             $this->platform = new MysqlPlatform();

--- a/tests/Propel/Tests/Generator/Platform/MysqlPlatformMigrationTest.php
+++ b/tests/Propel/Tests/Generator/Platform/MysqlPlatformMigrationTest.php
@@ -11,6 +11,7 @@ namespace Propel\Tests\Generator\Platform;
 use Propel\Generator\Config\GeneratorConfig;
 use Propel\Generator\Model\Diff\DatabaseComparator;
 use Propel\Generator\Platform\MysqlPlatform;
+use Propel\Generator\Platform\PlatformInterface;
 use Propel\Generator\Util\VfsTrait;
 
 class MysqlPlatformMigrationTest extends MysqlPlatformMigrationTestProvider
@@ -18,16 +19,16 @@ class MysqlPlatformMigrationTest extends MysqlPlatformMigrationTestProvider
     use VfsTrait;
 
     /**
-     * @var \Propel\Generator\Platform\PlatformInterface|null
+     * @var \Propel\Generator\Platform\MysqlPlatform|null
      */
     protected $platform;
 
     /**
      * Get the Platform object for this class
      *
-     * @return \Propel\Generator\Platform\PlatformInterface
+     * @return \Propel\Generator\Platform\MysqlPlatform
      */
-    protected function getPlatform()
+    protected function getPlatform(): PlatformInterface
     {
         if (!$this->platform) {
             $this->platform = new MysqlPlatform();

--- a/tests/Propel/Tests/Generator/Platform/MysqlPlatformMyISAMTest.php
+++ b/tests/Propel/Tests/Generator/Platform/MysqlPlatformMyISAMTest.php
@@ -18,6 +18,7 @@ use Propel\Generator\Model\Index;
 use Propel\Generator\Model\Table;
 use Propel\Generator\Model\VendorInfo;
 use Propel\Generator\Platform\MysqlPlatform;
+use Propel\Generator\Platform\PlatformInterface;
 
 class MysqlPlatformMyISAMTest extends PlatformTestProvider
 {
@@ -26,7 +27,7 @@ class MysqlPlatformMyISAMTest extends PlatformTestProvider
      *
      * @return \Propel\Generator\Platform\MysqlPlatform
      */
-    protected function getPlatform()
+    protected function getPlatform(): PlatformInterface
     {
         static $platform;
 

--- a/tests/Propel/Tests/Generator/Platform/MysqlPlatformTest.php
+++ b/tests/Propel/Tests/Generator/Platform/MysqlPlatformTest.php
@@ -975,23 +975,6 @@ CREATE TABLE `foo`
         $actualMysqlDataType = $this->getPlatform()->getDomainForType($propelDataType)->getSqlType();
         $this->assertEquals($expectedMysqlDataType, $actualMysqlDataType);
     }
-    
-    public function unavailableTypesDataProvider()
-    {
-        return [
-            [PropelTypes::UUID],
-        ];
-    }
-    
-    /**
-     * @dataProvider unavailableTypesDataProvider
-     */
-    public function testExceptionOnAccessOfUnavailableType(string $propelDataType)
-    {
-        $this->expectException(\Propel\Generator\Exception\EngineException::class);
-
-        $this->getPlatform()->getDomainForType($propelDataType);
-    }
 
     /**
      * @dataProvider providerForTestCreateSchemaWithUuidColumns
@@ -1000,9 +983,16 @@ CREATE TABLE `foo`
      */
     public function testCreateSchemaWithUuidColumns($schema)
     {
-        $this->expectException(\Propel\Generator\Exception\EngineException::class);
+        $expected = "
+CREATE TABLE `foo`
+(
+    `uuid` BINARY(16) DEFAULT vendor_specific_default() NOT NULL,
+    `other_uuid` BINARY(16),
+    PRIMARY KEY (`uuid`)
+) ENGINE=InnoDB;
+";
 
-        $table = $this->getTableFromSchema($schema);
+        $this->assertCreateTableMatches($expected, $schema);
     }
 
     /**

--- a/tests/Propel/Tests/Generator/Platform/MysqlPlatformTest.php
+++ b/tests/Propel/Tests/Generator/Platform/MysqlPlatformTest.php
@@ -19,6 +19,7 @@ use Propel\Generator\Model\Table;
 use Propel\Generator\Model\VendorInfo;
 use Propel\Generator\Platform\MysqlPlatform;
 use Propel\Generator\Model\PropelTypes;
+use Propel\Generator\Platform\PlatformInterface;
 
 class MysqlPlatformTest extends PlatformTestProvider
 {
@@ -27,7 +28,7 @@ class MysqlPlatformTest extends PlatformTestProvider
      *
      * @return \Propel\Generator\Platform\MysqlPlatform
      */
-    protected function getPlatform()
+    protected function getPlatform():PlatformInterface
     {
         static $platform;
 
@@ -1002,5 +1003,24 @@ CREATE TABLE `foo`
         $this->expectException(\Propel\Generator\Exception\EngineException::class);
 
         $table = $this->getTableFromSchema($schema);
+    }
+
+    /**
+     * @dataProvider providerForTestCreateSchemaWithUuidBinaryColumns
+     *
+     * @return void
+     */
+    public function testCreateSchemaWithUuidBinaryColumns($schema)
+    {
+        $expected = "
+CREATE TABLE `foo`
+(
+    `uuid-bin` BINARY(16) DEFAULT vendor_specific_default() NOT NULL,
+    `other_uuid-bin` BINARY(16),
+    PRIMARY KEY (`uuid-bin`)
+) ENGINE=InnoDB;
+";
+
+        $this->assertCreateTableMatches($expected, $schema);
     }
 }

--- a/tests/Propel/Tests/Generator/Platform/OraclePlatformMigrationTest.php
+++ b/tests/Propel/Tests/Generator/Platform/OraclePlatformMigrationTest.php
@@ -10,15 +10,16 @@ namespace Propel\Tests\Generator\Platform;
 
 use Propel\Generator\Model\Diff\DatabaseComparator;
 use Propel\Generator\Platform\OraclePlatform;
+use Propel\Generator\Platform\PlatformInterface;
 
 class OraclePlatformMigrationTest extends PlatformMigrationTestProvider
 {
     /**
      * Get the Platform object for this class
      *
-     * @return \Propel\Generator\Platform\PlatformInterface
+     * @return \Propel\Generator\Platform\OraclePlatform
      */
-    protected function getPlatform()
+    protected function getPlatform(): PlatformInterface
     {
         return new OraclePlatform();
     }

--- a/tests/Propel/Tests/Generator/Platform/OraclePlatformTest.php
+++ b/tests/Propel/Tests/Generator/Platform/OraclePlatformTest.php
@@ -14,15 +14,16 @@ use Propel\Generator\Model\IdMethod;
 use Propel\Generator\Model\IdMethodParameter;
 use Propel\Generator\Model\Table;
 use Propel\Generator\Platform\OraclePlatform;
+use Propel\Generator\Platform\PlatformInterface;
 
 class OraclePlatformTest extends PlatformTestProvider
 {
     /**
      * Get the Platform object for this class
      *
-     * @return \Propel\Generator\Platform\PlatformInterface
+     * @return \Propel\Generator\Platform\OraclePlatform
      */
-    protected function getPlatform()
+    protected function getPlatform(): PlatformInterface
     {
         return new OraclePlatform();
     }
@@ -659,7 +660,6 @@ EOF;
      */
     public function testCreateSchemaWithUuidColumns($schema)
     {
-        $table = $this->getTableFromSchema($schema);
         $expected = "
 CREATE TABLE foo
 (
@@ -669,6 +669,25 @@ CREATE TABLE foo
 
 ALTER TABLE foo ADD CONSTRAINT foo_pk PRIMARY KEY (uuid);
 ";
-        $this->assertEquals($expected, $this->getPlatform()->getAddTableDDL($table));
+        $this->assertCreateTableMatches($expected, $schema);
+    }
+
+    /**
+     * @dataProvider providerForTestCreateSchemaWithUuidBinaryColumns
+     *
+     * @return void
+     */
+    public function testCreateSchemaWithUuidBinaryColumns($schema)
+    {
+        $expected = "
+CREATE TABLE foo
+(
+    uuid-bin RAW(16) DEFAULT vendor_specific_default() NOT NULL,
+    other_uuid-bin RAW(16)
+);
+
+ALTER TABLE foo ADD CONSTRAINT foo_pk PRIMARY KEY (uuid-bin);
+";
+        $this->assertCreateTableMatches($expected, $schema);
     }
 }

--- a/tests/Propel/Tests/Generator/Platform/PgsqlPlatformMigrationTest.php
+++ b/tests/Propel/Tests/Generator/Platform/PgsqlPlatformMigrationTest.php
@@ -12,18 +12,18 @@ use Propel\Generator\Builder\Util\SchemaReader;
 use Propel\Generator\Model\Column;
 use Propel\Generator\Model\ColumnDefaultValue;
 use Propel\Generator\Model\Diff\ColumnComparator;
-use Propel\Generator\Model\Diff\TableDiff;
 use Propel\Generator\Model\Table;
 use Propel\Generator\Platform\PgsqlPlatform;
+use Propel\Generator\Platform\PlatformInterface;
 
 class PgsqlPlatformMigrationTest extends PlatformMigrationTestProvider
 {
     /**
      * Get the Platform object for this class
      *
-     * @return PgsqlPlatform
+     * @return \Propel\Generator\Platform\PgsqlPlatform
      */
-    protected function getPlatform(): PgsqlPlatform
+    protected function getPlatform(): PlatformInterface
     {
         return new PgsqlPlatform();
     }
@@ -460,6 +460,23 @@ EOF;
         $expected = <<<END
 
 ALTER TABLE "foo" ALTER COLUMN "id" TYPE uuid USING id::uuid;
+
+ALTER TABLE "foo" ALTER COLUMN "id" SET DEFAULT vendor_specific_uuid_generator_function();
+
+END;
+        $this->assertEquals($expected, $this->getPlatform()->getModifyTableColumnsDDL($tableDiff));
+    }
+
+    /**
+     * @dataProvider providerForTestMigrateToUuidBinColumn
+     *
+     * @return void
+     */
+    public function testMigrateToUuidBinColumn($tableDiff)
+    {
+        $expected = <<<END
+
+ALTER TABLE "foo" ALTER COLUMN "id" TYPE BYTEA USING NULL;
 
 ALTER TABLE "foo" ALTER COLUMN "id" SET DEFAULT vendor_specific_uuid_generator_function();
 

--- a/tests/Propel/Tests/Generator/Platform/PgsqlPlatformTest.php
+++ b/tests/Propel/Tests/Generator/Platform/PgsqlPlatformTest.php
@@ -17,6 +17,7 @@ use Propel\Generator\Model\PropelTypes;
 use Propel\Generator\Model\Table;
 use Propel\Generator\Model\Unique;
 use Propel\Generator\Platform\PgsqlPlatform;
+use Propel\Generator\Platform\PlatformInterface;
 
 class PgsqlPlatformTest extends PlatformTestProvider
 {
@@ -25,7 +26,7 @@ class PgsqlPlatformTest extends PlatformTestProvider
      *
      * @return \Propel\Generator\Platform\PgsqlPlatform
      */
-    protected function getPlatform()
+    protected function getPlatform(): PlatformInterface
     {
         return new PgsqlPlatform();
     }
@@ -836,13 +837,21 @@ ALTER TABLE "foo" DROP CONSTRAINT "foo_bar_fk";
     }
 
     /**
+     * @return void
+     */
+    public function assertCreateTableMatches(string $expected, $schema, ?string $tableName = 'foo' )
+    {
+        $table = $this->getTableFromSchema($schema, $tableName);
+        $this->assertEquals($expected, $this->getPlatform()->getAddTableDDL($table));
+    }
+
+    /**
      * @dataProvider providerForTestCreateSchemaWithUuidColumns
      *
      * @return void
      */
     public function testCreateSchemaWithUuidColumns($schema)
     {
-        $table = $this->getTableFromSchema($schema);
         $expected = <<< 'EOT'
 
 CREATE TABLE "foo"
@@ -853,6 +862,26 @@ CREATE TABLE "foo"
 );
 
 EOT;
-        $this->assertEquals($expected, $this->getPlatform()->getAddTableDDL($table));
+        $this->assertCreateTableMatches($expected, $schema);
+    }
+
+    /**
+     * @dataProvider providerForTestCreateSchemaWithUuidBinaryColumns
+     *
+     * @return void
+     */
+    public function testCreateSchemaWithUuidBinaryColumns($schema)
+    {
+        $expected = <<< 'EOT'
+
+CREATE TABLE "foo"
+(
+    "uuid-bin" BYTEA DEFAULT vendor_specific_default() NOT NULL,
+    "other_uuid-bin" BYTEA,
+    PRIMARY KEY ("uuid-bin")
+);
+
+EOT;
+        $this->assertCreateTableMatches($expected, $schema);
     }
 }

--- a/tests/Propel/Tests/Generator/Platform/PlatformMigrationTestProvider.php
+++ b/tests/Propel/Tests/Generator/Platform/PlatformMigrationTestProvider.php
@@ -620,4 +620,16 @@ EOF;
 
         return [[$this->buildTableDiff('foo', $tableColumnsFrom, $tableColumnsTo)]];
     }
+
+    public function providerForTestMigrateToUuidBinColumn()
+    {
+        $tableColumnsFrom = <<<EOF
+        <column name="id" primaryKey="true" type="VARCHAR" size="36" autoIncrement="true"/>
+EOF;
+        $tableColumnsTo = <<<EOF
+        <column name="id" primaryKey="true" type="UUID_BINARY" default="vendor_specific_uuid_generator_function()"/>
+EOF;
+
+        return [[$this->buildTableDiff('foo', $tableColumnsFrom, $tableColumnsTo)]];
+    }
 }

--- a/tests/Propel/Tests/Generator/Platform/PlatformMigrationTestProvider.php
+++ b/tests/Propel/Tests/Generator/Platform/PlatformMigrationTestProvider.php
@@ -624,10 +624,22 @@ EOF;
     public function providerForTestMigrateToUuidBinColumn()
     {
         $tableColumnsFrom = <<<EOF
-        <column name="id" primaryKey="true" type="VARCHAR" size="36" autoIncrement="true"/>
+        <column name="id" primaryKey="true" type="VARCHAR" size="36"/>
 EOF;
         $tableColumnsTo = <<<EOF
         <column name="id" primaryKey="true" type="UUID_BINARY" default="vendor_specific_uuid_generator_function()"/>
+EOF;
+
+        return [[$this->buildTableDiff('foo', $tableColumnsFrom, $tableColumnsTo)]];
+    }
+
+    public function providerForTestMigrateFromUuidBinColumn()
+    {
+        $tableColumnsFrom = <<<EOF
+        <column name="id" primaryKey="true" type="UUID_BINARY" default="vendor_specific_uuid_generator_function()"/>
+EOF;
+        $tableColumnsTo = <<<EOF
+        <column name="id" primaryKey="true" type="VARCHAR" size="36" content="UUID"/>
 EOF;
 
         return [[$this->buildTableDiff('foo', $tableColumnsFrom, $tableColumnsTo)]];

--- a/tests/Propel/Tests/Generator/Platform/PlatformTestProvider.php
+++ b/tests/Propel/Tests/Generator/Platform/PlatformTestProvider.php
@@ -22,6 +22,15 @@ use Propel\Generator\Model\Unique;
 abstract class PlatformTestProvider extends PlatformTestBase
 {
     /**
+     * @return void
+     */
+    public function assertCreateTableMatches(string $expected, $schema, ?string $tableName = 'foo' )
+    {
+        $table = $this->getTableFromSchema($schema, $tableName);
+        $this->assertEquals($expected, $this->getPlatform()->getAddTableDDL($table));
+    }
+
+    /**
      * @return string[][]
      */
     public function providerForTestGetAddTablesDDL()
@@ -368,6 +377,20 @@ EOF;
     <table name="foo">
         <column name="uuid" primaryKey="true" type="UUID" default="vendor_specific_default()"/>
         <column name="other_uuid" type="UUID"/>
+    </table>
+</database>
+EOF;
+
+        return [[$schema]];
+    }
+
+    public function providerForTestCreateSchemaWithUuidBinaryColumns()
+    {
+        $schema = <<<EOF
+<database name="test" identifierQuoting="true">
+    <table name="foo">
+        <column name="uuid-bin" primaryKey="true" type="UUID_BINARY" default="vendor_specific_default()"/>
+        <column name="other_uuid-bin" type="UUID_BINARY"/>
     </table>
 </database>
 EOF;

--- a/tests/Propel/Tests/Generator/Platform/SqlitePlatformTest.php
+++ b/tests/Propel/Tests/Generator/Platform/SqlitePlatformTest.php
@@ -431,23 +431,6 @@ DROP INDEX [babar];
 ";
         $this->assertEquals($expected, $this->getPlatform()->getCommentBlockDDL('foo bar'));
     }
-    
-    public function unavailableTypesDataProvider()
-    {
-        return [
-            [PropelTypes::UUID],
-        ];
-    }
-    
-    /**
-     * @dataProvider unavailableTypesDataProvider
-     */
-    public function testExceptionOnAccessOfUnavailableType(string $propelDataType)
-    {
-        $this->expectException(\Propel\Generator\Exception\EngineException::class);
-
-        $this->getPlatform()->getDomainForType($propelDataType);
-    }
 
     /**
      * @dataProvider providerForTestCreateSchemaWithUuidColumns
@@ -456,9 +439,16 @@ DROP INDEX [babar];
      */
     public function testCreateSchemaWithUuidColumns($schema)
     {
-        $this->expectException(\Propel\Generator\Exception\EngineException::class);
+        $expected = "
+CREATE TABLE [foo]
+(
+    [uuid] BLOB DEFAULT vendor_specific_default() NOT NULL,
+    [other_uuid] BLOB,
+    PRIMARY KEY ([uuid])
+);
+";
 
-        $table = $this->getTableFromSchema($schema);
+        $this->assertCreateTableMatches($expected, $schema);
     }
 
     /**

--- a/tests/Propel/Tests/Generator/Platform/SqlitePlatformTest.php
+++ b/tests/Propel/Tests/Generator/Platform/SqlitePlatformTest.php
@@ -14,6 +14,7 @@ use Propel\Generator\Model\IdMethod;
 use Propel\Generator\Model\IdMethodParameter;
 use Propel\Generator\Model\PropelTypes;
 use Propel\Generator\Model\Table;
+use Propel\Generator\Platform\PlatformInterface;
 use Propel\Generator\Platform\SqlitePlatform;
 use Propel\Runtime\Adapter\AdapterFactory;
 use Propel\Runtime\Connection\ConnectionFactory;
@@ -23,9 +24,9 @@ class SqlitePlatformTest extends PlatformTestProvider
     /**
      * Get the Platform object for this class
      *
-     * @return \Propel\Generator\Platform\PlatformInterface
+     * @return \Propel\Generator\Platform\SqlitePlatform
      */
-    protected function getPlatform()
+    protected function getPlatform(): PlatformInterface
     {
         return new SqlitePlatform();
     }
@@ -458,5 +459,24 @@ DROP INDEX [babar];
         $this->expectException(\Propel\Generator\Exception\EngineException::class);
 
         $table = $this->getTableFromSchema($schema);
+    }
+
+    /**
+     * @dataProvider providerForTestCreateSchemaWithUuidBinaryColumns
+     *
+     * @return void
+     */
+    public function testCreateSchemaWithUuidBinaryColumns($schema)
+    {
+        $expected = "
+CREATE TABLE [foo]
+(
+    [uuid-bin] BLOB DEFAULT vendor_specific_default() NOT NULL,
+    [other_uuid-bin] BLOB,
+    PRIMARY KEY ([uuid-bin])
+);
+";
+
+        $this->assertCreateTableMatches($expected, $schema);
     }
 }

--- a/tests/Propel/Tests/Helpers/CheckMysql8Trait.php
+++ b/tests/Propel/Tests/Helpers/CheckMysql8Trait.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Tests\Helpers;
+
+use Propel\Runtime\Propel;
+
+trait CheckMysql8Trait
+{
+    /**
+     * @var ?bool|null
+     */
+    protected static $isAtLeastMysql8 = null;
+
+    /**
+     * @param string|null $connectionName
+     *
+     * @return bool
+     */
+    protected function checkMysqlVersionAtLeast8(?string $connectionName = null): bool
+    {
+        if (static::$isAtLeastMysql8 === null) {
+            static::$isAtLeastMysql8 = $this->queryMySqlVersionAtLeast8($connectionName);
+        }
+
+        return static::$isAtLeastMysql8;
+    }
+
+    /**
+     * @param string|null $connectionName
+     *
+     * @return bool
+     */
+    protected function queryMySqlVersionAtLeast8(?string $connectionName = null): bool
+    {
+        $con = Propel::getServiceContainer()->getConnection($connectionName);
+        $query = "SELECT VERSION() NOT LIKE '%MariaDB%' AND VERSION() >= 8";
+        $result = $con->query($query)->fetchColumn(0);
+
+        return (bool)$result;
+    }
+}

--- a/tests/Propel/Tests/Runtime/Adapter/Pdo/OracleAdapterTest.php
+++ b/tests/Propel/Tests/Runtime/Adapter/Pdo/OracleAdapterTest.php
@@ -32,8 +32,9 @@ class OracleAdapterTest extends TestCaseFixtures
         return 'oracle';
     }
     
-    protected function createOracleSql(Criteria $query, &$params = []): string
+    protected function createOracleSql(Criteria $query): string
     {
+        $params = [];
         Propel::getServiceContainer()->setAdapter('oracle', new OracleAdapter());
         $query->setDbName('oracle');
         return $query->createSelectSql($params);
@@ -88,8 +89,12 @@ class OracleAdapterTest extends TestCaseFixtures
         $c = new Criteria();
         $c->addSelectColumn(BookTableMap::COL_ID);
         $c->addAsColumn('book_ID', BookTableMap::COL_ID);
-        $selectSql = $this->createOracleSql($c);
-        $this->assertEquals('SELECT book.id, book.id AS book_ID FROM book', $selectSql, 'createSelectSqlPart() returns a SQL SELECT clause with both select and as columns');
+        
+        $adapter = new OracleAdapter();
+        $fromClause = [];
+        $selectSql = $adapter->createSelectSqlPart($c, $fromClause);
+        $this->assertEquals('SELECT book.id, book.id AS book_ID', $selectSql, 'createSelectSqlPart() returns a SQL SELECT clause with both select and as columns');
+        $this->assertEquals(['book'], $fromClause, 'createSelectSqlPart() adds the tables from the select columns to the from clause');
     }
 
     /**

--- a/tests/Propel/Tests/Runtime/TypeTests/TypeTest.php
+++ b/tests/Propel/Tests/Runtime/TypeTests/TypeTest.php
@@ -6,7 +6,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Propel\Tests\Runtime;
+namespace Propel\Tests\Runtime\TypeTest;
 
 use Propel\Tests\Bookstore\Map\TypeObjectTableMap;
 use Propel\Tests\Bookstore\TypeObject;

--- a/tests/Propel/Tests/Runtime/TypeTests/UuidBinaryTypeTest.php
+++ b/tests/Propel/Tests/Runtime/TypeTests/UuidBinaryTypeTest.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Tests\Runtime\TypeTest;
+
+use Propel\Runtime\Propel;
+use Propel\Runtime\Util\UuidConverter;
+use Propel\Tests\Bookstore\Base\Book2Query;
+use Propel\Tests\Bookstore\Book2;
+use Propel\Tests\Bookstore\Map\Book2TableMap;
+use Propel\Tests\Helpers\Bookstore\BookstoreTestBase;
+
+/**
+ * @group database
+ */
+class UuidBinaryTypeTest extends BookstoreTestBase
+{
+    /** @var string */
+    protected $uuid = 'ffb35e14-6bd9-409b-a3f5-f176bfe54ebb';
+
+    /** @var \Propel\Tests\Bookstore\Book2 */
+    protected $book;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+    
+        if(!$this->book){
+            Book2Query::create()->deleteAll();
+            $this->book = new Book2();
+            $this->book->setUuidBin($this->uuid)->save();
+        }
+        Book2TableMap::clearInstancePool();
+    }
+
+    /**
+     * @return void
+     */
+    public function testModelRestoresUuid()
+    {
+        $retrievedBook = Book2Query::create()->findOneById($this->book->getId());
+        $this->assertSame($this->uuid, $retrievedBook->getUuidBin());
+    }
+
+    public function uuidFilterDataProvider(): array
+    {
+        return [
+            // description, uuid value
+            ['single uuid',
+                'b41a29db-cf78-4d43-83a9-4cd3e1e1b41a'
+            ],
+            ['uuid array', [
+                'b41a29db-cf78-4d43-83a9-4cd3e1e1b41a',
+                '5875b237-21a2-4e7c-a976-73c6f0f6af4e', 
+                'b1b838f9-0212-4638-b065-9c1ba291f55f']
+            ],
+            ['uuid array with null', [
+                'b41a29db-cf78-4d43-83a9-4cd3e1e1b41a',
+                null,
+                '5875b237-21a2-4e7c-a976-73c6f0f6af4e', 
+                'b1b838f9-0212-4638-b065-9c1ba291f55f']
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider uuidFilterDataProvider
+     * @return void
+     */
+    public function testQueryConvertsUuidParamToBin(string $description, $uuidValue)
+    {
+        $params = [];
+        Book2Query::create()->filterByUuidBin($uuidValue)->createSelectSql($params);
+        $paramValue = $params[0]['value'];
+
+        $expectedBin = UuidConverter::uuidToBinRecursive($uuidValue, true);
+        $this->assertSame($expectedBin, $paramValue, $description . ' - Uuid query params should be converted');
+    }
+
+    public function queryConfiguratorDataProvider(){
+        $uuidBin = UuidConverter::uuidToBin($this->uuid, true);
+
+        return [
+            // description, configurator
+            //['where string', fn(Book2Query $query) => $query->where("book2.uuid_bin = '$uuidBin'")],
+            ['where with param', fn(Book2Query $query) => $query->where("book2.uuid_bin = ?", $uuidBin, \PDO::PARAM_LOB)],
+            ['filterBy', fn(Book2Query $query) => $query->filterByUuidBin($this->uuid)],
+        ];
+    }
+
+    /**
+     * @dataProvider queryConfiguratorDataProvider
+     *
+     * @return void
+     */
+    public function testQueryResolvesUuidFilter(string $description, $queryConfigurator)
+    {
+        $bookQuery = Book2Query::create();
+        $queryConfigurator($bookQuery);
+        $result = $bookQuery->find();
+
+        $this->assertEquals(1, $result->count());
+        $loadedBook = $result[0];
+        $this->assertSame($this->book->getId(), $loadedBook->getId(), 'should retrive data trough '.$description);
+    }
+
+    /**
+     * @return void
+     */
+    public function testModelCanUpdateUuid()
+    {
+        $book = new Book2();
+        $book->save();
+
+        $updateUuid = 'a6afa354-27d1-458c-aee1-7118d08ab063';
+
+        $book->setUuidBin($updateUuid)->save();
+        $book->reload();
+
+        $this->assertSame($updateUuid, $book->getUuidBin());
+    }
+}

--- a/tests/Propel/Tests/Runtime/TypeTests/UuidBinaryTypeTest.php
+++ b/tests/Propel/Tests/Runtime/TypeTests/UuidBinaryTypeTest.php
@@ -8,7 +8,6 @@
 
 namespace Propel\Tests\Runtime\TypeTest;
 
-use Propel\Runtime\Propel;
 use Propel\Runtime\Util\UuidConverter;
 use Propel\Tests\Bookstore\Base\Book2Query;
 use Propel\Tests\Bookstore\Book2;

--- a/tests/Propel/Tests/Runtime/TypeTests/UuidTypeTest.php
+++ b/tests/Propel/Tests/Runtime/TypeTests/UuidTypeTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Tests\Runtime\TypeTest;
+
+use Propel\Tests\Bookstore\Base\Book2Query;
+use Propel\Tests\Bookstore\Book2;
+use Propel\Tests\Bookstore\Map\Book2TableMap;
+use Propel\Tests\Helpers\Bookstore\BookstoreTestBase;
+
+/**
+ * @group database
+ */
+class UuidTypeTest extends BookstoreTestBase
+{
+    /**
+     * @var string
+     */
+    protected $uuid = '28a8d3a6-83d8-4d8a-aa79-a6581e88d5d9';
+
+    /**
+     * @var \Propel\Tests\Bookstore\Book2
+     */
+    protected $book;
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!$this->book) {
+            Book2Query::create()->deleteAll();
+            $this->book = new Book2();
+            $this->book->setUuid($this->uuid)->save();
+        }
+        Book2TableMap::clearInstancePool();
+    }
+
+    /**
+     * @return void
+     */
+    public function testModelRestoresUuid()
+    {
+        $retrievedBook = Book2Query::create()->findOneById($this->book->getId());
+        $this->assertSame($this->uuid, $retrievedBook->getUuid());
+    }
+
+    /**
+     * @return void
+     */
+    public function testModelCanUpdateUuid()
+    {
+        $book = new Book2();
+        $book->save();
+
+        $updateUuid = '42a79e51-511a-4662-8956-cc89cf43f764';
+
+        $book->setUuid($updateUuid)->save();
+        $book->reload();
+
+        $this->assertSame($updateUuid, $book->getUuid());
+    }
+}

--- a/tests/Propel/Tests/Runtime/Util/UuidConverterMysqlCompatibilityTest.php
+++ b/tests/Propel/Tests/Runtime/Util/UuidConverterMysqlCompatibilityTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Tests\Runtime\Util;
+
+use PDO;
+use Propel\Runtime\Propel;
+use Propel\Runtime\Util\UuidConverter;
+use Propel\Tests\Helpers\Bookstore\BookstoreTestBase;
+
+/**
+ * @group mysql
+ * @group database
+ */
+class UuidConverterMysqlCompatibilityTest extends BookstoreTestBase
+{
+    /**
+     * @var ?bool
+     */
+    protected $isAtLeastMysql8 = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        if ($this->isAtLeastMysql8 === null) {
+            $this->isAtLeastMysql8 = $this->getMySqlVersionAtLeast8();
+        }
+        if (!$this->isAtLeastMysql8) {
+            $this->markTestSkipped('Test can only be run on MySQL version >= 8');
+        }
+    }
+
+    protected function getMySqlVersionAtLeast8(): bool
+    {
+        $con = Propel::getServiceContainer()->getConnection();
+        $query = "SELECT VERSION() NOT LIKE '%MariaDB%' AND VERSION() >= 8";
+        $result = $con->query($query)->fetchColumn(0);
+
+        return (bool) $result;
+    }
+
+    public function operationsDataProvider(): array
+    {
+        return [
+            // description, mysql function , converter callback, input value, input bin
+            ['uuid to bin without swap', 'SELECT UUID_TO_BIN(?, false)', fn($uuid) => UuidConverter::uuidToBin($uuid, false), false],
+            ['uuid to bin with swap', 'SELECT UUID_TO_BIN(?, true)', fn($uuid) => UuidConverter::uuidToBin($uuid, true), false],
+
+            ['bin to uuid without swap', 'SELECT BIN_TO_UUID(?, false)', fn($uuid) => UuidConverter::binToUuid($uuid, false), true],
+            ['bin to uuid with swap', 'SELECT BIN_TO_UUID(?, true)', fn($uuid) => UuidConverter::binToUuid($uuid, true), true],
+            
+        ];
+    }
+
+    /**
+     * @dataProvider operationsDataProvider
+     */
+    public function testBinToUuidBehavesLikeInMysql($description, $sqlStatement, $callback, $inputBin)
+    {
+        $value = ($inputBin)
+            ? hex2bin('aab5d5fd70c111e5a4fbb026b977eb28')
+            : 'aab5d5fd-70c1-11e5-a4fb-b026b977eb28'
+            ;
+        $mysqlBin = $this->executeStatement($sqlStatement, $value);
+
+        $propelBin = $callback($value);
+        $this->assertSame($mysqlBin, $propelBin, $description . ' should match between Propel and MySQL');
+    }
+
+    public function executeStatement(string $statement, string $value)
+    {
+        $con = Propel::getServiceContainer()->getConnection();
+        $ps = $con->prepare($statement);
+        $ps->bindParam(1, $value, PDO::PARAM_STR);
+        $ps->execute();
+        $result = $ps->fetch()[0];
+        $ps->closeCursor();
+
+        return $result;
+    }
+
+    
+}
+

--- a/tests/Propel/Tests/Runtime/Util/UuidConverterMysqlCompatibilityTest.php
+++ b/tests/Propel/Tests/Runtime/Util/UuidConverterMysqlCompatibilityTest.php
@@ -59,7 +59,7 @@ class UuidConverterMysqlCompatibilityTest extends BookstoreTestBase
         $this->assertSame($mysqlBin, $propelBin, $description . ' should match between Propel and MySQL');
     }
 
-    public function executeStatement(string $statement, string $value)
+    protected function executeStatement(string $statement, string $value)
     {
         $con = Propel::getServiceContainer()->getConnection();
         $ps = $con->prepare($statement);

--- a/tests/Propel/Tests/Runtime/Util/UuidConverterMysqlCompatibilityTest.php
+++ b/tests/Propel/Tests/Runtime/Util/UuidConverterMysqlCompatibilityTest.php
@@ -12,6 +12,7 @@ use PDO;
 use Propel\Runtime\Propel;
 use Propel\Runtime\Util\UuidConverter;
 use Propel\Tests\Helpers\Bookstore\BookstoreTestBase;
+use Propel\Tests\Helpers\CheckMysql8Trait;
 
 /**
  * @group mysql
@@ -19,29 +20,15 @@ use Propel\Tests\Helpers\Bookstore\BookstoreTestBase;
  */
 class UuidConverterMysqlCompatibilityTest extends BookstoreTestBase
 {
-    /**
-     * @var ?bool
-     */
-    protected $isAtLeastMysql8 = null;
+    use CheckMysql8Trait;
 
     protected function setUp(): void
     {
         parent::setUp();
-        if ($this->isAtLeastMysql8 === null) {
-            $this->isAtLeastMysql8 = $this->getMySqlVersionAtLeast8();
-        }
-        if (!$this->isAtLeastMysql8) {
+        if(!$this->checkMysqlVersionAtLeast8()){
             $this->markTestSkipped('Test can only be run on MySQL version >= 8');
+            return;
         }
-    }
-
-    protected function getMySqlVersionAtLeast8(): bool
-    {
-        $con = Propel::getServiceContainer()->getConnection();
-        $query = "SELECT VERSION() NOT LIKE '%MariaDB%' AND VERSION() >= 8";
-        $result = $con->query($query)->fetchColumn(0);
-
-        return (bool) $result;
     }
 
     public function operationsDataProvider(): array

--- a/tests/Propel/Tests/Runtime/Util/UuidConverterTest.php
+++ b/tests/Propel/Tests/Runtime/Util/UuidConverterTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Tests\Runtime\Util;
+
+use Propel\Runtime\Util\UuidConverter;
+use Propel\Tests\Helpers\BaseTestCase;
+
+class UuidConverterTest extends BaseTestCase
+{
+    public function uuidDataProvider(): array
+    {
+        return [
+            // uuid, hex, hexWithSwap
+            ['11112222-3333-4444-5555-666677778888', '11112222333344445555666677778888', '44443333111122225555666677778888'],
+            ['aab5d5fd-70c1-11e5-a4fb-b026b977eb28', 'aab5d5fd70c111e5a4fbb026b977eb28', '11e570c1aab5d5fda4fbb026b977eb28'],
+        ]; 
+    }
+
+    /**
+     * @dataProvider uuidDataProvider
+     * @return void
+     */
+    public function testUuidToBinWithSwap($uuid, $hex, $hexWithSwap)
+    {
+        $result = UuidConverter::uuidToBin($uuid, true);
+        $this->assertBinaryEquals($hexWithSwap, $result);
+    }
+
+    /**
+     * @dataProvider uuidDataProvider
+     * @return void
+     */
+    public function testUuidToBinWithoutSwap($uuid, $hex, $hexWithSwap)
+    {
+        $result = UuidConverter::uuidToBin($uuid, false);
+        $this->assertBinaryEquals($hex, $result);
+    }
+
+    /**
+     */
+    public function assertBinaryEquals(string $expected, $result)
+    {
+        $expected = hex2bin($expected);
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * @dataProvider uuidDataProvider
+     * @return void
+     */
+    public function testBinToUuidWithSwap($uuid, $hex, $hexWithSwap)
+    {
+        $bin = hex2bin($hexWithSwap);
+        $result = UuidConverter::binToUuid($bin, true);
+        $this->assertEquals($uuid, $result);
+    }
+
+    /**
+     * @dataProvider uuidDataProvider
+     * @return void
+     */
+    public function testBinToUuidWithoutSwap($uuid, $hex, $hexWithSwap)
+    {
+        $bin = hex2bin($hex);
+        $result = UuidConverter::binToUuid($bin, false);
+        $this->assertEquals($uuid, $result);
+    }
+
+    public function testFasterUuidToBin(){
+        $this->markTestSkipped();
+        $uuid = [];
+
+        for($i = 0; $i < 100000; $i++){
+            $uuids[] = $this->guidv4();
+        }
+        $swapFlag = true;
+        $regexDuration =  $this->measure([UuidConverter::class, 'uuidToBinRegex'], $uuids, $swapFlag);
+        $regularDuration = $this->measure([UuidConverter::class, 'uuidToBin'], $uuids, $swapFlag);
+
+        echo "regular took $regularDuration, regex took $regexDuration";
+        $this->assertLessThanOrEqual($regexDuration, $regularDuration, "regular took $regularDuration, regex took $regexDuration");
+    }
+
+}

--- a/tests/Propel/Tests/TestCase.php
+++ b/tests/Propel/Tests/TestCase.php
@@ -9,6 +9,7 @@
 namespace Propel\Tests;
 
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
+use Propel\Generator\Platform\PlatformInterface;
 
 class TestCase extends PHPUnitTestCase
 {
@@ -104,7 +105,7 @@ class TestCase extends PHPUnitTestCase
     /**
      * @return \Propel\Generator\Platform\PlatformInterface
      */
-    protected function getPlatform()
+    protected function getPlatform(): PlatformInterface
     {
         $className = sprintf('\\Propel\\Generator\\Platform\\%sPlatform', ucfirst($this->getDriver()));
 

--- a/tests/bin/setup.mysql.bat
+++ b/tests/bin/setup.mysql.bat
@@ -12,7 +12,7 @@ if "%mysql%" == "" (
 )       
 
 if "%mysql%" == "" (
-    echo Can not find mysql binary. Is it installed?
+    echo Cannot find mysql binary. Is it installed?
     exit /B 1
 )
 

--- a/tests/bin/setup.mysql.sh
+++ b/tests/bin/setup.mysql.sh
@@ -1,11 +1,6 @@
 #!/bin/sh
 
-mysql=`which mysql`;
-if [ "$mysql" = "" ]; then
-    mysql=`which mysql5`;
-fi
-
-if [ "$mysql" = "" ]; then
+if ! command -v mysql > /dev/null; then
     echo "Cannot find mysql binary. Is it installed?";
     exit 1;
 fi
@@ -15,42 +10,38 @@ if [ "$DB_USER" = "" ]; then
     DB_USER="root";
 fi
 
-pw_option=""
-if [ "$DB_PW" != "" ]; then
-	pw_option=" -p$DB_PW"
+if [ "$DB_NAME" = "" ]; then
+    echo "\$DB_NAME not set. Using 'test'.";
+    DB_NAME="test";
 fi
 
 DB_HOSTNAME=${DB_HOSTNAME-127.0.0.1};
-DB_NAME=${DB_NAME-test};
+DB_PW=${DB_PW-$MYSQL_PWD};
 
-"$mysql" --version;
+(
+    export MYSQL_PWD="$DB_PW"
 
-retry_count=0
-while true; do
-    "$mysql" --host="$DB_HOSTNAME" -u"$DB_USER" $pw_option -e "
-SET FOREIGN_KEY_CHECKS = 0;
-DROP DATABASE IF EXISTS $DB_NAME;
-DROP SCHEMA IF EXISTS second_hand_books;
-DROP SCHEMA IF EXISTS contest;
-DROP SCHEMA IF EXISTS bookstore_schemas;
-DROP SCHEMA IF EXISTS migration;
-SET FOREIGN_KEY_CHECKS = 1;
-"
-    if [ $? -eq 0 ] || [ $retry_count -ge 6 ]; then break; fi
-    retry_count=$((retry_count + 1))
-    sleep "$(awk "BEGIN{print 2 ^ $retry_count}")"
-done
+    echo "Dropping existing databases and schemas"
+    mysql --host="$DB_HOSTNAME" -u"$DB_USER" -e "
+    SET FOREIGN_KEY_CHECKS = 0;
+    DROP DATABASE IF EXISTS $DB_NAME;
+    DROP SCHEMA IF EXISTS second_hand_books;
+    DROP SCHEMA IF EXISTS contest;
+    DROP SCHEMA IF EXISTS bookstore_schemas;
+    DROP SCHEMA IF EXISTS migration;
+    SET FOREIGN_KEY_CHECKS = 1;
+    "
 
-"$mysql" --host="$DB_HOSTNAME" -u"$DB_USER" $pw_option -e "
-SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));
-CREATE DATABASE $DB_NAME;
-CREATE SCHEMA bookstore_schemas;
-CREATE SCHEMA contest;
-CREATE SCHEMA second_hand_books;
-CREATE SCHEMA migration;
-";
-
-
+    echo "Creating existing databases and schemas"
+    mysql --host="$DB_HOSTNAME" -u"$DB_USER" -e "
+    SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));
+    CREATE DATABASE $DB_NAME;
+    CREATE SCHEMA bookstore_schemas;
+    CREATE SCHEMA contest;
+    CREATE SCHEMA second_hand_books;
+    CREATE SCHEMA migration;
+    ";
+)
 
 DIR=`dirname $0`;
 dsn="mysql:host=$DB_HOSTNAME;dbname=$DB_NAME";

--- a/tests/bin/setup.pgsql.bat
+++ b/tests/bin/setup.pgsql.bat
@@ -9,7 +9,7 @@ set psql=
 @for %%e in (%PATHEXT%) do @for %%i in (psql%%e) do @if NOT "%%~$PATH:i"=="" set psql=%%~$PATH:i
 
 if "%psql%" == "" (
-    echo Can not find psql binary. Is it installed?
+    echo Cannot find psql binary. Is it installed?
     exit /B 1
 )
 

--- a/tests/bin/setup.pgsql.sh
+++ b/tests/bin/setup.pgsql.sh
@@ -25,15 +25,15 @@ else
 fi
 
 (
-    export PGPASSWORD=$DB_PW;
+    export PGPASSWORD="$DB_PW";
 
-    echo "removing existing test db"
+    echo "Dropping existing test db"
     dropdb  --host="$DB_HOSTNAME" --username="$DB_USER" $NO_PWD "$DB_NAME";
 
-    echo "creating new test db"
+    echo "Creating new test db"
     createdb  --host="$DB_HOSTNAME" --username="$DB_USER" $NO_PWD "$DB_NAME";
     
-    echo "creating schema"
+    echo "Creating schemas"
     psql --host="$DB_HOSTNAME" --username="$DB_USER" $NO_PWD -c '
     CREATE SCHEMA bookstore_schemas;
     CREATE SCHEMA contest;


### PR DESCRIPTION
This allows Propel to work with UUIDs stored in a binary data column like `BINARY(16)` in MySQL.

To use it, the column type in `schema.xml` has to be set to `UUID_BINARY`:
```xml
    <table name="my_table">
        <column name="uuid" required="false" type="UUID_BINARY"/>
    </table>
```

In models, fields of that type will always contain the UUID as string, conversion between binary value and string is done during loading (in `hydrate()`) or saving (in `doInsert()` or `buildCriteria()` from `doUpdate()`). Similar conversion happens in the `findBy` methods in the query class. 
This is a different approach than planned in #1914, but I found it integrates better into Propel.

Per default, UUID conversion will swap some bytes around, in accordance with MySQL's [`uuid_to_bin()`](https://dev.mysql.com/doc/refman/8.0/en/miscellaneous-functions.html#function_uuid-to-bin) function. This allows better indexing for version-1 UUIDs. The default behavior can be changed in `schema.xml` by setting the value of `UuidSwapFlag` in vendor information:
```xml
<?xml version="1.0" encoding="ISO-8859-1" standalone="no"?>
<database name="bookstore" defaultIdMethod="native"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    namespace="Propel\Tests\Bookstore"
>
    <vendor type="mysql">
          <parameter name="UuidSwapFlag" value="false"/>
    </vendor>
```

Caveats:
- Feature is in experimental state. It is tested, but only to an extend.
- No migration of columns with data at the moment (generated "ALTER TABLE" statements will fail).
- Changing `UuidSwapFlag` currently does not trigger a migration at all (it should cause all existing UUIDs to be (un)swapped).
- Going around the model classes, for example by using `select()` on the query class or manually setting a formatter like `SimpleArrayFormatter`, will leave UUIDs in their binary form and users have to convert them manually by calling `UuidConverter::binToUuid($uuidData, $swapFlag)` (depending on PDO behavior for the underlying dbms, they will have to read the resource/stream into a string first by calling `stream_get_contents($uuidData)`).
- Similarly, if for some reason the query class fails to detect UUID input and does not automatically convert it into the binary form, users will have to do it manually by calling `UuidConverter::uuidToBin($uuid, $swapFlag)`.

Realistically, this will take a brave user to test and give feedback.