### PR TITLE
re-enable agnostic tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,8 +117,7 @@ jobs:
               if: matrix.db-type != 'agnostic'
               run: tests/bin/setup.${{ matrix.db-type }}.sh
 
-            - name: Run database tests
-              if: matrix.db-type != 'agnostic'
+            - name: Run tests
               shell: 'script -q -e -c "bash {0}"'
               run: |
                   if [[ ${{ matrix.php-version }} == '7.4' && ${{ matrix.symfony-version == '5-max' }} ]]; then


### PR DESCRIPTION
Uff, turns out changes to ci in #1917 disabled agnostic tests