### PR TITLE
allow setting port in tests

### DIFF
--- a/tests/Propel/Tests/TestCaseFixtures.php
+++ b/tests/Propel/Tests/TestCaseFixtures.php
@@ -240,7 +240,7 @@ class TestCaseFixtures extends TestCase
         $configuration = $manager->getConfiguration();
         $dsn = $configuration['dsn'];
 
-        if ('sqlite' !== substr($dsn, 0, 6) && $withCredentials) {
+        if (substr($dsn, 0, 6) !== 'sqlite' && $withCredentials) {
             $dsn .= ';user=' . $configuration['user'];
             if (isset($configuration['password']) && $configuration['password']) {
                 $dsn .= ';password=' . $configuration['password'];

--- a/tests/bin/setup.mysql.sh
+++ b/tests/bin/setup.mysql.sh
@@ -17,12 +17,13 @@ fi
 
 DB_HOSTNAME=${DB_HOSTNAME-127.0.0.1};
 DB_PW=${DB_PW-$MYSQL_PWD};
+DB_PORT=${DB_PORT-3306};
 
 (
     export MYSQL_PWD="$DB_PW"
 
     echo "Dropping existing databases and schemas"
-    mysql --host="$DB_HOSTNAME" -u"$DB_USER" -e "
+    mysql --host="$DB_HOSTNAME" -P $DB_PORT -u"$DB_USER" -e "
     SET FOREIGN_KEY_CHECKS = 0;
     DROP DATABASE IF EXISTS $DB_NAME;
     DROP SCHEMA IF EXISTS second_hand_books;
@@ -30,19 +31,19 @@ DB_PW=${DB_PW-$MYSQL_PWD};
     DROP SCHEMA IF EXISTS bookstore_schemas;
     DROP SCHEMA IF EXISTS migration;
     SET FOREIGN_KEY_CHECKS = 1;
-    "
+    " || exit 1;
 
     echo "Creating existing databases and schemas"
-    mysql --host="$DB_HOSTNAME" -u"$DB_USER" -e "
+    mysql --host="$DB_HOSTNAME" -P $DB_PORT -u"$DB_USER" -e "
     SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));
     CREATE DATABASE $DB_NAME;
     CREATE SCHEMA bookstore_schemas;
     CREATE SCHEMA contest;
     CREATE SCHEMA second_hand_books;
     CREATE SCHEMA migration;
-    ";
-)
+    " || exit 1;
+) || exit 1;
 
 DIR=`dirname $0`;
-dsn="mysql:host=$DB_HOSTNAME;dbname=$DB_NAME";
+dsn="mysql:host=$DB_HOSTNAME;port=$DB_PORT;dbname=$DB_NAME";
 php $DIR/../../bin/propel test:prepare --vendor="mysql" --dsn="$dsn" --user="$DB_USER" --password="$DB_PW";

--- a/tests/bin/setup.pgsql.sh
+++ b/tests/bin/setup.pgsql.sh
@@ -16,7 +16,8 @@ if [ "$DB_NAME" = "" ]; then
 fi
 
 DB_HOSTNAME=${DB_HOSTNAME-127.0.0.1};
-DB_PW=${DB_PW-$PGPASSWORD};
+DB_PW=${DB_PW-$PGPASSWORD};.0.1};
+DB_PORT=${DB_PORT-5432};
 
 if [ -z "$DB_PW" ]; then
     echo "\$DB_PW not set. Leaving empty."
@@ -28,10 +29,10 @@ fi
     export PGPASSWORD="$DB_PW";
 
     echo "Dropping existing test db"
-    dropdb  --host="$DB_HOSTNAME" --username="$DB_USER" $NO_PWD "$DB_NAME";
+    dropdb  --host="$DB_HOSTNAME" --port=$DB_PORT --username="$DB_USER" $NO_PWD "$DB_NAME" || exit 1;
 
     echo "Creating new test db"
-    createdb  --host="$DB_HOSTNAME" --username="$DB_USER" $NO_PWD "$DB_NAME";
+    createdb  --host="$DB_HOSTNAME" --port=$DB_PORT --username="$DB_USER" $NO_PWD "$DB_NAME" || exit 1;
     
     echo "Creating schemas"
     psql --host="$DB_HOSTNAME" --username="$DB_USER" $NO_PWD -c '
@@ -40,8 +41,8 @@ fi
     CREATE SCHEMA second_hand_books;
     CREATE SCHEMA migration;
     ' "$DB_NAME" >/dev/null;
-)
+) || exit 1;
 
 DIR=`dirname $0`;
-dsn="pgsql:host=$DB_HOSTNAME;dbname=$DB_NAME";
+dsn="pgsql:host=$DB_HOSTNAME;port=$DB_PORT;dbname=$DB_NAME";
 php $DIR/../../bin/propel test:prepare --vendor="pgsql" --dsn="$dsn" --user="$DB_USER" --password="$DB_PW";


### PR DESCRIPTION
Allows to run tests on different ports using the `DB_PORT` environment variable

Had to update InitCommandTest as it parsed the DSN string by value position instead of by key