### PR TITLE
UUID adjustments for mariadb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,8 +117,7 @@ jobs:
               if: matrix.db-type != 'agnostic'
               run: tests/bin/setup.${{ matrix.db-type }}.sh
 
-            - name: Run database tests
-              if: matrix.db-type != 'agnostic'
+            - name: Run tests
               shell: 'script -q -e -c "bash {0}"'
               run: |
                   if [[ ${{ matrix.php-version }} == '7.4' && ${{ matrix.symfony-version == '5-max' }} ]]; then

--- a/src/Propel/Common/Config/PropelConfiguration.php
+++ b/src/Propel/Common/Config/PropelConfiguration.php
@@ -180,6 +180,7 @@ class PropelConfiguration implements ConfigurationInterface
                                     ->children()
                                         ->scalarNode('tableType')->defaultValue('InnoDB')->treatNullLike('InnoDB')->end()
                                         ->scalarNode('tableEngineKeyword')->defaultValue('ENGINE')->end()
+                                        ->scalarNode('uuidColumnType')->defaultValue('binary')->end()
                                     ->end()
                                 ->end()
                                 ->arrayNode('sqlite')

--- a/src/Propel/Generator/Model/Table.php
+++ b/src/Propel/Generator/Model/Table.php
@@ -565,35 +565,35 @@ class Table extends ScopedMappingModel implements IdMethod
      */
     public function addColumn($col): Column
     {
-        if ($col instanceof Column) {
-            if (isset($this->columnsByName[$col->getName()])) {
-                throw new EngineException(sprintf('Column "%s" declared twice in table "%s"', $col->getName(), $this->getName()));
-            }
+        if (is_array($col)) {
+            $column = new Column($col['name']);
+            $column->setTable($this);
+            $column->loadMapping($col);
 
-            $col->setTable($this);
-
-            if ($col->isInheritance()) {
-                $this->inheritanceColumn = $col;
-            }
-
-            $this->columns[] = $col;
-            $this->columnsByName[(string)$col->getName()] = $col;
-            $this->columnsByLowercaseName[strtolower((string)$col->getName())] = $col;
-            $this->columnsByPhpName[(string)$col->getPhpName()] = $col;
-            $col->setPosition(count($this->columns));
-
-            if ($col->requiresTransactionInPostgres()) {
-                $this->needsTransactionInPostgres = true;
-            }
-
-            return $col;
+            $col = $column;
         }
 
-        $column = new Column($col['name']);
-        $column->setTable($this);
-        $column->loadMapping($col);
+        if (isset($this->columnsByName[$col->getName()])) {
+            throw new EngineException(sprintf('Column "%s" declared twice in table "%s"', $col->getName(), $this->getName()));
+        }
 
-        return $this->addColumn($column); // call self w/ different param
+        $col->setTable($this);
+
+        if ($col->isInheritance()) {
+            $this->inheritanceColumn = $col;
+        }
+
+        $this->columns[] = $col;
+        $this->columnsByName[(string)$col->getName()] = $col;
+        $this->columnsByLowercaseName[strtolower((string)$col->getName())] = $col;
+        $this->columnsByPhpName[(string)$col->getPhpName()] = $col;
+        $col->setPosition(count($this->columns));
+
+        if ($col->requiresTransactionInPostgres()) {
+            $this->needsTransactionInPostgres = true;
+        }
+
+        return $col;
     }
 
     /**

--- a/src/Propel/Generator/Platform/DefaultPlatform.php
+++ b/src/Propel/Generator/Platform/DefaultPlatform.php
@@ -129,11 +129,19 @@ class DefaultPlatform implements PlatformInterface
     }
 
     /**
+     * @return void
+     */
+    protected function initialize(): void
+    {
+        $this->initializeTypeMap();
+    }
+
+    /**
      * Initialize the type -> Domain mapping.
      *
      * @return void
      */
-    protected function initialize(): void
+    protected function initializeTypeMap(): void
     {
         $this->schemaDomainMap = [];
         foreach (PropelTypes::getPropelTypes() as $type) {

--- a/src/Propel/Generator/Platform/MysqlPlatform.php
+++ b/src/Propel/Generator/Platform/MysqlPlatform.php
@@ -89,8 +89,6 @@ class MysqlPlatform extends DefaultPlatform
     }
 
     /**
-     * Setter for the tableEngineKeyword property
-     *
      * @param string $tableEngineKeyword
      *
      * @return void
@@ -101,8 +99,6 @@ class MysqlPlatform extends DefaultPlatform
     }
 
     /**
-     * Getter for the tableEngineKeyword property
-     *
      * @return string
      */
     public function getTableEngineKeyword(): string
@@ -111,8 +107,6 @@ class MysqlPlatform extends DefaultPlatform
     }
 
     /**
-     * Setter for the defaultTableEngine property
-     *
      * @param string $defaultTableEngine
      *
      * @return void
@@ -123,8 +117,6 @@ class MysqlPlatform extends DefaultPlatform
     }
 
     /**
-     * Getter for the defaultTableEngine property
-     *
      * @return string
      */
     public function getDefaultTableEngine(): string

--- a/src/Propel/Generator/Platform/MysqlPlatform.php
+++ b/src/Propel/Generator/Platform/MysqlPlatform.php
@@ -51,9 +51,9 @@ class MysqlPlatform extends DefaultPlatform
      *
      * @return void
      */
-    protected function initialize(): void
+    protected function initializeTypeMap(): void
     {
-        parent::initialize();
+        parent::initializeTypeMap();
         $this->setSchemaDomainMapping(new Domain(PropelTypes::BOOLEAN, 'TINYINT', 1));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::NUMERIC, 'DECIMAL'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::LONGVARCHAR, 'TEXT'));

--- a/src/Propel/Generator/Platform/OraclePlatform.php
+++ b/src/Propel/Generator/Platform/OraclePlatform.php
@@ -33,9 +33,9 @@ class OraclePlatform extends DefaultPlatform
      *
      * @return void
      */
-    protected function initialize(): void
+    protected function initializeTypeMap(): void
     {
-        parent::initialize();
+        parent::initializeTypeMap();
         $this->schemaDomainMap[PropelTypes::BOOLEAN] = new Domain(PropelTypes::BOOLEAN_EMU, 'NUMBER', 1, 0);
         $this->schemaDomainMap[PropelTypes::CLOB] = new Domain(PropelTypes::CLOB_EMU, 'CLOB');
         $this->schemaDomainMap[PropelTypes::CLOB_EMU] = $this->schemaDomainMap[PropelTypes::CLOB];

--- a/src/Propel/Generator/Platform/PgsqlPlatform.php
+++ b/src/Propel/Generator/Platform/PgsqlPlatform.php
@@ -40,9 +40,9 @@ class PgsqlPlatform extends DefaultPlatform
      *
      * @return void
      */
-    protected function initialize(): void
+    protected function initializeTypeMap(): void
     {
-        parent::initialize();
+        parent::initializeTypeMap();
         $this->setSchemaDomainMapping(new Domain(PropelTypes::BOOLEAN, 'BOOLEAN'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::TINYINT, 'INT2'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::SMALLINT, 'INT2'));

--- a/src/Propel/Generator/Platform/SqlitePlatform.php
+++ b/src/Propel/Generator/Platform/SqlitePlatform.php
@@ -47,8 +47,6 @@ class SqlitePlatform extends DefaultPlatform
     protected $tableAlteringWorkaround = true;
 
     /**
-     * Initializes db specific domain mapping.
-     *
      * @return void
      */
     protected function initialize(): void
@@ -58,6 +56,16 @@ class SqlitePlatform extends DefaultPlatform
         $version = $this->getVersion();
 
         $this->foreignKeySupport = version_compare($version, '3.6.19') >= 0;
+    }
+
+    /**
+     * Initializes db specific domain mapping.
+     *
+     * @return void
+     */
+    protected function initializeTypeMap(): void
+    {
+        parent::initializeTypeMap();
 
         $this->setSchemaDomainMapping(new Domain(PropelTypes::NUMERIC, 'DECIMAL'));
         $this->setSchemaDomainMapping(new Domain(PropelTypes::LONGVARCHAR, 'MEDIUMTEXT'));

--- a/src/Propel/Generator/Reverse/MysqlSchemaParser.php
+++ b/src/Propel/Generator/Reverse/MysqlSchemaParser.php
@@ -68,6 +68,7 @@ class MysqlSchemaParser extends AbstractSchemaParser
         'enum' => PropelTypes::CHAR,
         'set' => PropelTypes::CHAR,
         'binary' => PropelTypes::BINARY,
+        'uuid' => PropelTypes::UUID, // for MariaDB
     ];
 
     /**

--- a/tests/Propel/Tests/Generator/Platform/MysqlPlatformTest.php
+++ b/tests/Propel/Tests/Generator/Platform/MysqlPlatformTest.php
@@ -836,15 +836,13 @@ ALTER TABLE `foo` DROP FOREIGN KEY `foo_bar_fk`;
         $schema = '
 <database name="test1" identifierQuoting="true">
   <table name="foo">
-    <behavior name="AutoAddPK"/>
-    <column name="name" type="VARCHAR"/>
     <column name="subid" type="INTEGER"/>
+    <column name="id" type="INTEGER"/>
   </table>
   <table name="bar">
-    <behavior name="AutoAddPK"/>
 
-    <column name="name" type="VARCHAR"/>
     <column name="subid" type="INTEGER"/>
+    <column name="id" type="INTEGER"/>
 
     <foreign-key foreignTable="foo">
       <reference local="id" foreign="id"/>
@@ -857,10 +855,8 @@ ALTER TABLE `foo` DROP FOREIGN KEY `foo_bar_fk`;
         $expectedRelationSql = "
 CREATE TABLE `bar`
 (
-    `name` VARCHAR(255),
     `subid` INTEGER,
-    `id` INTEGER NOT NULL AUTO_INCREMENT,
-    PRIMARY KEY (`id`),
+    `id` INTEGER,
     INDEX `bar_fi_bb8268` (`id`, `subid`),
     CONSTRAINT `bar_fk_bb8268`
         FOREIGN KEY (`id`,`subid`)
@@ -1012,5 +1008,31 @@ CREATE TABLE `foo`
 ";
 
         $this->assertCreateTableMatches($expected, $schema);
+    }
+
+    /**
+     * @return void
+     */
+    public function testUuidColumnTypeDefaultsToBinary()
+    {
+        $platform = new MysqlPlatform();
+
+        $uuidSqlType = $platform->getDomainForType(PropelTypes::UUID)->getSqlType();
+        $this->assertEquals(PropelTypes::BINARY, $uuidSqlType);
+    }
+
+    /**
+     * @return void
+     */
+    public function testEnableUuidNativeType()
+    {
+        $platform = new MysqlPlatform();
+
+        $configProp['propel']['database']['adapters']['mysql']['uuidColumnType'] = 'native';
+        $config = new GeneratorConfig(__DIR__ . '/../../../../Fixtures/bookstore', $configProp);
+        $platform->setGeneratorConfig($config);
+
+        $uuidSqlType = $platform->getDomainForType(PropelTypes::UUID)->getSqlType();
+        $this->assertEquals(PropelTypes::UUID, $uuidSqlType);
     }
 }

--- a/tests/Propel/Tests/Helpers/CheckMysql8Trait.php
+++ b/tests/Propel/Tests/Helpers/CheckMysql8Trait.php
@@ -13,7 +13,7 @@ use Propel\Runtime\Propel;
 trait CheckMysql8Trait
 {
     /**
-     * @var ?bool|null
+     * @var bool|null
      */
     protected static $isAtLeastMysql8 = null;
 


### PR DESCRIPTION
Allows to use native uuid type on MariaDB by enabling it in the propel configuration:
```yaml
propel:
    adapters:
      mysql:
        uuidColumnType: native # <------ here
```

While the actual change is quite small, I had to went through a lot of places to find a suitable entry point. I had to refactor some methods along the way, and I think it is best to keep these changes. I have put them in different commits if this helps reviewing!

Also, this includes #1922 , agnostic tests are running