### PR TITLE
Implemented migration rollback.

### DIFF
--- a/src/Propel/Generator/Command/Executor/RollbackExecutor.php
+++ b/src/Propel/Generator/Command/Executor/RollbackExecutor.php
@@ -1,0 +1,190 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Generator\Command\Executor;
+
+use Exception;
+use Propel\Generator\Manager\MigrationManager;
+use Propel\Generator\Util\SqlParser;
+use Propel\Runtime\Exception\RuntimeException;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Service class for executing rollback.
+ */
+class RollbackExecutor implements RollbackExecutorInterface
+{
+    /**
+     * @var string
+     */
+    protected const COMMAND_OPTION_FAKE = 'fake';
+
+    /**
+     * @var string
+     */
+    protected const COMMAND_OPTION_FORCE = 'force';
+
+    /**
+     * @var string
+     */
+    protected const COMMAND_OPTION_VERBOSE = 'verbose';
+
+    /**
+     * @var \Symfony\Component\Console\Input\InputInterface
+     */
+    protected InputInterface $input;
+
+    /**
+     * @var \Symfony\Component\Console\Output\OutputInterface
+     */
+    protected OutputInterface $output;
+
+    /**
+     * @var \Propel\Generator\Manager\MigrationManager
+     */
+    protected MigrationManager $migrationManager;
+
+    /**
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @param \Propel\Generator\Manager\MigrationManager $migrationManager
+     */
+    public function __construct(
+        InputInterface $input,
+        OutputInterface $output,
+        MigrationManager $migrationManager,
+    ) {
+        $this->input = $input;
+        $this->output = $output;
+        $this->migrationManager = $migrationManager;
+    }
+
+    /**
+     * @param list<int> $previousTimestamps
+     *
+     * @return bool
+     */
+    public function executeRollbackToPreviousVersion(array &$previousTimestamps): bool
+    {
+        $nextMigrationTimestamp = array_pop($previousTimestamps);
+        if (!$nextMigrationTimestamp) {
+            $this->output->writeln('No migration were ever executed on this database - nothing to reverse.');
+
+            return false;
+        }
+
+        $this->output->writeln(sprintf(
+            'Executing migration %s down',
+            $this->migrationManager->getMigrationClassName($nextMigrationTimestamp),
+        ));
+
+        $nbPreviousTimestamps = count($previousTimestamps);
+        $previousTimestamp = 0;
+        if ($nbPreviousTimestamps) {
+            $previousTimestamp = $previousTimestamps[array_key_last($previousTimestamps)];
+        }
+
+        $migration = $this->migrationManager->getMigrationObject($nextMigrationTimestamp);
+        if (!$this->input->getOption(static::COMMAND_OPTION_FAKE) && $migration->preDown($this->migrationManager) === false) {
+            if (!$this->input->getOption(static::COMMAND_OPTION_FORCE)) {
+                $this->output->writeln('<error>preDown() returned false. Aborting migration.</error>');
+
+                return false;
+            }
+
+            $this->output->writeln('<error>preDown() returned false. Continue migration.</error>');
+        }
+
+        foreach ($migration->getDownSQL() as $datasource => $sql) {
+            $this->executeRollbackForDatasource($datasource, $sql);
+
+            $this->migrationManager->removeMigrationTimestamp($datasource, $nextMigrationTimestamp);
+
+            if ($this->input->getOption(static::COMMAND_OPTION_VERBOSE)) {
+                $this->output->writeln(sprintf(
+                    'Downgraded migration date to %d for datasource "%s"',
+                    $previousTimestamp,
+                    $datasource,
+                ));
+            }
+        }
+
+        if (!$this->input->getOption(static::COMMAND_OPTION_FAKE)) {
+            $migration->postDown($this->migrationManager);
+        }
+
+        if ($nbPreviousTimestamps) {
+            $this->output->writeln(sprintf('Reverse migration complete. %d more migrations available for reverse.', $nbPreviousTimestamps));
+        } else {
+            $this->output->writeln('Reverse migration complete. No more migration available for reverse');
+        }
+
+        return true;
+    }
+
+    /**
+     * @param string $datasource
+     * @param string $sql
+     *
+     * @throws \Propel\Runtime\Exception\RuntimeException
+     *
+     * @return void
+     */
+    protected function executeRollbackForDatasource(string $datasource, string $sql): void
+    {
+        $connection = $this->migrationManager->getConnection($datasource);
+
+        if ($this->input->getOption(static::COMMAND_OPTION_VERBOSE)) {
+            $this->output->writeln(sprintf(
+                'Connecting to database "%s" using DSN "%s"',
+                $datasource,
+                $connection['dsn'],
+            ));
+        }
+
+        $conn = $this->migrationManager->getAdapterConnection($datasource);
+        $res = 0;
+        $statements = SqlParser::parseString($sql);
+
+        if ($this->input->getOption(static::COMMAND_OPTION_FAKE)) {
+            return;
+        }
+
+        foreach ($statements as $statement) {
+            try {
+                if ($this->input->getOption(static::COMMAND_OPTION_VERBOSE)) {
+                    $this->output->writeln(sprintf('Executing statement "%s"', $statement));
+                }
+
+                $conn->exec($statement);
+                $res++;
+            } catch (Exception $e) {
+                if ($this->input->getOption(static::COMMAND_OPTION_FORCE)) {
+                    //continue, but print error message
+                    $this->output->writeln(
+                        sprintf('<error>Failed to execute SQL "%s". Continue migration.</error>', $statement),
+                    );
+                } else {
+                    throw new RuntimeException(
+                        sprintf('<error>Failed to execute SQL "%s". Aborting migration.</error>', $statement),
+                        0,
+                        $e,
+                    );
+                }
+            }
+        }
+
+        $this->output->writeln(sprintf(
+            '%d of %d SQL statements executed successfully on datasource "%s"',
+            $res,
+            count($statements),
+            $datasource,
+        ));
+    }
+}

--- a/src/Propel/Generator/Command/Executor/RollbackExecutorInterface.php
+++ b/src/Propel/Generator/Command/Executor/RollbackExecutorInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Generator\Command\Executor;
+
+/**
+ * Service interface for executing rollback.
+ */
+interface RollbackExecutorInterface
+{
+    /**
+     * @param list<int> $previousTimestamps
+     *
+     * @return bool
+     */
+    public function executeRollbackToPreviousVersion(array &$previousTimestamps): bool;
+}

--- a/src/Propel/Generator/Command/MigrationDownCommand.php
+++ b/src/Propel/Generator/Command/MigrationDownCommand.php
@@ -8,10 +8,8 @@
 
 namespace Propel\Generator\Command;
 
-use Exception;
+use Propel\Generator\Command\Executor\RollbackExecutor;
 use Propel\Generator\Manager\MigrationManager;
-use Propel\Generator\Util\SqlParser;
-use Propel\Runtime\Exception\RuntimeException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -41,8 +39,6 @@ class MigrationDownCommand extends AbstractCommand
 
     /**
      * @inheritDoc
-     *
-     * @throws \Propel\Runtime\Exception\RuntimeException
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
@@ -79,108 +75,12 @@ class MigrationDownCommand extends AbstractCommand
         $manager->setWorkingDirectory($generatorConfig->getSection('paths')['migrationDir']);
 
         $previousTimestamps = $manager->getAlreadyExecutedMigrationTimestamps();
-        $nextMigrationTimestamp = array_pop($previousTimestamps);
-        if (!$nextMigrationTimestamp) {
-            $output->writeln('No migration were ever executed on this database - nothing to reverse.');
 
-            return static::CODE_ERROR;
+        $rollbackExecutor = new RollbackExecutor($input, $output, $manager);
+        if ($rollbackExecutor->executeRollbackToPreviousVersion($previousTimestamps)) {
+            return static::CODE_SUCCESS;
         }
 
-        $output->writeln(sprintf(
-            'Executing migration %s down',
-            $manager->getMigrationClassName($nextMigrationTimestamp),
-        ));
-
-        $nbPreviousTimestamps = count($previousTimestamps);
-        if ($nbPreviousTimestamps) {
-            $previousTimestamp = array_pop($previousTimestamps);
-        } else {
-            $previousTimestamp = 0;
-        }
-
-        $migration = $manager->getMigrationObject($nextMigrationTimestamp);
-
-        if (!$input->getOption('fake')) {
-            if ($migration->preDown($manager) === false) {
-                if ($input->getOption('force')) {
-                    $output->writeln('<error>preDown() returned false. Continue migration.</error>');
-                } else {
-                    $output->writeln('<error>preDown() returned false. Aborting migration.</error>');
-
-                    return static::CODE_ERROR;
-                }
-            }
-        }
-
-        foreach ($migration->getDownSQL() as $datasource => $sql) {
-            $connection = $manager->getConnection($datasource);
-
-            if ($input->getOption('verbose')) {
-                $output->writeln(sprintf(
-                    'Connecting to database "%s" using DSN "%s"',
-                    $datasource,
-                    $connection['dsn'],
-                ));
-            }
-
-            $conn = $manager->getAdapterConnection($datasource);
-            $res = 0;
-            $statements = SqlParser::parseString($sql);
-
-            if (!$input->getOption('fake')) {
-                foreach ($statements as $statement) {
-                    try {
-                        if ($input->getOption('verbose')) {
-                            $output->writeln(sprintf('Executing statement "%s"', $statement));
-                        }
-
-                        $conn->exec($statement);
-                        $res++;
-                    } catch (Exception $e) {
-                        if ($input->getOption('force')) {
-                            //continue, but print error message
-                            $output->writeln(
-                                sprintf('<error>Failed to execute SQL "%s". Continue migration.</error>', $statement),
-                            );
-                        } else {
-                            throw new RuntimeException(
-                                sprintf('<error>Failed to execute SQL "%s". Aborting migration.</error>', $statement),
-                                0,
-                                $e,
-                            );
-                        }
-                    }
-                }
-
-                $output->writeln(sprintf(
-                    '%d of %d SQL statements executed successfully on datasource "%s"',
-                    $res,
-                    count($statements),
-                    $datasource,
-                ));
-            }
-
-            $manager->removeMigrationTimestamp($datasource, $nextMigrationTimestamp);
-
-            if ($input->getOption('verbose')) {
-                $output->writeln(sprintf(
-                    'Downgraded migration date to %d for datasource "%s"',
-                    $previousTimestamp,
-                    $datasource,
-                ));
-            }
-        }
-
-        if (!$input->getOption('fake')) {
-            $migration->postDown($manager);
-        }
-
-        if ($nbPreviousTimestamps) {
-            $output->writeln(sprintf('Reverse migration complete. %d more migrations available for reverse.', $nbPreviousTimestamps));
-        } else {
-            $output->writeln('Reverse migration complete. No more migration available for reverse');
-        }
-
-        return static::CODE_SUCCESS;
+        return static::CODE_ERROR;
     }
 }

--- a/tests/Fixtures/migration-command/migrate-to-version/version-1/schema.xml
+++ b/tests/Fixtures/migration-command/migrate-to-version/version-1/schema.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="ISO-8859-1" standalone="no"?>
+<database name="migration_command">
+
+    <table name="table1">
+        <column name="email" type="VARCHAR" required="false" primaryString="true"/>
+    </table>
+
+</database>

--- a/tests/Fixtures/migration-command/migrate-to-version/version-2/schema.xml
+++ b/tests/Fixtures/migration-command/migrate-to-version/version-2/schema.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="ISO-8859-1" standalone="no"?>
+<database name="migration_command">
+
+    <table name="table1">
+        <column name="created_at" required="false" type="TIMESTAMP"/>
+    </table>
+
+</database>

--- a/tests/Fixtures/migration-command/migrate-to-version/version-3/schema.xml
+++ b/tests/Fixtures/migration-command/migrate-to-version/version-3/schema.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="ISO-8859-1" standalone="no"?>
+<database name="migration_command">
+
+    <table name="table1">
+        <column name="name" type="VARCHAR" required="false"/>
+    </table>
+
+</database>

--- a/tests/Propel/Tests/Generator/Command/MigrationTest.php
+++ b/tests/Propel/Tests/Generator/Command/MigrationTest.php
@@ -13,6 +13,7 @@ use Propel\Generator\Command\MigrationCreateCommand;
 use Propel\Generator\Command\MigrationDiffCommand;
 use Propel\Generator\Command\MigrationDownCommand;
 use Propel\Generator\Command\MigrationMigrateCommand;
+use Propel\Generator\Command\MigrationStatusCommand;
 use Propel\Generator\Command\MigrationUpCommand;
 use Propel\Runtime\Propel;
 use Propel\Tests\TestCaseFixturesDatabase;
@@ -25,14 +26,56 @@ use Symfony\Component\Console\Output\StreamOutput;
  */
 class MigrationTest extends TestCaseFixturesDatabase
 {
+    /**
+     * @var bool
+     */
     private const MIGRATE_DOWN_AFTERWARDS = true;
+
+    /**
+     * @var string
+     */
     private const SCHEMA_DIR = __DIR__ . '/../../../../Fixtures/migration-command';
+
+    /**
+     * @var string
+     */
     private const OUTPUT_DIR = __DIR__ . '/../../../../migrationdiff';
+
+    /**
+     * @var string
+     */
+    private const SCHEMA_DIR_MIGRATE_TO_VERSION = __DIR__ . '/../../../../Fixtures/migration-command/migrate-to-version';
+
+    /**
+     * @see \Propel\Generator\Command\MigrationMigrateCommand::COMMAND_OPTION_MIGRATE_TO_VERSION
+     *
+     * @var string
+     */
+    private const COMMAND_OPTION_MIGRATE_TO_VERSION = '--migrate-to-version';
+
+    /**
+     * @see \Propel\Generator\Command\MigrationStatusCommand::COMMAND_OPTION_LAST_VERSION
+     *
+     * @var string
+     */
+    private const COMMAND_OPTION_LAST_VERSION = '--last-version';
+
+    /**
+     * @uses \Propel\Generator\Manager\MigrationManager::COL_VERSION
+     *
+     * @var string
+     */
+    private const COL_VERSION = 'version';
+
+    /**
+     * @var string
+     */
+    private const MIGRATION_TABLE = 'propel_migration';
 
     /**
      * @return void
      */
-    public function testDiffCommandCreatesFiles()
+    public function testDiffCommandCreatesFiles(): void
     {
         $this->deleteMigrationFiles();
         $this->runCommandAndAssertSuccess('migration:diff', new MigrationDiffCommand(), ['--schema-dir' => self::SCHEMA_DIR]);
@@ -42,7 +85,7 @@ class MigrationTest extends TestCaseFixturesDatabase
     /**
      * @return void
      */
-    public function testDiffCommandCreatesSuffixedFiles()
+    public function testDiffCommandCreatesSuffixedFiles(): void
     {
         $this->deleteMigrationFiles();
         $suffix = 'an_explanatory_filename_suffix';
@@ -53,7 +96,7 @@ class MigrationTest extends TestCaseFixturesDatabase
     /**
      * @return void
      */
-    public function testCreateCommandCreatesFiles()
+    public function testCreateCommandCreatesFiles(): void
     {
         $this->deleteMigrationFiles();
         $this->runCommandAndAssertSuccess('migration:create', new MigrationCreateCommand(), ['--schema-dir' => self::SCHEMA_DIR]);
@@ -63,7 +106,7 @@ class MigrationTest extends TestCaseFixturesDatabase
     /**
      * @return void
      */
-    public function testCreateCommandCreatesSuffixedFiles()
+    public function testCreateCommandCreatesSuffixedFiles(): void
     {
         $this->deleteMigrationFiles();
         $suffix = 'an_explanatory_filename_suffix';
@@ -74,7 +117,7 @@ class MigrationTest extends TestCaseFixturesDatabase
     /**
      * @return void
      */
-    public function testUpCommandPerformsUpMigration()
+    public function testUpCommandPerformsUpMigration(): void
     {
         $outputString = $this->runCommandAndAssertSuccess('migration:up', new MigrationUpCommand(), [], self::MIGRATE_DOWN_AFTERWARDS);
         $this->assertStringContainsString('Migration complete.', $outputString);
@@ -83,7 +126,7 @@ class MigrationTest extends TestCaseFixturesDatabase
     /**
      * @return void
      */
-    public function testDownCommandPerformsDownMigration()
+    public function testDownCommandPerformsDownMigration(): void
     {
         $this->migrateUp();
         $outputString = $this->runCommandAndAssertSuccess('migration:down', new MigrationDownCommand());
@@ -93,10 +136,123 @@ class MigrationTest extends TestCaseFixturesDatabase
     /**
      * @return void
      */
-    public function testMigrateCommandPerformsUpMigration()
+    public function testMigrateCommandPerformsUpMigration(): void
     {
         $outputString = $this->runCommandAndAssertSuccess('migration:migrate', new MigrationMigrateCommand(), [], self::MIGRATE_DOWN_AFTERWARDS);
         $this->assertStringContainsString('Migration complete.', $outputString);
+    }
+
+    /**
+     * @return void
+     */
+    public function testMigrateCommandShouldMigrateToTheLastVersionIfTheGivenVersionIsNotExists(): void
+    {
+        $outputString = $this->runCommandAndAssertSuccess(
+            'migration:migrate',
+            new MigrationMigrateCommand(),
+            [self::COMMAND_OPTION_MIGRATE_TO_VERSION => 0],
+            self::MIGRATE_DOWN_AFTERWARDS,
+        );
+
+        $this->assertStringContainsString('Migration complete.', $outputString);
+    }
+
+    /**
+     * @return void
+     */
+    public function testMigrateCommandShouldDoNothingIfGivenVersionIsTheLastAppliedVersion(): void
+    {
+        $this->setUpMigrateToVersion();
+
+        $migrationVersions = $this->getMigrationVersions();
+        $expectedVersion = $migrationVersions[array_key_last($migrationVersions)];
+
+        $outputString = $this->runCommandAndAssertSuccess(
+            'migration:migrate',
+            new MigrationMigrateCommand(),
+            [self::COMMAND_OPTION_MIGRATE_TO_VERSION => $expectedVersion],
+        );
+
+        $this->assertIsCurrentVersion($expectedVersion);
+        $this->assertStringContainsString(
+            sprintf('The last executed version of the migration is %s - nothing to migrate.', $expectedVersion),
+            $outputString,
+        );
+
+        $this->tearDownMigrateToVersion($migrationVersions);
+    }
+
+    /**
+     * @return void
+     */
+    public function testMigrateCommandShouldRollbackToTheGivenVersionIfItIsLowerThanTheCurrentVersion(): void
+    {
+        $this->setUpMigrateToVersion();
+
+        $migrationVersions = $this->getMigrationVersions();
+        $expectedVersion = $migrationVersions[array_key_first($migrationVersions)];
+
+        $outputString = $this->runCommandAndAssertSuccess(
+            'migration:migrate',
+            new MigrationMigrateCommand(),
+            [self::COMMAND_OPTION_MIGRATE_TO_VERSION => $expectedVersion],
+        );
+
+        $this->assertIsCurrentVersion($expectedVersion);
+        $this->assertStringContainsString(
+            sprintf('The last executed version of the migration is %s.', $expectedVersion),
+            $outputString,
+        );
+
+        $this->tearDownMigrateToVersion($migrationVersions);
+    }
+
+    /**
+     * @return void
+     */
+    public function testMigrateCommandShouldMigrateToTheGivenVersionIfItIsHigherThanTheCurrentVersion(): void
+    {
+        $this->setUpMigrateToVersion();
+
+        $migrationVersions = $this->getMigrationVersions();
+        $this->migrateDown();
+
+        $expectedVersion = $migrationVersions[array_key_last($migrationVersions)];
+
+        $outputString = $this->runCommandAndAssertSuccess(
+            'migration:migrate',
+            new MigrationMigrateCommand(),
+            [self::COMMAND_OPTION_MIGRATE_TO_VERSION => $expectedVersion],
+        );
+
+        $this->assertIsCurrentVersion($expectedVersion);
+        $this->assertStringContainsString('Migration complete. No further migration to execute.', $outputString);
+
+        $this->tearDownMigrateToVersion($migrationVersions);
+    }
+
+    /**
+     * @return void
+     */
+    public function testMigrationStatusCommandShouldReturnTheLastMigrationVersionWhenOptionIsProvided(): void
+    {
+        $outputString = $this->runCommandAndAssertSuccess(
+            'migration:status',
+            new MigrationStatusCommand(),
+            [self::COMMAND_OPTION_LAST_VERSION => true],
+        );
+
+        $this->assertStringContainsString('The last executed version of the migration is', $outputString);
+    }
+
+    /**
+     * @return void
+     */
+    public function testMigrationStatusCommandShouldNotReturnTheLastMigrationVersionWhenOptionIsNotProvided(): void
+    {
+        $outputString = $this->runCommandAndAssertSuccess('migration:status', new MigrationStatusCommand());
+
+        $this->assertStringNotContainsString('The last executed version of the migration is', $outputString);
     }
 
     /**
@@ -118,13 +274,13 @@ class MigrationTest extends TestCaseFixturesDatabase
      * @param array $additionalArguments
      * @param bool $migrateDownAfterwards
      *
-     * @return \Symfony\Component\Console\Output\StreamOutput
+     * @return string
      */
     private function runCommandAndAssertSuccess(
         string $commandName,
         AbstractCommand $commandInstance,
         array $additionalArguments = [],
-        bool $migrateDownAfterwards = false
+        bool $migrateDownAfterwards = false,
     ): string {
         $outputCapturer = new StreamOutput(fopen('php://temp', 'r+'));
         $exitCode = $this->runCommand($commandName, $commandInstance, $additionalArguments, $outputCapturer);
@@ -146,7 +302,7 @@ class MigrationTest extends TestCaseFixturesDatabase
     /**
      * @return void
      */
-    private function migrateUp()
+    private function migrateUp(): void
     {
         $this->runCommand('migration:up', new MigrationUpCommand());
     }
@@ -154,7 +310,7 @@ class MigrationTest extends TestCaseFixturesDatabase
     /**
      * @return void
      */
-    private function migrateDown()
+    private function migrateDown(): void
     {
         $this->runCommand('migration:down', new MigrationDownCommand());
     }
@@ -173,7 +329,7 @@ class MigrationTest extends TestCaseFixturesDatabase
         string $commandName,
         AbstractCommand $commandInstance,
         array $additionalArguments = [],
-        ?StreamOutput $outputCapturer = null
+        ?StreamOutput $outputCapturer = null,
     ): int {
         $applicationInputArguments = $this->buildApplicationInputArguments($commandName, $additionalArguments);
 
@@ -232,5 +388,76 @@ class MigrationTest extends TestCaseFixturesDatabase
         } else {
             $this->assertStringNotContainsString('CREATE TABLE ', $content);
         }
+    }
+
+    /**
+     * @param int $version
+     *
+     * @return void
+     */
+    private function assertIsCurrentVersion(int $version): void
+    {
+        $sql = sprintf('SELECT %s FROM %s', self::COL_VERSION, self::MIGRATION_TABLE);
+
+        $stmt = Propel::getServiceContainer()->getConnection()->prepare($sql);
+        $stmt->execute();
+
+        $versions = $stmt->fetchAll();
+        $lastVersion = array_pop($versions)[self::COL_VERSION];
+
+        $this->assertSame($version, $lastVersion);
+    }
+
+    /**
+     * @return void
+     */
+    private function setUpMigrateToVersion(): void
+    {
+        $this->deleteMigrationFiles();
+
+        /** @var array<string> $versionDirectories */
+        $versionDirectories = glob(
+            sprintf(
+                '%s%s*',
+                self::SCHEMA_DIR_MIGRATE_TO_VERSION,
+                DIRECTORY_SEPARATOR,
+            ),
+            GLOB_ONLYDIR,
+        );
+
+        foreach ($versionDirectories as $versionDirectory) {
+            $this->runCommand('migration:diff', new MigrationDiffCommand(), ['--schema-dir' => $versionDirectory]);
+            $this->migrateUp();
+            sleep(1);
+        }
+    }
+
+    /**
+     * @param list<int> $migrationVersions
+     *
+     * @return void
+     */
+    private function tearDownMigrateToVersion(array $migrationVersions): void
+    {
+        foreach ($migrationVersions as $migrationVersion) {
+            $this->migrateDown();
+        }
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function getMigrationVersions(): array
+    {
+        $migrationFiles = scandir(sprintf('%s%s', self::OUTPUT_DIR, DIRECTORY_SEPARATOR));
+
+        $migrationVersions = [];
+        foreach ($migrationFiles as $migrationFile) {
+            if (preg_match('/^PropelMigration_(\d+).*\.php$/', $migrationFile, $matches)) {
+                $migrationVersions[] = (int)$matches[1];
+            }
+        }
+
+        return $migrationVersions;
     }
 }

--- a/tests/Propel/Tests/Generator/Manager/MigrationManagerTest.php
+++ b/tests/Propel/Tests/Generator/Manager/MigrationManagerTest.php
@@ -8,8 +8,11 @@
 
 namespace Propel\Tests\Generator\Manager;
 
+use PDO;
+use PDOException;
 use Propel\Generator\Config\GeneratorConfig;
 use Propel\Generator\Manager\MigrationManager;
+use Propel\Generator\Platform\DefaultPlatform;
 use Propel\Tests\TestCase;
 
 /**
@@ -18,9 +21,25 @@ use Propel\Tests\TestCase;
 class MigrationManagerTest extends TestCase
 {
     /**
+     * @uses \Propel\Generator\Manager\MigrationManager::COL_VERSION
+     *
+     * @var string
+     */
+    private const COL_VERSION = 'version';
+
+    /**
+     * @uses \Propel\Generator\Manager\MigrationManager::COL_EXECUTION_DATETIME
+     *
+     * @var string
+     */
+    private const COL_EXECUTION_DATETIME = 'execution_datetime';
+
+    /**
+     * @param list<int> $migrationTimestamps
+     *
      * @return \Propel\Generator\Manager\MigrationManager
      */
-    private function createMigrationManager(array $migrationTimestamps)
+    private function createMigrationManager(array $migrationTimestamps): MigrationManager
     {
         $generatorConfig = new GeneratorConfig(__DIR__ . '/../../../../Fixtures/migration/');
 
@@ -46,7 +65,7 @@ class MigrationManagerTest extends TestCase
     /**
      * @return void
      */
-    public function testMigrationTableWillBeCreated()
+    public function testMigrationTableWillBeCreated(): void
     {
         $migrationManager = $this->createMigrationManager([]);
         $this->assertFalse($migrationManager->migrationTableExists('migration'));
@@ -56,30 +75,39 @@ class MigrationManagerTest extends TestCase
     }
 
     /**
+     * @dataProvider getAllDatabaseVersionsDataProvider
+     *
+     * @param array<int, string|null> $migrationData
+     * @param list<int> $expectedDatabaseVersions
+     *
      * @return void
      */
-    public function testGetAllDatabaseVersions()
+    public function testGetAllDatabaseVersions(array $migrationData, array $expectedDatabaseVersions): void
     {
-        $databaseVersions = [1, 2, 3];
         $migrationManager = $this->createMigrationManager([]);
         $migrationManager->createMigrationTable('migration');
 
-        foreach ($databaseVersions as $version) {
-            $migrationManager->updateLatestMigrationTimestamp('migration', $version);
-        }
+        $this->addMigrations($migrationManager, $migrationData);
 
-        $this->assertEquals($databaseVersions, $migrationManager->getAllDatabaseVersions());
+        $this->assertSame($expectedDatabaseVersions, $migrationManager->getAllDatabaseVersions());
     }
 
     /**
+     * @dataProvider getValidMigrationTimestampsDataProvider
+     *
+     * @param list<int> $localTimestamps
+     * @param list<int> $databaseTimestamps
+     * @param list<int> $expectedTimestamps
+     * @param int|null $expectedVersion
+     *
      * @return void
      */
-    public function testGetValidMigrationTimestamps()
-    {
-        $localTimestamps = [1, 2, 3, 4];
-        $databaseTimestamps = [1, 2];
-        $expectedMigrationTimestamps = [3, 4];
-
+    public function testGetValidMigrationTimestamps(
+        array $localTimestamps,
+        array $databaseTimestamps,
+        array $expectedTimestamps,
+        ?int $expectedVersion = null,
+    ): void {
         $migrationManager = $this->createMigrationManager($localTimestamps);
         $migrationManager->createMigrationTable('migration');
 
@@ -87,13 +115,13 @@ class MigrationManagerTest extends TestCase
             $migrationManager->updateLatestMigrationTimestamp('migration', $timestamp);
         }
 
-        $this->assertEquals($expectedMigrationTimestamps, $migrationManager->getValidMigrationTimestamps());
+        $this->assertSame($expectedTimestamps, $migrationManager->getValidMigrationTimestamps($expectedVersion));
     }
 
     /**
      * @return void
      */
-    public function testRemoveMigrationTimestamp()
+    public function testRemoveMigrationTimestamp(): void
     {
         $localTimestamps = [1, 2];
         $databaseTimestamps = [1, 2];
@@ -111,28 +139,33 @@ class MigrationManagerTest extends TestCase
     }
 
     /**
+     * @dataProvider getAlreadyExecutedTimestampsDataProvider
+     *
+     * @param list<int> $localTimestamps
+     * @param array<int, string|null> $databaseMigrationData
+     * @param list<int> $expectedTimestamps
+     * @param int|null $expectedVersion
+     *
      * @return void
      */
-    public function testGetAlreadyExecutedTimestamps()
-    {
-        $timestamps = [1, 2];
-
-        $migrationManager = $this->createMigrationManager($timestamps);
+    public function testGetAlreadyExecutedTimestamps(
+        array $localTimestamps,
+        array $databaseMigrationData,
+        array $expectedTimestamps,
+        ?int $expectedVersion = null,
+    ): void {
+        $migrationManager = $this->createMigrationManager($localTimestamps);
         $migrationManager->createMigrationTable('migration');
 
-        $this->assertEquals([], $migrationManager->getAlreadyExecutedMigrationTimestamps());
+        $this->addMigrations($migrationManager, $databaseMigrationData);
 
-        foreach ($timestamps as $timestamp) {
-            $migrationManager->updateLatestMigrationTimestamp('migration', $timestamp);
-        }
-
-        $this->assertEquals($timestamps, $migrationManager->getAlreadyExecutedMigrationTimestamps());
+        $this->assertSame($expectedTimestamps, $migrationManager->getAlreadyExecutedMigrationTimestamps($expectedVersion));
     }
 
     /**
      * @return void
      */
-    public function testIsPending()
+    public function testIsPending(): void
     {
         $localTimestamps = [1, 2];
 
@@ -149,7 +182,7 @@ class MigrationManagerTest extends TestCase
     /**
      * @return void
      */
-    public function testGetOldestDatabaseVersion()
+    public function testGetOldestDatabaseVersion(): void
     {
         $timestamps = [1, 2];
         $migrationManager = $this->createMigrationManager($timestamps);
@@ -165,7 +198,7 @@ class MigrationManagerTest extends TestCase
     /**
      * @return void
      */
-    public function testGetFirstUpMigrationTimestamp()
+    public function testGetFirstUpMigrationTimestamp(): void
     {
         $migrationManager = $this->createMigrationManager([1, 2, 3]);
         $migrationManager->createMigrationTable('migration');
@@ -178,7 +211,7 @@ class MigrationManagerTest extends TestCase
     /**
      * @return void
      */
-    public function testGetFirstDownMigrationTimestamp()
+    public function testGetFirstDownMigrationTimestamp(): void
     {
         $migrationManager = $this->createMigrationManager([1, 2, 3]);
         $migrationManager->createMigrationTable('migration');
@@ -192,7 +225,7 @@ class MigrationManagerTest extends TestCase
     /**
      * @return void
      */
-    public function testGetCommentMigrationManager()
+    public function testGetCommentMigrationManager(): void
     {
         $migrationManager = $this->createMigrationManager([1, 2, 3]);
 
@@ -204,18 +237,24 @@ class MigrationManagerTest extends TestCase
     /**
      * @return void
      */
-    public function testBuildVariableNamesFromConnectionNames()
+    public function testBuildVariableNamesFromConnectionNames(): void
     {
-        $manager = new class() extends MigrationManager{
+        $manager = new class () extends MigrationManager {
+            /**
+             * @param array<int|string, string> $migrationsUp
+             * @param array<string, string> $migrationsDown
+             *
+             * @return array<string, string>
+             */
             public function build(array $migrationsUp, array $migrationsDown): array
             {
                 return static::buildConnectionToVariableNameMap($migrationsUp, $migrationsDown);
             }
         };
-        
+
         $migrationsUp = array_fill_keys(['default', 'with space', '\/', '123'], '');
         $migrationsDown = array_fill_keys(['default', 'connection$', 'connection&', 'connection%'], '');
-        
+
         $expectedResult = [
             'default' => '$connection_default',
             'with space' => '$connection_withspace',
@@ -227,5 +266,316 @@ class MigrationManagerTest extends TestCase
         ];
         $result = $manager->build($migrationsUp, $migrationsDown);
         $this->assertEquals($expectedResult, $result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testCreateMigrationTableShouldTableWithColumns(): void
+    {
+        $migrationManager = $this->createMigrationManager([]);
+        $migrationManager->createMigrationTable('migration');
+
+        $this->assertTrue($migrationManager->migrationTableExists('migration'));
+        $this->assertTrue($this->columnExists($migrationManager, self::COL_VERSION));
+        $this->assertTrue($this->columnExists($migrationManager, self::COL_EXECUTION_DATETIME));
+    }
+
+    /**
+     * @return void
+     */
+    public function testUpdateLatestMigrationTimestamp(): void
+    {
+        $expectedVersion = 1;
+        $expectedExecutionDatetime = date('Y-m-d H:i:s');
+
+        $migrationManager = $this->createMigrationManager([]);
+        $migrationManager->createMigrationTable('migration');
+
+        $migrationManager->updateLatestMigrationTimestamp('migration', $expectedVersion);
+
+        $connection = $migrationManager->getAdapterConnection('migration');
+        $sql = sprintf(
+            'SELECT %s, %s FROM %s WHERE %s=%s',
+            self::COL_VERSION,
+            self::COL_EXECUTION_DATETIME,
+            $migrationManager->getMigrationTable(),
+            self::COL_VERSION,
+            $expectedVersion,
+        );
+
+        $stmt = $connection->prepare($sql);
+        $stmt->execute();
+        $migrationData = $stmt->fetch();
+
+        $this->assertSame($expectedVersion, $migrationData[self::COL_VERSION]);
+        $this->assertSame($expectedExecutionDatetime, $migrationData[self::COL_EXECUTION_DATETIME]);
+    }
+
+    /**
+     * @return void
+     */
+    public function testModifyMigrationTableIfOutdatedShouldNotUpdateTableIfExecutionDatetimeColumnExists(): void
+    {
+        $migrationManager = $this->createMigrationManager([]);
+        $migrationManager->createMigrationTable('migration');
+
+        $platformMock = $this->getMockBuilder(DefaultPlatform::class)
+            ->setMethods(['getAddColumnDDL'])
+            ->getMock();
+
+        $platformMock->expects($this->never())->method('getAddColumnDDL');
+
+        $migrationManager->modifyMigrationTableIfOutdated(
+            $migrationManager->getAdapterConnection('migration'),
+            $platformMock,
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testModifyMigrationTableIfOutdatedShouldAddExecutionDatetimeColumn(): void
+    {
+        $migrationManager = $this->createMigrationManager([]);
+        $migrationManager->createMigrationTable('migration');
+
+        $connection = $migrationManager->getAdapterConnection('migration');
+        $platform = $migrationManager->getPlatform('migration');
+
+        $sql = sprintf(
+            'ALTER TABLE %s DROP COLUMN %s',
+            $migrationManager->getMigrationTable(),
+            self::COL_EXECUTION_DATETIME,
+        );
+
+        $stmt = $connection->prepare($sql);
+        $stmt->execute();
+
+        $migrationManager->modifyMigrationTableIfOutdated($connection, $platform);
+
+        $this->assertTrue($this->columnExists($migrationManager, self::COL_EXECUTION_DATETIME));
+    }
+
+    /**
+     * @return void
+     */
+    public function testModifyMigrationTableShouldThrowExceptionIfMigrationTableDoesNotExist(): void
+    {
+        $migrationManager = $this->createMigrationManager([]);
+
+        $this->expectException(PDOException::class);
+
+        $migrationManager->modifyMigrationTableIfOutdated(
+            $migrationManager->getAdapterConnection('migration'),
+            $migrationManager->getPlatform('migration'),
+        );
+    }
+
+    /**
+     * @dataProvider isDatabaseVersionsAppliedDataProvider
+     *
+     * @param list<int> $localTimestamps
+     * @param list<int> $databaseTimestamps
+     * @param int $version
+     * @param bool $expectedIsDatabaseVersionApplied
+     *
+     * @return void
+     */
+    public function testIsDatabaseVersionsApplied(
+        array $localTimestamps,
+        array $databaseTimestamps,
+        int $version,
+        bool $expectedIsDatabaseVersionApplied,
+    ): void {
+        $migrationManager = $this->createMigrationManager($localTimestamps);
+        $migrationManager->createMigrationTable('migration');
+
+        foreach ($databaseTimestamps as $timestamp) {
+            $migrationManager->updateLatestMigrationTimestamp('migration', $timestamp);
+        }
+
+        $this->assertSame($expectedIsDatabaseVersionApplied, $migrationManager->isDatabaseVersionApplied($version));
+    }
+
+    /**
+     * @return array<int, array<int, array<int, mixed>>>
+     */
+    public function getAllDatabaseVersionsDataProvider(): array
+    {
+        return [
+            [
+                [
+                    1 => null,
+                    2 => null,
+                    3 => null,
+                ],
+                [1, 2, 3],
+            ],
+            [
+                [
+                    1 => date('Y-m-d H:i:s'),
+                    2 => date('Y-m-d H:i:s', strtotime('-1 day')),
+                    3 => date('Y-m-d H:i:s', strtotime('+1 day')),
+                ],
+                [2, 1, 3],
+            ],
+            [
+                [
+                    1 => date('Y-m-d H:i:s'),
+                    2 => date('Y-m-d H:i:s', strtotime('-1 day')),
+                    3 => date('Y-m-d H:i:s', strtotime('-1 day')),
+                ],
+                [2, 3, 1],
+            ],
+            [
+                [
+                    1 => null,
+                    2 => date('Y-m-d H:i:s', strtotime('+1 day')),
+                    3 => date('Y-m-d H:i:s'),
+                ],
+                [1, 3, 2],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, array<int, array<int>|int>>
+     */
+    public function getValidMigrationTimestampsDataProvider(): array
+    {
+        return [
+            'The method should return full diff if a specific version is not provided.' => [
+                [1, 2, 3],
+                [1, 2],
+                [3],
+            ],
+            'The method should return full diff if the given version is not found in the intersection.' => [
+                [1, 2, 3],
+                [1, 2],
+                [3],
+                4,
+            ],
+            'The method should cut all values from the diff after the given version.' => [
+                [1, 2, 3, 4],
+                [1],
+                [2, 3],
+                3,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, array<int, array|int>>
+     */
+    public function getAlreadyExecutedTimestampsDataProvider(): array
+    {
+        return [
+            'The method should return an empty array if no intersection is found.' => [
+                [1, 2, 3],
+                [],
+                [],
+            ],
+            'The method should return full intersection if a specific version is not provided.' => [
+                [1, 2, 3, 4],
+                [1 => null, 2 => null, 3 => null],
+                [1, 2, 3],
+            ],
+            'The method should return the intersection according to the order of executed migrations.' => [
+                [1, 2, 3, 4],
+                [1 => date('Y-m-d H:i:s'), 2 => null, 3 => null],
+                [2, 3, 1],
+            ],
+            'The method should return a full intersection if the given version is not found in the intersection.' => [
+                [1, 2, 3, 4],
+                [1 => null, 2 => null, 3 => null],
+                [1, 2, 3],
+                4,
+            ],
+            'The method should cut all values from the intersection before the given version.' => [
+                [1, 2, 3, 4],
+                [1 => null, 2 => null, 3 => null],
+                [3],
+                2,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<int, array<int, mixed>>
+     */
+    public function isDatabaseVersionsAppliedDataProvider(): array
+    {
+        return [
+            [
+                [1, 2, 3],
+                [1, 2],
+                4,
+                false,
+            ],
+            [
+                [1, 2, 3],
+                [1, 2],
+                1,
+                true,
+            ],
+        ];
+    }
+
+    /**
+     * @param \Propel\Generator\Manager\MigrationManager $migrationManager
+     * @param array<int, string|null> $migrationData
+     *
+     * @return void
+     */
+    private function addMigrations(MigrationManager $migrationManager, $migrationData): void
+    {
+        $platform = $migrationManager->getPlatform('migration');
+        $connection = $migrationManager->getAdapterConnection('migration');
+
+        foreach ($migrationData as $version => $executionDatetime) {
+            $sql = sprintf(
+                'INSERT INTO %s (%s, %s) VALUES (?, ?)',
+                $migrationManager->getMigrationTable(),
+                $platform->doQuoting(self::COL_VERSION),
+                $platform->doQuoting(self::COL_EXECUTION_DATETIME),
+            );
+
+            $stmt = $connection->prepare($sql);
+            $stmt->bindParam(1, $version, PDO::PARAM_INT);
+            $stmt->bindParam(
+                2,
+                $executionDatetime,
+                $executionDatetime === null ? PDO::PARAM_NULL : PDO::PARAM_STR,
+            );
+
+            $stmt->execute();
+        }
+    }
+
+    /**
+     * @param \Propel\Generator\Manager\MigrationManager $migrationManager
+     * @param string $columnName
+     *
+     * @return bool
+     */
+    private function columnExists(MigrationManager $migrationManager, string $columnName): bool
+    {
+        $connection = $migrationManager->getAdapterConnection('migration');
+
+        $sql = sprintf(
+            'SELECT %s FROM %s',
+            $columnName,
+            $migrationManager->getMigrationTable(),
+        );
+
+        try {
+            $stmt = $connection->prepare($sql);
+            $stmt->execute();
+
+            return true;
+        } catch (PDOException $e) {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
- Adjusted `MigrationMigrateCommand::execute()` with providing a new option `migrate-to-version` which allows defining the version to migrate database.
- Adjusted `MigrationStatusCommand::execute()` with providing a new option `last-version` which allows receiving the last executed version of the migration.