### PR TITLE
Implemented migration rollback.

### DIFF
--- a/src/Propel/Generator/Command/Executor/RollbackExecutor.php
+++ b/src/Propel/Generator/Command/Executor/RollbackExecutor.php
@@ -159,7 +159,7 @@ class RollbackExecutor
         foreach ($statements as $statement) {
             try {
                 if ($this->input->getOption(static::COMMAND_OPTION_VERBOSE)) {
-                    $this->output->writeln(sprintf('Executing statement "%s"', $statement));
+                    $this->output->writeln(sprintf('Executing statement `%s`', $statement));
                 }
 
                 $conn->exec($statement);
@@ -168,11 +168,11 @@ class RollbackExecutor
                 if ($this->input->getOption(static::COMMAND_OPTION_FORCE)) {
                     //continue, but print error message
                     $this->output->writeln(
-                        sprintf('<error>Failed to execute SQL "%s". Continue migration.</error>', $statement),
+                        sprintf('<error>Failed to execute SQL `%s`. Continue migration.</error>', $statement),
                     );
                 } else {
                     throw new RuntimeException(
-                        sprintf('<error>Failed to execute SQL "%s". Aborting migration.</error>', $statement),
+                        sprintf('<error>Failed to execute SQL `%s`. Aborting migration.</error>', $statement),
                         0,
                         $e,
                     );

--- a/src/Propel/Generator/Command/Executor/RollbackExecutor.php
+++ b/src/Propel/Generator/Command/Executor/RollbackExecutor.php
@@ -80,7 +80,7 @@ class RollbackExecutor
 
         $migration = $this->migrationManager->getMigrationObject($currentVersion);
 
-        $canBeRollback = $this->isFake() || $migration->preDown($this->migrationManager);
+        $canBeRollback = $this->isFake() || $migration->preDown($this->migrationManager) !== false;
         if (!$canBeRollback && !$this->isForce()) {
             $this->output->writeln('<error>preDown() returned false. Aborting migration.</error>');
 

--- a/src/Propel/Generator/Command/Executor/RollbackExecutor.php
+++ b/src/Propel/Generator/Command/Executor/RollbackExecutor.php
@@ -79,13 +79,15 @@ class RollbackExecutor
         ));
 
         $migration = $this->migrationManager->getMigrationObject($currentVersion);
-        if (!$this->isFake() && $migration->preDown($this->migrationManager) === false) {
-            if (!$this->isForce()) {
-                $this->output->writeln('<error>preDown() returned false. Aborting migration.</error>');
 
-                return false;
-            }
+        $canBeRollback = $this->isFake() || $migration->preDown($this->migrationManager);
+        if (!$canBeRollback && !$this->isForce()) {
+            $this->output->writeln('<error>preDown() returned false. Aborting migration.</error>');
 
+            return false;
+        }
+
+        if (!$canBeRollback) {
             $this->output->writeln('<error>preDown() returned false. Continue migration.</error>');
         }
 

--- a/src/Propel/Generator/Command/Executor/RollbackExecutor.php
+++ b/src/Propel/Generator/Command/Executor/RollbackExecutor.php
@@ -1,0 +1,190 @@
+<?php
+
+/**
+ * MIT License. This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Propel\Generator\Command\Executor;
+
+use Exception;
+use Propel\Generator\Manager\MigrationManager;
+use Propel\Generator\Util\SqlParser;
+use Propel\Runtime\Exception\RuntimeException;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Service class for executing rollback.
+ */
+class RollbackExecutor
+{
+    /**
+     * @var string
+     */
+    protected const COMMAND_OPTION_FAKE = 'fake';
+
+    /**
+     * @var string
+     */
+    protected const COMMAND_OPTION_FORCE = 'force';
+
+    /**
+     * @var string
+     */
+    protected const COMMAND_OPTION_VERBOSE = 'verbose';
+
+    /**
+     * @var \Symfony\Component\Console\Input\InputInterface
+     */
+    protected InputInterface $input;
+
+    /**
+     * @var \Symfony\Component\Console\Output\OutputInterface
+     */
+    protected OutputInterface $output;
+
+    /**
+     * @var \Propel\Generator\Manager\MigrationManager
+     */
+    protected MigrationManager $migrationManager;
+
+    /**
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @param \Propel\Generator\Manager\MigrationManager $migrationManager
+     */
+    public function __construct(
+        InputInterface $input,
+        OutputInterface $output,
+        MigrationManager $migrationManager
+    ) {
+        $this->input = $input;
+        $this->output = $output;
+        $this->migrationManager = $migrationManager;
+    }
+
+    /**
+     * @param list<int> $previousTimestamps
+     *
+     * @return bool
+     */
+    public function executeRollbackToPreviousVersion(array &$previousTimestamps): bool
+    {
+        $nextMigrationTimestamp = array_pop($previousTimestamps);
+        if (!$nextMigrationTimestamp) {
+            $this->output->writeln('No migration were ever executed on this database - nothing to reverse.');
+
+            return false;
+        }
+
+        $this->output->writeln(sprintf(
+            'Executing migration %s down',
+            $this->migrationManager->getMigrationClassName($nextMigrationTimestamp),
+        ));
+
+        $nbPreviousTimestamps = count($previousTimestamps);
+        $previousTimestamp = 0;
+        if ($nbPreviousTimestamps) {
+            $previousTimestamp = $previousTimestamps[array_key_last($previousTimestamps)];
+        }
+
+        $migration = $this->migrationManager->getMigrationObject($nextMigrationTimestamp);
+        if (!$this->input->getOption(static::COMMAND_OPTION_FAKE) && $migration->preDown($this->migrationManager) === false) {
+            if (!$this->input->getOption(static::COMMAND_OPTION_FORCE)) {
+                $this->output->writeln('<error>preDown() returned false. Aborting migration.</error>');
+
+                return false;
+            }
+
+            $this->output->writeln('<error>preDown() returned false. Continue migration.</error>');
+        }
+
+        foreach ($migration->getDownSQL() as $datasource => $sql) {
+            $this->executeRollbackForDatasource($datasource, $sql);
+
+            $this->migrationManager->removeMigrationTimestamp($datasource, $nextMigrationTimestamp);
+
+            if ($this->input->getOption(static::COMMAND_OPTION_VERBOSE)) {
+                $this->output->writeln(sprintf(
+                    'Downgraded migration date to %d for datasource "%s"',
+                    $previousTimestamp,
+                    $datasource,
+                ));
+            }
+        }
+
+        if (!$this->input->getOption(static::COMMAND_OPTION_FAKE)) {
+            $migration->postDown($this->migrationManager);
+        }
+
+        if ($nbPreviousTimestamps) {
+            $this->output->writeln(sprintf('Reverse migration complete. %d more migrations available for reverse.', $nbPreviousTimestamps));
+        } else {
+            $this->output->writeln('Reverse migration complete. No more migration available for reverse');
+        }
+
+        return true;
+    }
+
+    /**
+     * @param string $datasource
+     * @param string $sql
+     *
+     * @throws \Propel\Runtime\Exception\RuntimeException
+     *
+     * @return void
+     */
+    protected function executeRollbackForDatasource(string $datasource, string $sql): void
+    {
+        $connection = $this->migrationManager->getConnection($datasource);
+
+        if ($this->input->getOption(static::COMMAND_OPTION_VERBOSE)) {
+            $this->output->writeln(sprintf(
+                'Connecting to database "%s" using DSN "%s"',
+                $datasource,
+                $connection['dsn'],
+            ));
+        }
+
+        $conn = $this->migrationManager->getAdapterConnection($datasource);
+        $res = 0;
+        $statements = SqlParser::parseString($sql);
+
+        if ($this->input->getOption(static::COMMAND_OPTION_FAKE)) {
+            return;
+        }
+
+        foreach ($statements as $statement) {
+            try {
+                if ($this->input->getOption(static::COMMAND_OPTION_VERBOSE)) {
+                    $this->output->writeln(sprintf('Executing statement "%s"', $statement));
+                }
+
+                $conn->exec($statement);
+                $res++;
+            } catch (Exception $e) {
+                if ($this->input->getOption(static::COMMAND_OPTION_FORCE)) {
+                    //continue, but print error message
+                    $this->output->writeln(
+                        sprintf('<error>Failed to execute SQL "%s". Continue migration.</error>', $statement),
+                    );
+                } else {
+                    throw new RuntimeException(
+                        sprintf('<error>Failed to execute SQL "%s". Aborting migration.</error>', $statement),
+                        0,
+                        $e,
+                    );
+                }
+            }
+        }
+
+        $this->output->writeln(sprintf(
+            '%d of %d SQL statements executed successfully on datasource "%s"',
+            $res,
+            count($statements),
+            $datasource,
+        ));
+    }
+}

--- a/src/Propel/Generator/Command/MigrationDownCommand.php
+++ b/src/Propel/Generator/Command/MigrationDownCommand.php
@@ -8,10 +8,8 @@
 
 namespace Propel\Generator\Command;
 
-use Exception;
+use Propel\Generator\Command\Executor\RollbackExecutor;
 use Propel\Generator\Manager\MigrationManager;
-use Propel\Generator\Util\SqlParser;
-use Propel\Runtime\Exception\RuntimeException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -41,8 +39,6 @@ class MigrationDownCommand extends AbstractCommand
 
     /**
      * @inheritDoc
-     *
-     * @throws \Propel\Runtime\Exception\RuntimeException
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
@@ -79,108 +75,12 @@ class MigrationDownCommand extends AbstractCommand
         $manager->setWorkingDirectory($generatorConfig->getSection('paths')['migrationDir']);
 
         $previousTimestamps = $manager->getAlreadyExecutedMigrationTimestamps();
-        $nextMigrationTimestamp = array_pop($previousTimestamps);
-        if (!$nextMigrationTimestamp) {
-            $output->writeln('No migration were ever executed on this database - nothing to reverse.');
 
-            return static::CODE_ERROR;
+        $rollbackExecutor = new RollbackExecutor($input, $output, $manager);
+        if ($rollbackExecutor->executeRollbackToPreviousVersion($previousTimestamps)) {
+            return static::CODE_SUCCESS;
         }
 
-        $output->writeln(sprintf(
-            'Executing migration %s down',
-            $manager->getMigrationClassName($nextMigrationTimestamp),
-        ));
-
-        $nbPreviousTimestamps = count($previousTimestamps);
-        if ($nbPreviousTimestamps) {
-            $previousTimestamp = array_pop($previousTimestamps);
-        } else {
-            $previousTimestamp = 0;
-        }
-
-        $migration = $manager->getMigrationObject($nextMigrationTimestamp);
-
-        if (!$input->getOption('fake')) {
-            if ($migration->preDown($manager) === false) {
-                if ($input->getOption('force')) {
-                    $output->writeln('<error>preDown() returned false. Continue migration.</error>');
-                } else {
-                    $output->writeln('<error>preDown() returned false. Aborting migration.</error>');
-
-                    return static::CODE_ERROR;
-                }
-            }
-        }
-
-        foreach ($migration->getDownSQL() as $datasource => $sql) {
-            $connection = $manager->getConnection($datasource);
-
-            if ($input->getOption('verbose')) {
-                $output->writeln(sprintf(
-                    'Connecting to database "%s" using DSN "%s"',
-                    $datasource,
-                    $connection['dsn'],
-                ));
-            }
-
-            $conn = $manager->getAdapterConnection($datasource);
-            $res = 0;
-            $statements = SqlParser::parseString($sql);
-
-            if (!$input->getOption('fake')) {
-                foreach ($statements as $statement) {
-                    try {
-                        if ($input->getOption('verbose')) {
-                            $output->writeln(sprintf('Executing statement "%s"', $statement));
-                        }
-
-                        $conn->exec($statement);
-                        $res++;
-                    } catch (Exception $e) {
-                        if ($input->getOption('force')) {
-                            //continue, but print error message
-                            $output->writeln(
-                                sprintf('<error>Failed to execute SQL "%s". Continue migration.</error>', $statement),
-                            );
-                        } else {
-                            throw new RuntimeException(
-                                sprintf('<error>Failed to execute SQL "%s". Aborting migration.</error>', $statement),
-                                0,
-                                $e,
-                            );
-                        }
-                    }
-                }
-
-                $output->writeln(sprintf(
-                    '%d of %d SQL statements executed successfully on datasource "%s"',
-                    $res,
-                    count($statements),
-                    $datasource,
-                ));
-            }
-
-            $manager->removeMigrationTimestamp($datasource, $nextMigrationTimestamp);
-
-            if ($input->getOption('verbose')) {
-                $output->writeln(sprintf(
-                    'Downgraded migration date to %d for datasource "%s"',
-                    $previousTimestamp,
-                    $datasource,
-                ));
-            }
-        }
-
-        if (!$input->getOption('fake')) {
-            $migration->postDown($manager);
-        }
-
-        if ($nbPreviousTimestamps) {
-            $output->writeln(sprintf('Reverse migration complete. %d more migrations available for reverse.', $nbPreviousTimestamps));
-        } else {
-            $output->writeln('Reverse migration complete. No more migration available for reverse');
-        }
-
-        return static::CODE_SUCCESS;
+        return static::CODE_ERROR;
     }
 }

--- a/src/Propel/Generator/Command/MigrationMigrateCommand.php
+++ b/src/Propel/Generator/Command/MigrationMigrateCommand.php
@@ -9,6 +9,7 @@
 namespace Propel\Generator\Command;
 
 use Exception;
+use Propel\Generator\Command\Executor\RollbackExecutor;
 use Propel\Generator\Manager\MigrationManager;
 use Propel\Generator\Util\SqlParser;
 use Propel\Runtime\Exception\RuntimeException;
@@ -22,6 +23,16 @@ use Symfony\Component\Console\Output\OutputInterface;
 class MigrationMigrateCommand extends AbstractCommand
 {
     /**
+     * @var string
+     */
+    protected const COMMAND_OPTION_MIGRATE_TO_VERSION = 'migrate-to-version';
+
+    /**
+     * @var string
+     */
+    protected const COMMAND_OPTION_MIGRATE_TO_VERSION_DESCRIPTION = 'Defines the version to migrate database.';
+
+    /**
      * @inheritDoc
      */
     protected function configure()
@@ -34,6 +45,7 @@ class MigrationMigrateCommand extends AbstractCommand
             ->addOption('connection', null, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'Connection to use', [])
             ->addOption('fake', null, InputOption::VALUE_NONE, 'Does not touch the actual schema, but marks all migration as executed.')
             ->addOption('force', null, InputOption::VALUE_NONE, 'Continues with the migration even when errors occur.')
+            ->addOption(static::COMMAND_OPTION_MIGRATE_TO_VERSION, null, InputOption::VALUE_REQUIRED, static::COMMAND_OPTION_MIGRATE_TO_VERSION_DESCRIPTION)
             ->setName('migration:migrate')
             ->setAliases(['migrate'])
             ->setDescription('Execute all pending migrations');
@@ -78,13 +90,18 @@ class MigrationMigrateCommand extends AbstractCommand
         $manager->setMigrationTable($generatorConfig->getSection('migrations')['tableName']);
         $manager->setWorkingDirectory($generatorConfig->getSection('paths')['migrationDir']);
 
+        $version = $input->getOption(static::COMMAND_OPTION_MIGRATE_TO_VERSION);
+        if ($version && $manager->isDatabaseVersionApplied($version)) {
+            return $this->executeRollbackToVersion($input, $output, $manager, $version);
+        }
+
         if (!$manager->getFirstUpMigrationTimestamp()) {
             $output->writeln('All migrations were already executed - nothing to migrate.');
 
             return static::CODE_SUCCESS;
         }
 
-        $timestamps = $manager->getValidMigrationTimestamps();
+        $timestamps = $manager->getValidMigrationTimestamps($version);
         if (count($timestamps) > 1) {
             $output->writeln(sprintf('%d migrations to execute', count($timestamps)));
         }
@@ -185,6 +202,39 @@ class MigrationMigrateCommand extends AbstractCommand
         }
 
         $output->writeln('Migration complete. No further migration to execute.');
+
+        return static::CODE_SUCCESS;
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @param \Propel\Generator\Manager\MigrationManager $migrationManager
+     * @param int $version
+     *
+     * @return int
+     */
+    protected function executeRollbackToVersion(
+        InputInterface $input,
+        OutputInterface $output,
+        MigrationManager $migrationManager,
+        int $version
+    ): int {
+        $rollbackTimestamps = $migrationManager->getAlreadyExecutedMigrationTimestamps($version);
+        if ($rollbackTimestamps === []) {
+            $output->writeln(sprintf('The last executed version of the migration is %s - nothing to migrate.', $version));
+
+            return static::CODE_SUCCESS;
+        }
+
+        $rollbackExecutor = new RollbackExecutor($input, $output, $migrationManager);
+        while ($rollbackTimestamps !== []) {
+            if (!$rollbackExecutor->executeRollbackToPreviousVersion($rollbackTimestamps)) {
+                return static::CODE_ERROR;
+            }
+        }
+
+        $output->writeln(sprintf('The last executed version of the migration is %s.', $version));
 
         return static::CODE_SUCCESS;
     }

--- a/src/Propel/Generator/Manager/MigrationManager.php
+++ b/src/Propel/Generator/Manager/MigrationManager.php
@@ -633,12 +633,7 @@ class MigrationManager extends AbstractManager
         $stmt = $connection->prepare($sql);
         $stmt->execute();
 
-        $migrationData = [];
-        while ($migrationRow = $stmt->fetch()) {
-            $migrationData[] = $migrationRow;
-        }
-
-        return $migrationData;
+        return $stmt->fetchAll();
     }
 
     /**

--- a/src/Propel/Generator/Manager/MigrationManager.php
+++ b/src/Propel/Generator/Manager/MigrationManager.php
@@ -43,6 +43,11 @@ class MigrationManager extends AbstractManager
     protected const COL_EXECUTION_DATETIME = 'execution_datetime';
 
     /**
+     * @var string
+     */
+    protected const EXECUTION_DATETIME_FORMAT = 'Y-m-d H:i:s';
+
+    /**
      * @var array
      */
     protected $connections = [];
@@ -275,7 +280,7 @@ class MigrationManager extends AbstractManager
             $platform->doQuoting(static::COL_EXECUTION_DATETIME),
         );
 
-        $executionDatetime = date('Y-m-d H:i:s');
+        $executionDatetime = date(static::EXECUTION_DATETIME_FORMAT);
 
         $stmt = $conn->prepare($sql);
         $stmt->bindParam(1, $timestamp, PDO::PARAM_INT);

--- a/src/Propel/Generator/Manager/MigrationManager.php
+++ b/src/Propel/Generator/Manager/MigrationManager.php
@@ -33,6 +33,16 @@ class MigrationManager extends AbstractManager
     use PathTrait;
 
     /**
+     * @var string
+     */
+    protected const COL_VERSION = 'version';
+
+    /**
+     * @var string
+     */
+    protected const COL_EXECUTION_DATETIME = 'execution_datetime';
+
+    /**
      * @var array
      */
     protected $connections = [];
@@ -150,34 +160,27 @@ class MigrationManager extends AbstractManager
             throw new Exception('You must define database connection settings in a buildtime-conf.xml file to use migrations');
         }
 
-        /** @var array<int> $migrationTimestamps */
         $migrationTimestamps = [];
         foreach ($connections as $name => $params) {
-            $conn = $this->getAdapterConnection($name);
-            $platform = $this->getGeneratorConfig()->getConfiguredPlatform($conn);
-            if (!$platform->supportsMigrations()) {
-                continue;
-            }
-
-            $sql = sprintf('SELECT version FROM %s', $this->getMigrationTable());
-
             try {
-                $stmt = $conn->prepare($sql);
-                $stmt->execute();
-
-                while ($migrationTimestamp = $stmt->fetchColumn()) {
-                    /** @phpstan-var int $migrationTimestamp */
-                    $migrationTimestamps[] = $migrationTimestamp;
-                }
+                $migrationTimestamps += $this->getMigrationData($name);
             } catch (PDOException $e) {
                 $this->createMigrationTable($name);
                 $migrationTimestamps = [];
             }
         }
 
-        sort($migrationTimestamps);
+        usort($migrationTimestamps, function (array $a, array $b) {
+            if ($a[static::COL_EXECUTION_DATETIME] === $b[static::COL_EXECUTION_DATETIME]) {
+                return $a[static::COL_VERSION] <=> $b[static::COL_VERSION];
+            }
 
-        return $migrationTimestamps;
+            return $a[static::COL_EXECUTION_DATETIME] <=> $b[static::COL_EXECUTION_DATETIME];
+        });
+
+        return array_map(function (array $migrationTimestamp) {
+            return (int)$migrationTimestamp[static::COL_VERSION];
+        }, $migrationTimestamps);
     }
 
     /**
@@ -217,11 +220,9 @@ class MigrationManager extends AbstractManager
         $table = new Table($this->getMigrationTable());
         $database->addTable($table);
 
-        $column = new Column('version');
-        $column->getDomain()->copy($platform->getDomainForType('INTEGER'));
-        $column->setDefaultValue('0');
+        $table->addColumn($this->createVersionColumn($platform));
+        $table->addColumn($this->createExecutionDatetimeColumn($platform));
 
-        $table->addColumn($column);
         // insert the table into the database
         $statements = $platform->getAddTableDDL($table);
         $conn = $this->getAdapterConnection($datasource);
@@ -264,13 +265,21 @@ class MigrationManager extends AbstractManager
     {
         $platform = $this->getPlatform($datasource);
         $conn = $this->getAdapterConnection($datasource);
+
+        $this->modifyMigrationTableIfOutdated($conn, $platform);
+
         $sql = sprintf(
-            'INSERT INTO %s (%s) VALUES (?)',
+            'INSERT INTO %s (%s, %s) VALUES (?, ?)',
             $this->getMigrationTable(),
-            $platform->doQuoting('version'),
+            $platform->doQuoting(static::COL_VERSION),
+            $platform->doQuoting(static::COL_EXECUTION_DATETIME),
         );
+
+        $executionDatetime = date('Y-m-d H:i:s');
+
         $stmt = $conn->prepare($sql);
         $stmt->bindParam(1, $timestamp, PDO::PARAM_INT);
+        $stmt->bindParam(2, $executionDatetime);
         $stmt->execute();
     }
 
@@ -295,14 +304,25 @@ class MigrationManager extends AbstractManager
     }
 
     /**
-     * @return array<int>
+     * @param int|null $version
+     *
+     * @return list<int>
      */
-    public function getValidMigrationTimestamps(): array
+    public function getValidMigrationTimestamps(?int $version = null): array
     {
         $migrationTimestamps = array_diff($this->getMigrationTimestamps(), $this->getAllDatabaseVersions());
         sort($migrationTimestamps);
 
-        return $migrationTimestamps;
+        if ($version === null) {
+            return $migrationTimestamps;
+        }
+
+        $versionIndex = array_search($version, $migrationTimestamps, true);
+        if ($versionIndex === false) {
+            return $migrationTimestamps;
+        }
+
+        return array_slice($migrationTimestamps, 0, $versionIndex + 1);
     }
 
     /**
@@ -314,14 +334,30 @@ class MigrationManager extends AbstractManager
     }
 
     /**
-     * @return array<int>
+     * @param int|null $version
+     *
+     * @return list<int>
      */
-    public function getAlreadyExecutedMigrationTimestamps(): array
+    public function getAlreadyExecutedMigrationTimestamps(?int $version = null): array
     {
-        $migrationTimestamps = array_intersect($this->getMigrationTimestamps(), $this->getAllDatabaseVersions());
-        sort($migrationTimestamps);
+        $allDatabaseVersions = $this->getAllDatabaseVersions();
+        $migrationTimestamps = array_intersect($this->getMigrationTimestamps(), $allDatabaseVersions);
 
-        return $migrationTimestamps;
+        $sortOrder = array_flip($allDatabaseVersions);
+        usort($migrationTimestamps, function (int $a, int $b) use ($sortOrder) {
+            return $sortOrder[$a] <=> $sortOrder[$b];
+        });
+
+        if ($version === null) {
+            return $migrationTimestamps;
+        }
+
+        $versionIndex = array_search($version, $migrationTimestamps, true);
+        if ($versionIndex === false) {
+            return $migrationTimestamps;
+        }
+
+        return array_slice($migrationTimestamps, $versionIndex + 1);
     }
 
     /**
@@ -503,5 +539,123 @@ class MigrationManager extends AbstractManager
         }
 
         return array_pop($versions);
+    }
+
+    /**
+     * @param \Propel\Runtime\Connection\ConnectionInterface $connection
+     * @param \Propel\Generator\Platform\PlatformInterface $platform
+     *
+     * @return void
+     */
+    public function modifyMigrationTableIfOutdated(ConnectionInterface $connection, PlatformInterface $platform): void
+    {
+        if ($this->columnExists($connection, static::COL_EXECUTION_DATETIME)) {
+            return;
+        }
+
+        $table = new Table($this->getMigrationTable());
+
+        $column = $this->createExecutionDatetimeColumn($platform);
+        $column->setTable($table);
+
+        /** @phpstan-var \Propel\Generator\Platform\DefaultPlatform $platform */
+        $sql = $platform->getAddColumnDDL($column);
+
+        $stmt = $connection->prepare($sql);
+        $stmt->execute();
+    }
+
+    /**
+     * @param int $version
+     *
+     * @return bool
+     */
+    public function isDatabaseVersionApplied(int $version): bool
+    {
+        return in_array($version, $this->getAlreadyExecutedMigrationTimestamps());
+    }
+
+    /**
+     * @param string $connectionName
+     *
+     * @return array
+     */
+    protected function getMigrationData(string $connectionName): array
+    {
+        $connection = $this->getAdapterConnection($connectionName);
+        $platform = $this->getGeneratorConfig()->getConfiguredPlatform($connection);
+        if (!$platform->supportsMigrations()) {
+            return [];
+        }
+
+        $this->modifyMigrationTableIfOutdated($connection, $platform);
+
+        $sql = sprintf(
+            'SELECT %s, %s FROM %s',
+            static::COL_VERSION,
+            static::COL_EXECUTION_DATETIME,
+            $this->getMigrationTable(),
+        );
+
+        $stmt = $connection->prepare($sql);
+        $stmt->execute();
+
+        $migrationData = [];
+        while ($migrationRow = $stmt->fetch()) {
+            $migrationData[] = $migrationRow;
+        }
+
+        return $migrationData;
+    }
+
+    /**
+     * @param \Propel\Generator\Platform\PlatformInterface $platform
+     *
+     * @return \Propel\Generator\Model\Column
+     */
+    protected function createVersionColumn(PlatformInterface $platform): Column
+    {
+        $column = new Column(static::COL_VERSION);
+        $column->getDomain()->copy($platform->getDomainForType('INTEGER'));
+        $column->setDefaultValue('0');
+
+        return $column;
+    }
+
+    /**
+     * @param \Propel\Generator\Platform\PlatformInterface $platform
+     *
+     * @return \Propel\Generator\Model\Column
+     */
+    protected function createExecutionDatetimeColumn(PlatformInterface $platform): Column
+    {
+        $column = new Column(static::COL_EXECUTION_DATETIME);
+        $column->getDomain()->copy($platform->getDomainForType('DATETIME'));
+
+        return $column;
+    }
+
+    /**
+     * @param \Propel\Runtime\Connection\ConnectionInterface $connection
+     * @param string $columnName
+     *
+     * @return bool
+     */
+    protected function columnExists(ConnectionInterface $connection, string $columnName): bool
+    {
+        $sql = sprintf(
+            'SELECT %s FROM %s',
+            $columnName,
+            $this->getMigrationTable(),
+        );
+
+        try {
+            $stmt = $connection->prepare($sql);
+            $stmt->execute();
+
+            return true;
+        } catch (PDOException $e) {
+            return false;
+        }
     }
 }

--- a/tests/Fixtures/migrate-to-version/version-1/schema.xml
+++ b/tests/Fixtures/migrate-to-version/version-1/schema.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="ISO-8859-1" standalone="no"?>
+<database name="migration_command">
+
+    <table name="table1">
+        <column name="id" required="true" primaryKey="true" autoIncrement="true" type="INTEGER" description="Book Id"/>
+        <column name="title" type="VARCHAR" required="true" primaryString="true"/>
+        <column name="email" type="VARCHAR" required="false" primaryString="true"/>
+        <column name="table2_id" type="INTEGER"/>
+        <foreign-key foreignTable="table2" onDelete="setnull" onUpdate="cascade">
+            <reference local="table2_id" foreign="id"/>
+        </foreign-key>
+    </table>
+
+    <table name="table2">
+        <column name="id" required="true" primaryKey="true" autoIncrement="true" type="INTEGER"/>
+        <column name="title" type="VARCHAR"/>
+        <column name="created_at" required="false" type="TIMESTAMP"/>
+    </table>
+
+</database>

--- a/tests/Fixtures/migrate-to-version/version-2/schema.xml
+++ b/tests/Fixtures/migrate-to-version/version-2/schema.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="ISO-8859-1" standalone="no"?>
+<database name="migration_command">
+
+    <table name="table1">
+        <column name="id" required="true" primaryKey="true" autoIncrement="true" type="INTEGER" description="Book Id"/>
+        <column name="title" type="VARCHAR" required="true" primaryString="true"/>
+        <column name="email" type="VARCHAR" required="false" primaryString="true"/>
+        <column name="version" required="false" type="TIMESTAMP"/>
+        <column name="table2_id" type="INTEGER"/>
+        <foreign-key foreignTable="table2" onDelete="setnull" onUpdate="cascade">
+            <reference local="table2_id" foreign="id"/>
+        </foreign-key>
+    </table>
+
+    <table name="table2">
+        <column name="id" required="true" primaryKey="true" autoIncrement="true" type="INTEGER"/>
+        <column name="title" type="VARCHAR"/>
+        <column name="created_at" required="false" type="TIMESTAMP"/>
+    </table>
+
+</database>

--- a/tests/Fixtures/migrate-to-version/version-3/schema.xml
+++ b/tests/Fixtures/migrate-to-version/version-3/schema.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="ISO-8859-1" standalone="no"?>
+<database name="migration_command">
+
+    <table name="table1">
+        <column name="id" required="true" primaryKey="true" autoIncrement="true" type="INTEGER" description="Book Id"/>
+        <column name="title" type="VARCHAR" required="true" primaryString="true"/>
+        <column name="email" type="VARCHAR" required="false" primaryString="true"/>
+        <column name="name" type="VARCHAR" required="false"/>
+        <column name="created_at" required="false" type="TIMESTAMP"/>
+        <column name="table2_id" type="INTEGER"/>
+        <foreign-key foreignTable="table2" onDelete="setnull" onUpdate="cascade">
+            <reference local="table2_id" foreign="id"/>
+        </foreign-key>
+    </table>
+
+    <table name="table2">
+        <column name="id" required="true" primaryKey="true" autoIncrement="true" type="INTEGER"/>
+        <column name="title" type="VARCHAR"/>
+        <column name="created_at" required="false" type="TIMESTAMP"/>
+    </table>
+
+</database>

--- a/tests/Propel/Tests/Generator/Command/MigrationTest.php
+++ b/tests/Propel/Tests/Generator/Command/MigrationTest.php
@@ -13,6 +13,7 @@ use Propel\Generator\Command\MigrationCreateCommand;
 use Propel\Generator\Command\MigrationDiffCommand;
 use Propel\Generator\Command\MigrationDownCommand;
 use Propel\Generator\Command\MigrationMigrateCommand;
+use Propel\Generator\Command\MigrationStatusCommand;
 use Propel\Generator\Command\MigrationUpCommand;
 use Propel\Runtime\Propel;
 use Propel\Tests\TestCaseFixturesDatabase;
@@ -25,14 +26,56 @@ use Symfony\Component\Console\Output\StreamOutput;
  */
 class MigrationTest extends TestCaseFixturesDatabase
 {
+    /**
+     * @var bool
+     */
     private const MIGRATE_DOWN_AFTERWARDS = true;
+
+    /**
+     * @var string
+     */
     private const SCHEMA_DIR = __DIR__ . '/../../../../Fixtures/migration-command';
+
+    /**
+     * @var string
+     */
     private const OUTPUT_DIR = __DIR__ . '/../../../../migrationdiff';
+
+    /**
+     * @var string
+     */
+    private const SCHEMA_DIR_MIGRATE_TO_VERSION = __DIR__ . '/../../../../Fixtures/migrate-to-version';
+
+    /**
+     * @see \Propel\Generator\Command\MigrationMigrateCommand::COMMAND_OPTION_MIGRATE_TO_VERSION
+     *
+     * @var string
+     */
+    private const COMMAND_OPTION_MIGRATE_TO_VERSION = '--migrate-to-version';
+
+    /**
+     * @see \Propel\Generator\Command\MigrationStatusCommand::COMMAND_OPTION_LAST_VERSION
+     *
+     * @var string
+     */
+    private const COMMAND_OPTION_LAST_VERSION = '--last-version';
+
+    /**
+     * @uses \Propel\Generator\Manager\MigrationManager::COL_VERSION
+     *
+     * @var string
+     */
+    private const COL_VERSION = 'version';
+
+    /**
+     * @var string
+     */
+    private const MIGRATION_TABLE = 'propel_migration';
 
     /**
      * @return void
      */
-    public function testDiffCommandCreatesFiles()
+    public function testDiffCommandCreatesFiles(): void
     {
         $this->deleteMigrationFiles();
         $this->runCommandAndAssertSuccess('migration:diff', new MigrationDiffCommand(), ['--schema-dir' => self::SCHEMA_DIR]);
@@ -42,7 +85,7 @@ class MigrationTest extends TestCaseFixturesDatabase
     /**
      * @return void
      */
-    public function testDiffCommandCreatesSuffixedFiles()
+    public function testDiffCommandCreatesSuffixedFiles(): void
     {
         $this->deleteMigrationFiles();
         $suffix = 'an_explanatory_filename_suffix';
@@ -53,7 +96,7 @@ class MigrationTest extends TestCaseFixturesDatabase
     /**
      * @return void
      */
-    public function testCreateCommandCreatesFiles()
+    public function testCreateCommandCreatesFiles(): void
     {
         $this->deleteMigrationFiles();
         $this->runCommandAndAssertSuccess('migration:create', new MigrationCreateCommand(), ['--schema-dir' => self::SCHEMA_DIR]);
@@ -63,7 +106,7 @@ class MigrationTest extends TestCaseFixturesDatabase
     /**
      * @return void
      */
-    public function testCreateCommandCreatesSuffixedFiles()
+    public function testCreateCommandCreatesSuffixedFiles(): void
     {
         $this->deleteMigrationFiles();
         $suffix = 'an_explanatory_filename_suffix';
@@ -74,7 +117,7 @@ class MigrationTest extends TestCaseFixturesDatabase
     /**
      * @return void
      */
-    public function testUpCommandPerformsUpMigration()
+    public function testUpCommandPerformsUpMigration(): void
     {
         $outputString = $this->runCommandAndAssertSuccess('migration:up', new MigrationUpCommand(), [], self::MIGRATE_DOWN_AFTERWARDS);
         $this->assertStringContainsString('Migration complete.', $outputString);
@@ -83,7 +126,7 @@ class MigrationTest extends TestCaseFixturesDatabase
     /**
      * @return void
      */
-    public function testDownCommandPerformsDownMigration()
+    public function testDownCommandPerformsDownMigration(): void
     {
         $this->migrateUp();
         $outputString = $this->runCommandAndAssertSuccess('migration:down', new MigrationDownCommand());
@@ -93,10 +136,133 @@ class MigrationTest extends TestCaseFixturesDatabase
     /**
      * @return void
      */
-    public function testMigrateCommandPerformsUpMigration()
+    public function testMigrateCommandPerformsUpMigration(): void
     {
         $outputString = $this->runCommandAndAssertSuccess('migration:migrate', new MigrationMigrateCommand(), [], self::MIGRATE_DOWN_AFTERWARDS);
         $this->assertStringContainsString('Migration complete.', $outputString);
+    }
+
+    /**
+     * @return void
+     */
+    public function testMigrateCommandShouldMigrateToTheLastVersionIfTheGivenVersionIsNotExists(): void
+    {
+        $outputString = $this->runCommandAndAssertSuccess(
+            'migration:migrate',
+            new MigrationMigrateCommand(),
+            [self::COMMAND_OPTION_MIGRATE_TO_VERSION => 0],
+            self::MIGRATE_DOWN_AFTERWARDS,
+        );
+
+        $this->assertStringContainsString('Migration complete.', $outputString);
+    }
+
+    /**
+     * @return void
+     */
+    public function testMigrateCommandShouldDoNothingIfGivenVersionIsTheLastAppliedVersion(): void
+    {
+        $this->setUpMigrateToVersion();
+
+        $migrationVersions = $this->getMigrationVersions();
+        $expectedVersion = $migrationVersions[array_key_last($migrationVersions)];
+
+        $outputString = $this->runCommandAndAssertSuccess(
+            'migration:migrate',
+            new MigrationMigrateCommand(),
+            [self::COMMAND_OPTION_MIGRATE_TO_VERSION => $expectedVersion],
+        );
+
+        $this->assertIsCurrentVersion($expectedVersion);
+        $this->assertStringContainsString(
+            sprintf('The last executed version of the migration is %s - nothing to migrate.', $expectedVersion),
+            $outputString,
+        );
+
+        $this->tearDownMigrateToVersion($migrationVersions);
+    }
+
+    /**
+     * @return void
+     */
+    public function testMigrateCommandShouldRollbackToTheGivenVersionIfItIsLowerThanTheCurrentVersion(): void
+    {
+        $this->setUpMigrateToVersion();
+
+        $migrationVersions = $this->getMigrationVersions();
+        $expectedVersion = $migrationVersions[array_key_first($migrationVersions)];
+
+        $outputString = $this->runCommandAndAssertSuccess(
+            'migration:migrate',
+            new MigrationMigrateCommand(),
+            [self::COMMAND_OPTION_MIGRATE_TO_VERSION => $expectedVersion],
+        );
+
+        $this->assertIsCurrentVersion($expectedVersion);
+        $this->assertStringContainsString(
+            sprintf('The last executed version of the migration is %s.', $expectedVersion),
+            $outputString,
+        );
+
+        $this->tearDownMigrateToVersion($migrationVersions);
+    }
+
+    /**
+     * @return void
+     */
+    public function testMigrateCommandShouldMigrateToTheGivenVersionIfItIsHigherThanTheCurrentVersion(): void
+    {
+        $this->setUpMigrateToVersion();
+
+        $migrationVersions = $this->getMigrationVersions();
+        $this->migrateDown();
+
+        $expectedVersion = $migrationVersions[array_key_last($migrationVersions)];
+
+        $outputString = $this->runCommandAndAssertSuccess(
+            'migration:migrate',
+            new MigrationMigrateCommand(),
+            [self::COMMAND_OPTION_MIGRATE_TO_VERSION => $expectedVersion],
+        );
+
+        $this->assertIsCurrentVersion($expectedVersion);
+        $this->assertStringContainsString('Migration complete. No further migration to execute.', $outputString);
+
+        $this->tearDownMigrateToVersion($migrationVersions);
+    }
+
+    /**
+     * @return void
+     */
+    public function testMigrationStatusCommandShouldReturnTheLastMigrationVersionWhenOptionIsProvided(): void
+    {
+        $this->setUpMigrateToVersion();
+        $this->migrateDown();
+
+        $outputString = $this->runCommandAndAssertSuccess(
+            'migration:status',
+            new MigrationStatusCommand(),
+            [self::COMMAND_OPTION_LAST_VERSION => true],
+        );
+
+        $this->tearDownMigrateToVersion($this->getMigrationVersions());
+
+        $this->assertStringContainsString('The last executed version of the migration is', $outputString);
+    }
+
+    /**
+     * @return void
+     */
+    public function testMigrationStatusCommandShouldNotReturnTheLastMigrationVersionWhenOptionIsNotProvided(): void
+    {
+        $this->setUpMigrateToVersion();
+        $this->migrateDown();
+
+        $outputString = $this->runCommandAndAssertSuccess('migration:status', new MigrationStatusCommand());
+
+        $this->tearDownMigrateToVersion($this->getMigrationVersions());
+
+        $this->assertStringNotContainsString('The last executed version of the migration is', $outputString);
     }
 
     /**
@@ -118,7 +284,7 @@ class MigrationTest extends TestCaseFixturesDatabase
      * @param array $additionalArguments
      * @param bool $migrateDownAfterwards
      *
-     * @return \Symfony\Component\Console\Output\StreamOutput
+     * @return string
      */
     private function runCommandAndAssertSuccess(
         string $commandName,
@@ -146,7 +312,7 @@ class MigrationTest extends TestCaseFixturesDatabase
     /**
      * @return void
      */
-    private function migrateUp()
+    private function migrateUp(): void
     {
         $this->runCommand('migration:up', new MigrationUpCommand());
     }
@@ -154,7 +320,7 @@ class MigrationTest extends TestCaseFixturesDatabase
     /**
      * @return void
      */
-    private function migrateDown()
+    private function migrateDown(): void
     {
         $this->runCommand('migration:down', new MigrationDownCommand());
     }
@@ -232,5 +398,78 @@ class MigrationTest extends TestCaseFixturesDatabase
         } else {
             $this->assertStringNotContainsString('CREATE TABLE ', $content);
         }
+    }
+
+    /**
+     * @param int $version
+     *
+     * @return void
+     */
+    private function assertIsCurrentVersion(int $version): void
+    {
+        $sql = sprintf('SELECT %s FROM %s', self::COL_VERSION, self::MIGRATION_TABLE);
+
+        $stmt = Propel::getServiceContainer()->getConnection()->prepare($sql);
+        $stmt->execute();
+
+        $versions = $stmt->fetchAll();
+        $lastVersion = array_pop($versions)[self::COL_VERSION];
+
+        $this->assertSame($version, $lastVersion);
+    }
+
+    /**
+     * @return void
+     */
+    private function setUpMigrateToVersion(): void
+    {
+        $this->deleteMigrationFiles();
+
+        /** @var array<string> $versionDirectories */
+        $versionDirectories = glob(
+            sprintf(
+                '%s%s*',
+                self::SCHEMA_DIR_MIGRATE_TO_VERSION,
+                DIRECTORY_SEPARATOR,
+            ),
+            GLOB_ONLYDIR,
+        );
+
+        foreach ($versionDirectories as $versionDirectory) {
+            $this->runCommand('migration:diff', new MigrationDiffCommand(), ['--schema-dir' => $versionDirectory]);
+            $this->migrateUp();
+            sleep(1);
+        }
+    }
+
+    /**
+     * @param list<int> $migrationVersions
+     *
+     * @return void
+     */
+    private function tearDownMigrateToVersion(array $migrationVersions): void
+    {
+        foreach ($migrationVersions as $migrationVersion) {
+            $this->migrateDown();
+        }
+
+        $this->deleteMigrationFiles();
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function getMigrationVersions(): array
+    {
+        $migrationFiles = scandir(sprintf('%s%s', self::OUTPUT_DIR, DIRECTORY_SEPARATOR));
+
+        $migrationVersions = [];
+        foreach ($migrationFiles as $migrationFile) {
+            if (preg_match('/^PropelMigration_(\d+).*\.php$/', $migrationFile, $matches)) {
+                $migrationVersions[] = (int)$matches[1];
+            }
+        }
+
+        return $migrationVersions;
     }
 }

--- a/tests/Propel/Tests/Generator/Command/MigrationTest.php
+++ b/tests/Propel/Tests/Generator/Command/MigrationTest.php
@@ -175,7 +175,7 @@ class MigrationTest extends TestCaseFixturesDatabase
 
         $this->assertIsCurrentVersion($expectedVersion);
         $this->assertStringContainsString(
-            sprintf('The last executed version of the migration is %s - nothing to migrate.', $expectedVersion),
+            sprintf('Already at version %s.', $expectedVersion),
             $outputString,
         );
 
@@ -200,7 +200,7 @@ class MigrationTest extends TestCaseFixturesDatabase
 
         $this->assertIsCurrentVersion($expectedVersion);
         $this->assertStringContainsString(
-            sprintf('The last executed version of the migration is %s.', $expectedVersion),
+            sprintf('Successfully rollback to migration version %s.', $expectedVersion),
             $outputString,
         );
 
@@ -234,10 +234,25 @@ class MigrationTest extends TestCaseFixturesDatabase
     /**
      * @return void
      */
+    public function testMigrationStatusCommandShouldReturnEmptyWhenOptionIsProvidedAndMigrationsWereNotExecuted(): void
+    {
+        $outputString = $this->runCommandAndAssertSuccess(
+            'migration:status',
+            new MigrationStatusCommand(),
+            [self::COMMAND_OPTION_LAST_VERSION => true],
+        );
+
+        $this->assertEmpty(trim(str_replace('\n', '', $outputString)));
+    }
+
+    /**
+     * @return void
+     */
     public function testMigrationStatusCommandShouldReturnTheLastMigrationVersionWhenOptionIsProvided(): void
     {
         $this->setUpMigrateToVersion();
-        $this->migrateDown();
+
+        $migrationVersions = $this->getMigrationVersions();
 
         $outputString = $this->runCommandAndAssertSuccess(
             'migration:status',
@@ -247,7 +262,7 @@ class MigrationTest extends TestCaseFixturesDatabase
 
         $this->tearDownMigrateToVersion($this->getMigrationVersions());
 
-        $this->assertStringContainsString('The last executed version of the migration is', $outputString);
+        $this->assertSame((string)array_pop($migrationVersions), trim(str_replace('\n', '', $outputString)));
     }
 
     /**
@@ -262,7 +277,7 @@ class MigrationTest extends TestCaseFixturesDatabase
 
         $this->tearDownMigrateToVersion($this->getMigrationVersions());
 
-        $this->assertStringNotContainsString('The last executed version of the migration is', $outputString);
+        $this->assertStringContainsString('Checking Database Versions', $outputString);
     }
 
     /**

--- a/tests/Propel/Tests/Generator/Command/MigrationTest.php
+++ b/tests/Propel/Tests/Generator/Command/MigrationTest.php
@@ -415,7 +415,7 @@ class MigrationTest extends TestCaseFixturesDatabase
         $versions = $stmt->fetchAll();
         $lastVersion = array_pop($versions)[self::COL_VERSION];
 
-        $this->assertSame($version, $lastVersion);
+        $this->assertSame($version, (int)$lastVersion);
     }
 
     /**

--- a/tests/Propel/Tests/Generator/Manager/MigrationManagerTest.php
+++ b/tests/Propel/Tests/Generator/Manager/MigrationManagerTest.php
@@ -8,8 +8,13 @@
 
 namespace Propel\Tests\Generator\Manager;
 
+use PDO;
+use PDOException;
 use Propel\Generator\Config\GeneratorConfig;
 use Propel\Generator\Manager\MigrationManager;
+use Propel\Generator\Model\Column;
+use Propel\Generator\Model\Table;
+use Propel\Generator\Platform\DefaultPlatform;
 use Propel\Tests\TestCase;
 
 /**
@@ -18,9 +23,25 @@ use Propel\Tests\TestCase;
 class MigrationManagerTest extends TestCase
 {
     /**
+     * @uses \Propel\Generator\Manager\MigrationManager::COL_VERSION
+     *
+     * @var string
+     */
+    private const COL_VERSION = 'version';
+
+    /**
+     * @uses \Propel\Generator\Manager\MigrationManager::COL_EXECUTION_DATETIME
+     *
+     * @var string
+     */
+    private const COL_EXECUTION_DATETIME = 'execution_datetime';
+
+    /**
+     * @param list<int> $migrationTimestamps
+     *
      * @return \Propel\Generator\Manager\MigrationManager
      */
-    private function createMigrationManager(array $migrationTimestamps)
+    private function createMigrationManager(array $migrationTimestamps): MigrationManager
     {
         $generatorConfig = new GeneratorConfig(__DIR__ . '/../../../../Fixtures/migration/');
 
@@ -46,7 +67,7 @@ class MigrationManagerTest extends TestCase
     /**
      * @return void
      */
-    public function testMigrationTableWillBeCreated()
+    public function testMigrationTableWillBeCreated(): void
     {
         $migrationManager = $this->createMigrationManager([]);
         $this->assertFalse($migrationManager->migrationTableExists('migration'));
@@ -56,30 +77,39 @@ class MigrationManagerTest extends TestCase
     }
 
     /**
+     * @dataProvider getAllDatabaseVersionsDataProvider
+     *
+     * @param array<int, string|null> $migrationData
+     * @param list<int> $expectedDatabaseVersions
+     *
      * @return void
      */
-    public function testGetAllDatabaseVersions()
+    public function testGetAllDatabaseVersions(array $migrationData, array $expectedDatabaseVersions): void
     {
-        $databaseVersions = [1, 2, 3];
         $migrationManager = $this->createMigrationManager([]);
         $migrationManager->createMigrationTable('migration');
 
-        foreach ($databaseVersions as $version) {
-            $migrationManager->updateLatestMigrationTimestamp('migration', $version);
-        }
+        $this->addMigrations($migrationManager, $migrationData);
 
-        $this->assertEquals($databaseVersions, $migrationManager->getAllDatabaseVersions());
+        $this->assertSame($expectedDatabaseVersions, $migrationManager->getAllDatabaseVersions());
     }
 
     /**
+     * @dataProvider getValidMigrationTimestampsDataProvider
+     *
+     * @param list<int> $localTimestamps
+     * @param list<int> $databaseTimestamps
+     * @param list<int> $expectedTimestamps
+     * @param int|null $expectedVersion
+     *
      * @return void
      */
-    public function testGetValidMigrationTimestamps()
-    {
-        $localTimestamps = [1, 2, 3, 4];
-        $databaseTimestamps = [1, 2];
-        $expectedMigrationTimestamps = [3, 4];
-
+    public function testGetValidMigrationTimestamps(
+        array $localTimestamps,
+        array $databaseTimestamps,
+        array $expectedTimestamps,
+        ?int $expectedVersion = null
+    ): void {
         $migrationManager = $this->createMigrationManager($localTimestamps);
         $migrationManager->createMigrationTable('migration');
 
@@ -87,13 +117,13 @@ class MigrationManagerTest extends TestCase
             $migrationManager->updateLatestMigrationTimestamp('migration', $timestamp);
         }
 
-        $this->assertEquals($expectedMigrationTimestamps, $migrationManager->getValidMigrationTimestamps());
+        $this->assertSame($expectedTimestamps, $migrationManager->getValidMigrationTimestamps($expectedVersion));
     }
 
     /**
      * @return void
      */
-    public function testRemoveMigrationTimestamp()
+    public function testRemoveMigrationTimestamp(): void
     {
         $localTimestamps = [1, 2];
         $databaseTimestamps = [1, 2];
@@ -111,28 +141,33 @@ class MigrationManagerTest extends TestCase
     }
 
     /**
+     * @dataProvider getAlreadyExecutedTimestampsDataProvider
+     *
+     * @param list<int> $localTimestamps
+     * @param array<int, string|null> $databaseMigrationData
+     * @param list<int> $expectedTimestamps
+     * @param int|null $expectedVersion
+     *
      * @return void
      */
-    public function testGetAlreadyExecutedTimestamps()
-    {
-        $timestamps = [1, 2];
-
-        $migrationManager = $this->createMigrationManager($timestamps);
+    public function testGetAlreadyExecutedTimestamps(
+        array $localTimestamps,
+        array $databaseMigrationData,
+        array $expectedTimestamps,
+        ?int $expectedVersion = null
+    ): void {
+        $migrationManager = $this->createMigrationManager($localTimestamps);
         $migrationManager->createMigrationTable('migration');
 
-        $this->assertEquals([], $migrationManager->getAlreadyExecutedMigrationTimestamps());
+        $this->addMigrations($migrationManager, $databaseMigrationData);
 
-        foreach ($timestamps as $timestamp) {
-            $migrationManager->updateLatestMigrationTimestamp('migration', $timestamp);
-        }
-
-        $this->assertEquals($timestamps, $migrationManager->getAlreadyExecutedMigrationTimestamps());
+        $this->assertSame($expectedTimestamps, $migrationManager->getAlreadyExecutedMigrationTimestamps($expectedVersion));
     }
 
     /**
      * @return void
      */
-    public function testIsPending()
+    public function testIsPending(): void
     {
         $localTimestamps = [1, 2];
 
@@ -149,7 +184,7 @@ class MigrationManagerTest extends TestCase
     /**
      * @return void
      */
-    public function testGetOldestDatabaseVersion()
+    public function testGetOldestDatabaseVersion(): void
     {
         $timestamps = [1, 2];
         $migrationManager = $this->createMigrationManager($timestamps);
@@ -165,7 +200,7 @@ class MigrationManagerTest extends TestCase
     /**
      * @return void
      */
-    public function testGetFirstUpMigrationTimestamp()
+    public function testGetFirstUpMigrationTimestamp(): void
     {
         $migrationManager = $this->createMigrationManager([1, 2, 3]);
         $migrationManager->createMigrationTable('migration');
@@ -178,7 +213,7 @@ class MigrationManagerTest extends TestCase
     /**
      * @return void
      */
-    public function testGetFirstDownMigrationTimestamp()
+    public function testGetFirstDownMigrationTimestamp(): void
     {
         $migrationManager = $this->createMigrationManager([1, 2, 3]);
         $migrationManager->createMigrationTable('migration');
@@ -192,7 +227,7 @@ class MigrationManagerTest extends TestCase
     /**
      * @return void
      */
-    public function testGetCommentMigrationManager()
+    public function testGetCommentMigrationManager(): void
     {
         $migrationManager = $this->createMigrationManager([1, 2, 3]);
 
@@ -204,18 +239,24 @@ class MigrationManagerTest extends TestCase
     /**
      * @return void
      */
-    public function testBuildVariableNamesFromConnectionNames()
+    public function testBuildVariableNamesFromConnectionNames(): void
     {
-        $manager = new class() extends MigrationManager{
+        $manager = new class () extends MigrationManager {
+            /**
+             * @param array<int|string, string> $migrationsUp
+             * @param array<string, string> $migrationsDown
+             *
+             * @return array<string, string>
+             */
             public function build(array $migrationsUp, array $migrationsDown): array
             {
                 return static::buildConnectionToVariableNameMap($migrationsUp, $migrationsDown);
             }
         };
-        
+
         $migrationsUp = array_fill_keys(['default', 'with space', '\/', '123'], '');
         $migrationsDown = array_fill_keys(['default', 'connection$', 'connection&', 'connection%'], '');
-        
+
         $expectedResult = [
             'default' => '$connection_default',
             'with space' => '$connection_withspace',
@@ -227,5 +268,291 @@ class MigrationManagerTest extends TestCase
         ];
         $result = $manager->build($migrationsUp, $migrationsDown);
         $this->assertEquals($expectedResult, $result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testCreateMigrationTableShouldTableWithColumns(): void
+    {
+        $migrationManager = $this->createMigrationManager([]);
+        $migrationManager->createMigrationTable('migration');
+
+        $this->assertTrue($migrationManager->migrationTableExists('migration'));
+        $this->assertTrue($this->columnExists($migrationManager, self::COL_VERSION));
+        $this->assertTrue($this->columnExists($migrationManager, self::COL_EXECUTION_DATETIME));
+    }
+
+    /**
+     * @return void
+     */
+    public function testUpdateLatestMigrationTimestamp(): void
+    {
+        $expectedVersion = 1;
+        $expectedExecutionDatetime = date('Y-m-d H:i:s');
+
+        $migrationManager = $this->createMigrationManager([]);
+        $migrationManager->createMigrationTable('migration');
+
+        $migrationManager->updateLatestMigrationTimestamp('migration', $expectedVersion);
+
+        $connection = $migrationManager->getAdapterConnection('migration');
+        $sql = sprintf(
+            'SELECT %s, %s FROM %s WHERE %s=%s',
+            self::COL_VERSION,
+            self::COL_EXECUTION_DATETIME,
+            $migrationManager->getMigrationTable(),
+            self::COL_VERSION,
+            $expectedVersion,
+        );
+
+        $stmt = $connection->prepare($sql);
+        $stmt->execute();
+        $migrationData = $stmt->fetch();
+
+        $this->assertSame($expectedVersion, (int)$migrationData[self::COL_VERSION]);
+        $this->assertGreaterThanOrEqual($expectedExecutionDatetime, $migrationData[self::COL_EXECUTION_DATETIME]);
+    }
+
+    /**
+     * @return void
+     */
+    public function testModifyMigrationTableIfOutdatedShouldNotUpdateTableIfExecutionDatetimeColumnExists(): void
+    {
+        $migrationManager = $this->createMigrationManager([]);
+        $migrationManager->createMigrationTable('migration');
+
+        $platformMock = $this->getMockBuilder(DefaultPlatform::class)
+            ->setMethods(['getAddColumnDDL'])
+            ->getMock();
+
+        $platformMock->expects($this->never())->method('getAddColumnDDL');
+
+        $migrationManager->modifyMigrationTableIfOutdated(
+            $migrationManager->getAdapterConnection('migration'),
+            $platformMock,
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testModifyMigrationTableShouldThrowExceptionIfMigrationTableDoesNotExist(): void
+    {
+        $migrationManager = $this->createMigrationManager([]);
+
+        $this->expectException(PDOException::class);
+
+        $migrationManager->modifyMigrationTableIfOutdated(
+            $migrationManager->getAdapterConnection('migration'),
+            $migrationManager->getPlatform('migration'),
+        );
+    }
+
+    /**
+     * @dataProvider isDatabaseVersionsAppliedDataProvider
+     *
+     * @param list<int> $localTimestamps
+     * @param list<int> $databaseTimestamps
+     * @param int $version
+     * @param bool $expectedIsDatabaseVersionApplied
+     *
+     * @return void
+     */
+    public function testIsDatabaseVersionsApplied(
+        array $localTimestamps,
+        array $databaseTimestamps,
+        int $version,
+        bool $expectedIsDatabaseVersionApplied
+    ): void {
+        $migrationManager = $this->createMigrationManager($localTimestamps);
+        $migrationManager->createMigrationTable('migration');
+
+        foreach ($databaseTimestamps as $timestamp) {
+            $migrationManager->updateLatestMigrationTimestamp('migration', $timestamp);
+        }
+
+        $this->assertSame($expectedIsDatabaseVersionApplied, $migrationManager->isDatabaseVersionApplied($version));
+    }
+
+    /**
+     * @return array<int, array<int, array<int, mixed>>>
+     */
+    public function getAllDatabaseVersionsDataProvider(): array
+    {
+        return [
+            [
+                [
+                    1 => null,
+                    2 => null,
+                    3 => null,
+                ],
+                [1, 2, 3],
+            ],
+            [
+                [
+                    1 => date('Y-m-d H:i:s'),
+                    2 => date('Y-m-d H:i:s', strtotime('-1 day')),
+                    3 => date('Y-m-d H:i:s', strtotime('+1 day')),
+                ],
+                [2, 1, 3],
+            ],
+            [
+                [
+                    1 => date('Y-m-d H:i:s'),
+                    2 => date('Y-m-d H:i:s', strtotime('-1 day')),
+                    3 => date('Y-m-d H:i:s', strtotime('-1 day')),
+                ],
+                [2, 3, 1],
+            ],
+            [
+                [
+                    1 => null,
+                    2 => date('Y-m-d H:i:s', strtotime('+1 day')),
+                    3 => date('Y-m-d H:i:s'),
+                ],
+                [1, 3, 2],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, array<int, array<int>|int>>
+     */
+    public function getValidMigrationTimestampsDataProvider(): array
+    {
+        return [
+            'The method should return full diff if a specific version is not provided.' => [
+                [1, 2, 3],
+                [1, 2],
+                [3],
+            ],
+            'The method should return full diff if the given version is not found in the intersection.' => [
+                [1, 2, 3],
+                [1, 2],
+                [3],
+                4,
+            ],
+            'The method should cut all values from the diff after the given version.' => [
+                [1, 2, 3, 4],
+                [1],
+                [2, 3],
+                3,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, array<int, array|int>>
+     */
+    public function getAlreadyExecutedTimestampsDataProvider(): array
+    {
+        return [
+            'The method should return an empty array if no intersection is found.' => [
+                [1, 2, 3],
+                [],
+                [],
+            ],
+            'The method should return full intersection if a specific version is not provided.' => [
+                [1, 2, 3, 4],
+                [1 => null, 2 => null, 3 => null],
+                [1, 2, 3],
+            ],
+            'The method should return the intersection according to the order of executed migrations.' => [
+                [1, 2, 3, 4],
+                [1 => date('Y-m-d H:i:s'), 2 => null, 3 => null],
+                [2, 3, 1],
+            ],
+            'The method should return a full intersection if the given version is not found in the intersection.' => [
+                [1, 2, 3, 4],
+                [1 => null, 2 => null, 3 => null],
+                [1, 2, 3],
+                4,
+            ],
+            'The method should cut all values from the intersection before the given version.' => [
+                [1, 2, 3, 4],
+                [1 => null, 2 => null, 3 => null],
+                [3],
+                2,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<int, array<int, mixed>>
+     */
+    public function isDatabaseVersionsAppliedDataProvider(): array
+    {
+        return [
+            [
+                [1, 2, 3],
+                [1, 2],
+                4,
+                false,
+            ],
+            [
+                [1, 2, 3],
+                [1, 2],
+                1,
+                true,
+            ],
+        ];
+    }
+
+    /**
+     * @param \Propel\Generator\Manager\MigrationManager $migrationManager
+     * @param array<int, string|null> $migrationData
+     *
+     * @return void
+     */
+    private function addMigrations(MigrationManager $migrationManager, array $migrationData): void
+    {
+        $platform = $migrationManager->getPlatform('migration');
+        $connection = $migrationManager->getAdapterConnection('migration');
+
+        foreach ($migrationData as $version => $executionDatetime) {
+            $sql = sprintf(
+                'INSERT INTO %s (%s, %s) VALUES (?, ?)',
+                $migrationManager->getMigrationTable(),
+                $platform->doQuoting(self::COL_VERSION),
+                $platform->doQuoting(self::COL_EXECUTION_DATETIME),
+            );
+
+            $stmt = $connection->prepare($sql);
+            $stmt->bindParam(1, $version, PDO::PARAM_INT);
+            $stmt->bindParam(
+                2,
+                $executionDatetime,
+                $executionDatetime === null ? PDO::PARAM_NULL : PDO::PARAM_STR,
+            );
+
+            $stmt->execute();
+        }
+    }
+
+    /**
+     * @param \Propel\Generator\Manager\MigrationManager $migrationManager
+     * @param string $columnName
+     *
+     * @return bool
+     */
+    private function columnExists(MigrationManager $migrationManager, string $columnName): bool
+    {
+        $connection = $migrationManager->getAdapterConnection('migration');
+
+        $sql = sprintf(
+            'SELECT %s FROM %s',
+            $columnName,
+            $migrationManager->getMigrationTable(),
+        );
+
+        try {
+            $stmt = $connection->prepare($sql);
+            $stmt->execute();
+
+            return true;
+        } catch (PDOException $e) {
+            return false;
+        }
     }
 }

--- a/tests/Propel/Tests/Generator/Manager/MigrationManagerTest.php
+++ b/tests/Propel/Tests/Generator/Manager/MigrationManagerTest.php
@@ -37,6 +37,13 @@ class MigrationManagerTest extends TestCase
     private const COL_EXECUTION_DATETIME = 'execution_datetime';
 
     /**
+     * @uses \Propel\Generator\Manager\MigrationManager::EXECUTION_DATETIME_FORMAT
+     *
+     * @var string
+     */
+    private const EXECUTION_DATETIME_FORMAT = 'Y-m-d H:i:s';
+
+    /**
      * @param list<int> $migrationTimestamps
      *
      * @return \Propel\Generator\Manager\MigrationManager
@@ -289,7 +296,7 @@ class MigrationManagerTest extends TestCase
     public function testUpdateLatestMigrationTimestamp(): void
     {
         $expectedVersion = 1;
-        $expectedExecutionDatetime = date('Y-m-d H:i:s');
+        $expectedExecutionDatetime = date(self::EXECUTION_DATETIME_FORMAT);
 
         $migrationManager = $this->createMigrationManager([]);
         $migrationManager->createMigrationTable('migration');
@@ -391,25 +398,25 @@ class MigrationManagerTest extends TestCase
             ],
             [
                 [
-                    1 => date('Y-m-d H:i:s'),
-                    2 => date('Y-m-d H:i:s', strtotime('-1 day')),
-                    3 => date('Y-m-d H:i:s', strtotime('+1 day')),
+                    1 => date(self::EXECUTION_DATETIME_FORMAT),
+                    2 => date(self::EXECUTION_DATETIME_FORMAT, strtotime('-1 day')),
+                    3 => date(self::EXECUTION_DATETIME_FORMAT, strtotime('+1 day')),
                 ],
                 [2, 1, 3],
             ],
             [
                 [
-                    1 => date('Y-m-d H:i:s'),
-                    2 => date('Y-m-d H:i:s', strtotime('-1 day')),
-                    3 => date('Y-m-d H:i:s', strtotime('-1 day')),
+                    1 => date(self::EXECUTION_DATETIME_FORMAT),
+                    2 => date(self::EXECUTION_DATETIME_FORMAT, strtotime('-1 day')),
+                    3 => date(self::EXECUTION_DATETIME_FORMAT, strtotime('-1 day')),
                 ],
                 [2, 3, 1],
             ],
             [
                 [
                     1 => null,
-                    2 => date('Y-m-d H:i:s', strtotime('+1 day')),
-                    3 => date('Y-m-d H:i:s'),
+                    2 => date(self::EXECUTION_DATETIME_FORMAT, strtotime('+1 day')),
+                    3 => date(self::EXECUTION_DATETIME_FORMAT),
                 ],
                 [1, 3, 2],
             ],
@@ -460,7 +467,7 @@ class MigrationManagerTest extends TestCase
             ],
             'The method should return the intersection according to the order of executed migrations.' => [
                 [1, 2, 3, 4],
-                [1 => date('Y-m-d H:i:s'), 2 => null, 3 => null],
+                [1 => date(self::EXECUTION_DATETIME_FORMAT), 2 => null, 3 => null],
                 [2, 3, 1],
             ],
             'The method should return a full intersection if the given version is not found in the intersection.' => [


### PR DESCRIPTION
- Adjusted `MigrationMigrateCommand::execute()` with providing a new option `migrate-to-version` which allows defining the version to migrate database.
- Adjusted `MigrationStatusCommand::execute()` with providing a new option `last-version` which allows receiving the last executed version of the migration.