### PR TITLE
Remove deprecated link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,7 @@ Read the [Propel documentation](http://propelorm.org/documentation/01-installati
 
 Everybody is welcome to contribute to Propel! Just [fork the repository](https://docs.github.com/en/get-started/quickstart/fork-a-repo) and [create a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).
 
-Please include unit tests to verify your changes. Have a look at the [test suite documentation](http://propelorm.org/documentation/cookbook/working-with-test-suite.html) for more details about test development in Propel, like how to run tests locally. It also has information on how to apply [Propel coding standards](https://github.com/propelorm/Propel2/wiki/Coding-Standards).
-
-Check out [the roadmap](https://github.com/propelorm/Propel2/wiki) to get an overview of what we are working on.
+Please include unit tests to verify your changes. Have a look at the [test suite guide](http://propelorm.org/documentation/cookbook/working-with-test-suite.html) for more details about test development in Propel, like how to run tests locally. It also has information on how to apply [Propel coding standards](https://github.com/propelorm/Propel2/wiki/Coding-Standards).
 
 More detailed information can be found in our [contribution guideline](http://propelorm.org/contribute.html).
 


### PR DESCRIPTION
As discussed, this removes the deprecated link to the roadmap from the README.

Also changed "test suite documentation" to "test suite guide", seems more accurate.