### PR TITLE
Fix PHPStan

### DIFF
--- a/src/Propel/Common/Config/Loader/FileLoader.php
+++ b/src/Propel/Common/Config/Loader/FileLoader.php
@@ -179,6 +179,7 @@ abstract class FileLoader extends BaseFileLoader
          * when it matches the entire $value, it can resolve to any value.
          * otherwise, it is replaced with the resolved string or number.
          */
+        /** @phpstan-var string|null $onlyKey */
         $onlyKey = null;
         $replaced = preg_replace_callback('/%([^%\s]*+)%/', function ($match) use ($resolving, $value, &$onlyKey) {
             $key = $match[1];

--- a/src/Propel/Runtime/Util/PropelDateTime.php
+++ b/src/Propel/Runtime/Util/PropelDateTime.php
@@ -12,6 +12,7 @@ use DateTime;
 use DateTimeInterface;
 use DateTimeZone;
 use Exception;
+use InvalidArgumentException;
 use Propel\Runtime\Exception\PropelException;
 
 /**
@@ -70,13 +71,15 @@ class PropelDateTime extends DateTime
      *
      * @param string|null $time Optional, in seconds. Floating point allowed.
      *
+     * @throws \InvalidArgumentException
+     *
      * @return \DateTime
      */
     public static function createHighPrecision(?string $time = null): DateTime
     {
         $dateTime = DateTime::createFromFormat('U.u', $time ?: self::getMicrotime());
         if ($dateTime === false) {
-            throw new \InvalidArgumentException('Cannot create a datetime object from `' . $time . '`');
+            throw new InvalidArgumentException('Cannot create a datetime object from `' . $time . '`');
         }
 
         $dateTime->setTimeZone(new DateTimeZone(date_default_timezone_get()));

--- a/src/Propel/Runtime/Util/PropelDateTime.php
+++ b/src/Propel/Runtime/Util/PropelDateTime.php
@@ -68,13 +68,16 @@ class PropelDateTime extends DateTime
      *
      * Usually `new \Datetime()` does not contain milliseconds so you need a method like this.
      *
-     * @param bool|null $time optional in seconds. floating point allowed.
+     * @param string|null $time Optional, in seconds. Floating point allowed.
      *
      * @return \DateTime
      */
-    public static function createHighPrecision(?bool $time = null): DateTime
+    public static function createHighPrecision(?string $time = null): DateTime
     {
         $dateTime = DateTime::createFromFormat('U.u', $time ?: self::getMicrotime());
+        if ($dateTime === false) {
+            throw new \InvalidArgumentException('Cannot create a datetime object from `' . $time . '`');
+        }
 
         $dateTime->setTimeZone(new DateTimeZone(date_default_timezone_get()));
 

--- a/src/Propel/Runtime/Util/UuidConverter.php
+++ b/src/Propel/Runtime/Util/UuidConverter.php
@@ -9,12 +9,12 @@
 namespace Propel\Runtime\Util;
 
 /**
- * Helpes to manually convert uuids to byte types
+ * Helps to manually convert UUIDs to byte types
  */
 class UuidConverter
 {
     /**
-     * Transforms a uuid string to a binary string.
+     * Transforms a UUID string to a binary string.
      *
      * @param string $uuid
      * @param bool $swapFlag Swap first four bytes for better indexing of version-1 UUIDs (@link https://dev.mysql.com/doc/refman/8.0/en/miscellaneous-functions.html#function_uuid-to-bin)
@@ -31,11 +31,11 @@ class UuidConverter
                 $uuid,
             );
 
-        return hex2bin($rawHex);
+        return (string)hex2bin($rawHex);
     }
 
     /**
-     * Transforms a binary string to a uuid string.
+     * Transforms a binary string to a UUID string.
      *
      * @param string $bin
      * @param bool $swapFlag Assume bytes were swapped (@link https://dev.mysql.com/doc/refman/8.0/en/miscellaneous-functions.html#function_bin-to-uuid)

--- a/src/Propel/Runtime/Validator/Constraints/UniqueValidator.php
+++ b/src/Propel/Runtime/Validator/Constraints/UniqueValidator.php
@@ -37,7 +37,7 @@ class UniqueValidator extends ConstraintValidator
         $object = $this->context->getObject();
         if ($object->isNew() && $matches->count() > 0) {
             $this->context->addViolation($constraint->message);
-        } elseif ($object->isModified() && $matches->count() > (in_array($columnName, $object->getModifiedColumns()) ? 0 : 1)) {
+        } elseif ($object->isModified() && $matches->count() > (in_array($columnName, $object->getModifiedColumns(), true) ? 0 : 1)) {
             $this->context->addViolation($constraint->message);
         }
     }

--- a/tests/Propel/Tests/Runtime/Util/PropelDateTimeTest.php
+++ b/tests/Propel/Tests/Runtime/Util/PropelDateTimeTest.php
@@ -260,7 +260,7 @@ class PropelDateTimeTest extends TestCase
         $originalTimezone = date_default_timezone_get();
         date_default_timezone_set('America/New_York');
 
-        $createHP = PropelDateTime::createHighPrecision();
+        $createHP = PropelDateTime::createHighPrecision(PropelDateTime::getMicrotime());
 
         $dt = new DateTime();
         $dt->setTimezone(new DateTimeZone('America/New_York'));


### PR DESCRIPTION
PHPStan latest version seems to make master red

This fixes the issues for <=8.1

For 8.2 we first need to add the version into CI matrix and then fix the following:
```
 ------ -------------------------------------------------------------------------------------------------------------------------- 
  Line   Propel/Generator/Behavior/Archivable/ArchivableBehavior.php                                                               
 ------ -------------------------------------------------------------------------------------------------------------------------- 
  69     Call to function property_exists() with Propel\Generator\Model\Table and 'isArchiveTable' will always evaluate to false.  
 ------ -------------------------------------------------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   Propel/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceBehavior.php                                                                           
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------- 
  90     Ignored error pattern #^Access to an undefined property Propel\\Generator\\Model\\ForeignKey\:\:\$isParentChild\.$# in path                             
         /work/git/Propel2/src/Propel/Generator/Behavior/ConcreteInheritance/ConcreteInheritanceBehavior.php is expected to occur 1 time, but occurred 2 times.  
  389    Access to an undefined property Propel\Generator\Model\ForeignKey::$isParentChild.                                                                      
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------------------------------------------- 
  Line   Propel/Generator/Behavior/Versionable/VersionableBehavior.php                                                             
 ------ -------------------------------------------------------------------------------------------------------------------------- 
  70     Call to function property_exists() with Propel\Generator\Model\Table and 'isVersionTable' will always evaluate to false.  
 ------ -------------------------------------------------------------------------------------------------------------------------- 

                                                                                                                        
 [ERROR] Found 4 errors                                                                                                                                                                                                                      
```