### PR TITLE
Support ON UPDATE CURRENT_TIMESTAMP in MySQL

### DIFF
--- a/src/Propel/Generator/Reverse/MysqlSchemaParser.php
+++ b/src/Propel/Generator/Reverse/MysqlSchemaParser.php
@@ -264,6 +264,8 @@ class MysqlSchemaParser extends AbstractSchemaParser
         // BLOBs can't have any default values in MySQL
         $default = preg_match('~blob|text~', $nativeType) ? null : $row['Default'];
 
+        $extra = $row['Extra'];
+
         $propelType = $this->getMappedPropelType($nativeType);
         if (!$propelType) {
             $propelType = Column::DEFAULT_TYPE;
@@ -295,6 +297,9 @@ class MysqlSchemaParser extends AbstractSchemaParser
             }
             if (in_array($default, ['CURRENT_TIMESTAMP', 'current_timestamp()'], true)) {
                 $default = 'CURRENT_TIMESTAMP';
+                if (strpos(strtolower($extra), 'on update current_timestamp()') !== false) {
+                    $default = 'CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP';
+                }
                 $type = ColumnDefaultValue::TYPE_EXPR;
             } else {
                 $type = ColumnDefaultValue::TYPE_VALUE;

--- a/tests/Fixtures/bookstore/schema.xml
+++ b/tests/Fixtures/bookstore/schema.xml
@@ -174,6 +174,7 @@
         <column name="enabled" type="BOOLEAN" default="true"/>
         <column name="not_enabled" type="BOOLEAN" default="false"/>
         <column name="created" type="TIMESTAMP" defaultExpr="CURRENT_TIMESTAMP"/>
+        <column name="updated" type="TIMESTAMP" defaultExpr="CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"/>
         <column name="role_id" type="INTEGER" required="false" default="null"/>
         <column name="authenticator" type="VARCHAR" size="32" defaultExpr="'Password'"/>
         <foreign-key foreignTable="bookstore_employee" onDelete="cascade">

--- a/tests/Propel/Tests/Generator/Reverse/MysqlSchemaParserTest.php
+++ b/tests/Propel/Tests/Generator/Reverse/MysqlSchemaParserTest.php
@@ -9,6 +9,7 @@
 namespace Propel\Tests\Generator\Reverse;
 
 use PDO;
+use Propel\Generator\Model\ColumnDefaultValue;
 use Propel\Generator\Reverse\MysqlSchemaParser;
 use Propel\Tests\Bookstore\Map\BookTableMap;
 
@@ -80,5 +81,16 @@ EOT;
         $bookTable = $this->parsedDatabase->getTable('book');
         $this->assertEquals('Book Table', $bookTable->getDescription());
         $this->assertEquals('Book Title', $bookTable->getColumn('title')->getDescription());
+    }
+
+    /**
+     * @return void
+     */
+    public function testOnUpdateIsImported(): void
+    {
+        $onUpdateTable = $this->parsedDatabase->getTable('bookstore_employee_account');
+        $updatedAtColumn = $onUpdateTable->getColumn('updated');
+        $this->assertEquals(ColumnDefaultValue::TYPE_EXPR, $updatedAtColumn->getDefaultValue()->getType());
+        $this->assertEquals('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP', $updatedAtColumn->getDefaultValue()->getValue());
     }
 }


### PR DESCRIPTION
This PR adds support for `defaultExpr="CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"` for MySQL as requested in #1203. Previously, a migration would always contain an ALTER Statement to set `ON UPDATE CURRENT_TIMESTAMP` although it is already like that in the database. The root cause was that the `Extra` part was not checked in the `MysqlSchemaParser` class.