### PR TITLE
fix tests after Symfony PropertyInfo update

### DIFF
--- a/tests/Propel/Tests/Generator/Behavior/Validate/I18nConcreteInheritanceHandleValidateBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Validate/I18nConcreteInheritanceHandleValidateBehaviorTest.php
@@ -87,11 +87,6 @@ class I18nConcreteInheritanceHandleValidateBehaviorTest extends BookstoreTestBas
 
         $fictionMetadatas = $fictionMetadata->getPropertyMetadata('isbn');
 
-        // 1st is for ValidateTriggerFiction (base)
-        // 2nd is for ValidateTriggerBook (base)
-        // I'm not sure if this is needed. We should not care about validator internals
-        $this->assertCount(2, $fictionMetadatas);
-
         $expectedValidatorGroups = [
             'ValidateTriggerFiction',
             'ValidateTriggerBook',


### PR DESCRIPTION
With the current Symfony components, one test in the 5-max and and 6-max group fails, see for example [this run](https://github.com/alfredbez/Propel2/actions/runs/5519629077/jobs/10065145653).

Apparently, the [Symfony PropertyInfo](https://symfony.com/doc/current/components/property_info.html) has changed internally, and now an assertion fails. A comment in the test acknowledges that it tests Symfony internals:
```php
        $fictionMetadatas = $fictionMetadata->getPropertyMetadata('isbn');

        // 1st is for ValidateTriggerFiction (base)
        // 2nd is for ValidateTriggerBook (base)
        // I'm not sure if this is needed. We should not care about validator internals
        $this->assertCount(2, $fictionMetadatas);
``` 
Examining `$fictionMetadatas`, I can see that both `ValidateTriggerFiction` and `ValidateTriggerBook` are present in `$fictionMetadatas[0].constraintsByGroup`: 

![Screenshot_2023-07-11_15-42-15](https://github.com/propelorm/Propel2/assets/9800945/6f9d4efd-4277-4d2b-a5e4-03f99613c22f)

This is also successfully tested in the rest of the test case.

So apparently the PropertyInfo component now groups those constraints in the same PropertyMetadata object instead of using a new object for each. But this does not concern Propel. So we can just remove that assertion. We could also turn it into `assertNotEmpty()`, but that is tested implicitly in the next assertion.