### PR TITLE
criteria uses named joins internally

### DIFF
--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -1088,7 +1088,12 @@ class Criteria
 
         $join->setJoinType($joinType);
 
-        $this->addJoinObject($join);
+        if ($leftTableAlias !== null) {
+            $this->addJoinObject($join, $leftTableAlias);
+        }
+        else {
+            $this->addJoinObject($join, $leftTableName);
+        }
 
         return $this;
     }
@@ -1167,7 +1172,12 @@ class Criteria
         $join->setJoinType($joinType);
         $join->setJoinCondition($joinCondition);
 
-        $this->addJoinObject($join);
+        if ($join->getLeftTableAlias()) {
+            $this->addJoinObject($join, $join->getLeftTableAlias());
+        }
+        else {
+            $this->addJoinObject($join, $join->getLeftTableName());
+        }
 
         return $this;
     }
@@ -1176,13 +1186,18 @@ class Criteria
      * Add a join object to the Criteria
      *
      * @param \Propel\Runtime\ActiveQuery\Join $join A join object
+     * @param string $join A name for the join
      *
      * @return $this A modified Criteria object
      */
-    public function addJoinObject(Join $join)
+    public function addJoinObject(Join $join, ?string $name = null)
     {
         if (!in_array($join, $this->joins)) { // compare equality, NOT identity
-            $this->joins[] = $join;
+            if ($name === null) {
+                $this->joins[] = $join;
+            } else {
+                $this->joins[$name] = $join;
+            }
         }
 
         return $this;

--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -1184,9 +1184,9 @@ class Criteria
      * Add a join object to the Criteria
      *
      * @param \Propel\Runtime\ActiveQuery\Join $join A join object
-     * @param string $join A name for the join
+     * @param string|null $name
      *
-     * @return $this A modified Criteria object
+     * @return $this The current object, for fluid interface
      */
     public function addJoinObject(Join $join, ?string $name = null)
     {

--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -1088,10 +1088,11 @@ class Criteria
 
         $join->setJoinType($joinType);
 
-        if ($rightTableAlias !== null) {
-            $this->addJoinObject($join, $rightTableAlias);
-        } else {
-            $this->addJoinObject($join, $rightTableName);
+        if ($leftTableAlias !== null) {
+            $this->addJoinObject($join, $leftTableAlias);
+        }
+        else {
+            $this->addJoinObject($join, $leftTableName);
         }
 
         return $this;
@@ -1171,10 +1172,11 @@ class Criteria
         $join->setJoinType($joinType);
         $join->setJoinCondition($joinCondition);
 
-        if ($join->getRightTableAlias()) {
-            $this->addJoinObject($join, $join->getRightTableAlias());
-        } else {
-            $this->addJoinObject($join, $join->getRightTableName());
+        if ($join->getLeftTableAlias()) {
+            $this->addJoinObject($join, $join->getLeftTableAlias());
+        }
+        else {
+            $this->addJoinObject($join, $join->getLeftTableName());
         }
 
         return $this;

--- a/src/Propel/Runtime/ActiveQuery/Criteria.php
+++ b/src/Propel/Runtime/ActiveQuery/Criteria.php
@@ -1088,11 +1088,10 @@ class Criteria
 
         $join->setJoinType($joinType);
 
-        if ($leftTableAlias !== null) {
-            $this->addJoinObject($join, $leftTableAlias);
-        }
-        else {
-            $this->addJoinObject($join, $leftTableName);
+        if ($rightTableAlias !== null) {
+            $this->addJoinObject($join, $rightTableAlias);
+        } else {
+            $this->addJoinObject($join, $rightTableName);
         }
 
         return $this;
@@ -1172,11 +1171,10 @@ class Criteria
         $join->setJoinType($joinType);
         $join->setJoinCondition($joinCondition);
 
-        if ($join->getLeftTableAlias()) {
-            $this->addJoinObject($join, $join->getLeftTableAlias());
-        }
-        else {
-            $this->addJoinObject($join, $join->getLeftTableName());
+        if ($join->getRightTableAlias()) {
+            $this->addJoinObject($join, $join->getRightTableAlias());
+        } else {
+            $this->addJoinObject($join, $join->getRightTableName());
         }
 
         return $this;

--- a/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
+++ b/src/Propel/Runtime/ActiveQuery/ModelCriteria.php
@@ -726,29 +726,6 @@ class ModelCriteria extends BaseModelCriteria
     }
 
     /**
-     * Add a join object to the Criteria
-     *
-     * @see Criteria::addJoinObject()
-     *
-     * @param \Propel\Runtime\ActiveQuery\Join $join A join object
-     * @param string|null $name
-     *
-     * @return $this The current object, for fluid interface
-     */
-    public function addJoinObject(Join $join, ?string $name = null)
-    {
-        if (!in_array($join, $this->joins)) { // compare equality, NOT identity
-            if ($name === null) {
-                $this->joins[] = $join;
-            } else {
-                $this->joins[$name] = $join;
-            }
-        }
-
-        return $this;
-    }
-
-    /**
      * Adds a JOIN clause to the query and hydrates the related objects
      * Shortcut for $c->join()->with()
      * <code>


### PR DESCRIPTION
Criteria's joins ( from addJoin ) does not uses named joins, unlike... Criteria's joins.

There is a brain split at some time, where it exposes `public function getJoin(string $name): Join`, public methods that can never work on a raw Criteria instance that never put a name on these joins.

#1919