### PR TITLE
Improve PHP 8.2 compatibility : Partially-supported callable are deprecated

### DIFF
--- a/templates/Builder/Om/baseObjectMethodHook.php
+++ b/templates/Builder/Om/baseObjectMethodHook.php
@@ -8,7 +8,7 @@
     public function preSave(?ConnectionInterface $con = null): bool
     {
         <?php if ($hasBaseClass) : ?>
-        if (is_callable('parent::preSave')) {
+        if (is_callable(parent::class.'::preSave')) {
             return parent::preSave($con);
         }
         <?php endif?>
@@ -25,7 +25,7 @@
     public function postSave(?ConnectionInterface $con = null): void
     {
         <?php if ($hasBaseClass) : ?>
-        if (is_callable('parent::postSave')) {
+        if (is_callable(parent::class.'::postSave')) {
             parent::postSave($con);
         }
         <?php endif?>
@@ -41,7 +41,7 @@
     public function preInsert(?ConnectionInterface $con = null): bool
     {
         <?php if ($hasBaseClass) : ?>
-        if (is_callable('parent::preInsert')) {
+        if (is_callable(parent::class.'::preInsert')) {
             return parent::preInsert($con);
         }
         <?php endif?>
@@ -58,7 +58,7 @@
     public function postInsert(?ConnectionInterface $con = null): void
     {
         <?php if ($hasBaseClass) : ?>
-        if (is_callable('parent::postInsert')) {
+        if (is_callable(parent::class.'::postInsert')) {
             parent::postInsert($con);
         }
         <?php endif?>
@@ -74,7 +74,7 @@
     public function preUpdate(?ConnectionInterface $con = null): bool
     {
         <?php if ($hasBaseClass) : ?>
-        if (is_callable('parent::preUpdate')) {
+        if (is_callable(parent::class.'::preUpdate')) {
             return parent::preUpdate($con);
         }
         <?php endif?>
@@ -91,7 +91,7 @@
     public function postUpdate(?ConnectionInterface $con = null): void
     {
         <?php if ($hasBaseClass) : ?>
-        if (is_callable('parent::postUpdate')) {
+        if (is_callable(parent::class.'::postUpdate')) {
             parent::postUpdate($con);
         }
         <?php endif?>
@@ -107,7 +107,7 @@
     public function preDelete(?ConnectionInterface $con = null): bool
     {
         <?php if ($hasBaseClass) : ?>
-        if (is_callable('parent::preDelete')) {
+        if (is_callable(parent::class.'::preDelete')) {
             return parent::preDelete($con);
         }
         <?php endif?>
@@ -124,7 +124,7 @@
     public function postDelete(?ConnectionInterface $con = null): void
     {
         <?php if ($hasBaseClass) : ?>
-        if (is_callable('parent::postDelete')) {
+        if (is_callable(parent::class.'::postDelete')) {
             parent::postDelete($con);
         }
         <?php endif?>


### PR DESCRIPTION
The propel gen command when a table in schema.xml depends on a baseClass generates code
in the "Base" namespace that is not compatible with PHP 8.2. 

For example, when saving the object, a deprecation warning is displayed: 
`Deprecated: Use of "self" in callables is deprecated in ... on line ...`

This is a known issue whith PHP8.2 :
[https://php.watch/versions/8.2/partially-supported-callable-deprecation](url)