### PR TITLE
Make compatible with 8.2 ArrayIterator interface updates

### DIFF
--- a/src/Propel/Generator/Platform/DefaultPlatform.php
+++ b/src/Propel/Generator/Platform/DefaultPlatform.php
@@ -492,7 +492,7 @@ DROP TABLE IF EXISTS " . $this->quoteIdentifier($table->getName()) . ";
      * // '"foo","bar"'
      * </code>
      *
-     * @param Array<\Propel\Generator\Model\Column> $columns
+     * @param array<\Propel\Generator\Model\Column> $columns
      * @param string $delimiter The delimiter to use in separating the column names.
      *
      * @return string

--- a/src/Propel/Generator/Platform/DefaultPlatform.php
+++ b/src/Propel/Generator/Platform/DefaultPlatform.php
@@ -492,7 +492,7 @@ DROP TABLE IF EXISTS " . $this->quoteIdentifier($table->getName()) . ";
      * // '"foo","bar"'
      * </code>
      *
-     * @param array<Column> $columns
+     * @param array<\Propel\Generator\Model\Column> $columns
      * @param string $delimiter The delimiter to use in separating the column names.
      *
      * @return string

--- a/src/Propel/Generator/Platform/DefaultPlatform.php
+++ b/src/Propel/Generator/Platform/DefaultPlatform.php
@@ -492,7 +492,7 @@ DROP TABLE IF EXISTS " . $this->quoteIdentifier($table->getName()) . ";
      * // '"foo","bar"'
      * </code>
      *
-     * @param \Propel\Generator\Model\Column[] $columns
+     * @param Array<\Propel\Generator\Model\Column> $columns
      * @param string $delimiter The delimiter to use in separating the column names.
      *
      * @return string

--- a/src/Propel/Generator/Platform/DefaultPlatform.php
+++ b/src/Propel/Generator/Platform/DefaultPlatform.php
@@ -492,7 +492,7 @@ DROP TABLE IF EXISTS " . $this->quoteIdentifier($table->getName()) . ";
      * // '"foo","bar"'
      * </code>
      *
-     * @param array<\Propel\Generator\Model\Column> $columns
+     * @param array<Column> $columns
      * @param string $delimiter The delimiter to use in separating the column names.
      *
      * @return string

--- a/src/Propel/Generator/Platform/PlatformInterface.php
+++ b/src/Propel/Generator/Platform/PlatformInterface.php
@@ -143,7 +143,7 @@ interface PlatformInterface
      * // '"foo","bar"'
      * </code>
      *
-     * @param Array<\Propel\Generator\Model\Column>|Array<string> $columns
+     * @param array<\Propel\Generator\Model\Column>|array<string> $columns
      * @param string $delimiter The delimiter to use in separating the column names.
      *
      * @return string

--- a/src/Propel/Generator/Platform/PlatformInterface.php
+++ b/src/Propel/Generator/Platform/PlatformInterface.php
@@ -143,7 +143,7 @@ interface PlatformInterface
      * // '"foo","bar"'
      * </code>
      *
-     * @param \Propel\Generator\Model\Column[]|string[] $columns
+     * @param Array<\Propel\Generator\Model\Column>|Array<string> $columns
      * @param string $delimiter The delimiter to use in separating the column names.
      *
      * @return string

--- a/src/Propel/Generator/Platform/PlatformInterface.php
+++ b/src/Propel/Generator/Platform/PlatformInterface.php
@@ -143,7 +143,7 @@ interface PlatformInterface
      * // '"foo","bar"'
      * </code>
      *
-     * @param array<\Propel\Generator\Model\Column>|array<string> $columns
+     * @param array<Column>|string[] $columns
      * @param string $delimiter The delimiter to use in separating the column names.
      *
      * @return string

--- a/src/Propel/Generator/Platform/PlatformInterface.php
+++ b/src/Propel/Generator/Platform/PlatformInterface.php
@@ -143,7 +143,7 @@ interface PlatformInterface
      * // '"foo","bar"'
      * </code>
      *
-     * @param array<Column>|string[] $columns
+     * @param array<\Propel\Generator\Model\Column>|array<string> $columns
      * @param string $delimiter The delimiter to use in separating the column names.
      *
      * @return string

--- a/src/Propel/Runtime/Collection/CollectionIterator.php
+++ b/src/Propel/Runtime/Collection/CollectionIterator.php
@@ -248,8 +248,9 @@ class CollectionIterator extends ArrayIterator implements IteratorInterface
     /**
      * @param int $flags Not used
      *
-     * @return bool
+     * @return true
      */
+    #[\ReturnTypeWillChange]
     public function asort(int $flags = SORT_REGULAR): bool
     {
         parent::asort();
@@ -261,8 +262,9 @@ class CollectionIterator extends ArrayIterator implements IteratorInterface
     /**
      * @param int $flags Not used
      *
-     * @return bool
+     * @return true
      */
+    #[\ReturnTypeWillChange]
     public function ksort(int $flags = SORT_REGULAR): bool
     {
         parent::ksort();
@@ -274,8 +276,9 @@ class CollectionIterator extends ArrayIterator implements IteratorInterface
     /**
      * @param callable $callback
      *
-     * @return bool
+     * @return true
      */
+    #[\ReturnTypeWillChange]
     public function uasort($callback): bool
     {
         parent::uasort($callback);
@@ -287,8 +290,9 @@ class CollectionIterator extends ArrayIterator implements IteratorInterface
     /**
      * @param callable $callback
      *
-     * @return bool
+     * @return true
      */
+    #[\ReturnTypeWillChange]
     public function uksort($callback): bool
     {
         parent::uksort($callback);
@@ -298,8 +302,9 @@ class CollectionIterator extends ArrayIterator implements IteratorInterface
     }
 
     /**
-     * @return bool
+     * @return true
      */
+    #[\ReturnTypeWillChange]
     public function natsort(): bool
     {
         parent::natsort();
@@ -309,8 +314,9 @@ class CollectionIterator extends ArrayIterator implements IteratorInterface
     }
 
     /**
-     * @return bool
+     * @return true
      */
+    #[\ReturnTypeWillChange]
     public function natcasesort(): bool
     {
         parent::natcasesort();


### PR DESCRIPTION
`ArrayIterator` interface has gone with explicit `true` return values for sort methods.  However, PHP less than 8.2 will crap out on this.  We, instead, add the `#[\ReturnTypeWillChange]` attribute until we can make 8.2 the minimum supported version.

This replaces/closes #1984 