### PR TITLE
bugfix for #1662 - allow defaultValue for TEXT and BLOB fields (mariadb)

### DIFF
--- a/src/Propel/Generator/Platform/MysqlPlatform.php
+++ b/src/Propel/Generator/Platform/MysqlPlatform.php
@@ -464,10 +464,6 @@ DROP TABLE IF EXISTS " . $this->quoteIdentifier($table->getName()) . ";
             if ($def && $def->isExpression()) {
                 throw new EngineException('DATE columns cannot have default *expressions* in MySQL.');
             }
-        } elseif ($sqlType === 'TEXT' || $sqlType === 'BLOB') {
-            if ($domain->getDefaultValue()) {
-                throw new EngineException('BLOB and TEXT columns cannot have DEFAULT values. in MySQL.');
-            }
         }
 
         $ddl = [$this->quoteIdentifier($col->getName())];

--- a/src/Propel/Generator/Reverse/MysqlSchemaParser.php
+++ b/src/Propel/Generator/Reverse/MysqlSchemaParser.php
@@ -264,7 +264,7 @@ class MysqlSchemaParser extends AbstractSchemaParser
         // BLOBs can't have any default values in MySQL
 
         $default = $row['Default'];
-        if (!empty($default)) {
+        if ($default !== null) {
             if (preg_match('~blob|text~', $nativeType)) {
                 // mariadb has extra single quotes on TEXT type default values, but not on other types
                 $default = preg_replace('@^\'(.*)\'$@', '$1', $row['Default']);

--- a/src/Propel/Generator/Reverse/MysqlSchemaParser.php
+++ b/src/Propel/Generator/Reverse/MysqlSchemaParser.php
@@ -262,7 +262,14 @@ class MysqlSchemaParser extends AbstractSchemaParser
         }
 
         // BLOBs can't have any default values in MySQL
-        $default = preg_match('~blob|text~', $nativeType) ? null : $row['Default'];
+
+        $default = $row['Default'];
+        if (!empty($default)) {
+            if (preg_match('~blob|text~', $nativeType)) {
+                // mariadb has extra single quotes on TEXT type default values, but not on other types
+                $default = preg_replace('@^\'(.*)\'$@', '$1', $row['Default']);
+            }
+        }
 
         $propelType = $this->getMappedPropelType($nativeType);
         if (!$propelType) {


### PR DESCRIPTION
- removed blob/text default value checks
- implemented unquote of default values on TEXT/BLOB fields
- tested with mariadb 11.2.3