### PR TITLE
WIP Update CI with newer PHP and PSQL versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,15 +60,6 @@ jobs:
                   postgresql user: $DB_USER
                   postgresql password: $DB_PW
 
-            - name: Install PostgreSQL 12
-              if: matrix.db-type == 'pgsql' && matrix.php-version == '7.4'
-              uses: CasperWA/postgresql-action@v1.2
-              with:
-                  postgresql version: 12
-                  postgresql db: $DB_NAME
-                  postgresql user: $DB_USER
-                  postgresql password: $DB_PW
-
             - name: Install PostgreSQL min
               if: matrix.db-type == 'pgsql' && matrix.php-version == '7.4' && matrix.symfony-version == '6-min'
               uses: CasperWA/postgresql-action@v1.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,26 @@ jobs:
                   postgresql user: $DB_USER
                   postgresql password: $DB_PW
 
-            - name: Install PostgreSQL min
+            - name: Install PostgreSQL 16
+              if: matrix.db-type == 'pgsql' && matrix.php-version == '7.4' && matrix.symfony-version == '6-max'
+              uses: CasperWA/postgresql-action@v1.2
+              with:
+                  postgresql version: 16
+                  postgresql db: $DB_NAME
+                  postgresql user: $DB_USER
+                  postgresql password: $DB_PW
+
+            - name: Install PostgreSQL 12
               if: matrix.db-type == 'pgsql' && matrix.php-version == '7.4'
+              uses: CasperWA/postgresql-action@v1.2
+              with:
+                  postgresql version: 12
+                  postgresql db: $DB_NAME
+                  postgresql user: $DB_USER
+                  postgresql password: $DB_PW
+
+            - name: Install PostgreSQL min
+              if: matrix.db-type == 'pgsql' && matrix.php-version == '7.4' && matrix.symfony-version == '6-min'
               uses: CasperWA/postgresql-action@v1.2
               with:
                   postgresql version: 9

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
                   postgresql password: $DB_PW
 
             - name: Install PostgreSQL 16
-              if: matrix.db-type == 'pgsql' && matrix.php-version == '7.4' && matrix.symfony-version == '6-max'
+              if: matrix.db-type == 'pgsql' && matrix.php-version == '7.4' && matrix.symfony-version == '5-max'
               uses: CasperWA/postgresql-action@v1.2
               with:
                   postgresql version: 16
@@ -61,7 +61,7 @@ jobs:
                   postgresql password: $DB_PW
 
             - name: Install PostgreSQL min
-              if: matrix.db-type == 'pgsql' && matrix.php-version == '7.4' && matrix.symfony-version == '6-min'
+              if: matrix.db-type == 'pgsql' && matrix.php-version == '7.4' && matrix.symfony-version == '5-min'
               uses: CasperWA/postgresql-action@v1.2
               with:
                   postgresql version: 9

--- a/tests/bin/setup.pgsql.sh
+++ b/tests/bin/setup.pgsql.sh
@@ -16,7 +16,7 @@ if [ "$DB_NAME" = "" ]; then
 fi
 
 DB_HOSTNAME=${DB_HOSTNAME-127.0.0.1};
-DB_PW=${DB_PW-$PGPASSWORD};.0.1};
+DB_PW=${DB_PW-$PGPASSWORD};
 DB_PORT=${DB_PORT-5432};
 
 if [ -z "$DB_PW" ]; then


### PR DESCRIPTION
1. We need to include the PHP 8.3 in the standard CI process.
2. We need to ensure compatibility with the latest PSQL versions (atm the jobs are stopped).