### PR TITLE
FIX failing queries on datetime fields set to 1970-01-01 00:00:00 via (int) 0

### DIFF
--- a/src/Propel/Runtime/Util/PropelDateTime.php
+++ b/src/Propel/Runtime/Util/PropelDateTime.php
@@ -116,7 +116,7 @@ class PropelDateTime extends DateTime
         if ($value instanceof DateTimeInterface) {
             return $value;
         }
-        if (!$value) {
+        if ($value === false || $value === null || $value === '') {
             // '' is seen as NULL for temporal objects
             // because DateTime('') == DateTime('now') -- which is unexpected
             return null;

--- a/tests/Propel/Tests/Runtime/Util/PropelDateTimeTest.php
+++ b/tests/Propel/Tests/Runtime/Util/PropelDateTimeTest.php
@@ -208,6 +208,7 @@ class PropelDateTimeTest extends TestCase
             'Y-m-d' => ['2011-08-10', '2011-08-10 00:00:00'],
             // 1312960848 : Wed, 10 Aug 2011 07:20:48 GMT
             'unix_timestamp' => ['1312960848', '2011-08-10 07:20:48'],
+            'unix_timestamp_epoch' => ['0', '1970-01-01 00:00:00'],
             'Y-m-d H:is' => ['2011-08-10 10:22:15', '2011-08-10 10:22:15'],
             'Ymd' => ['20110810', '2011-08-10 00:00:00'],
             'Ymd2' => ['20110720', '2011-07-20 00:00:00'],
@@ -234,6 +235,7 @@ class PropelDateTimeTest extends TestCase
     public function testIsTimestamp()
     {
         $this->assertEquals(false, TestPropelDateTime::isTimestamp('20110325'));
+        $this->assertEquals(true, TestPropelDateTime::isTimestamp(0));
         $this->assertEquals(true, TestPropelDateTime::isTimestamp(1319580000));
         $this->assertEquals(true, TestPropelDateTime::isTimestamp('1319580000'));
         $this->assertEquals(false, TestPropelDateTime::isTimestamp('2011-07-20 00:00:00'));


### PR DESCRIPTION
The Problem was the not-type-safe null-check in the PropelDateTime util class.
Passing an Integer 0 (that e.g. comes from the SplFileInfo::getMtime()) to the setter of the field, results in the 0 being interpreted as null, thus the update/insert query is failing.


FIxes #2010

Changelog: Improved falsy value handling in PropelDateTime; now treats '', false, and null as null, and '0' as the Unix epoch