### PR TITLE
Fix php8.2 deprecation - Use of "parent" in callables is deprecated

### DIFF
--- a/templates/Builder/Om/baseObjectMethodHook.php
+++ b/templates/Builder/Om/baseObjectMethodHook.php
@@ -8,7 +8,7 @@
     public function preSave(?ConnectionInterface $con = null): bool
     {
         <?php if ($hasBaseClass) : ?>
-        if (is_callable('parent::preSave')) {
+        if (is_callable([parent::class, 'preSave'])) {
             return parent::preSave($con);
         }
         <?php endif?>
@@ -25,7 +25,7 @@
     public function postSave(?ConnectionInterface $con = null): void
     {
         <?php if ($hasBaseClass) : ?>
-        if (is_callable('parent::postSave')) {
+        if (is_callable([parent::class, 'postSave'])) {
             parent::postSave($con);
         }
         <?php endif?>
@@ -41,7 +41,7 @@
     public function preInsert(?ConnectionInterface $con = null): bool
     {
         <?php if ($hasBaseClass) : ?>
-        if (is_callable('parent::preInsert')) {
+        if (is_callable([parent::class, 'preInsert'])) {
             return parent::preInsert($con);
         }
         <?php endif?>
@@ -58,7 +58,7 @@
     public function postInsert(?ConnectionInterface $con = null): void
     {
         <?php if ($hasBaseClass) : ?>
-        if (is_callable('parent::postInsert')) {
+        if (is_callable([parent::class, 'postInsert'])) {
             parent::postInsert($con);
         }
         <?php endif?>
@@ -74,7 +74,7 @@
     public function preUpdate(?ConnectionInterface $con = null): bool
     {
         <?php if ($hasBaseClass) : ?>
-        if (is_callable('parent::preUpdate')) {
+        if (is_callable([parent::class, 'preUpdate'])) {
             return parent::preUpdate($con);
         }
         <?php endif?>
@@ -91,7 +91,7 @@
     public function postUpdate(?ConnectionInterface $con = null): void
     {
         <?php if ($hasBaseClass) : ?>
-        if (is_callable('parent::postUpdate')) {
+        if (is_callable([parent::class, 'postUpdate'])) {
             parent::postUpdate($con);
         }
         <?php endif?>
@@ -107,7 +107,7 @@
     public function preDelete(?ConnectionInterface $con = null): bool
     {
         <?php if ($hasBaseClass) : ?>
-        if (is_callable('parent::preDelete')) {
+        if (is_callable([parent::class, 'preDelete'])) {
             return parent::preDelete($con);
         }
         <?php endif?>
@@ -124,7 +124,7 @@
     public function postDelete(?ConnectionInterface $con = null): void
     {
         <?php if ($hasBaseClass) : ?>
-        if (is_callable('parent::postDelete')) {
+        if (is_callable([parent::class, 'postDelete'])) {
             parent::postDelete($con);
         }
         <?php endif?>


### PR DESCRIPTION
@see https://3v4l.org/dbOp6 when using `is_callable('parent::preSave')`

```
Output for 8.2.0 - 8.2.23, 8.3.0 - 8.3.11
    Deprecated: Use of "parent" in callables is deprecated in /in/dbOp6 on line 15
    Foo::preSave
    Bar::preSave
Output for 5.3.0 - 5.3.29, 5.4.0 - 5.4.45, 5.5.0 - 5.5.38, 5.6.0 - 5.6.40, 7.0.0 - 7.0.33, 7.1.0 - 7.1.33, 7.2.0 - 7.2.34, 7.3.0 - 7.3.33, 7.4.0 - 7.4.33, 8.0.0 - 8.0.30, 8.1.0 - 8.1.29
    Foo::preSave
    Bar::preSave
```

@see https://3v4l.org/OrSnV when using `is_callable([parent::class, 'preSave'])`, the syntax is also compatible with PHP 7.4, minimal version of the `Propel` library

```
Output for 5.5.0 - 5.5.38, 5.6.0 - 5.6.40, 7.0.0 - 7.0.33, 7.1.0 - 7.1.33, 7.2.0 - 7.2.34, 7.3.0 - 7.3.33, 7.4.0 - 7.4.33, 8.0.0 - 8.0.30, 8.1.0 - 8.1.29, 8.2.0 - 8.2.23, 8.3.0 - 8.3.11
    Foo::preSave
    Bar::preSave
Output for 5.4.0 - 5.4.45
    Parse error: syntax error, unexpected 'class' (T_CLASS), expecting identifier (T_STRING) or variable (T_VARIABLE) or '{' or '$' in /in/OrSnV on line 15

    Process exited with code 255.
```

