### PR TITLE
fix timestampable use of datetimeclass

### DIFF
--- a/src/Propel/Generator/Behavior/Timestampable/TimestampableBehavior.php
+++ b/src/Propel/Generator/Behavior/Timestampable/TimestampableBehavior.php
@@ -9,6 +9,7 @@
 namespace Propel\Generator\Behavior\Timestampable;
 
 use Propel\Generator\Builder\Om\AbstractOMBuilder;
+use Propel\Generator\Builder\Om\ObjectBuilder;
 use Propel\Generator\Model\Behavior;
 
 /**
@@ -102,7 +103,12 @@ class TimestampableBehavior extends Behavior
     {
         if ($this->withUpdatedAt()) {
             $updateColumn = $this->getTable()->getColumn($this->getParameter('update_column'));
-            $dateTimeClass = $builder->getDateTimeClass($updateColumn);
+
+            $dateTimeClass = 'DateTime';
+
+            if ($builder instanceof ObjectBuilder) {
+                $dateTimeClass = $builder->getDateTimeClass($updateColumn);
+            }
 
             $valueSource = strtoupper($updateColumn->getType()) === 'INTEGER'
                 ? 'time()'
@@ -130,7 +136,12 @@ $mtime = PropelDateTime::formatMicrotime(microtime(true));';
 
         if ($this->withCreatedAt()) {
             $createColumn = $this->getTable()->getColumn($this->getParameter('create_column'));
-            $dateTimeClass = $builder->getDateTimeClass($createColumn);
+
+            $dateTimeClass = 'DateTime';
+
+            if ($builder instanceof ObjectBuilder) {
+                $dateTimeClass = $builder->getDateTimeClass($createColumn);
+            }
 
             $script .= "
 \$highPrecisionCreate = PropelDateTime::createHighPrecision(\$mtime, '$dateTimeClass');";
@@ -146,7 +157,12 @@ if (!\$this->isColumnModified(" . $this->getColumnConstant('create_column', $bui
 
         if ($this->withUpdatedAt()) {
             $updateColumn = $this->getTable()->getColumn($this->getParameter('update_column'));
-            $dateTimeClass = $builder->getDateTimeClass($updateColumn);
+
+            $dateTimeClass = 'DateTime';
+
+            if ($builder instanceof ObjectBuilder) {
+                $dateTimeClass = $builder->getDateTimeClass($updateColumn);
+            }
 
             $script .= "
 \$highPrecisionUpdate = PropelDateTime::createHighPrecision(\$mtime, '$dateTimeClass');";

--- a/src/Propel/Generator/Behavior/Timestampable/TimestampableBehavior.php
+++ b/src/Propel/Generator/Behavior/Timestampable/TimestampableBehavior.php
@@ -101,9 +101,12 @@ class TimestampableBehavior extends Behavior
     public function preUpdate(AbstractOMBuilder $builder): string
     {
         if ($this->withUpdatedAt()) {
-            $valueSource = strtoupper($this->getTable()->getColumn($this->getParameter('update_column'))->getType()) === 'INTEGER'
+            $updateColumn = $this->getTable()->getColumn($this->getParameter('update_column'));
+            $dateTimeClass = $builder->getDateTimeClass($updateColumn);
+
+            $valueSource = strtoupper($updateColumn->getType()) === 'INTEGER'
                 ? 'time()'
-                : '\\Propel\\Runtime\\Util\\PropelDateTime::createHighPrecision()';
+                : "\\Propel\\Runtime\\Util\\PropelDateTime::createHighPrecision(null, '$dateTimeClass')";
 
             return 'if ($this->isModified() && !$this->isColumnModified(' . $this->getColumnConstant('update_column', $builder) . ")) {
     \$this->" . $this->getColumnSetter('update_column') . "({$valueSource});
@@ -123,12 +126,18 @@ class TimestampableBehavior extends Behavior
     public function preInsert(AbstractOMBuilder $builder): string
     {
         $script = '$time = time();
-$highPrecision = \\Propel\\Runtime\\Util\\PropelDateTime::createHighPrecision();';
+$mtime = PropelDateTime::formatMicrotime(microtime(true));';
 
         if ($this->withCreatedAt()) {
-            $valueSource = strtoupper($this->getTable()->getColumn($this->getParameter('create_column'))->getType()) === 'INTEGER'
+            $createColumn = $this->getTable()->getColumn($this->getParameter('create_column'));
+            $dateTimeClass = $builder->getDateTimeClass($createColumn);
+
+            $script .= "
+\$highPrecisionCreate = PropelDateTime::createHighPrecision(\$mtime, '$dateTimeClass');";
+
+            $valueSource = strtoupper($createColumn->getType()) === 'INTEGER'
                 ? '$time'
-                : '$highPrecision';
+                : '$highPrecisionCreate';
             $script .= "
 if (!\$this->isColumnModified(" . $this->getColumnConstant('create_column', $builder) . ")) {
     \$this->" . $this->getColumnSetter('create_column') . "({$valueSource});
@@ -136,9 +145,15 @@ if (!\$this->isColumnModified(" . $this->getColumnConstant('create_column', $bui
         }
 
         if ($this->withUpdatedAt()) {
-            $valueSource = strtoupper($this->getTable()->getColumn($this->getParameter('update_column'))->getType()) === 'INTEGER'
+            $updateColumn = $this->getTable()->getColumn($this->getParameter('update_column'));
+            $dateTimeClass = $builder->getDateTimeClass($updateColumn);
+
+            $script .= "
+\$highPrecisionUpdate = PropelDateTime::createHighPrecision(\$mtime, '$dateTimeClass');";
+
+            $valueSource = strtoupper($updateColumn->getType()) === 'INTEGER'
                 ? '$time'
-                : '$highPrecision';
+                : '$highPrecisionUpdate';
             $script .= "
 if (!\$this->isColumnModified(" . $this->getColumnConstant('update_column', $builder) . ")) {
     \$this->" . $this->getColumnSetter('update_column') . "({$valueSource});

--- a/src/Propel/Generator/Behavior/Timestampable/TimestampableBehavior.php
+++ b/src/Propel/Generator/Behavior/Timestampable/TimestampableBehavior.php
@@ -104,7 +104,7 @@ class TimestampableBehavior extends Behavior
         if ($this->withUpdatedAt()) {
             $updateColumn = $this->getTable()->getColumn($this->getParameter('update_column'));
 
-            $dateTimeClass = 'DateTime';
+            $dateTimeClass = DateTime::class;
 
             if ($builder instanceof ObjectBuilder) {
                 $dateTimeClass = $builder->getDateTimeClass($updateColumn);
@@ -137,7 +137,7 @@ $mtime = PropelDateTime::formatMicrotime(microtime(true));';
         if ($this->withCreatedAt()) {
             $createColumn = $this->getTable()->getColumn($this->getParameter('create_column'));
 
-            $dateTimeClass = 'DateTime';
+            $dateTimeClass = DateTime::class;
 
             if ($builder instanceof ObjectBuilder) {
                 $dateTimeClass = $builder->getDateTimeClass($createColumn);
@@ -158,7 +158,7 @@ if (!\$this->isColumnModified(" . $this->getColumnConstant('create_column', $bui
         if ($this->withUpdatedAt()) {
             $updateColumn = $this->getTable()->getColumn($this->getParameter('update_column'));
 
-            $dateTimeClass = 'DateTime';
+            $dateTimeClass = DateTime::class;
 
             if ($builder instanceof ObjectBuilder) {
                 $dateTimeClass = $builder->getDateTimeClass($updateColumn);

--- a/src/Propel/Generator/Behavior/Timestampable/TimestampableBehavior.php
+++ b/src/Propel/Generator/Behavior/Timestampable/TimestampableBehavior.php
@@ -8,6 +8,7 @@
 
 namespace Propel\Generator\Behavior\Timestampable;
 
+use DateTime;
 use Propel\Generator\Builder\Om\AbstractOMBuilder;
 use Propel\Generator\Builder\Om\ObjectBuilder;
 use Propel\Generator\Model\Behavior;

--- a/src/Propel/Generator/Behavior/Timestampable/TimestampableBehavior.php
+++ b/src/Propel/Generator/Behavior/Timestampable/TimestampableBehavior.php
@@ -106,7 +106,7 @@ class TimestampableBehavior extends Behavior
 
             $valueSource = strtoupper($updateColumn->getType()) === 'INTEGER'
                 ? 'time()'
-                : "\\Propel\\Runtime\\Util\\PropelDateTime::createHighPrecision(null, '$dateTimeClass')";
+                : "PropelDateTime::createHighPrecision(null, '$dateTimeClass')";
 
             return 'if ($this->isModified() && !$this->isColumnModified(' . $this->getColumnConstant('update_column', $builder) . ")) {
     \$this->" . $this->getColumnSetter('update_column') . "({$valueSource});

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -7360,7 +7360,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      *
      * @return string
      */
-    protected function getDateTimeClass(Column $column): string
+    public function getDateTimeClass(Column $column): string
     {
         if (PropelTypes::isPhpObjectType($column->getPhpType())) {
             return $column->getPhpType();

--- a/src/Propel/Runtime/Util/PropelDateTime.php
+++ b/src/Propel/Runtime/Util/PropelDateTime.php
@@ -73,23 +73,33 @@ class PropelDateTime extends DateTime
      *
      * @throws \InvalidArgumentException
      *
-     * @return \DateTime
+     * @return mixed An instance of $dateTimeClass
      */
-    public static function createHighPrecision(?string $time = null): DateTime
+    public static function createHighPrecision(?string $time = null, string $dateTimeClass = 'DateTime'): DateTimeInterface
     {
-        $dateTime = DateTime::createFromFormat('U.u', $time ?: self::getMicrotime());
+        $dateTime = $dateTimeClass::createFromFormat('U.u', $time ?: self::getMicrotime());
         if ($dateTime === false) {
             throw new InvalidArgumentException('Cannot create a datetime object from `' . $time . '`');
         }
 
-        $dateTime->setTimeZone(new DateTimeZone(date_default_timezone_get()));
+        $dateTime = $dateTime->setTimeZone(new DateTimeZone(date_default_timezone_get()));
 
         return $dateTime;
     }
 
     /**
-     * Get the current microtime with milliseconds. Making sure that the decimal point separator is always ".", ignoring
+     * Format the output of microtime(true) making sure that the decimal point separator is always ".", ignoring
      * what is set with the current locale. Otherwise, self::createHighPrecision would return false.
+     *
+     * @return string
+     */
+    public static function formatMicrotime(float $mtime): string
+    {
+        return number_format($mtime, 6, '.', '');
+    }
+
+    /**
+     * Get the current microtime with milliseconds.
      *
      * @return string
      */
@@ -97,7 +107,7 @@ class PropelDateTime extends DateTime
     {
         $mtime = microtime(true);
 
-        return number_format($mtime, 6, '.', '');
+        return self::formatMicrotime($mtime);
     }
 
     /**

--- a/src/Propel/Runtime/Util/PropelDateTime.php
+++ b/src/Propel/Runtime/Util/PropelDateTime.php
@@ -79,7 +79,9 @@ class PropelDateTime extends DateTime
      */
     public static function createHighPrecision(?string $time = null, string $dateTimeClass = 'DateTime'): DateTimeInterface
     {
-        if (!is_subclass_of($dateTimeClass, DateTime::class) && !is_subclass_of($dateTimeClass, DateTimeImmutable::class)) {
+        $allowStringIsA = true;
+
+        if (!is_a($dateTimeClass, DateTime::class, $allowStringIsA) && !is_a($dateTimeClass, DateTimeImmutable::class, $allowStringIsA)) {
             throw new InvalidArgumentException('`' . $dateTimeClass . '` needs to be an instance of DateTime or DateTimeImmutable');
         }
 

--- a/src/Propel/Runtime/Util/PropelDateTime.php
+++ b/src/Propel/Runtime/Util/PropelDateTime.php
@@ -9,6 +9,7 @@
 namespace Propel\Runtime\Util;
 
 use DateTime;
+use DateTimeImmutable;
 use DateTimeInterface;
 use DateTimeZone;
 use Exception;
@@ -70,13 +71,18 @@ class PropelDateTime extends DateTime
      * Usually `new \Datetime()` does not contain milliseconds so you need a method like this.
      *
      * @param string|null $time Optional, in seconds. Floating point allowed.
+     * @param string $dateTimeClass Optional, class name of the created object.
      *
      * @throws \InvalidArgumentException
      *
-     * @return DateTimeInterface An instance of $dateTimeClass
+     * @return \DateTimeInterface An instance of $dateTimeClass
      */
     public static function createHighPrecision(?string $time = null, string $dateTimeClass = 'DateTime'): DateTimeInterface
     {
+        if (!is_subclass_of($dateTimeClass, DateTime::class) && !is_subclass_of($dateTimeClass, DateTimeImmutable::class)) {
+            throw new InvalidArgumentException('`' . $dateTimeClass . '` needs to be an instance of DateTime or DateTimeImmutable');
+        }
+
         $dateTime = $dateTimeClass::createFromFormat('U.u', $time ?: self::getMicrotime());
         if ($dateTime === false) {
             throw new InvalidArgumentException('Cannot create a datetime object from `' . $time . '`');
@@ -90,6 +96,8 @@ class PropelDateTime extends DateTime
     /**
      * Format the output of microtime(true) making sure that the decimal point separator is always ".", ignoring
      * what is set with the current locale. Otherwise, self::createHighPrecision would return false.
+     *
+     * @param float $mtime Time in milliseconds.
      *
      * @return string
      */

--- a/src/Propel/Runtime/Util/PropelDateTime.php
+++ b/src/Propel/Runtime/Util/PropelDateTime.php
@@ -73,7 +73,7 @@ class PropelDateTime extends DateTime
      *
      * @throws \InvalidArgumentException
      *
-     * @return mixed An instance of $dateTimeClass
+     * @return DateTimeInterface An instance of $dateTimeClass
      */
     public static function createHighPrecision(?string $time = null, string $dateTimeClass = 'DateTime'): DateTimeInterface
     {

--- a/tests/Propel/Tests/Generator/Behavior/Timestampable/TimestampableBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Timestampable/TimestampableBehaviorTest.php
@@ -129,6 +129,7 @@ class TimestampableBehaviorTest extends BookstoreTestBase
         $tsave = time();
         $t1->save();
         $this->assertTimeEquals($tsave, $t1->getCreatedAt('U'), 'Timestampable sets created_column to time() on creation');
+        $this->assertEquals($t1->getCreatedAt('u'), $t1->getUpdatedAt('u'), 'Timestampable does not set created_column and updated_column to the same value on creation');
         sleep(1);
         $t1->setTitle('foo');
         $tupdate = time();

--- a/tests/Propel/Tests/Generator/Behavior/Timestampable/TimestampableBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Timestampable/TimestampableBehaviorTest.php
@@ -8,6 +8,7 @@
 
 namespace Propel\Tests\Generator\Behavior\Timestampable;
 
+use Propel\Generator\Config\QuickGeneratorConfig;
 use Propel\Generator\Util\QuickBuilder;
 use Propel\Runtime\Collection\ObjectCollection;
 use Propel\Tests\Bookstore\Behavior\Map\Table1TableMap;
@@ -17,6 +18,7 @@ use Propel\Tests\Bookstore\Behavior\Table2Query;
 use Propel\Tests\Helpers\Bookstore\BookstoreTestBase;
 use TableWithoutCreatedAt;
 use TableWithoutUpdatedAt;
+use TableDateTimeClass;
 
 /**
  * Tests for TimestampableBehavior class
@@ -354,5 +356,41 @@ EOF;
         $this->assertNull($obj->getUpdatedAt());
         $this->assertEquals(1, $obj->save());
         $this->assertNotNull($obj->getUpdatedAt());
+    }
+
+    /**
+     * @return void
+     */
+    public function testDateTimeClass()
+    {
+        $schema = <<<EOF
+<database name="timestampable_database">
+    <table name="table_date_time_class">
+        <column name="id" type="INTEGER" primaryKey="true" autoIncrement="true"/>
+        <behavior name="timestampable">
+        </behavior>
+    </table>
+</database>
+EOF;
+
+        // Custom Configuration to use DateTimeImmutable
+        $builder = new QuickBuilder();
+        $config = new QuickGeneratorConfig([
+            'propel' => [
+                'generator' => [
+                    'dateTime' => [
+                        'dateTimeClass' => 'DateTimeImmutable',
+                    ],
+                ],
+            ],
+        ]);
+        $builder->setSchema($schema);
+        $builder->setConfig($config);
+        $builder->build();
+
+        $obj = new TableDateTimeClass();
+        $obj->save();
+        $this->assertInstanceOf('DateTimeImmutable', $obj->getCreatedAt(), 'Timestampable behavior does not use the propel.generator.dateTime.dateTimeClass configuration property for created_column');
+        $this->assertInstanceOf('DateTimeImmutable', $obj->getUpdatedAt(), 'Timestampable behavior does not use the propel.generator.dateTime.dateTimeClass configuration property for updated_column');
     }
 }

--- a/tests/Propel/Tests/Generator/Behavior/Timestampable/TimestampableBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Timestampable/TimestampableBehaviorTest.php
@@ -95,7 +95,6 @@ class TimestampableBehaviorTest extends BookstoreTestBase
         $t1->save();
         $this->assertTimeEquals($tsave, $t1->getUpdatedAt('U'), 'Timestampable sets updated_column to time() on creation');
         sleep(1);
-        $tupdate = time();
         $t1->save();
         $this->assertTimeEquals($tsave, $t1->getUpdatedAt('U'), 'Timestampable only changes updated_column if the object was modified');
     }
@@ -132,7 +131,6 @@ class TimestampableBehaviorTest extends BookstoreTestBase
         $this->assertEquals($t1->getCreatedAt('u'), $t1->getUpdatedAt('u'), 'Timestampable does not set created_column and updated_column to the same value on creation');
         sleep(1);
         $t1->setTitle('foo');
-        $tupdate = time();
         $t1->save();
         $this->assertTimeEquals($tsave, $t1->getCreatedAt('U'), 'Timestampable does not update created_column on update');
     }

--- a/tests/Propel/Tests/Runtime/Util/PropelDateTimeTest.php
+++ b/tests/Propel/Tests/Runtime/Util/PropelDateTimeTest.php
@@ -10,6 +10,7 @@ namespace Propel\Tests\Runtime\Util;
 
 use DateTime;
 use DateTimeImmutable;
+use DateTimeInterface;
 use DateTimeZone;
 use PHPUnit\Framework\TestCase;
 use Propel\Runtime\Exception\PropelException;
@@ -247,11 +248,11 @@ class PropelDateTimeTest extends TestCase
     public function testCreateHighPrecision()
     {
         $createHP = PropelDateTime::createHighPrecision();
-        $this->assertInstanceOf(DateTime::class, $createHP);
+        $this->assertInstanceOf(DateTimeInterface::class, $createHP);
 
         setlocale(LC_ALL, 'de_DE.UTF-8');
         $createHP = PropelDateTime::createHighPrecision();
-        $this->assertInstanceOf(DateTime::class, $createHP);
+        $this->assertInstanceOf(DateTimeInterface::class, $createHP);
     }
 
     /**


### PR DESCRIPTION
The timestampable behavior doesn't use the `generator.dateTime.dateTimeClass` setting.
I took a few liberties adressing this:

- Reusing the getDateTimeClass method of `Propel\Generator\Builder\Om\ObjectBuilder`. For this it had to become `public`.
- `PropelDateTime::createHighPrecision` expects the output of `microtime` to be formatted with a dot. This places the formatting in a separate (static) method.
This allows keeping the updated_at and created_at microtimes in preInsert exactly the same value (instead of generating them independently).

I've avoided simplifying code to not break things.

What do you think?