### PR TITLE
PHP 8.4: fix deprecation notice

### DIFF
--- a/src/Propel/Generator/Behavior/AggregateColumn/AggregateColumnRelationBehavior.php
+++ b/src/Propel/Generator/Behavior/AggregateColumn/AggregateColumnRelationBehavior.php
@@ -111,7 +111,7 @@ protected \$old{$relationName}{$aggregateName};
         $relationName = $this->getRelationName($builder);
         $aggregateName = $this->getParameter('aggregate_name');
         $relatedClass = $builder->getClassNameFromBuilder($builder->getNewStubObjectBuilder($this->getForeignTable()));
-        $search = "    public function set{$relationName}({$relatedClass} \$v = null)
+        $search = "    public function set{$relationName}(?{$relatedClass} \$v = null)
     {";
         $replace = $search . "
         // aggregate_column_relation behavior

--- a/src/Propel/Generator/Behavior/Delegate/DelegateBehavior.php
+++ b/src/Propel/Generator/Behavior/Delegate/DelegateBehavior.php
@@ -342,7 +342,7 @@ protected \$delegatedFields = [
  *
  * @return \$this The current object, for fluid interface
  */
-public function filterBy(string \$column, \$value, string \$comparison = null)
+public function filterBy(string \$column, \$value, ?string \$comparison = null)
 {
     if (isset(\$this->delegatedFields[\$column])) {
         \$methodUse = \"use{\$this->delegatedFields[\$column]}Query\";

--- a/src/Propel/Generator/Behavior/NestedSet/NestedSetBehaviorObjectBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/NestedSet/NestedSetBehaviorObjectBuilderModifier.php
@@ -643,7 +643,7 @@ public function hasParent(): bool
  * @param $objectClassName \$parent
  * @return \$this The current object, for fluid interface
  */
-public function setParent($objectClassName \$parent = null)
+public function setParent(?$objectClassName \$parent = null)
 {
     \$this->aNestedSetParent = \$parent;
 

--- a/src/Propel/Generator/Behavior/NestedSet/NestedSetBehaviorQueryBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/NestedSet/NestedSetBehaviorQueryBuilderModifier.php
@@ -464,7 +464,7 @@ public function orderByLevel(\$reverse = false)
  *
  * @return {$this->objectClassName} The tree root object
  */
-public function findRoot(" . ($useScope ? '$scope = null, ' : '') . "ConnectionInterface \$con = null)
+public function findRoot(" . ($useScope ? '$scope = null, ' : '') . "?ConnectionInterface \$con = null)
 {
     return \$this
         ->addUsingAlias({$this->objectClassName}::LEFT_COL, 1, Criteria::EQUAL)";
@@ -524,7 +524,7 @@ public function findRoots(?ConnectionInterface \$con = null)
  *
  * @return {$this->objectClassName}[]|ObjectCollection|mixed the list of results, formatted by the current formatter
  */
-public function findTree(" . ($useScope ? '$scope = null, ' : '') . "ConnectionInterface \$con = null)
+public function findTree(" . ($useScope ? '$scope = null, ' : '') . "?ConnectionInterface \$con = null)
 {
     return \$this";
         if ($useScope) {
@@ -593,7 +593,7 @@ static public function retrieveRoots(?Criteria \$criteria = null, ?ConnectionInt
  * @param ConnectionInterface \$con Connection to use.
  * @return {$this->objectClassName}            Propel object for root node
  */
-static public function retrieveRoot(" . ($useScope ? '$scope = null, ' : '') . "ConnectionInterface \$con = null)
+static public function retrieveRoot(" . ($useScope ? '$scope = null, ' : '') . "?ConnectionInterface \$con = null)
 {
     \$c = new Criteria($tableMapClassName::DATABASE_NAME);
     \$c->add($objectClassName::LEFT_COL, 1, Criteria::EQUAL);";
@@ -633,7 +633,7 @@ static public function retrieveRoot(" . ($useScope ? '$scope = null, ' : '') . "
  * @param ConnectionInterface \$con Connection to use.
  * @return {$this->objectClassName}[]|ObjectCollection|mixed the list of results, formatted by the current formatter
  */
-static public function retrieveTree(" . ($useScope ? '$scope = null, ' : '') . "Criteria \$criteria = null, ?ConnectionInterface \$con = null)
+static public function retrieveTree(" . ($useScope ? '$scope = null, ' : '') . "?Criteria \$criteria = null, ?ConnectionInterface \$con = null)
 {
     if (null === \$criteria) {
         \$criteria = new Criteria($tableMapClassName::DATABASE_NAME);
@@ -666,7 +666,7 @@ static public function retrieveTree(" . ($useScope ? '$scope = null, ' : '') . "
  * @param $objectClassName \$node    Propel object for src node
  * @return bool
  */
-static public function isValid($objectClassName \$node = null)
+static public function isValid(?$objectClassName \$node = null)
 {
     if (is_object(\$node) && \$node->getRightValue() > \$node->getLeftValue()) {
         return true;
@@ -701,7 +701,7 @@ static public function isValid($objectClassName \$node = null)
  *
  * @return int The number of deleted nodes
  */
-static public function deleteTree(" . ($useScope ? '$scope = null, ' : '') . "ConnectionInterface \$con = null)
+static public function deleteTree(" . ($useScope ? '$scope = null, ' : '') . "?ConnectionInterface \$con = null)
 {";
         if ($useScope) {
             $script .= "

--- a/src/Propel/Generator/Behavior/Sortable/SortableBehaviorQueryBuilderModifier.php
+++ b/src/Propel/Generator/Behavior/Sortable/SortableBehaviorQueryBuilderModifier.php
@@ -445,7 +445,7 @@ public function getMaxRank(" . ($useScope ? "$methodSignature, " : '') . "?Conne
  *
  * @return int|null Highest position
  */
-public function getMaxRankArray(" . ($useScope ? '$scope, ' : '') . "ConnectionInterface \$con = null): ?int
+public function getMaxRankArray(" . ($useScope ? '$scope, ' : '') . "?ConnectionInterface \$con = null): ?int
 {
     if (\$con === null) {
         \$con = Propel::getConnection({$this->tableMapClassName}::DATABASE_NAME);
@@ -529,7 +529,7 @@ public function reorder(\$order, ?ConnectionInterface \$con = null)
  *
  * @return {$this->objectClassName}
  */
-static public function retrieveByRank(\$rank, " . ($useScope ? '$scope = null, ' : '') . "ConnectionInterface \$con = null)
+static public function retrieveByRank(\$rank, " . ($useScope ? '$scope = null, ' : '') . "?ConnectionInterface \$con = null)
 {
     if (null === \$con) {
         \$con = Propel::getServiceContainer()->getReadConnection({$this->tableMapClassName}::DATABASE_NAME);
@@ -693,7 +693,7 @@ static public function deleteList(\$scope, ?ConnectionInterface \$con = null): i
         $script .= "
  * @param ConnectionInterface \$con Connection to use.
  */
-static public function sortableShiftRank(\$delta, \$first, \$last = null, " . ($useScope ? '$scope = null, ' : '') . "ConnectionInterface \$con = null)
+static public function sortableShiftRank(\$delta, \$first, \$last = null, " . ($useScope ? '$scope = null, ' : '') . "?ConnectionInterface \$con = null)
 {
     if (null === \$con) {
         \$con = Propel::getServiceContainer()->getWriteConnection({$this->tableMapClassName}::DATABASE_NAME);

--- a/src/Propel/Generator/Builder/Om/AbstractOMBuilder.php
+++ b/src/Propel/Generator/Builder/Om/AbstractOMBuilder.php
@@ -806,7 +806,11 @@ abstract class AbstractOMBuilder extends DataModelBuilder
         if ($crossFK instanceof ForeignKey) {
             $crossObjectName = '$' . lcfirst($this->getFKPhpNameAffix($crossFK));
             $crossObjectClassName = $this->getClassNameFromTable($crossFK->getForeignTableOrFail());
-            $signature[] = "$crossObjectClassName $crossObjectName" . ($crossFK->isAtLeastOneLocalColumnRequired() ? '' : ' = null');
+            if ($crossFK->isAtLeastOneLocalColumnRequired()) {
+                $signature[] = "$crossObjectClassName $crossObjectName";
+            } else {
+                $signature[] = "?$crossObjectClassName $crossObjectName = null";
+            }
             $shortSignature[] = $crossObjectName;
             $normalizedShortSignature[] = $crossObjectName;
             $phpDoc[] = "

--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -1160,7 +1160,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
         $script .= "
     " . $visibility . " function get$cfc(\$asArray = true";
         if ($column->isLazyLoad()) {
-            $script .= ', ConnectionInterface $con = null';
+            $script .= ', ?ConnectionInterface $con = null';
         }
 
         $script .= ")
@@ -1278,7 +1278,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
         $script .= "
     " . $visibility . " function $name(";
         if ($column->isLazyLoad()) {
-            $script .= 'ConnectionInterface $con = null';
+            $script .= '?ConnectionInterface $con = null';
         }
 
         $script .= ")
@@ -1483,7 +1483,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      */
     $visibility function has$singularPhpName(\$value";
         if ($column->isLazyLoad()) {
-            $script .= ', ConnectionInterface $con = null';
+            $script .= ', ?ConnectionInterface $con = null';
         }
 
         $script .= "): bool
@@ -1557,7 +1557,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
         $script .= "
     " . $visibility . " function get$cfc(";
         if ($column->isLazyLoad()) {
-            $script .= 'ConnectionInterface $con = null';
+            $script .= '?ConnectionInterface $con = null';
         }
 
         $script .= ")
@@ -1852,6 +1852,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
             $typeHint .= ' ';
 
             if (!$column->isNotNull()) {
+                $typeHint = '?' . $typeHint;
                 $null = ' = null';
             }
         }
@@ -2206,7 +2207,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      */
     $visibility function add$singularPhpName(\$value";
         if ($col->isLazyLoad()) {
-            $script .= ', ConnectionInterface $con = null';
+            $script .= ', ?ConnectionInterface $con = null';
         }
 
         $script .= ")
@@ -2254,7 +2255,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      */
     $visibility function remove$singularPhpName(\$value";
         if ($col->isLazyLoad()) {
-            $script .= ', ConnectionInterface $con = null';
+            $script .= ', ?ConnectionInterface $con = null';
         }
         // we want to reindex the array, so array_ functions are not the best choice
         $script .= ")
@@ -4141,7 +4142,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
      * @return \$this The current object (for fluent API support)
      * @throws \Propel\Runtime\Exception\PropelException
      */
-    public function set" . $this->getFKPhpNameAffix($fk, false) . "($className \$v = null)
+    public function set" . $this->getFKPhpNameAffix($fk, false) . "(?$className \$v = null)
     {";
 
         foreach ($fk->getMapping() as $map) {
@@ -4958,11 +4959,11 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
     /**
      * Sets a single $className object as related to this object by a one-to-one relationship.
      *
-     * @param $className \$v $className
+     * @param $className|null \$v $className
      * @return \$this The current object (for fluent API support)
      * @throws \Propel\Runtime\Exception\PropelException
      */
-    public function set" . $this->getRefFKPhpNameAffix($refFK, false) . "($className \$v = null)
+    public function set" . $this->getRefFKPhpNameAffix($refFK, false) . "(?$className \$v = null)
     {
         \$this->$varName = \$v;
 

--- a/src/Propel/Generator/Builder/Om/QueryBuilder.php
+++ b/src/Propel/Generator/Builder/Om/QueryBuilder.php
@@ -1672,7 +1672,7 @@ class QueryBuilder extends AbstractOMBuilder
      */
     public function with{$relationName}Query(
         callable \$callable,
-        string \$relationAlias = null,
+        ?string \$relationAlias = null,
         ?string \$joinType = {$joinType}
     ) {
         \$relatedQuery = \$this->use{$relationName}Query(
@@ -1714,7 +1714,7 @@ class QueryBuilder extends AbstractOMBuilder
      *
      * @return \$this The current query, for fluid interface
      */
-    public function filterBy{$relName}($objectName, string \$comparison = null)
+    public function filterBy{$relName}($objectName, ?string \$comparison = null)
     {
         \$this
             ->use{$relationName}Query()

--- a/templates/Behavior/Validate/objectValidate.php
+++ b/templates/Behavior/Validate/objectValidate.php
@@ -6,7 +6,7 @@
  * @param ValidatorInterface|null $validator A Validator class instance
  * @return bool Whether all objects pass validation.
  */
-public function validate(ValidatorInterface $validator = null)
+public function validate(?ValidatorInterface $validator = null)
 {
     if (null === $validator) {
         $validator = new RecursiveValidator(


### PR DESCRIPTION
> Implicitly marking parameter [...] as nullable is deprecated, the explicit nullable type must be used instead