### PR TITLE
phpstan: column with whitespace-only size spec

### DIFF
--- a/src/Propel/Generator/Reverse/MysqlSchemaParser.php
+++ b/src/Propel/Generator/Reverse/MysqlSchemaParser.php
@@ -237,7 +237,7 @@ class MysqlSchemaParser extends AbstractSchemaParser
         $/x';
         if (preg_match($regexp, $row['Type'], $matches)) {
             $nativeType = $matches[1];
-            if ($matches[2]) {
+            if ($matches[2]) { // @phpstan-ignore if.alwaysTrue (see https://github.com/propelorm/Propel2/pull/2020#issuecomment-2535374330)
                 $cpos = strpos($matches[2], ',');
                 if ($cpos !== false) {
                     $size = (int)substr($matches[2], 0, $cpos);

--- a/src/Propel/Generator/Reverse/MysqlSchemaParser.php
+++ b/src/Propel/Generator/Reverse/MysqlSchemaParser.php
@@ -237,7 +237,7 @@ class MysqlSchemaParser extends AbstractSchemaParser
         $/x';
         if (preg_match($regexp, $row['Type'], $matches)) {
             $nativeType = $matches[1];
-            if ($matches[2]) {
+            if (trim($matches[2])) {
                 $cpos = strpos($matches[2], ',');
                 if ($cpos !== false) {
                     $size = (int)substr($matches[2], 0, $cpos);

--- a/src/Propel/Generator/Reverse/MysqlSchemaParser.php
+++ b/src/Propel/Generator/Reverse/MysqlSchemaParser.php
@@ -237,7 +237,7 @@ class MysqlSchemaParser extends AbstractSchemaParser
         $/x';
         if (preg_match($regexp, $row['Type'], $matches)) {
             $nativeType = $matches[1];
-            if (trim($matches[2])) {
+            if ($matches[2]) {
                 $cpos = strpos($matches[2], ',');
                 if ($cpos !== false) {
                     $size = (int)substr($matches[2], 0, $cpos);


### PR DESCRIPTION
@gechetspr this fixes the single phpstan error about the condition always being true. It has been adressed as an add-on in other pull requests, but I think it makes sense to handle this in a dedicated PR so CI improves for everyone.

However (this is pushing the limits of my PHP/regex knowledge): I think phpstan might actually be wrong here?
My reasoning: the function uses a regex on the column definition (e.g. `VARCHAR (25)`). The second match of the regex refers to anything between the brackets (column size). I think, because of the comments inside the regex, phpstan detects there will always be at least one space between the brackets. In that case the if statement is indeed always true.
But the regex contains an `/x` modifier, which ignores those whitespaces, no?

@staabm would you be able to chime in on what's happening here?

Edit: FWIW the other failing (mysql) tests is addressed separately in #2021.