### PR TITLE
test:mysql fix test setup

### DIFF
--- a/tests/Fixtures/schemas/schema.xml
+++ b/tests/Fixtures/schemas/schema.xml
@@ -67,6 +67,10 @@
         <foreign-key foreignTable="bookstore" foreignSchema="bookstore_schemas" onDelete="cascade">
             <reference local="bookstore_id" foreign="id"/>
         </foreign-key>
+        <unique>
+            <unique-column name="bookstore_id"/>
+            <unique-column name="id"/>
+        </unique>
     </table>
 
     <table name="second_hand_book" schema="second_hand_books">


### PR DESCRIPTION
@gechetspr this should fix the issue with the failing mysql tests.

I don't see how this has ever worked to be honest. If I go back in the git history the offending schema has never been any different in this respect.

When all tests are green, I'd be happy to look at some more deprecation warnings. PHPUnit for instance outputs some.

Edit: FWIW the other failing (phpstan) test is addressed separately in #2020.