### PR TITLE
phpunit: fix deprecation warnings

### DIFF
--- a/tests/Propel/Tests/Generator/Behavior/NestedSet/NestedSetBehaviorObjectBuilderModifierTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/NestedSet/NestedSetBehaviorObjectBuilderModifierTest.php
@@ -62,7 +62,7 @@ class NestedSetBehaviorObjectBuilderModifierTest extends TestCase
     {
         $expectedAttributes = ['nestedSetQueries'];
         foreach ($expectedAttributes as $attribute) {
-            $this->assertClassHasAttribute($attribute, 'NestedSetTable9');
+            $this->assertTrue(property_exists('NestedSetTable9', $attribute));
         }
     }
 

--- a/tests/Propel/Tests/Generator/Behavior/Validate/I18nConcreteInheritanceHandleValidateBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Validate/I18nConcreteInheritanceHandleValidateBehaviorTest.php
@@ -187,8 +187,8 @@ class I18nConcreteInheritanceHandleValidateBehaviorTest extends BookstoreTestBas
         $this->assertTrue(method_exists($class, 'validate'), "Class $class has no validate() method");
         $this->assertTrue(method_exists($class, 'getValidationFailures'), "Class $class has no getValidationFailures() method");
         $this->assertTrue(method_exists($class, 'loadValidatorMetadata'), "Class $class has no loadValidatorMetadata() method");
-        $this->assertClassHasAttribute('alreadyInValidation', $class, "Class $class has no 'alreadyInValidation' property");
-        $this->assertClassHasAttribute('validationFailures', $class, "Class $class has no 'validationFailures' property");
+        $this->assertTrue(property_exists($class, 'alreadyInValidation'), "Class $class has no 'alreadyInValidation' property");
+        $this->assertTrue(property_exists($class, 'validationFailures'), "Class $class has no 'validationFailures' property");
         $method = new ReflectionMethod($class, 'loadValidatorMetadata');
         $this->assertTrue($method->isStatic(), "Method loadValidatorMetadata() of class $class isn't static");
     }

--- a/tests/Propel/Tests/Generator/Behavior/Validate/ValidateBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Validate/ValidateBehaviorTest.php
@@ -79,7 +79,7 @@ class ValidateBehaviorTest extends BookstoreTestBase
     public function testHasAlreadyInValidationAttribute()
     {
         foreach ($this->classes as $class) {
-             $this->assertClassHasAttribute('alreadyInValidation', $class);
+            $this->assertTrue(property_exists($class, 'alreadyInValidation'));
         }
     }
 
@@ -89,7 +89,7 @@ class ValidateBehaviorTest extends BookstoreTestBase
     public function testHasValidationFailuresAttribute()
     {
         foreach ($this->classes as $class) {
-             $this->assertClassHasAttribute('validationFailures', $class);
+            $this->assertTrue(property_exists($class, 'validationFailures'));
         }
     }
 


### PR DESCRIPTION
This fixes deprecation warnings in PHPUnit 9 about `assertClassHasAttribute` being removed in PHPUnit 10.
There is no replacement so PHP's property_exists takes care of it now.

@gechetspr sorry about the PR-spam. Feel free to connect me to anyone else which can look at these PR's. Thank you!

**Edit:** FWIW, `assertObjectHasProperty` was backported tot PHPUnit 9.6.11, but as the name suggests, that works only on objects, not classes.