### PR TITLE
phpstan: fix deprecation warning

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,11 +2,12 @@ includes:
     - phpstan-baseline.neon
 parameters:
     level: 7
-    checkMissingIterableValueType: false
     reportUnmatchedIgnoredErrors: false
     paths:
         - '%rootDir%/../../../src/'
     ignoreErrors:
         - '#Call to an undefined method .+Collection::.+Array\(\)#'
         - '#Call to an undefined method object::.+\(\)#'
+        -
+            identifier: missingType.iterableValue
 


### PR DESCRIPTION
PHPStan will remove the config property `checkMissingIterableValueType`.
This PR replaces it by ignoring `missingType.iterableValue` errors as suggested by PHPStan.

@gechetspr this is my last PR to improve tests/CI/linting. Although GitHub does still have some actions-related warnings. I might look at those later on.