### PR TITLE
Fixed `Profiler::slowThreshold` setter method to accept float value.

### DIFF
--- a/src/Propel/Runtime/Util/Profiler.php
+++ b/src/Propel/Runtime/Util/Profiler.php
@@ -76,13 +76,13 @@ class Profiler
     }
 
     /**
-     * Set the duration which triggers the 'slow' label on details.
+     * Set the duration which triggers the 'slow' label on details, such as 0.1 (100ms) or 0.001 (1ms).
      *
-     * @param int $slowThreshold duration in seconds
+     * @param float $slowThreshold duration in seconds
      *
      * @return void
      */
-    public function setSlowThreshold(int $slowThreshold): void
+    public function setSlowThreshold(float $slowThreshold): void
     {
         $this->slowThreshold = $slowThreshold;
     }


### PR DESCRIPTION
Using Profiler with custom configuration, like `Propel::getServiceContainer()->setProfilerConfiguration(['slowThreshold' => 0.01]);` it not possible to set float value, when the property itself has `float` type.