### PR TITLE
Change BIGINT native PHP type back to int

### DIFF
--- a/src/Propel/Generator/Model/PropelTypes.php
+++ b/src/Propel/Generator/Model/PropelTypes.php
@@ -234,7 +234,7 @@ class PropelTypes
     /**
      * @var string
      */
-    public const BIGINT_NATIVE_TYPE = 'string';
+    public const BIGINT_NATIVE_TYPE = 'int';
 
     /**
      * @var string

--- a/tests/Propel/Tests/Generator/Model/ColumnTest.php
+++ b/tests/Propel/Tests/Generator/Model/ColumnTest.php
@@ -702,7 +702,7 @@ class ColumnTest extends ModelTestCase
             ['SMALLINT', 'int', true],
             ['TINYINT', 'int', true],
             ['INTEGER', 'int', true],
-            ['BIGINT', 'string', false],
+            ['BIGINT', 'int', true],
             ['FLOAT', 'double', true],
             ['DOUBLE', 'double', true],
             ['NUMERIC', 'string', false],
@@ -741,7 +741,7 @@ class ColumnTest extends ModelTestCase
     public function provideMappingUuidTypes()
     {
         return [
-            // column type, php type, 
+            // column type, php type,
             [PropelTypes::UUID, 'string'],
             [PropelTypes::UUID_BINARY, 'string'],
         ];


### PR DESCRIPTION
Originally BIGINT was mapped to PHP native type int back in 2005. This was changed to string in revision 56f6a84b8235ad13cdd339b2ade0c715aa44aa0c.

Apparently 32-bit PHP types were incapable of storing the full range of BIGINT without running out of bounds. This should not be an issue in times of 64 bit and the minimum required version of PHP being 7.4 for Propel2.