### PR TITLE
Log the full error message at once

### DIFF
--- a/src/Propel/Runtime/ActiveQuery/QueryExecutor/AbstractQueryExecutor.php
+++ b/src/Propel/Runtime/ActiveQuery/QueryExecutor/AbstractQueryExecutor.php
@@ -131,13 +131,16 @@ abstract class AbstractQueryExecutor
     protected function handleStatementException(Throwable $e, ?string $sql, $stmt = null): void
     {
         $internalMessage = $e->getMessage();
-        Propel::log($internalMessage, Propel::LOG_ERR);
 
         $isDebugMode = $this->connectionIsInDebugMode();
         if ($isDebugMode && $stmt instanceof StatementWrapper) {
             $sql = $stmt->getExecutedQueryString();
         }
         $publicMessage = "Unable to execute statement [$sql]";
+
+        $fullLogMessage = $publicMessage . PHP_EOL . "Reason: [$internalMessage]";
+        Propel::log($fullLogMessage, Propel::LOG_ERR);
+
         if ($isDebugMode) {
             $publicMessage .= PHP_EOL . "Reason: [$internalMessage]";
         }


### PR DESCRIPTION
**Problem statement:**
Originally, propel logs have only an exception, without an explanation of what happened.
And it returns the second part of the exception as a public message.

This fix just log them both together.