### PR TITLE
Refactor timestampable behavior

### DIFF
--- a/src/Propel/Runtime/Util/PropelDateTime.php
+++ b/src/Propel/Runtime/Util/PropelDateTime.php
@@ -79,9 +79,7 @@ class PropelDateTime extends DateTime
      */
     public static function createHighPrecision(?string $time = null, string $dateTimeClass = 'DateTime'): DateTimeInterface
     {
-        $allowStringIsA = true;
-
-        if (!is_a($dateTimeClass, DateTime::class, $allowStringIsA) && !is_a($dateTimeClass, DateTimeImmutable::class, $allowStringIsA)) {
+        if (!is_a($dateTimeClass, DateTime::class, true) && !is_a($dateTimeClass, DateTimeImmutable::class, true)) {
             throw new InvalidArgumentException('`' . $dateTimeClass . '` needs to be an instance of DateTime or DateTimeImmutable');
         }
 

--- a/tests/Propel/Tests/Generator/Behavior/Timestampable/TimestampableBehaviorTest.php
+++ b/tests/Propel/Tests/Generator/Behavior/Timestampable/TimestampableBehaviorTest.php
@@ -19,6 +19,7 @@ use Propel\Tests\Helpers\Bookstore\BookstoreTestBase;
 use TableWithoutCreatedAt;
 use TableWithoutUpdatedAt;
 use TableDateTimeClass;
+use TableColumnTypes;
 
 /**
  * Tests for TimestampableBehavior class
@@ -392,5 +393,29 @@ EOF;
         $obj->save();
         $this->assertInstanceOf('DateTimeImmutable', $obj->getCreatedAt(), 'Timestampable behavior does not use the propel.generator.dateTime.dateTimeClass configuration property for created_column');
         $this->assertInstanceOf('DateTimeImmutable', $obj->getUpdatedAt(), 'Timestampable behavior does not use the propel.generator.dateTime.dateTimeClass configuration property for updated_column');
+    }
+
+    /**
+     * @return void
+     */
+    public function testColumnTypes()
+    {
+        $schema = <<<EOF
+<database name="timestampable_database">
+    <table name="table_column_types">
+        <column name="id" type="INTEGER" primaryKey="true" autoIncrement="true"/>
+        <column name="created_at" type="INTEGER"/>
+        <behavior name="timestampable"/>
+    </table>
+</database>
+EOF;
+
+        $builder = new QuickBuilder();
+        $builder->setSchema($schema);
+        $builder->build();
+
+        $obj = new TableColumnTypes();
+        $obj->save();
+        $this->assertEquals($obj->getCreatedAt('U'), $obj->getUpdatedAt('U'), 'Timestampable does not set created_column and updated_column to the same value when column types are different');
     }
 }


### PR DESCRIPTION
Thanks to @mringler's feedback.

This avoids generation of unused variables inside the `save()` method of table classes by `TimestampableBehavior`.
Previously, either `$time` or `$mtime` would be unused if column types where either:

- updated_at = DATETIME, created_at = DATETIME (the default)
- updated_at = INTEGER, created_at = INTEGER

Additionally, if using INTEGER columns, there would also be an unused `$highPrecisionCreate` and/or `$highPrecisionUpdate` generated.

Note: there is also a commit simplifying `is_a` calls which got lost in a previous PR's force push.