### PR TITLE
removes user and password from dsn in commands (fixes #2013)

### DIFF
--- a/src/Propel/Generator/Command/AbstractCommand.php
+++ b/src/Propel/Generator/Command/AbstractCommand.php
@@ -144,23 +144,33 @@ abstract class AbstractCommand extends Command
      */
     protected function parseConnection(string $connection): array
     {
-        $length = strpos($connection, '=') ?: null;
-        $name = substr($connection, 0, $length);
-        $dsn = substr($connection, $length + 1, strlen($connection));
+        $firstEqualsSignPosition = strpos($connection, '=') ?: null;
+        $name = substr($connection, 0, $firstEqualsSignPosition);
+        $remainder = substr($connection, $firstEqualsSignPosition + 1);
 
-        $length = strpos($dsn, ':') ?: null;
-        $adapter = substr($dsn, 0, $length);
+        $firstColonPosition = strpos($remainder, ':') ?: null;
+        $adapter = substr($remainder, 0, $firstColonPosition);
+        $remainder = substr($remainder, $firstColonPosition + 1);
 
         $extras = [];
-        foreach (explode(';', $dsn) as $element) {
+        $dsn = $adapter . ':';
+        foreach (explode(';', $remainder) as $element) {
             $parts = explode('=', $element);
+
             if (count($parts) === 2) {
-                $extras[strtolower($parts[0])] = urldecode($parts[1]);
+                $key = strtolower($parts[0]);
+                $value = urldecode($parts[1]);
+                $extras[$key] = $value;
+
+                if ($key !== 'user' && $key !== 'password') {
+                    // dsn can't contain user or password for (at least) sql server
+                    $dsn .= $element . ';';
+                }
             }
         }
         $extras['adapter'] = $adapter;
 
-        return [$name, $dsn, $extras];
+        return [$name, trim($dsn, ';'), $extras];
     }
 
     /**

--- a/src/Propel/Generator/Command/AbstractCommand.php
+++ b/src/Propel/Generator/Command/AbstractCommand.php
@@ -162,11 +162,13 @@ abstract class AbstractCommand extends Command
                 $value = urldecode($parts[1]);
                 $extras[$key] = $value;
 
-                if ($key !== 'user' && $key !== 'password') {
+                if ($key === 'user' || $key === 'password') {
                     // dsn can't contain user or password for (at least) sql server
-                    $dsn .= $element . ';';
+                    continue;
                 }
             }
+
+            $dsn .= $element . ';';
         }
         $extras['adapter'] = $adapter;
 

--- a/tests/Propel/Tests/Generator/Command/AbstractCommandTest.php
+++ b/tests/Propel/Tests/Generator/Command/AbstractCommandTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  */
 class AbstractCommandTest extends TestCase
 {
-    protected $command;
+    protected TestableAbstractCommand $command;
 
     /**
      * @return void
@@ -33,7 +33,7 @@ class AbstractCommandTest extends TestCase
     /**
      * @return void
      */
-    public function testParseConnection()
+    public function testParseConnectionWithCredentials(): void
     {
         $user = 'root';
         $password = 'H7{“Qj1n>\%28=;P';
@@ -51,14 +51,41 @@ class AbstractCommandTest extends TestCase
         $this->assertCount(3, $result);
         $this->assertEquals($connectionName, $result[0]);
         $this->assertEquals($dsn, $result[1], 'DSN should not contain user and password parameters');
+        $this->assertArrayHasKey('adapter', $result[2]);
+        $this->assertEquals('mysql', $result[2]['adapter']);
+        $this->assertArrayHasKey('user', $result[2]);
         $this->assertEquals($user, $result[2]['user']);
+        $this->assertArrayHasKey('password', $result[2]);
         $this->assertEquals($password, $result[2]['password']);
     }
 
     /**
      * @return void
      */
-    public function testRecursiveSearch()
+    public function testParseConnectionWithoutCredentials(): void
+    {
+        $connectionName = 'bookstore';
+        $dsn = 'mysql:host=127.0.0.1;dbname=test';
+        $connection = sprintf(
+            '%s=%s',
+            $connectionName,
+            $dsn
+        );
+        $result = $this->command->parseConnection($connection);
+
+        $this->assertCount(3, $result);
+        $this->assertEquals($connectionName, $result[0]);
+        $this->assertEquals($dsn, $result[1], 'DSN should not contain user and password parameters');
+        $this->assertArrayHasKey('adapter', $result[2]);
+        $this->assertEquals('mysql', $result[2]['adapter']);
+        $this->assertArrayNotHasKey('user', $result[2]);
+        $this->assertArrayNotHasKey('password', $result[2]);
+    }
+
+    /**
+     * @return void
+     */
+    public function testRecursiveSearch(): void
     {
         $app = new Application();
         $app->add($this->command);
@@ -92,7 +119,7 @@ class TestableAbstractCommand extends AbstractCommand
     /**
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         parent::configure();
         $this->setName('testable-command');

--- a/tests/Propel/Tests/Generator/Command/AbstractCommandTest.php
+++ b/tests/Propel/Tests/Generator/Command/AbstractCommandTest.php
@@ -65,7 +65,7 @@ class AbstractCommandTest extends TestCase
     public function testParseConnectionWithoutCredentials(): void
     {
         $connectionName = 'bookstore';
-        $dsn = 'mysql:host=127.0.0.1;dbname=test';
+        $dsn = 'sqlite:/tmp/test.sq3';
         $connection = sprintf(
             '%s=%s',
             $connectionName,
@@ -77,7 +77,7 @@ class AbstractCommandTest extends TestCase
         $this->assertEquals($connectionName, $result[0]);
         $this->assertEquals($dsn, $result[1], 'DSN should not contain user and password parameters');
         $this->assertArrayHasKey('adapter', $result[2]);
-        $this->assertEquals('mysql', $result[2]['adapter']);
+        $this->assertEquals('sqlite', $result[2]['adapter']);
         $this->assertArrayNotHasKey('user', $result[2]);
         $this->assertArrayNotHasKey('password', $result[2]);
     }

--- a/tests/Propel/Tests/Generator/Command/AbstractCommandTest.php
+++ b/tests/Propel/Tests/Generator/Command/AbstractCommandTest.php
@@ -35,14 +35,23 @@ class AbstractCommandTest extends TestCase
      */
     public function testParseConnection()
     {
+        $user = 'root';
         $password = 'H7{“Qj1n>\%28=;P';
         $connectionName = 'bookstore';
-        $dsn = 'mysql:host=127.0.0.1;dbname=test;user=root;password=' . urlencode($password);
-        $result = $this->command->parseConnection($connectionName . '=' . $dsn);
+        $dsn = 'mysql:host=127.0.0.1;dbname=test';
+        $connection = sprintf(
+            '%s=%s;user=%s;password=%s',
+            $connectionName,
+            $dsn,
+            $user,
+            urlencode($password)
+        );
+        $result = $this->command->parseConnection($connection);
 
+        $this->assertCount(3, $result);
         $this->assertEquals($connectionName, $result[0]);
-        $this->assertEquals($dsn, $result[1]);
-        $this->assertEquals('root', $result[2]['user']);
+        $this->assertEquals($dsn, $result[1], 'DSN should not contain user and password parameters');
+        $this->assertEquals($user, $result[2]['user']);
         $this->assertEquals($password, $result[2]['password']);
     }
 


### PR DESCRIPTION
When calling the [PDO constructor](https://www.php.net/manual/en/pdo.construct.php) with the DSN, user and password parameters, the DSN can't also contain the credentials for MSSQL (see #2013). Other DBMSes (covered by the tests) don't care about this.

Some CLI commands derive the DSN from a connection string. This is a Propel-specific format that looks similar to a DSN but contains more information like the connection name and credentials. This parsing did not remove credentials from the DSN, something this PR addresses.