### PR TITLE
add supported php versions to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php-version: [ '7.4', '8.2' ]
+                php-version: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
                 db-type: [ sqlite, mysql, pgsql, agnostic ]
                 symfony-version: [ '5-min', '5-max', '6-min', '6-max', '7-min', '7-max']
                 exclude:
@@ -22,10 +22,22 @@ jobs:
                     php-version: '7.4'
                   - symfony-version: '6-max'
                     php-version: '7.4'
+                  - symfony-version: '6-min'
+                    php-version: '8.0'
+                  - symfony-version: '6-max'
+                    php-version: '8.0'
                   - symfony-version: '7-min'
                     php-version: '7.4'
                   - symfony-version: '7-max'
                     php-version: '7.4'
+                  - symfony-version: '7-min'
+                    php-version: '8.0'
+                  - symfony-version: '7-max'
+                    php-version: '8.0'
+                  - symfony-version: '7-min'
+                    php-version: '8.1'
+                  - symfony-version: '7-max'
+                    php-version: '8.1'
         env:
             DB_NAME: 'propel_tests'
             DB_USER: 'propel'


### PR DESCRIPTION
This adds all PHP versions that Propel should currently work on to CI.
It also disables tests with Symfony components which are not supported on some of these versions.