### PR TITLE
Fix sorting flags in CollectionIterator

### DIFF
--- a/src/Propel/Runtime/Collection/CollectionIterator.php
+++ b/src/Propel/Runtime/Collection/CollectionIterator.php
@@ -253,7 +253,7 @@ class CollectionIterator extends ArrayIterator implements IteratorInterface
     #[\ReturnTypeWillChange]
     public function asort(int $flags = SORT_REGULAR): bool
     {
-        parent::asort();
+        parent::asort($flags);
         $this->refreshPositions();
 
         return true;
@@ -267,7 +267,7 @@ class CollectionIterator extends ArrayIterator implements IteratorInterface
     #[\ReturnTypeWillChange]
     public function ksort(int $flags = SORT_REGULAR): bool
     {
-        parent::ksort();
+        parent::ksort($flags);
         $this->refreshPositions();
 
         return true;

--- a/tests/Propel/Tests/Runtime/Collection/CollectionIteratorTest.php
+++ b/tests/Propel/Tests/Runtime/Collection/CollectionIteratorTest.php
@@ -175,4 +175,22 @@ class CollectionIteratorTest extends BookstoreTestBase
             $this->assertEquals(!(bool)($key % 2), $iterator->isEven(), 'isEven() returns true only when the key is even');
         }
     }
+
+    /**
+     * @return void
+     */
+    public function testSortingUsesFlags()
+    {
+        $data = ['img10', 'img2'];
+        $collection = new Collection($data);
+        $iterator = new CollectionIterator($collection);
+        $iterator->asort(SORT_NATURAL);
+        $this->assertSame(['img2', 'img10'], array_values($iterator->getArrayCopy()), 'asort() should respect sorting flags');
+
+        $assoc = ['b10' => 'foo', 'b2' => 'bar'];
+        $collection = new Collection($assoc);
+        $iterator = new CollectionIterator($collection);
+        $iterator->ksort(SORT_NATURAL);
+        $this->assertSame(['b2', 'b10'], array_keys($iterator->getArrayCopy()), 'ksort() should respect sorting flags');
+    }
 }


### PR DESCRIPTION
## Summary
- fix CollectionIterator::asort() and ksort() to use flags
- test that sorting respects flags
