### PR TITLE
Fix lastInsertId to forward sequence name

### DIFF
--- a/src/Propel/Runtime/Connection/PdoConnection.php
+++ b/src/Propel/Runtime/Connection/PdoConnection.php
@@ -168,7 +168,7 @@ class PdoConnection implements ConnectionInterface
      */
     public function lastInsertId(?string $name = null)
     {
-        return $this->pdo->lastInsertId();
+        return $this->pdo->lastInsertId($name);
     }
 
     /**


### PR DESCRIPTION
### Summary
forward $name to underlying PDO when calling lastInsertId
