### PR TITLE
Additional iconv transliteration tests

### DIFF
--- a/tests/Propel/Tests/Generator/Util/IconvTransliterationTest.php
+++ b/tests/Propel/Tests/Generator/Util/IconvTransliterationTest.php
@@ -61,9 +61,9 @@ class IconvTransliterationTest extends TestCase
             ['fôo', 'foo'],
             ['€', 'EUR'],
             ['CŠŒŽšœžŸµÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÑÒÓÔÕÖÙÚÛÜÝßàáâãäåæçèéêëìíîïñòóôõöùúûüýÿ', 'CSOEZsoezYuAAAAAAAECEEEEIIIINOOOOOUUUUYssaaaaaaaeceeeeiiiinooooouuuuyy'],
-            ['ø', '?'],
-            ['Ø', '?'],
-            ['¥Ðð', '???'],
+            ['ø', 'o'],
+            ['Ø', 'O'],
+            ['¥Ðð', 'JPYDd'],
         ];
     }
 

--- a/tests/Propel/Tests/Generator/Util/IconvTransliterationTest.php
+++ b/tests/Propel/Tests/Generator/Util/IconvTransliterationTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * This file is part of the Propel package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT License
+ */
+
+use Propel\Generator\Util\PhpParser;
+use \Propel\Tests\TestCase;
+
+/**
+ *
+ */
+class IconvTransliterationTest extends TestCase
+{
+
+    /**
+     * Excerpt from http://php.net/manual/en/function.iconv.php#74101
+     * "Please note that iconv('UTF-8', 'ASCII//TRANSLIT', ...) doesn't work properly when locale category LC_CTYPE is set to C or POSIX. You must choose another locale otherwise all non-ASCII characters will be replaced with question marks."
+     */
+    public function testIconvSupportedLocale($in, $out)
+    {
+        if (!function_exists('iconv')) {
+            $this->markTestSkipped();
+        }
+        $LC_CTYPE = setlocale(LC_CTYPE, 0);
+        $this->assertNotEquals('C', $LC_CTYPE, 'iconv transliteration does not work properly when locale category LC_CTYPE is set to C or POSIX');
+        $this->assertNotEquals('POSIX', $LC_CTYPE, 'iconv transliteration does not work properly when locale category LC_CTYPE is set to C or POSIX');
+    }
+
+    public static function iconvTransliterationSlugProvider()
+    {
+        return [
+            ['foo', 'foo'],
+            ['fôo', 'foo'],
+            ['€', 'EUR'],
+            ['CŠŒŽšœžŸµÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÑÒÓÔÕÖÙÚÛÜÝßàáâãäåæçèéêëìíîïñòóôõöùúûüýÿ', 'CSOEZsoezYuAAAAAAAECEEEEIIIINOOOOOUUUUYssaaaaaaaeceeeeiiiinooooouuuuyy'],
+            ['ø', 'oe'],
+            ['Ø', 'OE'],
+            ['¥Ðð', '???'],
+        ];
+    }
+
+    /**
+     * @dataProvider iconvTransliterationSlugProvider
+     */
+    public function testIconvTransliteration($in, $out)
+    {
+        if (!function_exists('iconv')) {
+            $this->markTestSkipped();
+        }
+        $translit = iconv('utf-8', 'us-ascii//TRANSLIT', $in);
+        $this->assertEquals($out, $translit, 'iconv transliteration behaves as expected');
+    }
+
+}

--- a/tests/Propel/Tests/Generator/Util/IconvTransliterationTest.php
+++ b/tests/Propel/Tests/Generator/Util/IconvTransliterationTest.php
@@ -21,7 +21,7 @@ class IconvTransliterationTest extends TestCase
      * Excerpt from http://php.net/manual/en/function.iconv.php#74101
      * "Please note that iconv('UTF-8', 'ASCII//TRANSLIT', ...) doesn't work properly when locale category LC_CTYPE is set to C or POSIX. You must choose another locale otherwise all non-ASCII characters will be replaced with question marks."
      */
-    public function testIconvSupportedLocale($in, $out)
+    public function testIconvSupportedLocale()
     {
         if (!function_exists('iconv')) {
             $this->markTestSkipped();
@@ -38,8 +38,8 @@ class IconvTransliterationTest extends TestCase
             ['fôo', 'foo'],
             ['€', 'EUR'],
             ['CŠŒŽšœžŸµÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÑÒÓÔÕÖÙÚÛÜÝßàáâãäåæçèéêëìíîïñòóôõöùúûüýÿ', 'CSOEZsoezYuAAAAAAAECEEEEIIIINOOOOOUUUUYssaaaaaaaeceeeeiiiinooooouuuuyy'],
-            ['ø', 'oe'],
-            ['Ø', 'OE'],
+            ['ø', '?'],
+            ['Ø', '?'],
             ['¥Ðð', '???'],
         ];
     }


### PR DESCRIPTION
Based on initial https://github.com/propelorm/Propel2/pull/1057
This helps isolate odd iconv transliteration behavior, to make it clear when Propel2 is at fault and when failed tests stems from incorrect/unsupported locale configuration.

⚠️ Iconv transliteration tests may fail if the system locale is C or if libiconv version is inconsistent. To ensure stability, use en_US.UTF-8 locale when running tests.