### PR TITLE
Add limit operator for delete query for MySQL

### DIFF
--- a/src/Propel/Runtime/ActiveQuery/SqlBuilder/DeleteQuerySqlBuilder.php
+++ b/src/Propel/Runtime/ActiveQuery/SqlBuilder/DeleteQuerySqlBuilder.php
@@ -41,7 +41,7 @@ class DeleteQuerySqlBuilder extends AbstractSqlQueryBuilder
         $deleteFrom = $this->buildDeleteFromClause($tableName);
         $whereDto = $this->buildWhereClause($columnNames);
         $where = $whereDto->getSqlStatement();
-        $deleteStatement = "$deleteFrom $where";
+        $deleteStatement = implode(' ', array_filter([$deleteFrom, $where]));
         $params = $whereDto->getParameters();
 
         $limit = $this->criteria->getLimit();

--- a/src/Propel/Runtime/ActiveQuery/SqlBuilder/DeleteQuerySqlBuilder.php
+++ b/src/Propel/Runtime/ActiveQuery/SqlBuilder/DeleteQuerySqlBuilder.php
@@ -89,8 +89,12 @@ class DeleteQuerySqlBuilder extends AbstractSqlQueryBuilder
      */
     protected function buildWhereClause(array $columnNames): PreparedStatementDto
     {
-        $whereClause = [];
         $params = [];
+        if (count($columnNames) === 0) {
+            return new PreparedStatementDto('', $params);
+        }
+
+        $whereClause = [];
         foreach ($columnNames as $columnName) {
             $filter = $this->criteria->getCriterion($columnName);
             $whereClause[] = $this->buildStatementFromCriterion($filter, $params);

--- a/src/Propel/Runtime/ActiveQuery/SqlBuilder/DeleteQuerySqlBuilder.php
+++ b/src/Propel/Runtime/ActiveQuery/SqlBuilder/DeleteQuerySqlBuilder.php
@@ -44,6 +44,11 @@ class DeleteQuerySqlBuilder extends AbstractSqlQueryBuilder
         $deleteStatement = "$deleteFrom $where";
         $params = $whereDto->getParameters();
 
+        $limit = $this->criteria->getLimit();
+        if ($limit >= 0) {
+            $this->adapter->applyLimitForDelete($deleteStatement, $limit);
+        }
+
         return new PreparedStatementDto($deleteStatement, $params);
     }
 

--- a/src/Propel/Runtime/Adapter/Pdo/MysqlAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/MysqlAdapter.php
@@ -136,6 +136,21 @@ class MysqlAdapter extends PdoAdapter implements SqlAdapterInterface
     }
 
     /**
+     * Modifies the passed-in SQL to add LIMIT for DELETE Query.
+     *
+     * @param string $sql
+     * @param int $limit
+     *
+     * @return void
+     */
+    public function applyLimitForDelete(string &$sql, int $limit): void
+    {
+        if ($limit >= 0) {
+            $sql .= ' LIMIT ' . $limit;
+        }
+    }
+
+    /**
      * @see SqlAdapterInterface::random()
      *
      * @param string|null $seed

--- a/src/Propel/Runtime/Adapter/Pdo/PdoAdapter.php
+++ b/src/Propel/Runtime/Adapter/Pdo/PdoAdapter.php
@@ -108,6 +108,18 @@ abstract class PdoAdapter
     }
 
     /**
+     * Modifies the passed-in SQL to add LIMIT for DELETE Query.
+     *
+     * @param string $sql
+     * @param int $limit
+     *
+     * @return void
+     */
+    public function applyLimitForDelete(string &$sql, int $limit): void
+    {
+    }
+
+    /**
      * Prepare the parameters for a Connection
      *
      * @param array $params the connection parameters from the configuration

--- a/src/Propel/Runtime/Adapter/SqlAdapterInterface.php
+++ b/src/Propel/Runtime/Adapter/SqlAdapterInterface.php
@@ -62,6 +62,16 @@ interface SqlAdapterInterface extends AdapterInterface
     public function applyLimit(string &$sql, int $offset, int $limit, ?Criteria $criteria = null): void;
 
     /**
+     * Modifies the passed-in SQL to add LIMIT for DELETE Query.
+     *
+     * @param string $sql
+     * @param int $limit
+     *
+     * @return void
+     */
+    public function applyLimitForDelete(string &$sql, int $limit): void;
+
+    /**
      * Modifies the passed-in SQL to add locking capabilities
      *
      * @param string $sql

--- a/tests/Propel/Tests/Runtime/Adapter/Pdo/MysqlAdapterTest.php
+++ b/tests/Propel/Tests/Runtime/Adapter/Pdo/MysqlAdapterTest.php
@@ -8,6 +8,8 @@
 
 namespace Propel\Tests\Runtime\Adapter\Pdo;
 
+use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\ActiveQuery\SqlBuilder\DeleteQuerySqlBuilder;
 use Propel\Runtime\Adapter\Pdo\MysqlAdapter;
 use Propel\Tests\Bookstore\BookQuery;
 use Propel\Tests\Bookstore\Map\BookTableMap;
@@ -171,6 +173,25 @@ class MysqlAdapterTest extends TestCaseFixtures
         $params = [];
         $generatedSql = $query->createSelectSql($params);
         $this->assertSame($expectedSql, $generatedSql, 'Subquery should contain shared read lock');
+    }
+
+    /**
+     * Test `ApplyLimitForDelete`
+     *
+     * @return void
+     */
+    public function testApplyLimitForDelete()
+    {
+        $criteria = new Criteria();
+        $criteria->setLimit(10);
+
+        $queryBuilder = new DeleteQuerySqlBuilder($criteria);
+        $sql = $queryBuilder->build(BookTableMap::TABLE_NAME, []);
+
+        // Expect a TOP N result with no subquery
+        $expected = 'DELETE FROM book LIMIT 10';
+
+        $this->assertEquals($expected, $sql);
     }
 }
 

--- a/tests/Propel/Tests/Runtime/Adapter/Pdo/MysqlAdapterTest.php
+++ b/tests/Propel/Tests/Runtime/Adapter/Pdo/MysqlAdapterTest.php
@@ -10,6 +10,7 @@ namespace Propel\Tests\Runtime\Adapter\Pdo;
 
 use Propel\Runtime\ActiveQuery\Criteria;
 use Propel\Runtime\ActiveQuery\SqlBuilder\DeleteQuerySqlBuilder;
+use Propel\Runtime\ActiveQuery\SqlBuilder\PreparedStatementDto;
 use Propel\Runtime\Adapter\Pdo\MysqlAdapter;
 use Propel\Tests\Bookstore\BookQuery;
 use Propel\Tests\Bookstore\Map\BookTableMap;
@@ -186,12 +187,12 @@ class MysqlAdapterTest extends TestCaseFixtures
         $criteria->setLimit(10);
 
         $queryBuilder = new DeleteQuerySqlBuilder($criteria);
-        $sql = $queryBuilder->build(BookTableMap::TABLE_NAME, []);
+        $statementDto = $queryBuilder->build(BookTableMap::TABLE_NAME, []);
 
         // Expect a TOP N result with no subquery
         $expected = 'DELETE FROM book LIMIT 10';
 
-        $this->assertEquals($expected, $sql);
+        $this->assertEquals($expected, $statementDto->getSqlStatement());
     }
 }
 

--- a/tests/Propel/Tests/Runtime/Adapter/Pdo/MysqlAdapterTest.php
+++ b/tests/Propel/Tests/Runtime/Adapter/Pdo/MysqlAdapterTest.php
@@ -189,7 +189,6 @@ class MysqlAdapterTest extends TestCaseFixtures
         $queryBuilder = new DeleteQuerySqlBuilder($criteria);
         $statementDto = $queryBuilder->build(BookTableMap::TABLE_NAME, []);
 
-        // Expect a TOP N result with no subquery
         $expected = 'DELETE FROM book LIMIT 10';
 
         $this->assertEquals($expected, $statementDto->getSqlStatement());


### PR DESCRIPTION
Adds the possibility to limit DELETE query for MySQL.

From MySQL [doc](https://dev.mysql.com/doc/refman/8.4/en/delete.html)

DELETE [LOW_PRIORITY] [QUICK] [IGNORE] FROM tbl_name [[AS] tbl_alias]
    [PARTITION (partition_name [, partition_name] ...)]
    [WHERE where_condition]
    [ORDER BY ...]
    [LIMIT row_count]