### PR TITLE
1966 - changed method "getPDOType" case to match opcache keys rules

### DIFF
--- a/src/Propel/Generator/Builder/Om/QueryBuilder.php
+++ b/src/Propel/Generator/Builder/Om/QueryBuilder.php
@@ -1378,7 +1378,7 @@ class QueryBuilder extends AbstractOMBuilder
                 ->addUsingAlias(" . $this->getColumnConstant($localValueOrColumn) . ", $rightValue, \$comparison)";
             } else {
                 $leftValue = var_export($localValueOrColumn, true);
-                $bindingType = $foreignColumn->getPDOType();
+                $bindingType = $foreignColumn->getPdoType();
                 $script .= "
                 ->where(\"$leftValue = ?\", $rightValue, $bindingType)";
             }

--- a/src/Propel/Generator/Model/Column.php
+++ b/src/Propel/Generator/Model/Column.php
@@ -1253,9 +1253,9 @@ class Column extends MappingModel
      *
      * @return int
      */
-    public function getPDOType(): int
+    public function getPdoType(): int
     {
-        return PropelTypes::getPDOType($this->getType());
+        return PropelTypes::getPdoType($this->getType());
     }
 
     /**

--- a/src/Propel/Generator/Model/PropelTypes.php
+++ b/src/Propel/Generator/Model/PropelTypes.php
@@ -520,7 +520,7 @@ class PropelTypes
      *
      * @return int
      */
-    public static function getPDOType(string $type): int
+    public static function getPdoType(string $type): int
     {
         return self::$mappingTypeToPDOTypeMap[$type];
     }

--- a/src/Propel/Generator/Platform/MysqlPlatform.php
+++ b/src/Propel/Generator/Platform/MysqlPlatform.php
@@ -1047,7 +1047,7 @@ ALTER TABLE %s ADD %s %s;
     {
         // FIXME - This is a temporary hack to get around apparent bugs w/ PDO+MYSQL
         // See http://pecl.php.net/bugs/bug.php?id=9919
-        if ($column->getPDOType() === PDO::PARAM_BOOL) {
+        if ($column->getPdoType() === PDO::PARAM_BOOL) {
             return sprintf(
                 "
 %s\$stmt->bindValue(%s, (int) %s, PDO::PARAM_INT);",

--- a/tests/Propel/Tests/Generator/Model/ColumnTest.php
+++ b/tests/Propel/Tests/Generator/Model/ColumnTest.php
@@ -442,7 +442,7 @@ class ColumnTest extends ModelTestCase
         $column->setDomain($domain);
         $column->setType($mappingType);
 
-        $this->assertSame($pdoType, $column->getPDOType());
+        $this->assertSame($pdoType, $column->getPdoType());
     }
 
     public function providePdoTypes()


### PR DESCRIPTION
According to the issue https://github.com/propelorm/Propel2/issues/1966#issuecomment-3151757444
I open the PR to change the case of the method "getPDOType".
This way opcache will save it with the same case of how PHP calls it