### PR TITLE
Fix PHP 8.5 deprecation, use (bool) cast in generated code

### DIFF
--- a/src/Propel/Generator/Builder/Om/ObjectBuilder.php
+++ b/src/Propel/Generator/Builder/Om/ObjectBuilder.php
@@ -2423,7 +2423,7 @@ abstract class " . $this->getUnqualifiedClassName() . $parentClass . ' implement
             if (is_string(\$v)) {
                 \$v = in_array(strtolower(\$v), array('false', 'off', '-', 'no', 'n', '0', '')) ? false : true;
             } else {
-                \$v = (boolean) \$v;
+                \$v = (bool) \$v;
             }
         }
 


### PR DESCRIPTION
These "non-standard cast names" are deprecated in PHP 8.5 and `(bool)` is supported in all PHP versions that propel supports. 