### PR TITLE
fix(mysql): allow DEFAULT values for TEXT columns

### DIFF
--- a/src/Propel/Generator/Platform/MysqlPlatform.php
+++ b/src/Propel/Generator/Platform/MysqlPlatform.php
@@ -464,9 +464,9 @@ DROP TABLE IF EXISTS " . $this->quoteIdentifier($table->getName()) . ";
             if ($def && $def->isExpression()) {
                 throw new EngineException('DATE columns cannot have default *expressions* in MySQL.');
             }
-        } elseif ($sqlType === 'TEXT' || $sqlType === 'BLOB') {
+        } elseif ($sqlType === 'BLOB') {
             if ($domain->getDefaultValue()) {
-                throw new EngineException('BLOB and TEXT columns cannot have DEFAULT values. in MySQL.');
+                throw new EngineException('BLOB columns cannot have DEFAULT values in MySQL.');
             }
         }
 

--- a/src/Propel/Generator/Reverse/MysqlSchemaParser.php
+++ b/src/Propel/Generator/Reverse/MysqlSchemaParser.php
@@ -265,8 +265,9 @@ class MysqlSchemaParser extends AbstractSchemaParser
         if (preg_match('~blob~', $nativeType)) {
             $default = null;
         } elseif ($row['Default'] !== null && $row['Default'] !== '' && preg_match('~text~', $nativeType)) {
-            // MariaDB wraps TEXT type default values in extra single quotes, but not other types
-            $default = preg_replace('@^\'(.*)\'$@', '$1', $row['Default']);
+            // MySQL 8.0+ wraps TEXT defaults with a charset prefix like _utf8mb3'value'
+            // MariaDB wraps TEXT type default values in extra single quotes like 'value'
+            $default = preg_replace('~^(?:_\w+)?\'(.*)\'$~', '$1', $row['Default']);
         } else {
             $default = $row['Default'];
         }

--- a/src/Propel/Generator/Reverse/MysqlSchemaParser.php
+++ b/src/Propel/Generator/Reverse/MysqlSchemaParser.php
@@ -262,7 +262,14 @@ class MysqlSchemaParser extends AbstractSchemaParser
         }
 
         // BLOBs can't have any default values in MySQL
-        $default = preg_match('~blob|text~', $nativeType) ? null : $row['Default'];
+        if (preg_match('~blob~', $nativeType)) {
+            $default = null;
+        } elseif ($row['Default'] !== null && $row['Default'] !== '' && preg_match('~text~', $nativeType)) {
+            // MariaDB wraps TEXT type default values in extra single quotes, but not other types
+            $default = preg_replace('@^\'(.*)\'$@', '$1', $row['Default']);
+        } else {
+            $default = $row['Default'];
+        }
 
         $propelType = $this->getMappedPropelType($nativeType);
         if (!$propelType) {

--- a/tests/Propel/Tests/Generator/Platform/MysqlPlatformTest.php
+++ b/tests/Propel/Tests/Generator/Platform/MysqlPlatformTest.php
@@ -10,6 +10,7 @@ namespace Propel\Tests\Generator\Platform;
 
 use Propel\Generator\Builder\Util\SchemaReader;
 use Propel\Generator\Config\GeneratorConfig;
+use Propel\Generator\Exception\EngineException;
 use Propel\Generator\Model\Column;
 use Propel\Generator\Model\ColumnDefaultValue;
 use Propel\Generator\Model\IdMethod;
@@ -479,6 +480,32 @@ DROP TABLE IF EXISTS `Woopah`.`foo`;
         $column->getDomain()->setDefaultValue(new ColumnDefaultValue(123, ColumnDefaultValue::TYPE_VALUE));
         $expected = '`foo` DOUBLE(3,2) DEFAULT 123 NOT NULL';
         $this->assertEquals($expected, $this->getPlatform()->getColumnDDL($column));
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetColumnDDLTextDefaultValue(): void
+    {
+        $column = new Column('foo');
+        $column->getDomain()->copy($this->getPlatform()->getDomainForType(PropelTypes::LONGVARCHAR));
+        $column->getDomain()->setDefaultValue(new ColumnDefaultValue('hello', ColumnDefaultValue::TYPE_VALUE));
+        $expected = '`foo` TEXT DEFAULT \'hello\'';
+        $this->assertEquals($expected, $this->getPlatform()->getColumnDDL($column));
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetColumnDDLBlobDefaultValueThrowsException(): void
+    {
+        $this->expectException(EngineException::class);
+        $this->expectExceptionMessage('BLOB columns cannot have DEFAULT values in MySQL.');
+
+        $column = new Column('bar');
+        $column->getDomain()->copy($this->getPlatform()->getDomainForType(PropelTypes::BLOB));
+        $column->getDomain()->setDefaultValue(new ColumnDefaultValue('data', ColumnDefaultValue::TYPE_VALUE));
+        $this->getPlatform()->getColumnDDL($column);
     }
 
     /**

--- a/tests/Propel/Tests/Generator/Reverse/MysqlSchemaParserTest.php
+++ b/tests/Propel/Tests/Generator/Reverse/MysqlSchemaParserTest.php
@@ -9,7 +9,10 @@
 namespace Propel\Tests\Generator\Reverse;
 
 use PDO;
+use Propel\Generator\Config\QuickGeneratorConfig;
 use Propel\Generator\Model\ColumnDefaultValue;
+use Propel\Generator\Model\Database;
+use Propel\Generator\Platform\DefaultPlatform;
 use Propel\Generator\Reverse\MysqlSchemaParser;
 use Propel\Tests\Bookstore\Map\BookTableMap;
 
@@ -92,5 +95,71 @@ EOT;
         $updatedAtColumn = $onUpdateTable->getColumn('updated');
         $this->assertEquals(ColumnDefaultValue::TYPE_EXPR, $updatedAtColumn->getDefaultValue()->getType());
         $this->assertEquals('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP', $updatedAtColumn->getDefaultValue()->getValue());
+    }
+
+    /**
+     * @return void
+     */
+    public function testTextDefaultValues(): void
+    {
+        $serverVersion = $this->con->getAttribute(PDO::ATTR_SERVER_VERSION);
+        $isMariaDb = stripos($serverVersion, 'mariadb') !== false;
+
+        if ($isMariaDb) {
+            if (version_compare(preg_replace('/^.*?(\d+\.\d+\.\d+).*$/', '$1', $serverVersion), '10.2.1', '<')) {
+                $this->markTestSkipped('TEXT columns with DEFAULT values require MariaDB 10.2.1+');
+            }
+        } else {
+            if (version_compare($serverVersion, '8.0.13', '<')) {
+                $this->markTestSkipped('TEXT columns with DEFAULT values require MySQL 8.0.13+');
+            }
+        }
+
+        $this->con->exec('DROP TABLE IF EXISTS test_text_defaults');
+        $this->con->exec("CREATE TABLE test_text_defaults (
+            id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+            content_text TEXT DEFAULT ('hello text'),
+            content_text_empty TEXT DEFAULT (''),
+            content_text_not_null TEXT NOT NULL,
+            content_text_none TEXT
+        )");
+
+        try {
+            $parser = new MysqlSchemaParser($this->con);
+            $parser->setGeneratorConfig(new QuickGeneratorConfig());
+
+            $database = new Database();
+            $database->setPlatform(new DefaultPlatform());
+            $parser->parse($database);
+
+            $table = $database->getTable('test_text_defaults');
+            $this->assertNotNull($table, 'Table test_text_defaults should be parsed');
+
+            // TEXT with default value
+            $contentText = $table->getColumn('content_text');
+            $this->assertNotNull($contentText, 'Column content_text should exist');
+            $this->assertNotNull($contentText->getDefaultValue(), 'TEXT column default value should be preserved');
+            $this->assertEquals(ColumnDefaultValue::TYPE_VALUE, $contentText->getDefaultValue()->getType());
+            $this->assertEquals('hello text', $contentText->getDefaultValue()->getValue());
+
+            // TEXT with empty string default
+            $contentTextEmpty = $table->getColumn('content_text_empty');
+            $this->assertNotNull($contentTextEmpty, 'Column content_text_empty should exist');
+            $this->assertNotNull($contentTextEmpty->getDefaultValue(), 'TEXT column with empty default should be preserved');
+            $this->assertEquals(ColumnDefaultValue::TYPE_VALUE, $contentTextEmpty->getDefaultValue()->getType());
+            $this->assertEquals('', $contentTextEmpty->getDefaultValue()->getValue());
+
+            // TEXT NOT NULL without default
+            $contentTextNotNull = $table->getColumn('content_text_not_null');
+            $this->assertNotNull($contentTextNotNull, 'Column content_text_not_null should exist');
+            $this->assertNull($contentTextNotNull->getDefaultValue(), 'TEXT NOT NULL column without default should have no default');
+
+            // TEXT without default (nullable, implicit DEFAULT NULL)
+            $contentTextNone = $table->getColumn('content_text_none');
+            $this->assertNotNull($contentTextNone, 'Column content_text_none should exist');
+            $this->assertNull($contentTextNone->getDefaultValue(), 'TEXT column without explicit default should have no default');
+        } finally {
+            $this->con->exec('DROP TABLE IF EXISTS test_text_defaults');
+        }
     }
 }


### PR DESCRIPTION
allow DEFAULT values for TEXT columns on MySQL 8.0.13+ and MariaDB 10.2.1+

Remove the EngineException that blocked DEFAULT values for TEXT columns while keeping it for BLOB types. Update the reverse schema parser to preserve TEXT default values during introspection, with handling for MariaDB's extra single-quote wrapping on TEXT defaults.